### PR TITLE
fix(deploy): start.sh pulls images from GHCR

### DIFF
--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -17,6 +17,7 @@ services:
       retries: 5
 
   web:
+    image: ${WEB_IMAGE:-ghcr.io/simonjcarr/infrawatch/web:latest}
     build:
       context: .
       dockerfile: apps/web/Dockerfile
@@ -39,6 +40,7 @@ services:
       - agent_dist:/var/lib/infrawatch/agent-dist
 
   ingest:
+    image: ${INGEST_IMAGE:-ghcr.io/simonjcarr/infrawatch/ingest:latest}
     build:
       context: .
       dockerfile: apps/ingest/Dockerfile

--- a/start.sh
+++ b/start.sh
@@ -70,10 +70,14 @@ if [ -z "${GITHUB_REPO_OWNER:-}" ] || [ -z "${GITHUB_REPO_NAME:-}" ]; then
   echo "WARNING: GITHUB_REPO_OWNER / GITHUB_REPO_NAME not set — the web app will not be able to fetch agent binaries from GitHub Releases."
 fi
 
-docker compose -f docker-compose.single.yml build web ingest
-docker compose -f docker-compose.single.yml pull
+# Always pull the latest published images from GHCR. This is the production
+# install path — users running Infrawatch from Docker do not have a source
+# checkout to build from. To run a locally-built image instead, set
+# WEB_IMAGE / INGEST_IMAGE in your environment (or .env) before invoking this
+# script, or run `docker compose -f docker-compose.single.yml build` manually.
+docker compose -f docker-compose.single.yml pull db web ingest
 docker compose -f docker-compose.single.yml down
-docker compose -f docker-compose.single.yml up -d
+docker compose -f docker-compose.single.yml up -d --pull always
 
 # Wait for the DB to be ready, then apply all pending migrations directly from the
 # host filesystem. This is the authoritative migration step:


### PR DESCRIPTION
## Summary
- The published GHCR images at \`ghcr.io/simonjcarr/infrawatch/{web,ingest}:latest\` are the supported way to run Infrawatch — production users do not have a source checkout. Previously \`docker-compose.single.yml\` only declared \`build:\` (no \`image:\`), so \`docker compose pull\` skipped both services ("No image to be pulled") and \`start.sh\` silently fell back to building from the local working tree, leaving the installed version lagging behind \`main\`.
- Add \`image: ghcr.io/simonjcarr/infrawatch/{web,ingest}:latest\` to both services. The \`build:\` blocks are kept for contributors who want to rebuild locally; both can be overridden via \`WEB_IMAGE\` / \`INGEST_IMAGE\` env vars.
- Update \`start.sh\` to pull explicitly and pass \`--pull always\` to \`up -d\` so freshly-published images are always rolled in.

## Follow-ups (not in this PR — flag for triage)
- The migration step in \`start.sh\` still calls \`pnpm --filter web run db:migrate\` from the host, which requires a source checkout. For pure-Docker users this won't work — we should run migrations inside the \`web\` container instead (e.g. \`docker compose run --rm web node migrate.js\`).
- \`docker-compose.single.yml\` mounts \`./.release-please-manifest.json\` into the ingest container as a host bind. The image already bakes the manifest in at build time, so for production users without a checkout this mount will fail or hide the in-image copy. Consider dropping the bind and trusting the baked manifest.

## Test plan
- [ ] On a clean checkout, run \`./start.sh\` and confirm both \`web\` and \`ingest\` images are pulled from GHCR rather than built locally
- [ ] Confirm sidebar footer reflects the version baked into the pulled image (e.g. \`Community Edition v0.2.0\`)
- [ ] Confirm \`docker compose -f docker-compose.single.yml build\` still works for contributors who want to rebuild locally
- [ ] Verify \`WEB_IMAGE=ghcr.io/.../web:sha-abc1234 ./start.sh\` pins to a specific SHA-tagged image

🤖 Generated with [Claude Code](https://claude.com/claude-code)