### PR TITLE
ci(docker): build multi-arch web/ingest images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,9 @@ jobs:
             type=sha,prefix=sha-,format=short
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,6 +51,7 @@ jobs:
         with:
           context: .
           file: ./apps/web/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -81,6 +85,9 @@ jobs:
             type=sha,prefix=sha-,format=short
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -89,6 +96,7 @@ jobs:
         with:
           context: .
           file: ./apps/ingest/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- The web and ingest images on GHCR are currently published as \`linux/amd64\` only, so pulling them on arm64 hosts (Apple Silicon, Graviton, Raspberry Pi) fails with \`no matching manifest for linux/arm64/v8\`. This blocks \`./start.sh\` on any arm64 dev machine after PR #26.
- Add \`docker/setup-qemu-action@v3\` and \`platforms: linux/amd64,linux/arm64\` to both the \`build-web\` and \`build-ingest\` jobs in \`.github/workflows/docker-publish.yml\`. Each push to \`main\` will now publish a multi-arch manifest list under \`:latest\`.
- This commit was originally pushed to PR #26 but landed after the merge, so it never made it onto \`main\`.

## Test plan
- [ ] Workflow run on this PR succeeds for both jobs
- [ ] After merge, inspect the published manifest with \`docker buildx imagetools inspect ghcr.io/simonjcarr/infrawatch/web:latest\` and confirm both \`linux/amd64\` and \`linux/arm64\` are listed
- [ ] On an arm64 host, \`./start.sh\` pulls cleanly with no manifest errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)