### PR TITLE
feat(agent): add --tls-skip-verify flag to agent install flow

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -27,6 +27,7 @@ func main() {
 	tokenFlag := flag.String("token", "", "Enrolment token (overrides config file and INFRAWATCH_ORG_TOKEN)")
 	addressFlag := flag.String("address", "", "Ingest address host:port (overrides config file and INFRAWATCH_INGEST_ADDRESS)")
 	installFlag := flag.Bool("install", false, "Install agent as a system service and exit (requires --token)")
+	tlsSkipVerifyFlag := flag.Bool("tls-skip-verify", false, "Skip TLS certificate verification — use when ingest uses a self-signed cert (insecure)")
 	flag.Parse()
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -39,7 +40,7 @@ func main() {
 			slog.Error("--token is required when using --install")
 			os.Exit(1)
 		}
-		if err := install.Run(*tokenFlag, strings.TrimSpace(*addressFlag)); err != nil {
+		if err := install.Run(*tokenFlag, strings.TrimSpace(*addressFlag), *tlsSkipVerifyFlag); err != nil {
 			slog.Error("install failed", "err", err)
 			os.Exit(1)
 		}
@@ -58,6 +59,9 @@ func main() {
 	}
 	if *addressFlag != "" {
 		cfg.Ingest.Address = strings.TrimSpace(*addressFlag)
+	}
+	if *tlsSkipVerifyFlag {
+		cfg.Ingest.TLSSkipVerify = true
 	}
 
 	if cfg.Agent.OrgToken == "" {

--- a/agent/internal/install/install.go
+++ b/agent/internal/install/install.go
@@ -18,14 +18,15 @@ import (
 // Run performs a full system installation for the current OS.
 // It must be called as root (Linux/macOS) or Administrator (Windows).
 // orgToken is required. ingestAddress is optional — pass empty string to keep the existing value.
-func Run(orgToken, ingestAddress string) error {
+// tlsSkipVerify disables TLS certificate verification; use when ingest uses a self-signed cert.
+func Run(orgToken, ingestAddress string, tlsSkipVerify bool) error {
 	switch runtime.GOOS {
 	case "linux":
-		return installLinux(orgToken, ingestAddress)
+		return installLinux(orgToken, ingestAddress, tlsSkipVerify)
 	case "darwin":
-		return installDarwin(orgToken, ingestAddress)
+		return installDarwin(orgToken, ingestAddress, tlsSkipVerify)
 	case "windows":
-		return installWindows(orgToken, ingestAddress)
+		return installWindows(orgToken, ingestAddress, tlsSkipVerify)
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
@@ -34,8 +35,8 @@ func Run(orgToken, ingestAddress string) error {
 // mergeConfig loads the existing config at cfgPath (if present), then overlays
 // any explicitly provided flag values on top. This preserves fields like
 // ca_cert_file and tls_skip_verify across reinstalls.
-// orgToken is always applied. ingestAddress is only applied if non-empty.
-func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string) *agentconfig.Config {
+// orgToken is always applied. ingestAddress and tlsSkipVerify are only applied if non-zero.
+func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string, tlsSkipVerify bool) *agentconfig.Config {
 	cfg, err := agentconfig.Load(cfgPath)
 	if err != nil {
 		// File missing or unparseable — start from scratch with caller-supplied defaults.
@@ -56,6 +57,9 @@ func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string) *agent
 	cfg.Agent.OrgToken = orgToken
 	if ingestAddress != "" {
 		cfg.Ingest.Address = ingestAddress
+	}
+	if tlsSkipVerify {
+		cfg.Ingest.TLSSkipVerify = true
 	}
 
 	return cfg
@@ -81,7 +85,7 @@ func backupConfig(cfgPath string) {
 
 // ── Linux / systemd ───────────────────────────────────────────────────────────
 
-func installLinux(orgToken, ingestAddress string) error {
+func installLinux(orgToken, ingestAddress string, tlsSkipVerify bool) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("install must be run as root (try: sudo ./infrawatch-agent --install ...)")
 	}
@@ -96,7 +100,7 @@ func installLinux(orgToken, ingestAddress string) error {
 	if err := mkdirs("/etc/infrawatch", dataDir); err != nil {
 		return fmt.Errorf("creating directories: %w", err)
 	}
-	cfg := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir)
+	cfg := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify)
 	if err := writeConfig(cfgPath, cfg); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
@@ -135,7 +139,7 @@ WantedBy=multi-user.target
 
 // ── macOS / launchd ───────────────────────────────────────────────────────────
 
-func installDarwin(orgToken, ingestAddress string) error {
+func installDarwin(orgToken, ingestAddress string, tlsSkipVerify bool) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("install must be run as root (try: sudo ./infrawatch-agent --install ...)")
 	}
@@ -151,7 +155,7 @@ func installDarwin(orgToken, ingestAddress string) error {
 	if err := mkdirs("/etc/infrawatch", dataDir, "/var/log"); err != nil {
 		return fmt.Errorf("creating directories: %w", err)
 	}
-	cfg := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir)
+	cfg := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify)
 	if err := writeConfig(cfgPath, cfg); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
@@ -197,7 +201,7 @@ func installDarwin(orgToken, ingestAddress string) error {
 
 // ── Windows / Service Control Manager ────────────────────────────────────────
 
-func installWindows(orgToken, ingestAddress string) error {
+func installWindows(orgToken, ingestAddress string, tlsSkipVerify bool) error {
 	if !isAdmin() {
 		return fmt.Errorf("install must be run as Administrator")
 	}
@@ -214,7 +218,7 @@ func installWindows(orgToken, ingestAddress string) error {
 	if err := copyBinary(dest); err != nil {
 		return fmt.Errorf("copying binary: %w", err)
 	}
-	cfg := mergeConfig(cfgFile, orgToken, ingestAddress, dataDir)
+	cfg := mergeConfig(cfgFile, orgToken, ingestAddress, dataDir, tlsSkipVerify)
 	if err := writeConfig(cfgFile, cfg); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}

--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -38,6 +38,7 @@ import type { AgentEnrolmentToken } from '@/lib/db/schema'
 const createTokenSchema = z.object({
   label: z.string().min(1, 'Label is required').max(100),
   autoApprove: z.boolean(),
+  skipVerify: z.boolean(),
   maxUses: z.string().optional(),
   expiresInDays: z.string().optional(),
 })
@@ -108,10 +109,11 @@ export function AgentsSettingsClient({
     formState: { errors },
   } = useForm<CreateTokenForm>({
     resolver: zodResolver(createTokenSchema),
-    defaultValues: { label: '', autoApprove: false },
+    defaultValues: { label: '', autoApprove: false, skipVerify: true },
   })
 
   const autoApprove = watch('autoApprove')
+  const skipVerify = watch('skipVerify')
 
   const createMutation = useMutation({
     mutationFn: (data: CreateTokenForm) =>
@@ -122,13 +124,16 @@ export function AgentsSettingsClient({
         expiresInDays:
           data.expiresInDays !== '' && data.expiresInDays ? Number(data.expiresInDays) : undefined,
       }),
-    onSuccess: (result) => {
+    onSuccess: (result, variables) => {
       if ('error' in result) return
       queryClient.invalidateQueries({ queryKey: ['enrolment-tokens', orgId] })
       setNewTokenValue(result.token)
-      setNewInstallCommand(
-        `curl -fsSL "${window.location.origin}/api/agent/install?token=${result.token}" | sudo bash`,
-      )
+      const installUrl = new URL(`${window.location.origin}/api/agent/install`)
+      installUrl.searchParams.set('token', result.token)
+      if (variables.skipVerify) {
+        installUrl.searchParams.set('skip_verify', 'true')
+      }
+      setNewInstallCommand(`curl -fsSL "${installUrl.toString()}" | sudo bash`)
       reset()
     },
   })
@@ -337,6 +342,24 @@ export function AgentsSettingsClient({
                   <p className="text-xs text-muted-foreground">
                     Agents registered with this token are automatically approved without manual
                     review.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  id="skipVerify"
+                  className="h-4 w-4 rounded border-border"
+                  checked={skipVerify}
+                  onChange={(e) => setValue('skipVerify', e.target.checked)}
+                />
+                <div>
+                  <Label htmlFor="skipVerify" className="font-normal cursor-pointer">
+                    Accept self-signed certificates
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Enable if your ingest service uses a self-signed or private CA certificate.
                   </p>
                 </div>
               </div>

--- a/apps/web/app/api/agent/install/route.ts
+++ b/apps/web/app/api/agent/install/route.ts
@@ -13,8 +13,9 @@ import { NextRequest, NextResponse } from 'next/server'
  *   sudo ./infrawatch-agent --install --token <TOKEN>
  *
  * Query parameters:
- *   token  - Enrolment token from the Infrawatch UI
- *   ingest - gRPC ingest address host:port (default: <server-hostname>:9443)
+ *   token       - Enrolment token from the Infrawatch UI
+ *   ingest      - gRPC ingest address host:port (default: <server-hostname>:9443)
+ *   skip_verify - Set to "true" to disable TLS certificate verification (for self-signed certs)
  */
 export async function GET(request: NextRequest) {
   const host = request.headers.get('host') ?? 'localhost'
@@ -26,9 +27,10 @@ export async function GET(request: NextRequest) {
 
   const bareHost = host.split(':')[0]
   const ingestAddress = searchParams.get('ingest') ?? `${bareHost}:9443`
+  const skipVerify = searchParams.get('skip_verify') === 'true'
 
   const script = token
-    ? buildAutoInstallScript(serverURL, token, ingestAddress)
+    ? buildAutoInstallScript(serverURL, token, ingestAddress, skipVerify)
     : buildDownloadScript(serverURL, ingestAddress)
 
   return new NextResponse(script, {
@@ -39,7 +41,13 @@ export async function GET(request: NextRequest) {
   })
 }
 
-function buildAutoInstallScript(serverURL: string, token: string, ingestAddress: string): string {
+function buildAutoInstallScript(
+  serverURL: string,
+  token: string,
+  ingestAddress: string,
+  skipVerify: boolean,
+): string {
+  const tlsFlag = skipVerify ? ' --tls-skip-verify' : ''
   return `#!/bin/sh
 set -e
 
@@ -64,7 +72,7 @@ chmod +x infrawatch-agent
 echo "Binary downloaded."
 
 # ── Self-install ───────────────────────────────────────────────────────────────
-sudo ./infrawatch-agent --install --token "${token}" --address "${ingestAddress}"
+sudo ./infrawatch-agent --install --token "${token}" --address "${ingestAddress}"${tlsFlag}
 `
 }
 


### PR DESCRIPTION
## Summary

- Adds `--tls-skip-verify` CLI flag to the agent binary, written into `agent.toml` during `--install` so environments with self-signed or private CA certificates work without manual config editing
- Install script route (`/api/agent/install`) now accepts a `skip_verify=true` query param and appends the flag to the generated install command
- Token creation UI adds an "Accept self-signed certificates" checkbox (checked by default) that controls whether the generated curl command includes `&skip_verify=true`

## Test plan

- [ ] Create an enrolment token — confirm "Accept self-signed certificates" is checked by default
- [ ] Verify generated curl command includes `&skip_verify=true`
- [ ] Uncheck the box — verify curl command has no `skip_verify` param
- [ ] Run the curl command on a server with a self-signed ingest cert — agent should start without x509 errors
- [ ] Check `/etc/infrawatch/agent.toml` — should contain `tls_skip_verify = true`
- [ ] Agent should appear in Hosts → Pending Agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)