### PR TITLE
fix(agent): self-update survives systemd (syscall.Exec + Restart=always)

### DIFF
--- a/agent/internal/install/install.go
+++ b/agent/internal/install/install.go
@@ -112,8 +112,11 @@ Wants=network-online.target
 
 [Service]
 ExecStart=/usr/local/bin/infrawatch-agent -config /etc/infrawatch/agent.toml
-Restart=on-failure
-RestartSec=10
+# Restart=always so that the agent comes back up after a clean self-update
+# exit (the update path swaps the binary and exits 0, relying on systemd to
+# re-exec it). on-failure would leave the service dead.
+Restart=always
+RestartSec=5
 StandardOutput=journal
 StandardError=journal
 

--- a/agent/internal/updater/reexec_unix.go
+++ b/agent/internal/updater/reexec_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package updater
+
+import "syscall"
+
+// reExec replaces the current process with a new invocation of `exe`, using
+// the supplied args and env. On success this never returns — the kernel
+// overlays the current process image with the new binary, preserving PID and
+// cgroup membership so systemd does not tear the service down.
+func reExec(exe string, args, env []string) error {
+	return syscall.Exec(exe, args, env)
+}

--- a/agent/internal/updater/reexec_windows.go
+++ b/agent/internal/updater/reexec_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// reExec on Windows spawns the new binary as a child process and exits the
+// current one. Windows has no equivalent of syscall.Exec, so the service
+// manager is expected to be configured to restart the service on exit.
+func reExec(exe string, args, env []string) error {
+	cmd := exec.Command(exe, args[1:]...) //nolint:gosec // exe is our own binary
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting updated agent process: %w", err)
+	}
+	os.Exit(0)
+	return nil // unreachable
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -15,7 +15,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 )
@@ -87,20 +86,15 @@ func Update(latestVersion, downloadBaseURL string) error {
 
 	slog.Info("update downloaded, restarting agent", "version", latestVersion)
 
-	// Re-exec: start the new binary with the same arguments and environment,
-	// then exit the current process. Using exec.Command + os.Exit rather than
-	// syscall.Exec so this compiles and works on all target platforms including
-	// Windows.
-	cmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec // exe is the path to our own binary
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = os.Environ()
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("starting updated agent process: %w", err)
+	// Re-exec into the updated binary. This is platform-specific:
+	//   - On Unix we use syscall.Exec so the running process is replaced in
+	//     place (same PID). This keeps systemd happy — it never sees the
+	//     service exit, and the cgroup is reused without being torn down.
+	//   - On Windows syscall.Exec is unavailable; reExec there spawns the new
+	//     binary as a child and exits, and the Windows service manager is
+	//     expected to be configured to restart on exit.
+	if err := reExec(exe, os.Args, os.Environ()); err != nil {
+		return fmt.Errorf("re-execing updated agent: %w", err)
 	}
-
-	os.Exit(0)
-	return nil // unreachable
+	return nil // unreachable on unix (syscall.Exec replaces the process)
 }


### PR DESCRIPTION
## Summary
Two bugs were keeping the agent dead after a self-update under systemd. Observed on an almalinux9 host running v0.9.0 updating to v0.11.0 — journal showed a successful download, a clean \`systemd[1]: infrawatch-agent.service: Deactivated successfully\`, and then nothing.

1. **\`Restart=on-failure\` in the generated unit file.** The updater exits cleanly (\`status=0\`) after swapping the binary, so systemd treats it as a successful shutdown and leaves the service dead. Changed to \`Restart=always\` with a shorter \`RestartSec\` so crash-recovery paths also benefit.
2. **The updater re-execed via \`exec.Command\` + \`os.Exit\`**, which spawns the new binary as a *child* of the dying main process. Under systemd the child lives in the same cgroup, so when the main PID exits the cgroup is torn down and the child is killed regardless of \`Restart=\` policy. Replaced with \`syscall.Exec\` on Unix (\`reexec_unix.go\`), which overlays the current process image in place — same PID, same cgroup, systemd never sees the service exit. Windows keeps the spawn-and-exit path (\`reexec_windows.go\`) because it has no equivalent primitive; the Windows service manager is expected to restart on exit.

## Manual recovery for existing hosts
Hosts already running v0.9.0 have the broken unit file on disk. After this PR ships a new agent release and those hosts attempt an update, they will *still* hit the child-process-killed issue once (because the fix only takes effect from the new binary onwards). Recovery is a one-off:

\`\`\`
sudo sed -i 's/Restart=on-failure/Restart=always/' /etc/systemd/system/infrawatch-agent.service
sudo systemctl daemon-reload
sudo systemctl start infrawatch-agent
\`\`\`

## Test plan
- [ ] \`go build ./agent/...\` and \`GOOS=windows GOARCH=amd64 go build ./agent/...\` both succeed
- [ ] On a fresh host, install the agent via \`--install\`, confirm the unit file contains \`Restart=always\`
- [ ] Trigger a self-update and confirm the PID persists across the update (\`ps\` or journal) — no \`Deactivated successfully\` line
- [ ] After update, \`systemctl status infrawatch-agent\` shows \`active (running)\` with the new version
- [ ] Windows smoke test: service restarts after self-update under the Windows service manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)