### PR TITLE
fix(checks): remove type exports from 'use server' file causing ReferenceError

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx
@@ -40,8 +40,11 @@ import {
   deleteCheck,
   getCheckResults,
 } from '@/lib/actions/checks'
-import type { CheckWithLatestResult, CheckResultRow } from '@/lib/actions/checks'
-import type { CheckType } from '@/lib/db/schema'
+import type { Check, CheckResultRow, CheckType } from '@/lib/db/schema'
+
+type CheckWithLatestResult = Check & {
+  latestResult: Pick<CheckResultRow, 'status' | 'ranAt' | 'output'> | null
+}
 
 interface Props {
   orgId: string
@@ -185,7 +188,7 @@ function AddCheckDialog({
       } else if (checkType === 'process') {
         config = { process_name: processName }
       } else {
-        config = { url: httpUrl, expected_status: parseInt(httpStatus, 10) }
+        config = { url: httpUrl, expected_status: parseInt(httpStatus, 10) || 200 }
       }
       return createCheck(orgId, { hostId, name, checkType, config, intervalSeconds })
     },
@@ -197,6 +200,9 @@ function AddCheckDialog({
       queryClient.invalidateQueries({ queryKey: ['checks', orgId, hostId] })
       onOpenChange(false)
       resetForm()
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
     },
   })
 
@@ -314,7 +320,7 @@ function AddCheckDialog({
               min={10}
               max={3600}
               value={intervalSeconds}
-              onChange={(e) => setIntervalSeconds(parseInt(e.target.value, 10))}
+              onChange={(e) => setIntervalSeconds(parseInt(e.target.value, 10) || 60)}
             />
           </div>
 

--- a/apps/web/lib/actions/checks.ts
+++ b/apps/web/lib/actions/checks.ts
@@ -4,13 +4,7 @@ import { z } from 'zod'
 import { db } from '@/lib/db'
 import { checks, checkResults } from '@/lib/db/schema'
 import { eq, and, isNull, desc } from 'drizzle-orm'
-import type { Check, CheckResultRow, CheckConfig, CheckType } from '@/lib/db/schema'
-
-export type { Check, CheckResultRow }
-
-export type CheckWithLatestResult = Check & {
-  latestResult: Pick<CheckResultRow, 'status' | 'ranAt' | 'output'> | null
-}
+import type { CheckConfig, CheckType, CheckResultRow } from '@/lib/db/schema'
 
 const portConfigSchema = z.object({
   host: z.string().min(1),
@@ -41,7 +35,7 @@ const updateCheckSchema = z.object({
   intervalSeconds: z.number().int().min(10).max(3600).optional(),
 })
 
-export async function getChecks(orgId: string, hostId: string): Promise<CheckWithLatestResult[]> {
+export async function getChecks(orgId: string, hostId: string) {
   const rows = await db.query.checks.findMany({
     where: and(
       eq(checks.organisationId, orgId),
@@ -51,8 +45,7 @@ export async function getChecks(orgId: string, hostId: string): Promise<CheckWit
     orderBy: checks.createdAt,
   })
 
-  // Fetch latest result for each check
-  const withResults: CheckWithLatestResult[] = await Promise.all(
+  const withResults = await Promise.all(
     rows.map(async (check) => {
       const latest = await db.query.checkResults.findFirst({
         where: eq(checkResults.checkId, check.id),


### PR DESCRIPTION
## Summary

- Turbopack treats `export type` declarations in a `'use server'` file as value exports, emitting a runtime reference to `Check` which doesn't exist as a JavaScript value — causing `ReferenceError: Check is not defined` at module evaluation on every request to the host detail page
- Removed `export type { Check, CheckResultRow }` and `export type CheckWithLatestResult` from `lib/actions/checks.ts`
- Moved `CheckWithLatestResult` type definition into `checks-tab.tsx` (the only consumer), importing `Check` and `CheckResultRow` directly from the schema
- Fixed `NaN` on empty interval/status inputs in the Add Check dialog (fallback to `60`/`200`)
- Added `onError` handler to the create mutation so unexpected server throws surface in the UI

## Test plan

- [ ] Navigate to a host detail page — page should load without a 500 error
- [ ] Open the Checks tab — list should render (empty state if no checks yet)
- [ ] Add a check — dialog should close and the check should appear in the list
- [ ] Clear the interval field and re-submit — should default to 60, not fail with NaN

🤖 Generated with [Claude Code](https://claude.com/claude-code)