### PR TITLE
fix(agent): reset heartbeat backoff after stable stream

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -61,8 +61,12 @@ func New(client agentv1.IngestServiceClient, agentID, jwtToken, version string, 
 }
 
 // Run starts the heartbeat stream. It reconnects automatically on transient
-// errors, backing off up to 60 seconds between attempts.
+// errors, backing off up to 60 seconds between attempts. The backoff resets
+// to 1s after any stream that ran stably for at least minStableTime, so a
+// transient blip (e.g. firewall state expiry) does not leave the agent
+// waiting 60s between retries on the next failure.
 func (r *Runner) Run(ctx context.Context) error {
+	const minStableTime = 10 * time.Second
 	backoff := time.Second
 	maxBackoff := 60 * time.Second
 
@@ -71,9 +75,14 @@ func (r *Runner) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 
+		start := time.Now()
 		err := r.runStream(ctx)
 		if err == nil || err == context.Canceled || err == context.DeadlineExceeded {
 			return err
+		}
+
+		if time.Since(start) >= minStableTime {
+			backoff = time.Second // stream was stable — reset backoff
 		}
 
 		slog.Warn("heartbeat stream ended, reconnecting", "err", err, "backoff", backoff)


### PR DESCRIPTION
## Summary

- Heartbeat reconnect backoff was never reset after a successful stream, causing the agent to wait up to 60s between retries after a failure→recovery→failure cycle
- This manifested as the agent appearing stuck after a firewall state expiry (OPNSense between VLANs), requiring a manual `systemctl restart`
- Fix: track stream start time in `Run()`; if the stream ran ≥10s before failing, reset backoff to 1s before the next retry

## Root cause

In `agent/internal/heartbeat/heartbeat.go`, the `backoff` variable doubles after each failed attempt (1s → 2s → 4s … → 60s) but was never reset when a stream ran successfully. Confirmed by the logs: a second disconnect 2 minutes after recovery retried after exactly 32s — the leftover value from the first failure sequence.

## Test plan

- [ ] Build passes: `cd agent && go build ./...`
- [ ] Deploy to a host behind OPNSense, observe `journalctl -u infrawatch-agent -f`
- [ ] After any reconnect, confirm a subsequent disconnect retries with `backoff=1s` not a large inherited value
- [ ] Optionally: briefly block port 9443 on OPNSense firewall, confirm agent reconnects within ~1s of the rule being removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)