### PR TITLE
feat(dist): customer bundle + hardcoded agent repo + first-run start.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,26 @@
 # =============================================================================
-# Infrawatch — Local Development Environment (example)
+# Infrawatch — Configuration
 # =============================================================================
-# Copy this file to .env and fill in your values.
-# The .env file is read by docker-compose.dev.yml.
+# Copy this file to .env and edit the values below before running ./start.sh.
 # =============================================================================
 
-# --- PostgreSQL / TimescaleDB ---
-POSTGRES_USER=infrawatch
-POSTGRES_PASSWORD=infrawatch
-POSTGRES_DB=infrawatch
-POSTGRES_PORT=5432
+# === Required: edit before first run ===
+# Public URL of the Infrawatch web UI (no trailing slash).
+BETTER_AUTH_URL=http://localhost:3000
 
-# --- Agent binary distribution ---
-# Used by the web app to lazily fetch agent binaries from GitHub Releases
-# on first request and cache them in the agent_dist volume.
-GITHUB_REPO_OWNER=
-GITHUB_REPO_NAME=
-# Public base URL of the web app — agents construct their download URL from
-# this when self-updating, so it MUST be reachable from every agent host
-# (not just from inside the docker network or from localhost). For a single
-# server on a LAN this is typically http://<server-ip>:3000.
+# Comma-separated list of allowed origins for the auth callback.
+BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
+
+# Public URL agents use to download new binaries from the web app.
+# Must be reachable from each agent host (not just localhost).
 AGENT_DOWNLOAD_BASE_URL=http://localhost:3000
+
+# === Generated automatically on first run if blank ===
+# 64-character random hex used to sign auth sessions. start.sh will
+# generate one for you on first run if you leave this empty.
+BETTER_AUTH_SECRET=
+
+# === Optional image overrides (advanced) ===
+# Pin to a specific image tag instead of :latest.
+# WEB_IMAGE=ghcr.io/simonjcarr/infrawatch/web:sha-abc1234
+# INGEST_IMAGE=ghcr.io/simonjcarr/infrawatch/ingest:sha-abc1234

--- a/.github/workflows/customer-bundle.yml
+++ b/.github/workflows/customer-bundle.yml
@@ -1,0 +1,53 @@
+name: Customer Bundle
+
+on:
+  push:
+    tags:
+      - 'web/v*'
+
+permissions:
+  contents: write
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#web/}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage bundle files
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          mkdir -p dist/infrawatch
+          cp docker-compose.single.yml dist/infrawatch/docker-compose.yml
+          cp start.sh                  dist/infrawatch/start.sh
+          cp .env.example              dist/infrawatch/.env.example
+          cp deploy/customer-bundle/README.md dist/infrawatch/README.md
+          echo "$VERSION" > dist/infrawatch/VERSION
+          chmod +x dist/infrawatch/start.sh
+          # Bundled compose file is named docker-compose.yml so plain
+          # `docker compose` works without -f. Strip the explicit -f from
+          # the bundled start.sh to match.
+          sed -i 's/-f docker-compose.single.yml //g' dist/infrawatch/start.sh
+
+      - name: Create zip
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          (cd dist && zip -r "../infrawatch-single-${VERSION}.zip" infrawatch)
+          cp "infrawatch-single-${VERSION}.zip" infrawatch-single.zip
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          gh release upload "$GITHUB_REF_NAME" \
+            "infrawatch-single-${VERSION}.zip" \
+            "infrawatch-single.zip" \
+            --clobber

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,10 +16,6 @@ BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
 
 # --- Agent ---
 # Directory where agent binaries are stored and served from.
-# On first request the server auto-downloads from GitHub (if GITHUB_REPO_OWNER/NAME are set).
+# On first request the server auto-downloads from the official GitHub release.
 # For air-gapped deployments, manually place binaries here.
 AGENT_DIST_DIR=./data/agent-dist
-
-# Required for initial binary sync from GitHub. Can be omitted once binaries are cached locally.
-GITHUB_REPO_OWNER=simonjcarr
-GITHUB_REPO_NAME=infrawatch

--- a/apps/web/app/api/agent/download/route.ts
+++ b/apps/web/app/api/agent/download/route.ts
@@ -2,9 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import fs from 'fs'
 import path from 'path'
 import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
+import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from '@/lib/agent/repo'
 
-const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? ''
-const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME ?? ''
 const AGENT_DIST_DIR = process.env.AGENT_DIST_DIR ?? './data/agent-dist'
 
 interface GitHubAsset {
@@ -61,17 +60,15 @@ export async function GET(request: NextRequest) {
   }
 
   // ── 2: Fetch from GitHub release for the required version ─────────────────
-  if (GITHUB_REPO_OWNER && GITHUB_REPO_NAME) {
-    const tag = `agent/${REQUIRED_AGENT_VERSION}`
-    const release = await fetchRelease(tag)
-    if (release) {
-      const asset = release.assets.find((a) => a.name === baseName)
-      if (asset) {
-        const binary = await fetchBinaryFromGitHub(asset.browser_download_url)
-        if (binary) {
-          await cacheLocally(versionedPath, binary)
-          return new NextResponse(binary, buildHeaders(baseName, binary.byteLength))
-        }
+  const tag = `agent/${REQUIRED_AGENT_VERSION}`
+  const release = await fetchRelease(tag)
+  if (release) {
+    const asset = release.assets.find((a) => a.name === baseName)
+    if (asset) {
+      const binary = await fetchBinaryFromGitHub(asset.browser_download_url)
+      if (binary) {
+        await cacheLocally(versionedPath, binary)
+        return new NextResponse(binary, buildHeaders(baseName, binary.byteLength))
       }
     }
   }
@@ -87,9 +84,7 @@ export async function GET(request: NextRequest) {
     {
       error:
         `No binary available for ${os}/${arch} (required version: ${REQUIRED_AGENT_VERSION}). ` +
-        (GITHUB_REPO_OWNER
-          ? `Ensure a GitHub release exists for tag "agent/${REQUIRED_AGENT_VERSION}".`
-          : `Set GITHUB_REPO_OWNER + GITHUB_REPO_NAME, or run \`make agent\` to build locally.`),
+        `Ensure a GitHub release exists for tag "agent/${REQUIRED_AGENT_VERSION}" in ${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}.`,
     },
     { status: 503 }
   )
@@ -108,7 +103,7 @@ const ghHeaders: Record<string, string> = {
 async function fetchRelease(tag: string): Promise<GitHubRelease | null> {
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/tags/${encodeURIComponent(tag)}`,
+      `https://api.github.com/repos/${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}/releases/tags/${encodeURIComponent(tag)}`,
       { headers: ghHeaders }
     )
     if (!res.ok) return null

--- a/apps/web/app/api/agent/latest/route.ts
+++ b/apps/web/app/api/agent/latest/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from 'next/server'
-
-const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? ''
-const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME ?? ''
+import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from '@/lib/agent/repo'
 
 interface GitHubRelease {
   tag_name: string
@@ -15,13 +13,6 @@ interface GitHubRelease {
  * Filters GitHub releases to those tagged agent/v* and returns the newest.
  */
 export async function GET() {
-  if (!GITHUB_REPO_OWNER || !GITHUB_REPO_NAME) {
-    return NextResponse.json(
-      { error: 'GITHUB_REPO_OWNER and GITHUB_REPO_NAME must be set' },
-      { status: 503 }
-    )
-  }
-
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
@@ -31,7 +22,7 @@ export async function GET() {
   }
 
   const res = await fetch(
-    `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases?per_page=20`,
+    `https://api.github.com/repos/${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}/releases?per_page=20`,
     { headers, next: { revalidate: 300 } }
   )
 

--- a/apps/web/lib/agent/cache-prewarm.ts
+++ b/apps/web/lib/agent/cache-prewarm.ts
@@ -1,9 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 import { REQUIRED_AGENT_VERSION } from './version'
+import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from './repo'
 
-const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER ?? ''
-const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME ?? ''
 const AGENT_DIST_DIR = process.env.AGENT_DIST_DIR ?? './data/agent-dist'
 
 const PLATFORMS = [
@@ -34,17 +33,12 @@ interface GitHubRelease {
  * prewarm failure must never prevent the server from starting.
  */
 export async function prewarmAgentCache(): Promise<void> {
-  if (!GITHUB_REPO_OWNER || !GITHUB_REPO_NAME) {
-    console.log('[agent-cache] GitHub not configured — skipping prewarm')
-    return
-  }
-
   const tag = `agent/${REQUIRED_AGENT_VERSION}`
   let release: GitHubRelease | null = null
 
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/tags/${encodeURIComponent(tag)}`,
+      `https://api.github.com/repos/${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}/releases/tags/${encodeURIComponent(tag)}`,
       {
         headers: {
           Accept: 'application/vnd.github+json',

--- a/apps/web/lib/agent/repo.ts
+++ b/apps/web/lib/agent/repo.ts
@@ -1,0 +1,10 @@
+/**
+ * Source repository for the official Infrawatch agent binaries.
+ *
+ * Hardcoded on purpose: there is exactly one place agent binaries come from.
+ * Customers should never be configuring this — if the project is renamed
+ * before public release, it's a one-time grep/replace per CLAUDE.md, not a
+ * customer-facing toggle.
+ */
+export const AGENT_REPO_OWNER = 'simonjcarr'
+export const AGENT_REPO_NAME = 'infrawatch'

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -1,0 +1,84 @@
+# Infrawatch — Quickstart
+
+This bundle contains everything you need to run Infrawatch on a single host
+using Docker. The container images are pulled from GitHub Container Registry
+(`ghcr.io/simonjcarr/infrawatch/*`) the first time you start the stack.
+
+## Prerequisites
+
+- Docker Engine 24+ with the Compose plugin (`docker compose version`)
+- `openssl`
+- `curl`
+
+## First run
+
+```sh
+cd infrawatch
+./start.sh
+```
+
+The first invocation copies `.env.example` → `.env`, sets safe permissions
+on it, and exits. Open `.env` in your editor and set:
+
+- `BETTER_AUTH_URL` — public URL of the web UI (no trailing slash)
+- `BETTER_AUTH_TRUSTED_ORIGINS` — comma-separated allowed callback origins
+- `AGENT_DOWNLOAD_BASE_URL` — public URL agents will hit to self-update;
+  must be reachable from every agent host, not just `localhost`
+
+Leave `BETTER_AUTH_SECRET` blank — `start.sh` will generate one for you on
+the next run and write it back to `.env`.
+
+## Second run
+
+```sh
+./start.sh
+```
+
+This will:
+
+1. Generate `BETTER_AUTH_SECRET` if it is still blank
+2. Generate dev TLS certificates under `./deploy/dev-tls/` for the ingest
+   service
+3. Pull the latest `web`, `ingest`, and `db` images from GHCR
+4. Start the stack
+5. The web container runs database migrations on its own startup
+
+Open `http://localhost:3000` (or whatever you set as `BETTER_AUTH_URL`) and
+follow the in-app onboarding to create your first organisation and admin
+user.
+
+## Installing the agent
+
+After signing in, follow the in-app instructions on the **Hosts** page to
+install the agent on a server you want to monitor. Agents download their
+binary from your Infrawatch server using `AGENT_DOWNLOAD_BASE_URL`.
+
+## Updating
+
+```sh
+./start.sh
+```
+
+re-pulls `:latest` and recreates any containers whose image has changed.
+
+To pin to a specific image version instead of `:latest`, set `WEB_IMAGE`
+and `INGEST_IMAGE` in `.env` (see commented examples in `.env.example`).
+
+## Troubleshooting
+
+```sh
+docker compose ps                       # container status
+docker compose logs web ingest db       # last logs
+cat VERSION                             # bundle version
+```
+
+Data lives in named Docker volumes (`db_data`, `ingest_data`, `agent_dist`).
+
+## Uninstall
+
+```sh
+docker compose down -v
+```
+
+This removes the containers **and the volumes** — destroying all stored
+data. Back up first if you need to keep anything.

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -34,8 +34,6 @@ services:
       BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:3000}
       NODE_ENV: production
       AGENT_DIST_DIR: /var/lib/infrawatch/agent-dist
-      GITHUB_REPO_OWNER: ${GITHUB_REPO_OWNER:-}
-      GITHUB_REPO_NAME: ${GITHUB_REPO_NAME:-}
     volumes:
       - agent_dist:/var/lib/infrawatch/agent-dist
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,133 +21,21 @@ That's it. No local Go, Node.js, or pnpm required.
 
 ## Option A — Pre-built images from GHCR
 
-The fastest way to get Infrawatch running. Images are published to the GitHub Container Registry on every push to `main`.
-
-### Step 1 — Create a working directory
+The fastest way to get Infrawatch running. One command downloads a small bundle (compose file, `start.sh`, `.env.example`, README) from the latest GitHub release and unpacks it into `./infrawatch`:
 
 ```bash
-mkdir infrawatch && cd infrawatch
+curl -fsSL https://raw.githubusercontent.com/simonjcarr/infrawatch/main/install.sh | bash
+cd infrawatch
+./start.sh        # first run: creates .env from the example, then exits
+$EDITOR .env      # set BETTER_AUTH_URL, AGENT_DOWNLOAD_BASE_URL, etc.
+./start.sh        # second run: generates secret, certs, pulls images, boots
 ```
 
-### Step 2 — Generate dev TLS certificates
+To pin a specific bundle version: `INFRAWATCH_VERSION=v0.3.0 bash` instead of plain `bash`.
 
-The ingest service (gRPC) requires TLS. Generate a self-signed certificate using Docker:
+The bundled `start.sh` generates dev TLS certs, generates `BETTER_AUTH_SECRET` if blank, pulls the latest `web`/`ingest`/`db` images from GHCR, and starts the stack. Database migrations run inside the web container automatically on startup.
 
-```bash
-mkdir -p deploy/dev-tls
-docker run --rm \
-  -v "$(pwd)/deploy/dev-tls:/out" \
-  alpine/openssl req -x509 \
-  -newkey rsa:4096 \
-  -keyout /out/server.key \
-  -out /out/server.crt \
-  -days 365 \
-  -nodes \
-  -subj "/CN=localhost" \
-  -addext "subjectAltName=DNS:localhost,DNS:ingest,IP:127.0.0.1"
-```
-
-### Step 3 — Create the docker-compose file
-
-Create `docker-compose.yml` with the following content:
-
-```yaml
-services:
-  db:
-    image: timescale/timescaledb:latest-pg16
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: infrawatch
-      POSTGRES_PASSWORD: infrawatch
-      POSTGRES_DB: infrawatch
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U infrawatch -d infrawatch"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  web:
-    image: ghcr.io/simonjcarr/infrawatch/web:latest
-    restart: unless-stopped
-    depends_on:
-      db:
-        condition: service_healthy
-    ports:
-      - "3000:3000"
-    environment:
-      DATABASE_URL: postgresql://infrawatch:infrawatch@db:5432/infrawatch
-      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
-      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
-      BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:3000}
-      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
-      NODE_ENV: production
-
-  ingest:
-    image: ghcr.io/simonjcarr/infrawatch/ingest:latest
-    restart: unless-stopped
-    depends_on:
-      db:
-        condition: service_healthy
-    ports:
-      - "9443:9443"   # gRPC (TLS)
-      - "8080:8080"   # JWKS + healthz HTTP
-    environment:
-      DATABASE_URL: postgresql://infrawatch:infrawatch@db:5432/infrawatch
-      INGEST_TLS_CERT: /etc/infrawatch/tls/server.crt
-      INGEST_TLS_KEY: /etc/infrawatch/tls/server.key
-      INGEST_JWT_KEY_FILE: /var/lib/infrawatch/jwt_key.pem
-    volumes:
-      - ./deploy/dev-tls:/etc/infrawatch/tls:ro
-      - ingest_data:/var/lib/infrawatch
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-volumes:
-  db_data:
-  ingest_data:
-```
-
-### Step 4 — Create the env file
-
-Create a `.env` file in the same directory:
-
-```env
-BETTER_AUTH_SECRET=change-this-to-a-long-random-string
-BETTER_AUTH_URL=http://localhost:3000
-BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-```
-
-> Generate a strong secret with: `openssl rand -hex 32`
-
-### Step 5 — Start the stack
-
-```bash
-docker compose up -d
-```
-
-Pull the latest images and start all three services. Wait until healthy:
-
-```bash
-docker compose ps
-```
-
-All three should show `healthy` or `running`.
-
-### Step 6 — Run database migrations
-
-Migrations run inside the web container using the bundled migration script:
-
-```bash
-docker compose exec web node migrate.js
-```
-
-### Step 7 — Continue from [Create your account](#step-create-your-account)
+When all three containers show `healthy` in `docker compose ps`, continue from [Create your account](#step-create-your-account). The full quickstart, troubleshooting, and uninstall instructions are in `infrawatch/README.md` inside the bundle.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Infrawatch one-line installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/simonjcarr/infrawatch/main/install.sh | bash
+#
+# Optional: pin a specific version.
+#
+#   curl -fsSL https://raw.githubusercontent.com/simonjcarr/infrawatch/main/install.sh \
+#     | INFRAWATCH_VERSION=v0.3.0 bash
+#
+set -euo pipefail
+
+REPO_OWNER="simonjcarr"
+REPO_NAME="infrawatch"
+
+if [ "$(id -u)" = "0" ]; then
+  echo "ERROR: do not run this installer as root." >&2
+  echo "Run it as the user that will operate Infrawatch (must be in the docker group)." >&2
+  exit 1
+fi
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command '$1' not found in PATH" >&2
+    exit 1
+  fi
+}
+need docker
+need curl
+need unzip
+need openssl
+
+if [ -d "infrawatch" ]; then
+  echo "ERROR: ./infrawatch already exists. Move or remove it first." >&2
+  exit 1
+fi
+
+if [ -n "${INFRAWATCH_VERSION:-}" ]; then
+  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/web/${INFRAWATCH_VERSION}/infrawatch-single-${INFRAWATCH_VERSION}.zip"
+  echo "Downloading Infrawatch ${INFRAWATCH_VERSION}..."
+else
+  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download/infrawatch-single.zip"
+  echo "Downloading the latest Infrawatch release..."
+fi
+
+TMP=$(mktemp -t infrawatch.XXXXXX.zip)
+trap 'rm -f "$TMP"' EXIT
+
+curl -fsSL -o "$TMP" "$URL"
+unzip -q "$TMP" -d .
+
+echo ""
+echo "Installed to ./infrawatch"
+echo ""
+echo "Next steps:"
+echo "  cd infrawatch"
+echo "  ./start.sh        # creates .env from the example"
+echo "  \$EDITOR .env      # set BETTER_AUTH_URL etc."
+echo "  ./start.sh        # boots the stack"
+echo ""

--- a/start.sh
+++ b/start.sh
@@ -1,16 +1,49 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Load .env so values like AGENT_DOWNLOAD_BASE_URL, GITHUB_REPO_OWNER etc.
-# are available both to this script and (via export) to the docker compose
-# variable substitution that follows. docker compose also reads .env on its
-# own, but we need these in the bash environment too because start.sh
-# inspects them and prints warnings.
-if [ -f ".env" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  source .env
-  set +a
+# First-run bootstrap: if .env is missing but .env.example is here, copy it
+# and ask the user to review before continuing. We never want to silently
+# boot with placeholder secrets.
+if [ ! -f ".env" ]; then
+  if [ -f ".env.example" ]; then
+    cp .env.example .env
+    chmod 600 .env
+    echo ""
+    echo "Created .env from .env.example."
+    echo "Edit .env to set your URLs, then re-run ./start.sh."
+    echo ""
+    exit 0
+  else
+    echo "ERROR: no .env and no .env.example found in $(pwd)" >&2
+    exit 1
+  fi
+fi
+
+# Load .env so values like AGENT_DOWNLOAD_BASE_URL are available both to
+# this script and (via export) to the docker compose variable substitution
+# that follows.
+set -a
+# shellcheck disable=SC1091
+source .env
+set +a
+
+# Auto-generate BETTER_AUTH_SECRET on first run if blank. Written back to
+# .env in place so subsequent runs reuse the same secret.
+if [ -z "${BETTER_AUTH_SECRET:-}" ]; then
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "ERROR: openssl is required to generate BETTER_AUTH_SECRET" >&2
+    exit 1
+  fi
+  GENERATED_SECRET=$(openssl rand -hex 32)
+  # Portable in-place edit (BSD/GNU sed compatible).
+  if grep -q '^BETTER_AUTH_SECRET=' .env; then
+    awk -v s="$GENERATED_SECRET" '/^BETTER_AUTH_SECRET=/ {print "BETTER_AUTH_SECRET=" s; next} {print}' .env > .env.tmp && mv .env.tmp .env
+  else
+    echo "BETTER_AUTH_SECRET=$GENERATED_SECRET" >> .env
+  fi
+  chmod 600 .env
+  export BETTER_AUTH_SECRET="$GENERATED_SECRET"
+  echo "Generated BETTER_AUTH_SECRET and wrote it to .env."
 fi
 
 # Generate dev TLS certificates for the ingest service if they don't exist
@@ -45,13 +78,6 @@ fi
 # running this script for remote agents (e.g. AGENT_DOWNLOAD_BASE_URL=https://infrawatch.example.com).
 export AGENT_DOWNLOAD_BASE_URL="${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}"
 echo "Agent download base URL: ${AGENT_DOWNLOAD_BASE_URL}"
-
-# GITHUB_REPO_OWNER / GITHUB_REPO_NAME let the web app lazily fetch agent
-# binaries from GitHub Releases on first request and cache them in the
-# agent_dist volume. Without these, only locally-built binaries are served.
-if [ -z "${GITHUB_REPO_OWNER:-}" ] || [ -z "${GITHUB_REPO_NAME:-}" ]; then
-  echo "WARNING: GITHUB_REPO_OWNER / GITHUB_REPO_NAME not set — the web app will not be able to fetch agent binaries from GitHub Releases."
-fi
 
 # Always pull the latest published images from GHCR. This is the production
 # install path — users running Infrawatch from Docker do not have a source


### PR DESCRIPTION
## Summary
- Adds a customer distribution bundle (`infrawatch-single-<ver>.zip`) built on every `web/v*` tag and uploaded to the matching GitHub Release, plus an unversioned `infrawatch-single.zip` alias for `releases/latest/download`.
- New `install.sh` at the repo root: `curl -fsSL .../install.sh | bash` downloads and unpacks the latest bundle into `./infrawatch`.
- `start.sh` is now first-run friendly: bootstraps `.env` from `.env.example` (chmod 600, exits so the user can edit), then auto-generates `BETTER_AUTH_SECRET` via `openssl rand -hex 32` if blank.
- Hardcodes the agent source repo in `apps/web/lib/agent/repo.ts`. Removes `GITHUB_REPO_OWNER` / `GITHUB_REPO_NAME` from `.env.example`, the compose file, and the download / latest / cache-prewarm code paths — there is exactly one place agent binaries come from.
- `.env.example` rewritten as the customer-facing config file (`BETTER_AUTH_*`, `AGENT_DOWNLOAD_BASE_URL`, optional `WEB_IMAGE`/`INGEST_IMAGE` overrides).
- `docs/getting-started.md` Option A shortened to point at the installer.

## Test plan
- [ ] `pnpm run build` clean (verified locally)
- [ ] Push a throwaway `web/v0.0.0-test` tag, confirm `customer-bundle.yml` produces both zips and uploads them
- [ ] In an empty dir: `curl -fsSL .../install.sh | bash`, `cd infrawatch`, `./start.sh` (creates .env, exits), `./start.sh` (generates secret, certs, pulls images, boots)
- [ ] `GET /api/agent/latest` and `/api/agent/download?os=linux&arch=amd64` resolve without `GITHUB_REPO_OWNER` set
- [ ] `INFRAWATCH_VERSION=v<x> bash` pins to an older bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)