### PR TITLE
fix(agent): reuse HTTP client and reset stream dedup map on reconnect

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,52 @@
 **Phase 2 — Monitoring & Alerting**
 
 ## Current Status
-🟡 Phase 2 in progress — Full alert pipeline built: ingest evaluates alert rules on every heartbeat, fires/resolves instances, and POSTs to webhook channels. Alert rules support `check_status` (consecutive failures) and `metric_threshold` (cpu/memory/disk vs threshold). Web UI has a live Alerts page (active alerts, history, acknowledge, webhook channel management), an Alerts tab on each host detail page (rule builder + active count badge), and an alert count column in the host inventory table. Auto-refresh 30 s throughout. mTLS and Redpanda deferred.
+🟡 Phase 2 in progress — Full alert pipeline built with multi-channel notifications (webhook + SMTP email). Ingest evaluates rules on every heartbeat, fires/resolves instances. Alert rules support `check_status` and `metric_threshold`. Web UI has a live Alerts page, per-host Alerts tab, alert count badge in inventory, and a Global Alert Defaults settings page that auto-applies configured rules to every newly-approved host. Agent HTTP check resource leak fixed; stream dedup map reset on reconnect. mTLS and Redpanda deferred.
 
 ---
 
 ## What Has Been Built
+
+### Session 11 — Agent HTTP client fix and stream dedup reset
+
+**HTTP check resource leak** (`agent/internal/checks/http.go`)
+- Shared a single `http.Client` (with `Transport`) across all HTTP check goroutines instead of creating a new one per check — prevents file-descriptor exhaustion from accumulated idle transports on hosts with many HTTP checks
+- Response bodies are now always drained before close so TCP connections are cleanly returned to the pool
+
+**Stream dedup map reset on reconnect** (`agent/internal/heartbeat/heartbeat.go`)
+- `seenQueryIDs` map is cleared at the start of each new stream session so ad-hoc queries that were pending when a stream died are re-executed on the new stream rather than silently dropped
+
+**Build state**
+- `go build ./agent/...` — compiles ✅
+
+---
+
+### Session 10 — SMTP email notifications and global alert defaults
+
+**SMTP notification channel** (`apps/web/lib/db/schema/alerts.ts`, `apps/web/lib/actions/alerts.ts`, `apps/web/app/(dashboard)/alerts/alerts-client.tsx`)
+- New `SmtpChannelConfig` interface: host, port, secure, optional username/password, fromAddress, fromName, toAddresses (array)
+- `NotificationChannelType` union type `'webhook' | 'smtp'` replaces the hard-coded `'webhook'` literal on `notificationChannels.type`
+- `notificationChannels.config` now typed as `WebhookChannelConfig | SmtpChannelConfig`
+- `createNotificationChannel` action handles both channel types; SMTP passwords are redacted (`hasSecret`) the same way webhook secrets are
+- Alerts page updated: Add Channel dialog has a type selector that switches between webhook and SMTP field sets; channel list renders type badge and appropriate masked credentials
+
+**Global alert defaults** (`apps/web/lib/db/schema/alerts.ts`, migration `0009_global_alert_defaults.sql`, `apps/web/lib/actions/alerts.ts`, `apps/web/lib/actions/agents.ts`)
+- New `isGlobalDefault` boolean column on `alertRules` (default false); migration `0009` adds it
+- `getGlobalAlertDefaults(orgId)` — fetches all global-default rules for the org
+- `createGlobalAlertDefault(orgId, input)` — creates a rule with `isGlobalDefault = true`; only `metric_threshold` type allowed for defaults
+- `deleteGlobalAlertDefault(orgId, ruleId)` — soft-deletes a global default rule
+- `applyGlobalDefaultsToHost(orgId, hostId)` — clones each active global-default rule as a host-scoped rule; called from `approveAgent` immediately after manual approval
+- `getAlertRules` now excludes global defaults from regular host/org rule listings (prevents duplicates in the Alerts tab)
+
+**Global Alert Defaults settings page** (`apps/web/app/(dashboard)/settings/alerts/`)
+- New `page.tsx` — admin-only server component; fetches initial defaults, passes to client
+- `alerts-client.tsx` — table of default metric threshold rules with Add/Delete; Add dialog: metric (cpu/memory/disk), operator, threshold %, severity
+- Sidebar link "Global Alert Defaults" added under Administration
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
 
 ### Session 9 — Alert rule builder + alert state machine
 

--- a/agent/internal/checks/http.go
+++ b/agent/internal/checks/http.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -12,13 +13,23 @@ type HttpConfig struct {
 	ExpectedStatus int    `json:"expected_status"`
 }
 
+// httpClient is shared across all HTTP checks so that the underlying transport
+// and its connection pool are reused rather than recreated on every execution.
+// Without this, each check invocation creates a new Transport whose idle
+// connections hold open file descriptors until the GC finalises the object —
+// over hours of operation this exhausts the process's FD limit.
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
 func runHttpCheck(cfg HttpConfig) (status, output string) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(cfg.URL)
+	resp, err := httpClient.Get(cfg.URL)
 	if err != nil {
 		return "fail", fmt.Sprintf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	// Drain the body before closing so the Transport can reuse the connection.
+	// Without this the underlying TCP connection cannot be cleanly returned to
+	// the pool and accumulates as a leaked file descriptor.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
 
 	expected := cfg.ExpectedStatus
 	if expected == 0 {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -93,6 +93,13 @@ func (r *Runner) runStream(ctx context.Context) error {
 		return fmt.Errorf("opening heartbeat stream: %w", err)
 	}
 
+	// Reset the dedup map per stream session. Queries pushed on a previous
+	// (now-dead) stream will be re-pushed by the server on reconnect and must
+	// be re-executed; keeping stale IDs would silently drop them.
+	r.seenMu.Lock()
+	r.seenQueryIDs = make(map[string]struct{})
+	r.seenMu.Unlock()
+
 	slog.Info("heartbeat stream opened", "agent_id", r.agentID)
 
 	// Background receiver: the server pushes HeartbeatResponses both as


### PR DESCRIPTION
## Summary

- Share a single `http.Client` across all HTTP checks to prevent FD exhaustion from accumulated idle transports over long runtimes
- Drain response bodies before closing so TCP connections are cleanly returned to the pool
- Reset `seenQueryIDs` dedup map at the start of each heartbeat stream session so queries from a dead stream are re-executed on reconnect rather than silently dropped

## Test plan

- [ ] Verify HTTP checks still execute correctly and return expected pass/fail status
- [ ] Verify agent reconnects correctly after a lost heartbeat stream and re-executes pending queries
- [ ] Long-running agent shows stable FD count under `/proc/<pid>/fd` (no accumulation over time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)