### PR TITLE
fix(deploy): bake manifest into ingest image, drop source deps from start.sh

### DIFF
--- a/apps/ingest/Dockerfile
+++ b/apps/ingest/Dockerfile
@@ -20,8 +20,16 @@ RUN apk add --no-cache ca-certificates wget
 
 COPY --from=builder /dist/ingest /usr/local/bin/ingest
 
+# Bake the release-please manifest into the image. Both the web and ingest
+# images are built from the same commit, so they always agree on the
+# required agent version. Production users running from GHCR have no source
+# checkout to bind-mount.
+COPY .release-please-manifest.json /etc/infrawatch/release-please-manifest.json
+
 # Create runtime directories
 RUN mkdir -p /etc/infrawatch/tls /var/lib/infrawatch
+
+ENV INGEST_RELEASE_MANIFEST_PATH=/etc/infrawatch/release-please-manifest.json
 
 EXPOSE 9443 8080
 

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -61,13 +61,12 @@ services:
       # inside the docker network). Override via .env / start.sh for remote
       # agents; defaults to localhost for single-host dev.
       INGEST_AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
-      # Manifest path inside the container — kept in sync with the volume mount
-      # below so the ingest service auto-discovers the latest agent version
-      # from release-please without any env-var bookkeeping.
-      INGEST_RELEASE_MANIFEST_PATH: /etc/infrawatch/release-please-manifest.json
+      # The release-please manifest is baked into the ingest image at build
+      # time (see apps/ingest/Dockerfile) and INGEST_RELEASE_MANIFEST_PATH is
+      # set there as well, so production users running from GHCR do not need
+      # a source checkout for the agent version to be discovered.
     volumes:
       - ./deploy/dev-tls:/etc/infrawatch/tls:ro
-      - ./.release-please-manifest.json:/etc/infrawatch/release-please-manifest.json:ro
       - ingest_data:/var/lib/infrawatch
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]

--- a/start.sh
+++ b/start.sh
@@ -39,23 +39,6 @@ if [ ! -f "$CERT_DIR/server.crt" ] || [ ! -f "$CERT_DIR/server.key" ]; then
   echo "TLS certificates generated (SANs: ${SAN})."
 fi
 
-# The database URL used by the Docker Compose stack — must match docker-compose.single.yml.
-# Defined here as the single source of truth for the migration steps below.
-DOCKER_DB_URL="postgresql://infrawatch:infrawatch@localhost:5432/infrawatch"
-
-# Surface the agent version that release-please has pinned in the manifest.
-# Both the web app and the ingest service read this same file, so a single
-# release-please commit fully drives the agent rollout — no env-var bumping
-# required. Agents will self-update on their next heartbeat after this runs.
-if [ -f ".release-please-manifest.json" ] && command -v node &>/dev/null; then
-  AGENT_VERSION=$(node -e "try { console.log(JSON.parse(require('fs').readFileSync('.release-please-manifest.json','utf8')).agent || '') } catch (e) {}" 2>/dev/null || true)
-  if [ -n "${AGENT_VERSION:-}" ]; then
-    echo "Pinned agent version (from .release-please-manifest.json): v${AGENT_VERSION}"
-  else
-    echo "WARNING: .release-please-manifest.json has no 'agent' entry — agent auto-update will be disabled."
-  fi
-fi
-
 # AGENT_DOWNLOAD_BASE_URL is the URL agents use to download new binaries.
 # It must be reachable from each agent host, not just from inside Docker.
 # Defaults to http://localhost:3000 for single-host dev; export it before
@@ -79,20 +62,7 @@ docker compose -f docker-compose.single.yml pull db web ingest
 docker compose -f docker-compose.single.yml down
 docker compose -f docker-compose.single.yml up -d --pull always
 
-# Wait for the DB to be ready, then apply all pending migrations directly from the
-# host filesystem. This is the authoritative migration step:
-#   - The web container image bakes in migration files at build time, so any migration
-#     added after the last build may be absent from the image.
-#   - Running from the host guarantees we always use the current source tree.
-#   - DATABASE_URL is set explicitly to the Docker DB, not read from .env.local,
-#     so this works correctly even when .env.local points elsewhere.
-echo "Waiting for database to be ready..."
-until docker compose -f docker-compose.single.yml exec db pg_isready -U infrawatch -d infrawatch &>/dev/null; do
-  sleep 1
-done
-echo "Applying database migrations..."
-if ! DATABASE_URL="$DOCKER_DB_URL" pnpm --filter web run db:migrate; then
-  echo "ERROR: database migration failed — aborting."
-  exit 1
-fi
-echo "Migrations applied successfully."
+# Database migrations are applied automatically by the web container on
+# startup (its CMD runs `node migrate.js && node server.js`), and the
+# release-please manifest is baked into both web and ingest images at build
+# time. Nothing else for this script to do.


### PR DESCRIPTION
## Summary
Production users will run Infrawatch from GHCR with only \`docker-compose.single.yml\` and \`start.sh\` — no source checkout. The previous wiring still leaked two host-source dependencies, which caused web and ingest to disagree on the required agent version whenever the local checkout drifted from \`main\`:

1. \`docker-compose.single.yml\` bind-mounted \`./.release-please-manifest.json\` into the ingest container, so ingest read whatever the user happened to have on disk while web read the version baked into its image at build time. Confirmed in testing: web showed "Update available (v0.11.1)" while ingest still served \`agent: 0.11.0\` from a stale local file.
2. \`start.sh\` ran \`pnpm --filter web run db:migrate\` from the host, which requires a source checkout, node, and node_modules.

## Changes
- **\`apps/ingest/Dockerfile\`** — \`COPY .release-please-manifest.json /etc/infrawatch/release-please-manifest.json\` and set \`ENV INGEST_RELEASE_MANIFEST_PATH=...\` so the ingest binary picks it up by default. Both web and ingest are built from the same commit, so they always agree.
- **\`docker-compose.single.yml\`** — drop the host bind mount of the manifest and the now-redundant \`INGEST_RELEASE_MANIFEST_PATH\` env override.
- **\`start.sh\`** — remove the host migration step (the web container's CMD already runs \`node migrate.js && node server.js\` on every startup) and remove the local manifest-reading block. The script now does only what a source-less production install needs: load \`.env\`, generate dev TLS certs on first run, pull, down, up.

## Test plan
- [ ] On a clean host with **no source checkout** (just \`docker-compose.single.yml\` + \`start.sh\` + \`.env\`), \`./start.sh\` brings the stack up successfully
- [ ] \`docker compose exec ingest cat /etc/infrawatch/release-please-manifest.json\` matches the version baked into the web image
- [ ] Cut a new agent release on main, re-run \`./start.sh\` on the test host, confirm agents receive the new version on next heartbeat without any local file edits
- [ ] First-boot migration runs cleanly via the web container's startup CMD

🤖 Generated with [Claude Code](https://claude.com/claude-code)