### PR TITLE
feat(alerts): test notifications, edit channels, and SMTP dispatch

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,46 @@
 **Phase 2 — Monitoring & Alerting**
 
 ## Current Status
-🟡 Phase 2 in progress — Full alert pipeline built with multi-channel notifications (webhook + SMTP email). Ingest evaluates rules on every heartbeat, fires/resolves instances. Alert rules support `check_status` and `metric_threshold`. Web UI has a live Alerts page, per-host Alerts tab, alert count badge in inventory, and a Global Alert Defaults settings page that auto-applies configured rules to every newly-approved host. Agent HTTP check resource leak fixed; stream dedup map reset on reconnect. mTLS and Redpanda deferred.
+🟡 Phase 2 in progress — Full alert pipeline built with multi-channel notifications (webhook + SMTP email). Notification channels now support test delivery with a result log dialog, in-place editing, and a three-way encryption selector (none/STARTTLS/SSL-TLS). SMTP dispatch is now wired into the Go ingest service — previously only webhooks were dispatched. Ingest evaluates rules on every heartbeat, fires/resolves instances. Alert rules support `check_status` and `metric_threshold`. Web UI has a live Alerts page, per-host Alerts tab, alert count badge in inventory, and a Global Alert Defaults settings page that auto-applies configured rules to every newly-approved host. mTLS and Redpanda deferred.
 
 ---
 
 ## What Has Been Built
+
+### Session 12 — Notification channel test, edit, and SMTP dispatch fix
+
+**Test notification button** (`apps/web/app/(dashboard)/alerts/alerts-client.tsx`, `apps/web/lib/actions/alerts.ts`)
+- Flask icon button per channel row; sends a real test payload and shows a `TestLogDialog` with success confirmation or the exact error string (e.g. SMTP auth failure, HTTP 401, TLS version mismatch)
+- Webhook test: POSTs `alert.test` JSON payload with HMAC-SHA256 signature when a secret is set; 10 s timeout
+- SMTP test: sends via nodemailer using the stored channel config; nodemailer installed as a new web dependency
+- Button shows `Loader2` spinner while in flight; result dialog stays open until dismissed
+
+**Edit notification channel** (`apps/web/app/(dashboard)/alerts/alerts-client.tsx`, `apps/web/lib/actions/alerts.ts`)
+- Pencil icon button opens type-specific edit dialog (`EditWebhookDialog` / `EditSmtpDialog`) pre-filled from the safe config
+- Secret/password fields labelled "leave blank to keep existing" when a value is already stored; empty submission preserves the existing credential
+- `updateNotificationChannel` server action merges with the existing DB row so secrets are never lost
+
+**SMTP encryption field** (`apps/web/lib/db/schema/alerts.ts`, `apps/web/lib/actions/alerts.ts`, `apps/web/app/(dashboard)/alerts/alerts-client.tsx`)
+- `SmtpChannelConfig.secure: boolean` replaced with `encryption: 'none' | 'starttls' | 'tls'`; new `SmtpEncryption` type exported from schema
+- Zod schemas and `NotificationChannelSafe` type updated throughout
+- `normaliseSmtpConfig()` backward-compat function converts legacy `secure: bool` rows on read (`true → 'tls'`, `false → 'starttls'`) — no migration needed (JSONB)
+- `sendTestNotification` maps encryption to nodemailer: `tls → secure: true`, `starttls → requireTLS: true`, `none → plain`
+- UI: checkbox replaced with labelled `SmtpEncryptionSelect` (three options with descriptions); selecting a mode auto-fills the conventional port (465/587/25)
+- Channel details column now shows encryption mode: e.g. `smtp.eu.mailgun.org:587 (STARTTLS) → ...`
+
+**SMTP alert dispatch — Go ingest service** (`apps/ingest/internal/db/queries/alerts.sql.go`, `apps/ingest/internal/handlers/alerts.go`, `apps/ingest/internal/handlers/notify.go`)
+- `SmtpChannelRow` struct and `GetEnabledSmtpChannels` query added — previously absent; SMTP channels were silently never fetched
+- `smtpChannelConfig` struct with `effectiveEncryption()` handles both new `encryption` field and legacy `secure: bool`
+- `sendSmtpEmail`: implements all three modes — `tls` (direct TLS via `crypto/tls` + `smtp.NewClient`), `starttls` (`smtp.Dial` + `StartTLS`), `none` (`smtp.SendMail`); `smtpSend` helper for MAIL/RCPT/DATA sequence
+- `dispatchSmtp` fans out to all SMTP channels in goroutines, logging failures (best-effort, same pattern as webhooks)
+- `notifChannels` struct bundles `webhooks` and `smtp` slices; `evaluateCheckStatusRule` and `evaluateMetricThresholdRule` updated to accept and dispatch to both
+- All four fire/resolve points in both rule evaluators now call both `dispatchWebhooks` and `dispatchSmtp`
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+- `go build ./apps/ingest/...` — compiles ✅
+
+---
 
 ### Session 11 — Agent HTTP client fix and stream dedup reset
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,27 @@
 
 ## What Has Been Built
 
+### Session 13 — Alert silencing + migration runner root-cause fix
+
+**Alert silencing feature** (`apps/web/lib/db/schema/alerts.ts`, `apps/web/lib/actions/alerts.ts`, `apps/web/app/(dashboard)/alerts/alerts-client.tsx`, `apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx`, `apps/ingest/internal/db/queries/alerts.sql.go`, `apps/ingest/internal/handlers/alerts.go`)
+- New `alert_silences` table — host-scoped or org-wide time windows that suppress alert evaluation; migration `0010_eager_chameleon.sql` generated via `db:generate`
+- Server actions: `getSilences`, `getActiveSilencesForHost`, `createSilence`, `deleteSilence`
+- Go ingest: `IsHostSilenced` query short-circuits `evaluateAlerts` so silenced hosts skip rule evaluation entirely
+- UI: dedicated Silences card on `/alerts` page with Active/Upcoming/Expired badges + add dialog; per-host "Silence Host" button and amber active-silence banner with one-click remove on the host detail Alerts tab
+
+**Migration runner root-cause fix** (`apps/web/lib/db/migrations/meta/_journal.json`, `apps/web/lib/db/migrations/0009_global_alert_defaults.sql`, `apps/web/Dockerfile`, `start.sh`)
+- Recurring "migrations not applied" symptom traced to `_journal.json`: drizzle-orm's migrator decides pending migrations by comparing each entry's `when` timestamp against `MAX(created_at)` in `__drizzle_migrations`. Migration 0008 had been hand-crafted with `when: 1775900000000` (artificially in the future), so 0009 and 0010 — with smaller `when` values — were silently classified as already applied and skipped with no error.
+- Fix: bumped 0009 → `1775900000001` and 0010 → `1775900000002` so timestamps are strictly monotonic
+- 0009 SQL rewritten with `IF NOT EXISTS` guards because its column had been applied to live DBs without being tracked
+- Dockerfile: migration SQL files now copied directly from build context (`COPY --chown=nextjs:nodejs apps/web/lib/db/migrations …`) so the layer is always invalidated when migrations change, regardless of builder-stage cache hits
+- `start.sh`: explicit `DOCKER_DB_URL` constant and fail-fast on `pnpm db:migrate` failure so silent skips can never happen again
+- **Going forward:** never hand-craft migration files or `_journal.json` entries — always `pnpm run db:generate` so `when` is `Date.now()` and remains monotonic
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+- `go build ./apps/ingest/...` — compiles ✅
+- `alert_silences` table verified present; `__drizzle_migrations` has all 11 rows
+
 ### Session 12 — Notification channel test, edit, and SMTP dispatch fix
 
 **Test notification button** (`apps/web/app/(dashboard)/alerts/alerts-client.tsx`, `apps/web/lib/actions/alerts.ts`)

--- a/agent/internal/grpc/client.go
+++ b/agent/internal/grpc/client.go
@@ -2,8 +2,10 @@ package agentgrpc
 
 import (
 	"fmt"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Connect establishes a gRPC connection to the ingest service.
@@ -13,7 +15,23 @@ func Connect(address, caCertFile string, skipVerify bool) (*grpc.ClientConn, err
 		return nil, fmt.Errorf("building TLS credentials: %w", err)
 	}
 
-	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(creds))
+	// Keepalive is essential: the heartbeat stream is mostly idle (one send
+	// every 30s) and stateful middleboxes (NAT, conntrack, cloud LBs) silently
+	// evict idle TCP flows after 1–4 hours. Without HTTP/2 PINGs the agent
+	// keeps writing to a half-open socket and never notices the stream is dead
+	// until the OS gives up — which can take much longer than the user will
+	// tolerate. PermitWithoutStream lets us keep the connection warm even
+	// during reconnect backoff windows.
+	kp := keepalive.ClientParameters{
+		Time:                30 * time.Second,
+		Timeout:             10 * time.Second,
+		PermitWithoutStream: true,
+	}
+
+	conn, err := grpc.NewClient(address,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithKeepaliveParams(kp),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to %s: %w", address, err)
 	}

--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -181,6 +181,23 @@ func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, orgID strin
 	return result, rows.Err()
 }
 
+// IsHostSilenced returns true if the given host (or the whole org) currently has
+// an active silence window covering now.
+func IsHostSilenced(ctx context.Context, pool *pgxpool.Pool, orgID, hostID string) (bool, error) {
+	const q = `
+		SELECT COUNT(*) > 0
+		FROM alert_silences
+		WHERE organisation_id = $1
+		  AND deleted_at IS NULL
+		  AND starts_at <= NOW()
+		  AND ends_at   >= NOW()
+		  AND (host_id = $2 OR host_id IS NULL)
+	`
+	var silenced bool
+	err := pool.QueryRow(ctx, q, orgID, hostID).Scan(&silenced)
+	return silenced, err
+}
+
 // GetEnabledWebhookChannels returns all enabled, non-deleted webhook notification
 // channels for the given organisation.
 func GetEnabledWebhookChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]WebhookChannelRow, error) {

--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -147,6 +147,40 @@ func GetRecentCheckResults(ctx context.Context, pool *pgxpool.Pool, checkID stri
 	return result, rows.Err()
 }
 
+// SmtpChannelRow is a row from notification_channels where type = 'smtp'.
+type SmtpChannelRow struct {
+	ID         string
+	ConfigJSON string // raw JSONB as text
+}
+
+// GetEnabledSmtpChannels returns all enabled, non-deleted SMTP notification
+// channels for the given organisation.
+func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]SmtpChannelRow, error) {
+	const q = `
+		SELECT id, config::text
+		FROM notification_channels
+		WHERE organisation_id = $1
+		  AND type = 'smtp'
+		  AND enabled = true
+		  AND deleted_at IS NULL
+	`
+	rows, err := pool.Query(ctx, q, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []SmtpChannelRow
+	for rows.Next() {
+		var r SmtpChannelRow
+		if err := rows.Scan(&r.ID, &r.ConfigJSON); err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
 // GetEnabledWebhookChannels returns all enabled, non-deleted webhook notification
 // channels for the given organisation.
 func GetEnabledWebhookChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]WebhookChannelRow, error) {

--- a/apps/ingest/internal/grpc/server.go
+++ b/apps/ingest/internal/grpc/server.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/infrawatch/ingest/internal/handlers"
 	agentv1 "github.com/infrawatch/proto/agent/v1"
@@ -35,8 +37,22 @@ func Serve(port int, creds credentials.TransportCredentials, reg *handlers.Regis
 		return fmt.Errorf("listening on :%d: %w", port, err)
 	}
 
+	// Permit the agent's 30s client pings (with safety margin) and proactively
+	// ping idle agents from the server side too, so a dead peer is detected
+	// within ~80s instead of waiting for the OS TCP timeout.
+	enforcement := keepalive.EnforcementPolicy{
+		MinTime:             10 * time.Second,
+		PermitWithoutStream: true,
+	}
+	serverKp := keepalive.ServerParameters{
+		Time:    60 * time.Second,
+		Timeout: 20 * time.Second,
+	}
+
 	opts := []grpc.ServerOption{
 		grpc.Creds(creds),
+		grpc.KeepaliveEnforcementPolicy(enforcement),
+		grpc.KeepaliveParams(serverKp),
 		grpc.ChainUnaryInterceptor(RecoveryUnaryInterceptor, LoggingUnaryInterceptor),
 		grpc.ChainStreamInterceptor(RecoveryStreamInterceptor, LoggingStreamInterceptor),
 	}

--- a/apps/ingest/internal/handlers/alerts.go
+++ b/apps/ingest/internal/handlers/alerts.go
@@ -32,10 +32,16 @@ type metricThresholdConfig struct {
 	Threshold float64 `json:"threshold"` // 0–100
 }
 
-// webhookChannelConfig matches the JSONB stored in notification_channels.config.
+// webhookChannelConfig matches the JSONB stored in notification_channels.config for webhook channels.
 type webhookChannelConfig struct {
 	URL    string `json:"url"`
 	Secret string `json:"secret"`
+}
+
+// notifChannels bundles all notification channel types for a single dispatch call.
+type notifChannels struct {
+	webhooks []queries.WebhookChannelRow
+	smtp     []queries.SmtpChannelRow
 }
 
 // evaluateAlerts is called after check results are persisted for a heartbeat.
@@ -56,10 +62,20 @@ func evaluateAlerts(
 		return
 	}
 
-	channels, err := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
+	var channels notifChannels
+
+	webhooks, err := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
 	if err != nil {
-		// Non-fatal: alerts still fire; notifications are best-effort.
 		slog.Warn("evaluateAlerts: fetching webhook channels", "org_id", orgID, "err", err)
+	} else {
+		channels.webhooks = webhooks
+	}
+
+	smtpChs, err := queries.GetEnabledSmtpChannels(ctx, pool, orgID)
+	if err != nil {
+		slog.Warn("evaluateAlerts: fetching smtp channels", "org_id", orgID, "err", err)
+	} else {
+		channels.smtp = smtpChs
 	}
 
 	for _, rule := range rules {
@@ -78,7 +94,7 @@ func evaluateCheckStatusRule(
 	rule queries.AlertRuleRow,
 	hostID, hostname string,
 	checkStatuses map[string]string,
-	channels []queries.WebhookChannelRow,
+	channels notifChannels,
 ) {
 	var cfg checkStatusConfig
 	if err := json.Unmarshal([]byte(rule.ConfigJSON), &cfg); err != nil {
@@ -125,14 +141,16 @@ func evaluateCheckStatusRule(
 			return
 		}
 		slog.Info("alert fired", "instance_id", id, "rule", rule.Name, "host", hostname)
-		dispatchWebhooks(ctx, channels, AlertEvent{
+		ev := AlertEvent{
 			Event:     "alert.fired",
 			Severity:  rule.Severity,
 			Host:      hostname,
 			Rule:      rule.Name,
 			Message:   message,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-		})
+		}
+		dispatchWebhooks(ctx, channels.webhooks, ev)
+		dispatchSmtp(channels.smtp, ev)
 		return
 	}
 
@@ -143,14 +161,16 @@ func evaluateCheckStatusRule(
 			return
 		}
 		slog.Info("alert resolved", "instance_id", existing.ID, "rule", rule.Name, "host", hostname)
-		dispatchWebhooks(ctx, channels, AlertEvent{
+		ev := AlertEvent{
 			Event:     "alert.resolved",
 			Severity:  rule.Severity,
 			Host:      hostname,
 			Rule:      rule.Name,
 			Message:   fmt.Sprintf("Check recovered on host %s", hostname),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-		})
+		}
+		dispatchWebhooks(ctx, channels.webhooks, ev)
+		dispatchSmtp(channels.smtp, ev)
 	}
 }
 
@@ -160,7 +180,7 @@ func evaluateMetricThresholdRule(
 	rule queries.AlertRuleRow,
 	hostID, hostname string,
 	metrics heartbeatMetrics,
-	channels []queries.WebhookChannelRow,
+	channels notifChannels,
 ) {
 	var cfg metricThresholdConfig
 	if err := json.Unmarshal([]byte(rule.ConfigJSON), &cfg); err != nil {
@@ -202,14 +222,16 @@ func evaluateMetricThresholdRule(
 			return
 		}
 		slog.Info("alert fired", "instance_id", id, "rule", rule.Name, "host", hostname)
-		dispatchWebhooks(ctx, channels, AlertEvent{
+		ev := AlertEvent{
 			Event:     "alert.fired",
 			Severity:  rule.Severity,
 			Host:      hostname,
 			Rule:      rule.Name,
 			Message:   message,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-		})
+		}
+		dispatchWebhooks(ctx, channels.webhooks, ev)
+		dispatchSmtp(channels.smtp, ev)
 		return
 	}
 
@@ -219,14 +241,16 @@ func evaluateMetricThresholdRule(
 			return
 		}
 		slog.Info("alert resolved", "instance_id", existing.ID, "rule", rule.Name, "host", hostname)
-		dispatchWebhooks(ctx, channels, AlertEvent{
+		ev := AlertEvent{
 			Event:     "alert.resolved",
 			Severity:  rule.Severity,
 			Host:      hostname,
 			Rule:      rule.Name,
 			Message:   fmt.Sprintf("%s recovered on host %s (current: %.1f%%)", cfg.Metric, hostname, currentValue),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-		})
+		}
+		dispatchWebhooks(ctx, channels.webhooks, ev)
+		dispatchSmtp(channels.smtp, ev)
 	}
 }
 

--- a/apps/ingest/internal/handlers/alerts.go
+++ b/apps/ingest/internal/handlers/alerts.go
@@ -53,6 +53,15 @@ func evaluateAlerts(
 	checkStatuses map[string]string,
 	metrics heartbeatMetrics,
 ) {
+	// Skip evaluation entirely if the host is currently silenced.
+	silenced, err := queries.IsHostSilenced(ctx, pool, orgID, hostID)
+	if err != nil {
+		slog.Warn("evaluateAlerts: checking silence", "host_id", hostID, "err", err)
+	} else if silenced {
+		slog.Debug("evaluateAlerts: host silenced, skipping", "host_id", hostID)
+		return
+	}
+
 	rules, err := queries.GetAlertRulesForHost(ctx, pool, orgID, hostID)
 	if err != nil {
 		slog.Warn("evaluateAlerts: fetching rules", "host_id", hostID, "err", err)

--- a/apps/ingest/internal/handlers/notify.go
+++ b/apps/ingest/internal/handlers/notify.go
@@ -5,11 +5,17 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"net/smtp"
+	"strings"
 	"time"
+
+	"github.com/infrawatch/ingest/internal/db/queries"
 )
 
 // AlertEvent is the payload sent to webhook notification channels.
@@ -53,5 +59,143 @@ func postWebhook(ctx context.Context, url, secret string, event AlertEvent) {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		slog.Warn("webhook: non-2xx response", "url", url, "status", resp.StatusCode)
+	}
+}
+
+// smtpChannelConfig matches the JSONB stored in notification_channels.config for SMTP channels.
+// It handles both the current `encryption` field and the legacy `secure` boolean.
+type smtpChannelConfig struct {
+	Host        string   `json:"host"`
+	Port        int      `json:"port"`
+	Encryption  string   `json:"encryption"` // 'none' | 'starttls' | 'tls'
+	Secure      *bool    `json:"secure"`      // legacy field — superseded by Encryption
+	Username    string   `json:"username"`
+	Password    string   `json:"password"`
+	FromAddress string   `json:"fromAddress"`
+	FromName    string   `json:"fromName"`
+	ToAddresses []string `json:"toAddresses"`
+}
+
+func (c *smtpChannelConfig) effectiveEncryption() string {
+	if c.Encryption != "" {
+		return c.Encryption
+	}
+	// Backward compat: derive from old `secure` boolean
+	if c.Secure != nil && *c.Secure {
+		return "tls"
+	}
+	return "starttls"
+}
+
+// sendSmtpEmail delivers an AlertEvent to a single SMTP channel.
+func sendSmtpEmail(cfg smtpChannelConfig, event AlertEvent) error {
+	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+
+	from := cfg.FromAddress
+	if cfg.FromName != "" {
+		from = fmt.Sprintf("%s <%s>", cfg.FromName, cfg.FromAddress)
+	}
+
+	eventLabel := map[string]string{
+		"alert.fired":    "FIRING",
+		"alert.resolved": "RESOLVED",
+		"alert.test":     "TEST",
+	}[event.Event]
+	if eventLabel == "" {
+		eventLabel = strings.ToUpper(event.Event)
+	}
+
+	subject := fmt.Sprintf("[Infrawatch] %s — %s on %s", eventLabel, event.Rule, event.Host)
+	body := fmt.Sprintf(
+		"Alert: %s\r\nSeverity: %s\r\nHost: %s\r\nRule: %s\r\nMessage: %s\r\nTime: %s\r\n",
+		event.Event, event.Severity, event.Host, event.Rule, event.Message, event.Timestamp,
+	)
+	msg := []byte(fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s",
+		from,
+		strings.Join(cfg.ToAddresses, ", "),
+		subject,
+		body,
+	))
+
+	switch cfg.effectiveEncryption() {
+	case "tls":
+		conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: cfg.Host})
+		if err != nil {
+			return fmt.Errorf("tls dial: %w", err)
+		}
+		client, err := smtp.NewClient(conn, cfg.Host)
+		if err != nil {
+			return fmt.Errorf("smtp client: %w", err)
+		}
+		defer client.Close()
+		if cfg.Username != "" {
+			if err := client.Auth(smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)); err != nil {
+				return fmt.Errorf("smtp auth: %w", err)
+			}
+		}
+		return smtpSend(client, cfg.FromAddress, cfg.ToAddresses, msg)
+
+	case "starttls":
+		client, err := smtp.Dial(addr)
+		if err != nil {
+			return fmt.Errorf("smtp dial: %w", err)
+		}
+		defer client.Close()
+		if err := client.StartTLS(&tls.Config{ServerName: cfg.Host}); err != nil {
+			return fmt.Errorf("starttls: %w", err)
+		}
+		if cfg.Username != "" {
+			if err := client.Auth(smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)); err != nil {
+				return fmt.Errorf("smtp auth: %w", err)
+			}
+		}
+		return smtpSend(client, cfg.FromAddress, cfg.ToAddresses, msg)
+
+	default: // "none"
+		var auth smtp.Auth
+		if cfg.Username != "" {
+			auth = smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+		}
+		if err := smtp.SendMail(addr, auth, cfg.FromAddress, cfg.ToAddresses, msg); err != nil {
+			return fmt.Errorf("smtp sendmail: %w", err)
+		}
+		return nil
+	}
+}
+
+func smtpSend(client *smtp.Client, from string, to []string, msg []byte) error {
+	if err := client.Mail(from); err != nil {
+		return fmt.Errorf("MAIL FROM: %w", err)
+	}
+	for _, addr := range to {
+		if err := client.Rcpt(addr); err != nil {
+			return fmt.Errorf("RCPT TO %s: %w", addr, err)
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("DATA: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("write body: %w", err)
+	}
+	return w.Close()
+}
+
+// dispatchSmtp fans out an AlertEvent to all configured SMTP channels.
+// Each delivery runs in its own goroutine; failures are logged and discarded.
+func dispatchSmtp(smtpChannels []queries.SmtpChannelRow, event AlertEvent) {
+	for _, ch := range smtpChannels {
+		var cfg smtpChannelConfig
+		if err := json.Unmarshal([]byte(ch.ConfigJSON), &cfg); err != nil {
+			slog.Warn("dispatchSmtp: unmarshal channel config", "channel_id", ch.ID, "err", err)
+			continue
+		}
+		go func(c smtpChannelConfig) {
+			if err := sendSmtpEmail(c, event); err != nil {
+				slog.Warn("smtp: delivery failed", "host", c.Host, "err", err)
+			}
+		}(cfg)
 	}
 }

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -71,9 +71,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/
 # Release-please manifest — read at runtime to determine the required agent version
 COPY --from=builder --chown=nextjs:nodejs /app/.release-please-manifest.json /app/.release-please-manifest.json
 
-# Migration script and SQL files — uses drizzle-orm (prod dep), no drizzle-kit needed
+# Migration script — from builder stage (same source, no caching concern)
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/migrate.js ./apps/web/migrate.js
-COPY --from=builder --chown=nextjs:nodejs /app/apps/web/lib/db/migrations ./apps/web/lib/db/migrations
+# Migration SQL files — copied DIRECTLY from the build context so this layer is always
+# invalidated when any migration file changes, regardless of builder-stage cache hits.
+COPY --chown=nextjs:nodejs apps/web/lib/db/migrations ./apps/web/lib/db/migrations
 
 # Next.js standalone only traces the specific files it needs for server.js, not the full
 # package structure required for CJS require() in migrate.js. Copy full packages explicitly.

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -13,6 +13,7 @@ import {
   Pencil,
   Plus,
   Trash2,
+  VolumeX,
   Webhook,
   XCircle,
 } from 'lucide-react'
@@ -55,9 +56,13 @@ import {
   deleteNotificationChannel,
   updateNotificationChannel,
   sendTestNotification,
+  getSilences,
+  createSilence,
+  deleteSilence,
 } from '@/lib/actions/alerts'
-import type { AlertInstanceWithRule, NotificationChannelSafe } from '@/lib/actions/alerts'
+import type { AlertInstanceWithRule, NotificationChannelSafe, AlertSilenceWithHost } from '@/lib/actions/alerts'
 import type { AlertSeverity, AlertInstanceStatus } from '@/lib/db/schema'
+import type { HostWithAgent } from '@/lib/actions/agents'
 
 // ─── Severity Badge ────────────────────────────────────────────────────────────
 
@@ -713,6 +718,127 @@ function EditSmtpDialog({
   )
 }
 
+// ─── Add Silence Dialog ────────────────────────────────────────────────────────
+
+function toLocalDatetimeValue(d: Date): string {
+  // Returns a string suitable for <input type="datetime-local"> in local time
+  const offset = d.getTimezoneOffset() * 60_000
+  return new Date(d.getTime() - offset).toISOString().slice(0, 16)
+}
+
+const silenceFormSchema = z.object({
+  hostId: z.string().optional(),
+  reason: z.string().min(1, 'Reason is required').max(255),
+  startsAt: z.string().min(1, 'Start time is required'),
+  endsAt: z.string().min(1, 'End time is required'),
+})
+
+type SilenceFormValues = z.infer<typeof silenceFormSchema>
+
+function AddSilenceDialog({
+  orgId,
+  userId,
+  hosts,
+  open,
+  onOpenChange,
+  onSuccess,
+  prefilledHostId,
+}: {
+  orgId: string
+  userId: string
+  hosts: HostWithAgent[]
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+  prefilledHostId?: string
+}) {
+  const now = new Date()
+  const inOneHour = new Date(now.getTime() + 60 * 60 * 1000)
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<SilenceFormValues>({
+    resolver: zodResolver(silenceFormSchema),
+    defaultValues: {
+      hostId: prefilledHostId ?? '',
+      startsAt: toLocalDatetimeValue(now),
+      endsAt: toLocalDatetimeValue(inOneHour),
+    },
+  })
+
+  async function onSubmit(values: SilenceFormValues) {
+    const result = await createSilence(orgId, userId, {
+      hostId: values.hostId || null,
+      reason: values.reason,
+      startsAt: new Date(values.startsAt).toISOString(),
+      endsAt: new Date(values.endsAt).toISOString(),
+    })
+    if ('error' in result) return
+    reset()
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create Silence</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="silence-host">Host <span className="text-muted-foreground font-normal">(leave blank for org-wide)</span></Label>
+            <select
+              id="silence-host"
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              {...register('hostId')}
+            >
+              <option value="">All hosts (org-wide)</option>
+              {hosts.map((h) => (
+                <option key={h.id} value={h.id}>
+                  {h.hostname}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="silence-reason">Reason</Label>
+            <Input
+              id="silence-reason"
+              placeholder="e.g. Scheduled maintenance window"
+              {...register('reason')}
+            />
+            {errors.reason && <p className="text-sm text-red-600">{errors.reason.message}</p>}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="silence-starts">Starts at</Label>
+              <Input id="silence-starts" type="datetime-local" {...register('startsAt')} />
+              {errors.startsAt && <p className="text-sm text-red-600">{errors.startsAt.message}</p>}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="silence-ends">Ends at</Label>
+              <Input id="silence-ends" type="datetime-local" {...register('endsAt')} />
+              {errors.endsAt && <p className="text-sm text-red-600">{errors.endsAt.message}</p>}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Create Silence
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 // ─── Main Component ────────────────────────────────────────────────────────────
 
 interface AlertsClientProps {
@@ -721,6 +847,8 @@ interface AlertsClientProps {
   initialActive: AlertInstanceWithRule[]
   initialRecent: AlertInstanceWithRule[]
   initialChannels: NotificationChannelSafe[]
+  initialSilences: AlertSilenceWithHost[]
+  hosts: HostWithAgent[]
 }
 
 type SeverityFilter = 'all' | AlertSeverity
@@ -731,11 +859,14 @@ export function AlertsClient({
   initialActive,
   initialRecent,
   initialChannels,
+  initialSilences,
+  hosts,
 }: AlertsClientProps) {
   const qc = useQueryClient()
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all')
   const [addWebhookOpen, setAddWebhookOpen] = useState(false)
   const [addSmtpOpen, setAddSmtpOpen] = useState(false)
+  const [addSilenceOpen, setAddSilenceOpen] = useState(false)
   const [editingChannel, setEditingChannel] = useState<NotificationChannelSafe | null>(null)
   const [testingChannelId, setTestingChannelId] = useState<string | null>(null)
   const [testLog, setTestLog] = useState<TestLogEntry | null>(null)
@@ -761,6 +892,13 @@ export function AlertsClient({
     refetchInterval: 60_000,
   })
 
+  const { data: silences = [] } = useQuery({
+    queryKey: ['silences', orgId],
+    queryFn: () => getSilences(orgId),
+    initialData: initialSilences,
+    refetchInterval: 60_000,
+  })
+
   const acknowledgeMutation = useMutation({
     mutationFn: (instanceId: string) => acknowledgeAlert(orgId, instanceId, currentUserId),
     onSuccess: () => {
@@ -772,6 +910,13 @@ export function AlertsClient({
     mutationFn: (channelId: string) => deleteNotificationChannel(orgId, channelId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+    },
+  })
+
+  const deleteSilenceMutation = useMutation({
+    mutationFn: (silenceId: string) => deleteSilence(orgId, silenceId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['silences', orgId] })
     },
   })
 
@@ -950,6 +1095,108 @@ export function AlertsClient({
         </CardContent>
       </Card>
 
+      {/* Silences */}
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between">
+          <div>
+            <CardTitle className="text-base flex items-center gap-2">
+              <VolumeX className="size-4 text-muted-foreground" />
+              Silences
+            </CardTitle>
+            <CardDescription className="mt-1">
+              Suppress alert firing during planned maintenance windows
+            </CardDescription>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            onClick={() => setAddSilenceOpen(true)}
+          >
+            <Plus className="size-3.5 mr-1" />
+            Add Silence
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {silences.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              No silences configured
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Scope</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>Starts</TableHead>
+                  <TableHead>Ends</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {silences.map((s) => {
+                  const now = new Date()
+                  const start = new Date(s.startsAt)
+                  const end = new Date(s.endsAt)
+                  const isActive = start <= now && end >= now
+                  const isExpired = end < now
+                  return (
+                    <TableRow key={s.id}>
+                      <TableCell className="font-medium">
+                        {s.hostname ? (
+                          <Link href={`/hosts/${s.hostId}`} className="hover:underline text-foreground">
+                            {s.hostname}
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground italic">All hosts</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
+                        {s.reason}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {formatAbsolute(s.startsAt)}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {formatAbsolute(s.endsAt)}
+                      </TableCell>
+                      <TableCell>
+                        {isActive ? (
+                          <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
+                            Active
+                          </Badge>
+                        ) : isExpired ? (
+                          <Badge className="bg-gray-100 text-gray-600 border-gray-200 hover:bg-gray-100">
+                            Expired
+                          </Badge>
+                        ) : (
+                          <Badge className="bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100">
+                            Upcoming
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="Remove silence"
+                          className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                          onClick={() => deleteSilenceMutation.mutate(s.id)}
+                          disabled={deleteSilenceMutation.isPending}
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Notification Channels */}
       <Card>
         <CardHeader className="flex flex-row items-start justify-between">
@@ -1067,6 +1314,14 @@ export function AlertsClient({
         </CardContent>
       </Card>
 
+      <AddSilenceDialog
+        orgId={orgId}
+        userId={currentUserId}
+        hosts={hosts}
+        open={addSilenceOpen}
+        onOpenChange={setAddSilenceOpen}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['silences', orgId] })}
+      />
       <AddWebhookDialog
         orgId={orgId}
         open={addWebhookOpen}

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -1,16 +1,20 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow, format } from 'date-fns'
 import {
   Bell,
   BellOff,
   CheckCircle2,
+  FlaskConical,
+  Loader2,
   Mail,
+  Pencil,
   Plus,
   Trash2,
   Webhook,
+  XCircle,
 } from 'lucide-react'
 import Link from 'next/link'
 import { useForm } from 'react-hook-form'
@@ -49,6 +53,8 @@ import {
   getNotificationChannels,
   createNotificationChannel,
   deleteNotificationChannel,
+  updateNotificationChannel,
+  sendTestNotification,
 } from '@/lib/actions/alerts'
 import type { AlertInstanceWithRule, NotificationChannelSafe } from '@/lib/actions/alerts'
 import type { AlertSeverity, AlertInstanceStatus } from '@/lib/db/schema'
@@ -202,11 +208,25 @@ function AddWebhookDialog({
 
 // ─── SMTP Dialog ──────────────────────────────────────────────────────────────
 
+type SmtpEncryptionValue = 'none' | 'starttls' | 'tls'
+
+const ENCRYPTION_DEFAULTS: Record<SmtpEncryptionValue, number> = {
+  none: 25,
+  starttls: 587,
+  tls: 465,
+}
+
+const ENCRYPTION_LABELS: Record<SmtpEncryptionValue, { label: string; description: string }> = {
+  none:     { label: 'None',     description: 'Unencrypted — not recommended' },
+  starttls: { label: 'STARTTLS', description: 'Plain connect, upgrades to TLS (port 587)' },
+  tls:      { label: 'SSL/TLS',  description: 'Direct TLS connection (port 465)' },
+}
+
 const smtpFormSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
   host: z.string().min(1, 'Host is required'),
   port: z.number().int().min(1).max(65535),
-  secure: z.boolean(),
+  encryption: z.enum(['none', 'starttls', 'tls']),
   username: z.string().optional(),
   password: z.string().optional(),
   fromAddress: z.string().email('Must be a valid email'),
@@ -215,6 +235,32 @@ const smtpFormSchema = z.object({
 })
 
 type SmtpFormValues = z.infer<typeof smtpFormSchema>
+
+function SmtpEncryptionSelect({
+  value,
+  onChange,
+}: {
+  value: SmtpEncryptionValue
+  onChange: (v: SmtpEncryptionValue) => void
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as SmtpEncryptionValue)}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {(Object.entries(ENCRYPTION_LABELS) as [SmtpEncryptionValue, { label: string; description: string }][]).map(
+          ([key, { label, description }]) => (
+            <SelectItem key={key} value={key}>
+              <span className="font-medium">{label}</span>
+              <span className="ml-2 text-muted-foreground text-xs">{description}</span>
+            </SelectItem>
+          ),
+        )}
+      </SelectContent>
+    </Select>
+  )
+}
 
 function AddSmtpDialog({
   orgId,
@@ -236,10 +282,15 @@ function AddSmtpDialog({
     formState: { errors, isSubmitting },
   } = useForm<SmtpFormValues>({
     resolver: zodResolver(smtpFormSchema),
-    defaultValues: { port: 587, secure: false },
+    defaultValues: { port: 587, encryption: 'starttls' },
   })
 
-  const secure = watch('secure')
+  const encryption = watch('encryption') as SmtpEncryptionValue
+
+  function handleEncryptionChange(v: SmtpEncryptionValue) {
+    setValue('encryption', v)
+    setValue('port', ENCRYPTION_DEFAULTS[v])
+  }
 
   async function onSubmit(values: SmtpFormValues) {
     const toAddresses = values.toAddresses
@@ -253,7 +304,7 @@ function AddSmtpDialog({
       config: {
         host: values.host,
         port: values.port,
-        secure: values.secure,
+        encryption: values.encryption,
         username: values.username || undefined,
         password: values.password || undefined,
         fromAddress: values.fromAddress,
@@ -287,21 +338,13 @@ function AddSmtpDialog({
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="smtp-port">Port</Label>
-              <Input id="smtp-port" type="number" placeholder="587" {...register('port', { valueAsNumber: true })} />
+              <Input id="smtp-port" type="number" {...register('port', { valueAsNumber: true })} />
               {errors.port && <p className="text-sm text-red-600">{errors.port.message}</p>}
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <input
-              id="smtp-secure"
-              type="checkbox"
-              className="h-4 w-4 rounded border-input"
-              checked={secure}
-              onChange={(e) => setValue('secure', e.target.checked)}
-            />
-            <Label htmlFor="smtp-secure" className="font-normal cursor-pointer">
-              Use TLS/SSL
-            </Label>
+          <div className="space-y-1.5">
+            <Label>Encryption</Label>
+            <SmtpEncryptionSelect value={encryption} onChange={handleEncryptionChange} />
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
@@ -354,6 +397,322 @@ function AddSmtpDialog({
   )
 }
 
+// ─── Test Log Dialog ───────────────────────────────────────────────────────────
+
+interface TestLogEntry {
+  channelName: string
+  channelType: 'webhook' | 'smtp'
+  ok: boolean
+  message: string
+  at: Date
+}
+
+function TestLogDialog({
+  entry,
+  onClose,
+}: {
+  entry: TestLogEntry
+  onClose: () => void
+}) {
+  return (
+    <Dialog open onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {entry.channelType === 'smtp' ? (
+              <Mail className="size-4 text-muted-foreground" />
+            ) : (
+              <Webhook className="size-4 text-muted-foreground" />
+            )}
+            Test Notification — {entry.channelName}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div
+            className={`flex items-start gap-3 rounded-md border p-3 ${
+              entry.ok
+                ? 'border-green-200 bg-green-50 text-green-800'
+                : 'border-red-200 bg-red-50 text-red-800'
+            }`}
+          >
+            {entry.ok ? (
+              <CheckCircle2 className="size-4 mt-0.5 shrink-0 text-green-600" />
+            ) : (
+              <XCircle className="size-4 mt-0.5 shrink-0 text-red-600" />
+            )}
+            <div className="space-y-1 min-w-0">
+              <p className="text-sm font-medium">
+                {entry.ok ? 'Test notification sent successfully' : 'Test notification failed'}
+              </p>
+              {!entry.ok && (
+                <p className="text-sm font-mono break-all">{entry.message}</p>
+              )}
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Sent at {entry.at.toLocaleTimeString()} on {entry.at.toLocaleDateString()}
+          </p>
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Edit Webhook Dialog ───────────────────────────────────────────────────────
+
+const editWebhookFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  url: z.string().url('Must be a valid URL'),
+  secret: z.string().optional(),
+})
+
+type EditWebhookFormValues = z.infer<typeof editWebhookFormSchema>
+
+function EditWebhookDialog({
+  orgId,
+  channel,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  channel: NotificationChannelSafe & { type: 'webhook' }
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<EditWebhookFormValues>({ resolver: zodResolver(editWebhookFormSchema) })
+
+  useEffect(() => {
+    if (open) reset({ name: channel.name, url: channel.config.url, secret: '' })
+  }, [open, channel, reset])
+
+  async function onSubmit(values: EditWebhookFormValues) {
+    const result = await updateNotificationChannel(orgId, channel.id, {
+      name: values.name,
+      url: values.url,
+      secret: values.secret || undefined,
+    })
+    if ('error' in result) return
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Webhook Channel</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-webhook-name">Name</Label>
+            <Input id="edit-webhook-name" defaultValue={channel.name} {...register('name')} />
+            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-webhook-url">URL</Label>
+            <Input id="edit-webhook-url" type="url" defaultValue={channel.config.url} {...register('url')} />
+            {errors.url && <p className="text-sm text-red-600">{errors.url.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-webhook-secret">
+              Secret{' '}
+              <span className="text-muted-foreground font-normal">
+                ({channel.config.hasSecret ? 'leave blank to keep existing' : 'optional'})
+              </span>
+            </Label>
+            <Input
+              id="edit-webhook-secret"
+              placeholder={channel.config.hasSecret ? '••••••••' : 'Used for HMAC-SHA256 signature'}
+              type="password"
+              {...register('secret')}
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Edit SMTP Dialog ──────────────────────────────────────────────────────────
+
+const editSmtpFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  host: z.string().min(1, 'Host is required'),
+  port: z.number().int().min(1).max(65535),
+  encryption: z.enum(['none', 'starttls', 'tls']),
+  username: z.string().optional(),
+  password: z.string().optional(),
+  fromAddress: z.string().email('Must be a valid email'),
+  fromName: z.string().optional(),
+  toAddresses: z.string().min(1, 'At least one recipient required'),
+})
+
+type EditSmtpFormValues = z.infer<typeof editSmtpFormSchema>
+
+function EditSmtpDialog({
+  orgId,
+  channel,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  channel: NotificationChannelSafe & { type: 'smtp' }
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<EditSmtpFormValues>({
+    resolver: zodResolver(editSmtpFormSchema),
+    defaultValues: {
+      name: channel.name,
+      host: channel.config.host,
+      port: channel.config.port,
+      encryption: channel.config.encryption,
+      username: channel.config.username ?? '',
+      password: '',
+      fromAddress: channel.config.fromAddress,
+      fromName: channel.config.fromName ?? '',
+      toAddresses: channel.config.toAddresses.join(', '),
+    },
+  })
+
+  const encryption = watch('encryption') as SmtpEncryptionValue
+
+  function handleEncryptionChange(v: SmtpEncryptionValue) {
+    setValue('encryption', v)
+    setValue('port', ENCRYPTION_DEFAULTS[v])
+  }
+
+  async function onSubmit(values: EditSmtpFormValues) {
+    const toAddresses = values.toAddresses
+      .split(',')
+      .map((e) => e.trim())
+      .filter(Boolean)
+
+    const result = await updateNotificationChannel(orgId, channel.id, {
+      name: values.name,
+      host: values.host,
+      port: values.port,
+      encryption: values.encryption,
+      username: values.username || undefined,
+      password: values.password || undefined,
+      fromAddress: values.fromAddress,
+      fromName: values.fromName || undefined,
+      toAddresses,
+    })
+    if ('error' in result) return
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit SMTP Channel</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-smtp-name">Name</Label>
+            <Input id="edit-smtp-name" {...register('name')} />
+            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-2 space-y-1.5">
+              <Label htmlFor="edit-smtp-host">Host</Label>
+              <Input id="edit-smtp-host" {...register('host')} />
+              {errors.host && <p className="text-sm text-red-600">{errors.host.message}</p>}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-smtp-port">Port</Label>
+              <Input id="edit-smtp-port" type="number" {...register('port', { valueAsNumber: true })} />
+              {errors.port && <p className="text-sm text-red-600">{errors.port.message}</p>}
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label>Encryption</Label>
+            <SmtpEncryptionSelect value={encryption} onChange={handleEncryptionChange} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-smtp-username">
+                Username <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input id="edit-smtp-username" {...register('username')} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-smtp-password">
+                Password{' '}
+                <span className="text-muted-foreground font-normal">
+                  ({channel.config.hasPassword ? 'leave blank to keep existing' : 'optional'})
+                </span>
+              </Label>
+              <Input
+                id="edit-smtp-password"
+                type="password"
+                placeholder={channel.config.hasPassword ? '••••••••' : ''}
+                {...register('password')}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-smtp-from">From address</Label>
+              <Input id="edit-smtp-from" {...register('fromAddress')} />
+              {errors.fromAddress && <p className="text-sm text-red-600">{errors.fromAddress.message}</p>}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="edit-smtp-fromname">
+                From name <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input id="edit-smtp-fromname" {...register('fromName')} />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-smtp-to">Recipients</Label>
+            <Input id="edit-smtp-to" {...register('toAddresses')} />
+            <p className="text-xs text-muted-foreground">Comma-separated list of email addresses</p>
+            {errors.toAddresses && <p className="text-sm text-red-600">{errors.toAddresses.message}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 // ─── Main Component ────────────────────────────────────────────────────────────
 
 interface AlertsClientProps {
@@ -377,6 +736,9 @@ export function AlertsClient({
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all')
   const [addWebhookOpen, setAddWebhookOpen] = useState(false)
   const [addSmtpOpen, setAddSmtpOpen] = useState(false)
+  const [editingChannel, setEditingChannel] = useState<NotificationChannelSafe | null>(null)
+  const [testingChannelId, setTestingChannelId] = useState<string | null>(null)
+  const [testLog, setTestLog] = useState<TestLogEntry | null>(null)
 
   const { data: activeAlerts = [] } = useQuery({
     queryKey: ['alerts', orgId, 'firing'],
@@ -412,6 +774,19 @@ export function AlertsClient({
       qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
     },
   })
+
+  async function handleTestNotification(channel: NotificationChannelSafe) {
+    setTestingChannelId(channel.id)
+    const result = await sendTestNotification(orgId, channel.id)
+    setTestingChannelId(null)
+    setTestLog({
+      channelName: channel.name,
+      channelType: channel.type,
+      ok: 'success' in result,
+      message: 'error' in result ? result.error : 'Notification delivered successfully.',
+      at: new Date(),
+    })
+  }
 
   const filteredActive = severityFilter === 'all'
     ? activeAlerts
@@ -641,22 +1016,48 @@ export function AlertsClient({
                     <TableCell className="text-sm text-muted-foreground">
                       {ch.type === 'smtp' ? (
                         <span>
-                          {ch.config.host}:{ch.config.port} → {ch.config.toAddresses.join(', ')}
+                          {ch.config.host}:{ch.config.port} ({ch.config.encryption.toUpperCase()}) → {ch.config.toAddresses.join(', ')}
                         </span>
                       ) : (
                         <span className="font-mono truncate block max-w-xs">{ch.config.url}</span>
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                        onClick={() => deleteChannelMutation.mutate(ch.id)}
-                        disabled={deleteChannelMutation.isPending}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="Send test notification"
+                          onClick={() => handleTestNotification(ch)}
+                          disabled={testingChannelId === ch.id}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          {testingChannelId === ch.id ? (
+                            <Loader2 className="size-3.5 animate-spin" />
+                          ) : (
+                            <FlaskConical className="size-3.5" />
+                          )}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="Edit channel"
+                          onClick={() => setEditingChannel(ch)}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          <Pencil className="size-3.5" />
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="Delete channel"
+                          className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                          onClick={() => deleteChannelMutation.mutate(ch.id)}
+                          disabled={deleteChannelMutation.isPending}
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -678,6 +1079,33 @@ export function AlertsClient({
         onOpenChange={setAddSmtpOpen}
         onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
       />
+      {testLog && (
+        <TestLogDialog entry={testLog} onClose={() => setTestLog(null)} />
+      )}
+      {editingChannel?.type === 'webhook' && (
+        <EditWebhookDialog
+          orgId={orgId}
+          channel={editingChannel}
+          open={true}
+          onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
+          onSuccess={() => {
+            setEditingChannel(null)
+            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+          }}
+        />
+      )}
+      {editingChannel?.type === 'smtp' && (
+        <EditSmtpDialog
+          orgId={orgId}
+          channel={editingChannel}
+          open={true}
+          onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
+          onSuccess={() => {
+            setEditingChannel(null)
+            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/alerts/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
-import { getAlertInstances, getNotificationChannels } from '@/lib/actions/alerts'
+import { getAlertInstances, getNotificationChannels, getSilences } from '@/lib/actions/alerts'
+import { listHosts } from '@/lib/actions/agents'
 import { AlertsClient } from './alerts-client'
 
 export const metadata: Metadata = {
@@ -11,10 +12,12 @@ export default async function AlertsPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
 
-  const [activeAlerts, recentAlerts, channels] = await Promise.all([
+  const [activeAlerts, recentAlerts, channels, silences, hosts] = await Promise.all([
     getAlertInstances(orgId, { status: 'firing', limit: 100 }),
     getAlertInstances(orgId, { limit: 50 }),
     getNotificationChannels(orgId),
+    getSilences(orgId),
+    listHosts(orgId),
   ])
 
   return (
@@ -24,6 +27,8 @@ export default async function AlertsPage() {
       initialActive={activeAlerts}
       initialRecent={recentAlerts}
       initialChannels={channels}
+      initialSilences={silences}
+      hosts={hosts}
     />
   )
 }

--- a/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { formatDistanceToNow } from 'date-fns'
-import { Bell, Plus, Trash2 } from 'lucide-react'
+import { formatDistanceToNow, format } from 'date-fns'
+import { Bell, Plus, Trash2, VolumeX, VolumeOff } from 'lucide-react'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -41,9 +41,12 @@ import {
   updateAlertRule,
   deleteAlertRule,
   getAlertInstances,
+  getActiveSilencesForHost,
+  createSilence,
+  deleteSilence,
 } from '@/lib/actions/alerts'
 import { getChecksWithHistory } from '@/lib/actions/checks'
-import type { AlertRule, AlertSeverity } from '@/lib/db/schema'
+import type { AlertRule, AlertSeverity, AlertSilence } from '@/lib/db/schema'
 
 // ─── Form schema (flat — validation applied per conditionType in onSubmit) ─────
 
@@ -85,6 +88,107 @@ function ruleConditionSummary(rule: AlertRule): string {
     return `${cfg['metric']} ${op} ${cfg['threshold']}%`
   }
   return '—'
+}
+
+// ─── Silence Dialog (host-scoped) ─────────────────────────────────────────────
+
+function toLocalDatetimeValue(d: Date): string {
+  const offset = d.getTimezoneOffset() * 60_000
+  return new Date(d.getTime() - offset).toISOString().slice(0, 16)
+}
+
+const silenceFormSchema = z.object({
+  reason: z.string().min(1, 'Reason is required').max(255),
+  startsAt: z.string().min(1, 'Start time is required'),
+  endsAt: z.string().min(1, 'End time is required'),
+})
+
+type SilenceFormValues = z.infer<typeof silenceFormSchema>
+
+function AddSilenceDialog({
+  orgId,
+  hostId,
+  userId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  hostId: string
+  userId: string
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const now = new Date()
+  const inOneHour = new Date(now.getTime() + 60 * 60 * 1000)
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<SilenceFormValues>({
+    resolver: zodResolver(silenceFormSchema),
+    defaultValues: {
+      startsAt: toLocalDatetimeValue(now),
+      endsAt: toLocalDatetimeValue(inOneHour),
+    },
+  })
+
+  async function onSubmit(values: SilenceFormValues) {
+    const result = await createSilence(orgId, userId, {
+      hostId,
+      reason: values.reason,
+      startsAt: new Date(values.startsAt).toISOString(),
+      endsAt: new Date(values.endsAt).toISOString(),
+    })
+    if ('error' in result) return
+    reset()
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create Silence for This Host</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="silence-reason">Reason</Label>
+            <Input
+              id="silence-reason"
+              placeholder="e.g. Scheduled maintenance window"
+              {...register('reason')}
+            />
+            {errors.reason && <p className="text-sm text-red-600">{errors.reason.message}</p>}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="silence-starts">Starts at</Label>
+              <Input id="silence-starts" type="datetime-local" {...register('startsAt')} />
+              {errors.startsAt && <p className="text-sm text-red-600">{errors.startsAt.message}</p>}
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="silence-ends">Ends at</Label>
+              <Input id="silence-ends" type="datetime-local" {...register('endsAt')} />
+              {errors.endsAt && <p className="text-sm text-red-600">{errors.endsAt.message}</p>}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Create Silence
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
 }
 
 // ─── Add Rule Dialog ──────────────────────────────────────────────────────────
@@ -335,9 +439,10 @@ interface Props {
   currentUserId: string
 }
 
-export function AlertsTab({ orgId, hostId }: Props) {
+export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
   const qc = useQueryClient()
   const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const [addSilenceOpen, setAddSilenceOpen] = useState(false)
 
   const { data: allRules = [] } = useQuery({
     queryKey: ['alert-rules', orgId, hostId],
@@ -349,6 +454,12 @@ export function AlertsTab({ orgId, hostId }: Props) {
     queryKey: ['alerts', orgId, 'firing', hostId],
     queryFn: () => getAlertInstances(orgId, { status: 'firing', hostId }),
     refetchInterval: 30_000,
+  })
+
+  const { data: activeSilences = [] } = useQuery({
+    queryKey: ['silences-active', orgId, hostId],
+    queryFn: () => getActiveSilencesForHost(orgId, hostId),
+    refetchInterval: 60_000,
   })
 
   const hostRules = allRules.filter((r) => r.hostId === hostId)
@@ -365,8 +476,41 @@ export function AlertsTab({ orgId, hostId }: Props) {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['alert-rules', orgId, hostId] }),
   })
 
+  const deleteSilenceMutation = useMutation({
+    mutationFn: (silenceId: string) => deleteSilence(orgId, silenceId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['silences-active', orgId, hostId] }),
+  })
+
+  const currentSilence = activeSilences[0] ?? null
+
   return (
     <div className="space-y-6">
+      {/* Active silence banner */}
+      {currentSilence != null && (
+        <Card className="border-amber-200 bg-amber-50">
+          <CardContent className="pt-4 pb-4">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm text-amber-900 flex items-center gap-2">
+                <VolumeOff className="size-4 shrink-0" />
+                <span>
+                  <strong>Alerts silenced</strong> — {currentSilence.reason}.{' '}
+                  Ends {format(new Date(currentSilence.endsAt), 'MMM d, HH:mm')}.
+                </span>
+              </p>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-amber-800 hover:text-amber-900 hover:bg-amber-100 shrink-0 -mt-0.5"
+                onClick={() => deleteSilenceMutation.mutate(currentSilence.id)}
+                disabled={deleteSilenceMutation.isPending}
+              >
+                Remove silence
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Active alerts summary */}
       {activeAlerts.length > 0 && (
         <Card className="border-red-200 bg-red-50">
@@ -391,10 +535,16 @@ export function AlertsTab({ orgId, hostId }: Props) {
             <CardTitle className="text-base">Alert Rules</CardTitle>
             <CardDescription className="mt-1">Rules that apply specifically to this host</CardDescription>
           </div>
-          <Button size="sm" variant="outline" className="shrink-0" onClick={() => setAddDialogOpen(true)}>
-            <Plus className="size-3.5 mr-1" />
-            Add Rule
-          </Button>
+          <div className="flex items-center gap-2 shrink-0">
+            <Button size="sm" variant="outline" onClick={() => setAddSilenceOpen(true)}>
+              <VolumeX className="size-3.5 mr-1" />
+              Silence Host
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => setAddDialogOpen(true)}>
+              <Plus className="size-3.5 mr-1" />
+              Add Rule
+            </Button>
+          </div>
         </CardHeader>
         <CardContent>
           {hostRules.length === 0 ? (
@@ -498,6 +648,14 @@ export function AlertsTab({ orgId, hostId }: Props) {
         open={addDialogOpen}
         onOpenChange={setAddDialogOpen}
         onSuccess={() => qc.invalidateQueries({ queryKey: ['alert-rules', orgId, hostId] })}
+      />
+      <AddSilenceDialog
+        orgId={orgId}
+        hostId={hostId}
+        userId={currentUserId}
+        open={addSilenceOpen}
+        onOpenChange={setAddSilenceOpen}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['silences-active', orgId, hostId] })}
       />
     </div>
   )

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -4,8 +4,8 @@ import { z } from 'zod'
 import { createHmac } from 'crypto'
 import nodemailer from 'nodemailer'
 import { db } from '@/lib/db'
-import { alertRules, alertInstances, notificationChannels, hosts } from '@/lib/db/schema'
-import { eq, and, isNull, desc, inArray, sql } from 'drizzle-orm'
+import { alertRules, alertInstances, notificationChannels, alertSilences, hosts } from '@/lib/db/schema'
+import { eq, and, isNull, desc, inArray, sql, lte, gte } from 'drizzle-orm'
 import type {
   AlertRule,
   AlertInstance,
@@ -16,6 +16,7 @@ import type {
   WebhookChannelConfig,
   SmtpChannelConfig,
   SmtpEncryption,
+  AlertSilence,
 } from '@/lib/db/schema'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -631,4 +632,120 @@ export async function sendTestNotification(
       return { error: err instanceof Error ? err.message : 'Failed to send email' }
     }
   }
+}
+
+// ─── Alert Silences ───────────────────────────────────────────────────────────
+
+export type AlertSilenceWithHost = AlertSilence & { hostname: string | null }
+
+const createSilenceSchema = z.object({
+  hostId: z.string().min(1).nullable().optional(),
+  ruleId: z.string().min(1).nullable().optional(),
+  reason: z.string().min(1).max(255),
+  startsAt: z.string().datetime(),
+  endsAt: z.string().datetime(),
+}).refine((d) => new Date(d.endsAt) > new Date(d.startsAt), {
+  message: 'End time must be after start time',
+  path: ['endsAt'],
+})
+
+export async function getSilences(orgId: string): Promise<AlertSilenceWithHost[]> {
+  const rows = await db
+    .select({
+      id: alertSilences.id,
+      organisationId: alertSilences.organisationId,
+      hostId: alertSilences.hostId,
+      ruleId: alertSilences.ruleId,
+      reason: alertSilences.reason,
+      startsAt: alertSilences.startsAt,
+      endsAt: alertSilences.endsAt,
+      createdBy: alertSilences.createdBy,
+      createdAt: alertSilences.createdAt,
+      updatedAt: alertSilences.updatedAt,
+      deletedAt: alertSilences.deletedAt,
+      metadata: alertSilences.metadata,
+      hostname: hosts.hostname,
+    })
+    .from(alertSilences)
+    .leftJoin(hosts, eq(alertSilences.hostId, hosts.id))
+    .where(
+      and(
+        eq(alertSilences.organisationId, orgId),
+        isNull(alertSilences.deletedAt),
+      ),
+    )
+    .orderBy(desc(alertSilences.startsAt))
+
+  return rows
+}
+
+export async function getActiveSilencesForHost(
+  orgId: string,
+  hostId: string,
+): Promise<AlertSilence[]> {
+  const now = new Date()
+  return db.query.alertSilences.findMany({
+    where: and(
+      eq(alertSilences.organisationId, orgId),
+      isNull(alertSilences.deletedAt),
+      lte(alertSilences.startsAt, now),
+      gte(alertSilences.endsAt, now),
+      // match host-specific silences for this host, or org-wide silences (hostId IS NULL)
+      // We use a raw SQL OR here via the Drizzle `or` helper imported above
+      sql`(${alertSilences.hostId} = ${hostId} OR ${alertSilences.hostId} IS NULL)`,
+    ),
+  })
+}
+
+export async function createSilence(
+  orgId: string,
+  userId: string,
+  input: unknown,
+): Promise<{ success: true; id: string } | { error: string }> {
+  const parsed = createSilenceSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
+  const data = parsed.data
+
+  try {
+    const [row] = await db
+      .insert(alertSilences)
+      .values({
+        organisationId: orgId,
+        hostId: data.hostId ?? null,
+        ruleId: data.ruleId ?? null,
+        reason: data.reason,
+        startsAt: new Date(data.startsAt),
+        endsAt: new Date(data.endsAt),
+        createdBy: userId,
+      })
+      .returning({ id: alertSilences.id })
+
+    if (!row) return { error: 'Insert failed' }
+    return { success: true, id: row.id }
+  } catch {
+    return { error: 'Failed to create silence' }
+  }
+}
+
+export async function deleteSilence(
+  orgId: string,
+  silenceId: string,
+): Promise<{ success: true } | { error: string }> {
+  const existing = await db.query.alertSilences.findFirst({
+    where: and(
+      eq(alertSilences.id, silenceId),
+      eq(alertSilences.organisationId, orgId),
+      isNull(alertSilences.deletedAt),
+    ),
+  })
+  if (!existing) return { error: 'Silence not found' }
+
+  await db
+    .update(alertSilences)
+    .set({ deletedAt: new Date() })
+    .where(and(eq(alertSilences.id, silenceId), eq(alertSilences.organisationId, orgId)))
+
+  return { success: true }
 }

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -1,6 +1,8 @@
 'use server'
 
 import { z } from 'zod'
+import { createHmac } from 'crypto'
+import nodemailer from 'nodemailer'
 import { db } from '@/lib/db'
 import { alertRules, alertInstances, notificationChannels, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, desc, inArray, sql } from 'drizzle-orm'
@@ -13,6 +15,7 @@ import type {
   NotificationChannel,
   WebhookChannelConfig,
   SmtpChannelConfig,
+  SmtpEncryption,
 } from '@/lib/db/schema'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -51,6 +54,8 @@ const updateAlertRuleSchema = z.object({
   config: z.union([checkStatusConfigSchema, metricThresholdConfigSchema]).optional(),
 })
 
+const smtpEncryptionSchema = z.enum(['none', 'starttls', 'tls'])
+
 const createNotificationChannelSchema = z.discriminatedUnion('type', [
   z.object({
     name: z.string().min(1).max(100),
@@ -66,7 +71,7 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
     config: z.object({
       host: z.string().min(1),
       port: z.number().int().min(1).max(65535),
-      secure: z.boolean(),
+      encryption: smtpEncryptionSchema,
       username: z.string().optional(),
       password: z.string().optional(),
       fromAddress: z.string().email(),
@@ -366,8 +371,30 @@ export async function getActiveAlertCountsForHosts(
 
 export type NotificationChannelSafe = Omit<NotificationChannel, 'config' | 'type'> & (
   | { type: 'webhook'; config: { url: string; hasSecret: boolean } }
-  | { type: 'smtp'; config: { host: string; port: number; fromAddress: string; toAddresses: string[]; hasPassword: boolean } }
+  | {
+      type: 'smtp'
+      config: {
+        host: string
+        port: number
+        encryption: SmtpEncryption
+        username?: string
+        fromAddress: string
+        fromName?: string
+        toAddresses: string[]
+        hasPassword: boolean
+      }
+    }
 )
+
+/** Normalise SMTP config rows written before the encryption field was introduced. */
+function normaliseSmtpConfig(raw: unknown): SmtpChannelConfig {
+  const obj = raw as Record<string, unknown>
+  if (obj.encryption !== undefined) return obj as unknown as SmtpChannelConfig
+  // Rows written with the old `secure: boolean` field
+  const encryption: SmtpEncryption = obj.secure ? 'tls' : 'starttls'
+  const { secure: _removed, ...rest } = obj
+  return { ...rest, encryption } as unknown as SmtpChannelConfig
+}
 
 export async function getNotificationChannels(orgId: string): Promise<NotificationChannelSafe[]> {
   const rows = await db.query.notificationChannels.findMany({
@@ -380,14 +407,17 @@ export async function getNotificationChannels(orgId: string): Promise<Notificati
 
   return rows.map((ch) => {
     if (ch.type === 'smtp') {
-      const cfg = ch.config as SmtpChannelConfig
+      const cfg = normaliseSmtpConfig(ch.config)
       return {
         ...ch,
         type: 'smtp' as const,
         config: {
           host: cfg.host,
           port: cfg.port,
+          encryption: cfg.encryption,
+          username: cfg.username,
           fromAddress: cfg.fromAddress,
+          fromName: cfg.fromName,
           toAddresses: cfg.toAddresses,
           hasPassword: !!(cfg.password),
         },
@@ -454,4 +484,151 @@ export async function deleteNotificationChannel(
     )
 
   return { success: true }
+}
+
+const updateWebhookChannelSchema = z.object({
+  name: z.string().min(1).max(100),
+  url: z.string().url(),
+  secret: z.string().optional(),
+})
+
+const updateSmtpChannelSchema = z.object({
+  name: z.string().min(1).max(100),
+  host: z.string().min(1),
+  port: z.number().int().min(1).max(65535),
+  encryption: smtpEncryptionSchema,
+  username: z.string().optional(),
+  password: z.string().optional(),
+  fromAddress: z.string().email(),
+  fromName: z.string().optional(),
+  toAddresses: z.array(z.string().email()).min(1),
+})
+
+export async function updateNotificationChannel(
+  orgId: string,
+  channelId: string,
+  input: unknown,
+): Promise<{ success: true } | { error: string }> {
+  const existing = await db.query.notificationChannels.findFirst({
+    where: and(
+      eq(notificationChannels.id, channelId),
+      eq(notificationChannels.organisationId, orgId),
+      isNull(notificationChannels.deletedAt),
+    ),
+  })
+  if (!existing) return { error: 'Notification channel not found' }
+
+  try {
+    if (existing.type === 'webhook') {
+      const parsed = updateWebhookChannelSchema.safeParse(input)
+      if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+      const { name, url, secret } = parsed.data
+      const existingConfig = existing.config as WebhookChannelConfig
+      const newConfig: WebhookChannelConfig = {
+        url,
+        // Non-empty string replaces; empty/absent keeps existing
+        secret: secret || existingConfig.secret,
+      }
+      await db
+        .update(notificationChannels)
+        .set({ name, config: newConfig, updatedAt: new Date() })
+        .where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organisationId, orgId)))
+    } else {
+      const parsed = updateSmtpChannelSchema.safeParse(input)
+      if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+      const { name, host, port, encryption, username, password, fromAddress, fromName, toAddresses } = parsed.data
+      const existingConfig = normaliseSmtpConfig(existing.config)
+      const newConfig: SmtpChannelConfig = {
+        host,
+        port,
+        encryption,
+        username: username || undefined,
+        // Non-empty string replaces; empty/absent keeps existing
+        password: password || existingConfig.password,
+        fromAddress,
+        fromName: fromName || undefined,
+        toAddresses,
+      }
+      await db
+        .update(notificationChannels)
+        .set({ name, config: newConfig, updatedAt: new Date() })
+        .where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organisationId, orgId)))
+    }
+    return { success: true }
+  } catch {
+    return { error: 'Failed to update notification channel' }
+  }
+}
+
+export async function sendTestNotification(
+  orgId: string,
+  channelId: string,
+): Promise<{ success: true } | { error: string }> {
+  const existing = await db.query.notificationChannels.findFirst({
+    where: and(
+      eq(notificationChannels.id, channelId),
+      eq(notificationChannels.organisationId, orgId),
+      isNull(notificationChannels.deletedAt),
+    ),
+  })
+  if (!existing) return { error: 'Notification channel not found' }
+
+  if (existing.type === 'webhook') {
+    const cfg = existing.config as WebhookChannelConfig
+    const payload = JSON.stringify({
+      event: 'alert.test',
+      severity: 'info',
+      host: 'test-host',
+      rule: 'Test Notification',
+      message: 'This is a test notification from Infrawatch.',
+      timestamp: new Date().toISOString(),
+    })
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'Infrawatch/1.0',
+    }
+
+    if (cfg.secret) {
+      const sig = createHmac('sha256', cfg.secret).update(payload).digest('hex')
+      headers['X-Infrawatch-Signature'] = `sha256=${sig}`
+    }
+
+    try {
+      const res = await fetch(cfg.url, {
+        method: 'POST',
+        headers,
+        body: payload,
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!res.ok) {
+        return { error: `Webhook returned ${res.status} ${res.statusText}` }
+      }
+      return { success: true }
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'Request failed' }
+    }
+  } else {
+    const cfg = normaliseSmtpConfig(existing.config)
+    const transporter = nodemailer.createTransport({
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.encryption === 'tls',
+      requireTLS: cfg.encryption === 'starttls',
+      auth: cfg.username ? { user: cfg.username, pass: cfg.password ?? '' } : undefined,
+    })
+
+    try {
+      await transporter.sendMail({
+        from: cfg.fromName ? `"${cfg.fromName}" <${cfg.fromAddress}>` : cfg.fromAddress,
+        to: cfg.toAddresses.join(', '),
+        subject: 'Infrawatch Test Notification',
+        text: 'This is a test notification from Infrawatch. Your SMTP channel is configured correctly.',
+        html: '<p>This is a test notification from <strong>Infrawatch</strong>. Your SMTP channel is configured correctly.</p>',
+      })
+      return { success: true }
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'Failed to send email' }
+    }
+  }
 }

--- a/apps/web/lib/db/migrations/0009_global_alert_defaults.sql
+++ b/apps/web/lib/db/migrations/0009_global_alert_defaults.sql
@@ -1,3 +1,3 @@
-ALTER TABLE "alert_rules" ADD COLUMN "is_global_default" boolean DEFAULT false NOT NULL;
+ALTER TABLE "alert_rules" ADD COLUMN IF NOT EXISTS "is_global_default" boolean DEFAULT false NOT NULL;
 --> statement-breakpoint
-CREATE INDEX "alert_rules_org_global_idx" ON "alert_rules" USING btree ("organisation_id","is_global_default");
+CREATE INDEX IF NOT EXISTS "alert_rules_org_global_idx" ON "alert_rules" USING btree ("organisation_id","is_global_default");

--- a/apps/web/lib/db/migrations/0010_eager_chameleon.sql
+++ b/apps/web/lib/db/migrations/0010_eager_chameleon.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "alert_silences" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organisation_id" text NOT NULL,
+	"host_id" text,
+	"rule_id" text,
+	"reason" text NOT NULL,
+	"starts_at" timestamp with time zone NOT NULL,
+	"ends_at" timestamp with time zone NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"metadata" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "alert_silences" ADD CONSTRAINT "alert_silences_organisation_id_organisations_id_fk" FOREIGN KEY ("organisation_id") REFERENCES "public"."organisations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "alert_silences" ADD CONSTRAINT "alert_silences_host_id_hosts_id_fk" FOREIGN KEY ("host_id") REFERENCES "public"."hosts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "alert_silences" ADD CONSTRAINT "alert_silences_rule_id_alert_rules_id_fk" FOREIGN KEY ("rule_id") REFERENCES "public"."alert_rules"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "alert_silences" ADD CONSTRAINT "alert_silences_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "alert_silences_org_host_idx" ON "alert_silences" USING btree ("organisation_id","host_id");--> statement-breakpoint
+CREATE INDEX "alert_silences_org_active_idx" ON "alert_silences" USING btree ("organisation_id","starts_at","ends_at");

--- a/apps/web/lib/db/migrations/meta/0010_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,2514 @@
+{
+  "id": "fbda57bb-3bf3-4ad9-9c5b-7c04c7b50cb3",
+  "prevId": "c80821a5-c187-4a1c-a591-821102fbcd97",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organisations": {
+      "name": "organisations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licence_tier": {
+          "name": "licence_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "licence_key": {
+          "name": "licence_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organisations_slug_unique": {
+          "name": "organisations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totp_credential": {
+      "name": "totp_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "totp_credential_user_id_user_id_fk": {
+          "name": "totp_credential_user_id_user_id_fk",
+          "tableFrom": "totp_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organisation_id_organisations_id_fk": {
+          "name": "user_organisation_id_organisations_id_fk",
+          "tableFrom": "user",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organisation_id_organisations_id_fk": {
+          "name": "invitations_organisation_id_organisations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_id_user_id_fk": {
+          "name": "invitations_invited_by_id_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_enrolment_tokens": {
+      "name": "agent_enrolment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_approve": {
+          "name": "auto_approve",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_enrolment_tokens_organisation_id_organisations_id_fk": {
+          "name": "agent_enrolment_tokens_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_enrolment_tokens",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_enrolment_tokens_created_by_id_user_id_fk": {
+          "name": "agent_enrolment_tokens_created_by_id_user_id_fk",
+          "tableFrom": "agent_enrolment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_enrolment_tokens_token_unique": {
+          "name": "agent_enrolment_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_status_history": {
+      "name": "agent_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_status_history_agent_id_agents_id_fk": {
+          "name": "agent_status_history_agent_id_agents_id_fk",
+          "tableFrom": "agent_status_history",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_status_history_organisation_id_organisations_id_fk": {
+          "name": "agent_status_history_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_status_history",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_id": {
+          "name": "approved_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolment_token_id": {
+          "name": "enrolment_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_organisation_id_organisations_id_fk": {
+          "name": "agents_organisation_id_organisations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_approved_by_id_user_id_fk": {
+          "name": "agents_approved_by_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_enrolment_token_id_agent_enrolment_tokens_id_fk": {
+          "name": "agents_enrolment_token_id_agent_enrolment_tokens_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "agent_enrolment_tokens",
+          "columnsFrom": [
+            "enrolment_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_public_key_unique": {
+          "name": "agents_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosts": {
+      "name": "hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_addresses": {
+          "name": "ip_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_percent": {
+          "name": "disk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosts_organisation_id_organisations_id_fk": {
+          "name": "hosts_organisation_id_organisations_id_fk",
+          "tableFrom": "hosts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hosts_agent_id_agents_id_fk": {
+          "name": "hosts_agent_id_agents_id_fk",
+          "tableFrom": "hosts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_tags": {
+      "name": "resource_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_tags_resource_idx": {
+          "name": "resource_tags_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_tags_org_kv_idx": {
+          "name": "resource_tags_org_kv_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_tags_organisation_id_organisations_id_fk": {
+          "name": "resource_tags_organisation_id_organisations_id_fk",
+          "tableFrom": "resource_tags",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_metrics": {
+      "name": "host_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_percent": {
+          "name": "disk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_metrics_organisation_id_organisations_id_fk": {
+          "name": "host_metrics_organisation_id_organisations_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_metrics_host_id_hosts_id_fk": {
+          "name": "host_metrics_host_id_hosts_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_results": {
+      "name": "check_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "check_results_check_idx": {
+          "name": "check_results_check_idx",
+          "columns": [
+            {
+              "expression": "check_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "check_results_org_idx": {
+          "name": "check_results_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "check_results_check_id_checks_id_fk": {
+          "name": "check_results_check_id_checks_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "checks",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "check_results_host_id_hosts_id_fk": {
+          "name": "check_results_host_id_hosts_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "check_results_organisation_id_organisations_id_fk": {
+          "name": "check_results_organisation_id_organisations_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checks": {
+      "name": "checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "checks_org_host_idx": {
+          "name": "checks_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checks_organisation_id_organisations_id_fk": {
+          "name": "checks_organisation_id_organisations_id_fk",
+          "tableFrom": "checks",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "checks_host_id_hosts_id_fk": {
+          "name": "checks_host_id_hosts_id_fk",
+          "tableFrom": "checks",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_queries": {
+      "name": "agent_queries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_queries_host_status_idx": {
+          "name": "agent_queries_host_status_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_queries_org_idx": {
+          "name": "agent_queries_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_queries_organisation_id_organisations_id_fk": {
+          "name": "agent_queries_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_queries",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_queries_host_id_hosts_id_fk": {
+          "name": "agent_queries_host_id_hosts_id_fk",
+          "tableFrom": "agent_queries",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_instances": {
+      "name": "alert_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_instances_org_status_idx": {
+          "name": "alert_instances_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_instances_rule_host_status_idx": {
+          "name": "alert_instances_rule_host_status_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_instances_rule_id_alert_rules_id_fk": {
+          "name": "alert_instances_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_instances_host_id_hosts_id_fk": {
+          "name": "alert_instances_host_id_hosts_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_instances_organisation_id_organisations_id_fk": {
+          "name": "alert_instances_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rules": {
+      "name": "alert_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warning'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_global_default": {
+          "name": "is_global_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_rules_org_host_idx": {
+          "name": "alert_rules_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_enabled_idx": {
+          "name": "alert_rules_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_global_idx": {
+          "name": "alert_rules_org_global_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_global_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_organisation_id_organisations_id_fk": {
+          "name": "alert_rules_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_rules_host_id_hosts_id_fk": {
+          "name": "alert_rules_host_id_hosts_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_silences": {
+      "name": "alert_silences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_silences_org_host_idx": {
+          "name": "alert_silences_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_silences_org_active_idx": {
+          "name": "alert_silences_org_active_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_silences_organisation_id_organisations_id_fk": {
+          "name": "alert_silences_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_host_id_hosts_id_fk": {
+          "name": "alert_silences_host_id_hosts_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_rule_id_alert_rules_id_fk": {
+          "name": "alert_silences_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_created_by_user_id_fk": {
+          "name": "alert_silences_created_by_user_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_channels_org_enabled_idx": {
+          "name": "notification_channels_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_organisation_id_organisations_id_fk": {
+          "name": "notification_channels_organisation_id_organisations_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -68,8 +68,15 @@
     {
       "idx": 9,
       "version": "7",
-      "when": 1744070400000,
+      "when": 1775900000001,
       "tag": "0009_global_alert_defaults",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1775900000002,
+      "tag": "0010_eager_chameleon",
       "breakpoints": true
     }
   ]

--- a/apps/web/lib/db/schema/alerts.ts
+++ b/apps/web/lib/db/schema/alerts.ts
@@ -24,10 +24,13 @@ export interface WebhookChannelConfig {
   secret?: string
 }
 
+export type SmtpEncryption = 'none' | 'starttls' | 'tls'
+
 export interface SmtpChannelConfig {
   host: string
   port: number
-  secure: boolean
+  /** 'none' = plain, 'starttls' = STARTTLS on connect, 'tls' = direct SSL/TLS */
+  encryption: SmtpEncryption
   username?: string
   password?: string
   fromAddress: string

--- a/apps/web/lib/db/schema/alerts.ts
+++ b/apps/web/lib/db/schema/alerts.ts
@@ -2,6 +2,7 @@ import { pgTable, text, timestamp, jsonb, boolean, index } from 'drizzle-orm/pg-
 import { createId } from '@paralleldrive/cuid2'
 import { organisations } from './organisations'
 import { hosts } from './hosts'
+import { users } from './auth'
 
 export interface CheckStatusConfig {
   checkId: string
@@ -92,9 +93,29 @@ export const notificationChannels = pgTable('notification_channels', {
   index('notification_channels_org_enabled_idx').on(table.organisationId, table.enabled),
 ])
 
+export const alertSilences = pgTable('alert_silences', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  organisationId: text('organisation_id').notNull().references(() => organisations.id),
+  hostId: text('host_id').references(() => hosts.id),      // null = org-wide silence
+  ruleId: text('rule_id').references(() => alertRules.id), // null = silence all rules
+  reason: text('reason').notNull(),
+  startsAt: timestamp('starts_at', { withTimezone: true }).notNull(),
+  endsAt: timestamp('ends_at', { withTimezone: true }).notNull(),
+  createdBy: text('created_by').notNull().references(() => users.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  metadata: jsonb('metadata'),
+}, (table) => [
+  index('alert_silences_org_host_idx').on(table.organisationId, table.hostId),
+  index('alert_silences_org_active_idx').on(table.organisationId, table.startsAt, table.endsAt),
+])
+
 export type AlertRule = typeof alertRules.$inferSelect
 export type NewAlertRule = typeof alertRules.$inferInsert
 export type AlertInstance = typeof alertInstances.$inferSelect
 export type NewAlertInstance = typeof alertInstances.$inferInsert
 export type NotificationChannel = typeof notificationChannels.$inferSelect
 export type NewNotificationChannel = typeof notificationChannels.$inferInsert
+export type AlertSilence = typeof alertSilences.$inferSelect
+export type NewAlertSilence = typeof alertSilences.$inferInsert

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "jose": "^6.2.2",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
+    "nodemailer": "^8.0.4",
     "postgres": "^3.4.8",
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/nodemailer": "^8.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "dotenv": "^17.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       next:
         specifier: 16.2.1
         version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      nodemailer:
+        specifier: ^8.0.4
+        version: 8.0.4
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -87,6 +90,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.37
+      '@types/nodemailer':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -2092,6 +2098,9 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
+  '@types/nodemailer@8.0.0':
+    resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -3875,6 +3884,10 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nodemailer@8.0.4:
+    resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
+    engines: {node: '>=6.0.0'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -6482,6 +6495,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@8.0.0':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -8288,6 +8305,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.36: {}
+
+  nodemailer@8.0.4: {}
 
   npm-run-path@4.0.1:
     dependencies:

--- a/start.sh
+++ b/start.sh
@@ -27,18 +27,29 @@ if [ ! -f "$CERT_DIR/server.crt" ] || [ ! -f "$CERT_DIR/server.key" ]; then
   echo "TLS certificates generated (SANs: ${SAN})."
 fi
 
+# The database URL used by the Docker Compose stack — must match docker-compose.single.yml.
+# Defined here as the single source of truth for the migration steps below.
+DOCKER_DB_URL="postgresql://infrawatch:infrawatch@localhost:5432/infrawatch"
+
 docker compose -f docker-compose.single.yml build web ingest
 docker compose -f docker-compose.single.yml pull
 docker compose -f docker-compose.single.yml down
 docker compose -f docker-compose.single.yml up -d
 
-# Wait for the DB to be ready and apply any pending migrations from the host.
-# This is a safety net: the web container also runs migrate.js on startup, but
-# Docker layer caching can cause a rebuilt image to miss newly added migration
-# files if the builder layer was cached before the file existed.
+# Wait for the DB to be ready, then apply all pending migrations directly from the
+# host filesystem. This is the authoritative migration step:
+#   - The web container image bakes in migration files at build time, so any migration
+#     added after the last build may be absent from the image.
+#   - Running from the host guarantees we always use the current source tree.
+#   - DATABASE_URL is set explicitly to the Docker DB, not read from .env.local,
+#     so this works correctly even when .env.local points elsewhere.
 echo "Waiting for database to be ready..."
 until docker compose -f docker-compose.single.yml exec db pg_isready -U infrawatch -d infrawatch &>/dev/null; do
   sleep 1
 done
 echo "Applying database migrations..."
-pnpm --filter web run db:migrate
+if ! DATABASE_URL="$DOCKER_DB_URL" pnpm --filter web run db:migrate; then
+  echo "ERROR: database migration failed — aborting."
+  exit 1
+fi
+echo "Migrations applied successfully."


### PR DESCRIPTION
## Summary

- **Test notifications**: Each channel row now has a flask button that sends a test payload and shows a result dialog with the exact success or error message. Webhooks include HMAC-SHA256 signature; SMTP sends via nodemailer.
- **Edit channels**: Pencil button opens a pre-filled edit dialog for both webhook and SMTP channels. Secret/password fields show "leave blank to keep existing" when already set.
- **SMTP encryption fix**: Replaced the ambiguous `secure: boolean` field with `encryption: 'none' | 'starttls' | 'tls'`. The UI now shows a labelled select with port auto-suggestion. Existing DB rows are normalised on read for backward compat.
- **SMTP alert dispatch (Go)**: The ingest service was only dispatching webhooks — SMTP channels were silently ignored. Added `GetEnabledSmtpChannels`, `smtpChannelConfig` with legacy `secure` fallback, and `dispatchSmtp` fanning out to all SMTP channels at each of the four fire/resolve points.

## Test plan

- [ ] Add a webhook channel and send a test — verify the log dialog shows success or the exact HTTP error
- [ ] Add an SMTP channel with STARTTLS/587, send a test — verify email is received and log dialog shows success
- [ ] Set encryption to SSL/TLS on a STARTTLS server — verify the log dialog shows the TLS error (not a silent failure)
- [ ] Edit an existing channel — verify fields are pre-filled, secret/password is preserved when left blank
- [ ] Trigger an alert condition — verify email is received from the ingest service (not just the test button)
- [ ] Resolve an alert — verify resolution email is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)