### PR TITLE
fix(agent): gRPC reconnect reliability + heartbeat interval chart

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 
+	"google.golang.org/grpc"
+
 	agentgrpc "github.com/infrawatch/agent/internal/grpc"
 	"github.com/infrawatch/agent/internal/checks"
 	"github.com/infrawatch/agent/internal/config"
@@ -102,19 +104,23 @@ func runAgent(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	conn, err := agentgrpc.Connect(cfg.Ingest.Address, cfg.Ingest.CACertFile, cfg.Ingest.TLSSkipVerify)
-	if err != nil {
-		slog.Error("connecting to ingest service", "err", err, "address", cfg.Ingest.Address)
-		return err
+	// dialFunc creates a fresh gRPC connection each time it is called. The
+	// heartbeat runner calls it once per stream attempt so that a stuck or
+	// stale ClientConn from a previous attempt can never block reconnection.
+	dialFunc := func() (*grpc.ClientConn, error) {
+		return agentgrpc.Connect(cfg.Ingest.Address, cfg.Ingest.CACertFile, cfg.Ingest.TLSSkipVerify)
 	}
-	defer conn.Close()
-
-	client := agentv1.NewIngestServiceClient(conn)
 
 	if state.JWTToken == "" {
 		slog.Info("registering agent", "address", cfg.Ingest.Address)
-		registrar := registration.New(client, keypair, cfg.Agent.OrgToken, version)
+		regConn, err := dialFunc()
+		if err != nil {
+			slog.Error("connecting to ingest service", "err", err, "address", cfg.Ingest.Address)
+			return err
+		}
+		registrar := registration.New(agentv1.NewIngestServiceClient(regConn), keypair, cfg.Agent.OrgToken, version)
 		newState, err := registrar.Register(ctx, state.AgentID)
+		regConn.Close()
 		if err != nil {
 			return err
 		}
@@ -129,6 +135,6 @@ func runAgent(ctx context.Context, cfg *config.Config) error {
 
 	slog.Info("starting heartbeat", "interval_secs", cfg.Agent.HeartbeatIntervalSecs, "version", version)
 	executor := checks.NewExecutor()
-	hb := heartbeat.New(client, state.AgentID, state.JWTToken, version, cfg.Agent.HeartbeatIntervalSecs, executor)
+	hb := heartbeat.New(dialFunc, state.AgentID, state.JWTToken, version, cfg.Agent.HeartbeatIntervalSecs, executor)
 	return hb.Run(ctx)
 }

--- a/agent/internal/grpc/client.go
+++ b/agent/internal/grpc/client.go
@@ -1,7 +1,9 @@
 package agentgrpc
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
@@ -15,13 +17,9 @@ func Connect(address, caCertFile string, skipVerify bool) (*grpc.ClientConn, err
 		return nil, fmt.Errorf("building TLS credentials: %w", err)
 	}
 
-	// Keepalive is essential: the heartbeat stream is mostly idle (one send
-	// every 30s) and stateful middleboxes (NAT, conntrack, cloud LBs) silently
-	// evict idle TCP flows after 1–4 hours. Without HTTP/2 PINGs the agent
-	// keeps writing to a half-open socket and never notices the stream is dead
-	// until the OS gives up — which can take much longer than the user will
-	// tolerate. PermitWithoutStream lets us keep the connection warm even
-	// during reconnect backoff windows.
+	// HTTP/2-level keepalive: sends PING frames every 30s so gRPC detects a
+	// dead connection within 40s (30s interval + 10s timeout). This catches
+	// cases where the server closes the stream cleanly (GOAWAY) or drops it.
 	kp := keepalive.ClientParameters{
 		Time:                30 * time.Second,
 		Timeout:             10 * time.Second,
@@ -31,6 +29,14 @@ func Connect(address, caCertFile string, skipVerify bool) (*grpc.ClientConn, err
 	conn, err := grpc.NewClient(address,
 		grpc.WithTransportCredentials(creds),
 		grpc.WithKeepaliveParams(kp),
+		// TCP-level keepalive: the OS probes the peer every 15s. This catches
+		// half-open connections (e.g. NAT state expired, Docker network
+		// restarted) where no RST is sent — the Linux default without this is
+		// ~2 hours, causing the agent to appear stuck until manually restarted.
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			d := &net.Dialer{KeepAlive: 15 * time.Second}
+			return d.DialContext(ctx, "tcp", addr)
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to %s: %w", address, err)

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/infrawatch/agent/internal/checks"
 	"github.com/infrawatch/agent/internal/updater"
 	agentv1 "github.com/infrawatch/proto/agent/v1"
@@ -20,7 +22,11 @@ import (
 
 // Runner manages the bidirectional heartbeat stream with the ingest service.
 type Runner struct {
-	client   agentv1.IngestServiceClient
+	// dialFunc creates a fresh gRPC connection for each stream attempt. A new
+	// connection is used every time rather than reusing a long-lived ClientConn
+	// because gRPC's internal TRANSIENT_FAILURE state can get stuck after a
+	// server restart — a fresh connection always starts clean.
+	dialFunc func() (*grpc.ClientConn, error)
 	agentID  string
 	jwtToken string
 	version  string
@@ -46,10 +52,12 @@ type Runner struct {
 	resultsReady chan struct{}
 }
 
-// New creates a new heartbeat Runner.
-func New(client agentv1.IngestServiceClient, agentID, jwtToken, version string, intervalSecs int, executor *checks.Executor) *Runner {
+// New creates a new heartbeat Runner. dialFunc is called once per stream
+// attempt to obtain a fresh gRPC connection; the runner closes it when the
+// stream ends.
+func New(dialFunc func() (*grpc.ClientConn, error), agentID, jwtToken, version string, intervalSecs int, executor *checks.Executor) *Runner {
 	return &Runner{
-		client:       client,
+		dialFunc:     dialFunc,
 		agentID:      agentID,
 		jwtToken:     jwtToken,
 		version:      version,
@@ -97,7 +105,13 @@ func (r *Runner) Run(ctx context.Context) error {
 }
 
 func (r *Runner) runStream(ctx context.Context) error {
-	stream, err := r.client.Heartbeat(ctx)
+	conn, err := r.dialFunc()
+	if err != nil {
+		return fmt.Errorf("connecting to ingest: %w", err)
+	}
+	defer conn.Close()
+
+	stream, err := agentv1.NewIngestServiceClient(conn).Heartbeat(ctx)
 	if err != nil {
 		return fmt.Errorf("opening heartbeat stream: %w", err)
 	}

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -89,7 +89,7 @@ func main() {
 	grpcErr := make(chan error, 1)
 	go func() {
 		slog.Info("gRPC server starting", "port", cfg.GRPCPort)
-		grpcErr <- ingestgrpc.Serve(cfg.GRPCPort, creds, regHandler, hbHandler)
+		grpcErr <- ingestgrpc.Serve(ctx, cfg.GRPCPort, creds, regHandler, hbHandler)
 	}()
 
 	select {

--- a/apps/ingest/internal/grpc/server.go
+++ b/apps/ingest/internal/grpc/server.go
@@ -3,6 +3,7 @@ package ingestgrpc
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"time"
 
@@ -30,8 +31,12 @@ func (s *ingestService) Heartbeat(stream agentv1.IngestService_HeartbeatServer) 
 }
 
 // Serve starts the gRPC server on the given port with TLS credentials.
-// Blocks until the server stops.
-func Serve(port int, creds credentials.TransportCredentials, reg *handlers.RegisterHandler, hb *handlers.HeartbeatHandler) error {
+// Blocks until the server stops. When ctx is cancelled (e.g. SIGTERM), Serve
+// sends a gRPC GOAWAY to all connected agents so they reconnect immediately
+// rather than hitting exponential backoff. If streams don't drain within 30s,
+// the server is force-stopped — this covers the case where a container is
+// killed before context cancellation can propagate.
+func Serve(ctx context.Context, port int, creds credentials.TransportCredentials, reg *handlers.RegisterHandler, hb *handlers.HeartbeatHandler) error {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return fmt.Errorf("listening on :%d: %w", port, err)
@@ -60,6 +65,26 @@ func Serve(port int, creds credentials.TransportCredentials, reg *handlers.Regis
 
 	svc := &ingestService{reg: reg, hb: hb}
 	agentv1.RegisterIngestServiceServer(grpcServer, svc)
+
+	// Graceful shutdown on context cancellation. GracefulStop sends GOAWAY
+	// so agents reconnect immediately; Stop is the hard fallback if streams
+	// don't drain within 30s (e.g. a long-running check is in flight).
+	go func() {
+		<-ctx.Done()
+		slog.Info("gRPC server shutting down gracefully")
+		stopped := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(stopped)
+		}()
+		select {
+		case <-stopped:
+			slog.Info("gRPC server stopped gracefully")
+		case <-time.After(30 * time.Second):
+			slog.Warn("graceful stop timed out, forcing shutdown")
+			grpcServer.Stop()
+		}
+	}()
 
 	return grpcServer.Serve(lis)
 }

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -19,6 +19,10 @@ import Link from 'next/link'
 import {
   LineChart,
   Line,
+  BarChart,
+  Bar,
+  Cell,
+  ReferenceLine,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -37,8 +41,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { getHost, getHostMetrics, getAgentOfflinePeriods } from '@/lib/actions/agents'
-import type { HostWithAgent, MetricsRange, OfflinePeriod } from '@/lib/actions/agents'
+import { getHost, getHostMetrics, getAgentOfflinePeriods, getHeartbeatHistory } from '@/lib/actions/agents'
+import type { HostWithAgent, MetricsRange, OfflinePeriod, HeartbeatPoint } from '@/lib/actions/agents'
 import { useHostStream } from '@/hooks/use-host-stream'
 import type { DiskInfo, NetworkInterface } from '@/lib/db/schema'
 import { ChecksTab } from './checks-tab'
@@ -194,6 +198,13 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, late
         ? getAgentOfflinePeriods(orgId, initialHost.agentId, metricsRange)
         : Promise.resolve([]),
     enabled: activeTab === 'metrics' && !!initialHost.agentId,
+    refetchInterval: 60_000,
+  })
+
+  const { data: heartbeatData = [] } = useQuery<HeartbeatPoint[]>({
+    queryKey: ['host-heartbeat-history', orgId, initialHost.id, metricsRange],
+    queryFn: () => getHeartbeatHistory(orgId, initialHost.id, metricsRange),
+    enabled: activeTab === 'metrics',
     refetchInterval: 60_000,
   })
 
@@ -514,86 +525,172 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, late
               </CardContent>
             </Card>
           ) : (
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base flex items-center gap-2">
-                  <Activity className="size-4 text-muted-foreground" />
-                  CPU, Memory &amp; Disk Usage (%)
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={320}>
-                  <LineChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-                    <XAxis
-                      dataKey="time"
-                      type="number"
-                      scale="time"
-                      domain={['dataMin', () => Date.now()]}
-                      tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
-                      tickLine={false}
-                      tickFormatter={(ts: number) => format(new Date(ts), tickFormat)}
-                      interval="preserveStartEnd"
-                    />
-                    <YAxis
-                      domain={[0, 100]}
-                      tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
-                      tickLine={false}
-                      tickFormatter={(v: number) => `${v}%`}
-                      width={40}
-                    />
-                    <Tooltip
-                      formatter={(value) => [`${value}%`]}
-                      labelFormatter={(ts) => format(new Date(Number(ts)), 'MMM d HH:mm:ss')}
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--popover))',
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '6px',
-                        color: 'hsl(var(--popover-foreground))',
-                        fontSize: '12px',
-                      }}
-                    />
-                    <Legend
-                      wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }}
-                    />
-                    {offlinePeriods.map((period, i) => (
-                      <ReferenceArea
-                        key={i}
-                        x1={period.start}
-                        x2={period.end ?? Date.now()}
-                        fill="hsl(220, 13%, 60%)"
-                        fillOpacity={0.15}
-                        label={{ value: 'Offline', position: 'insideTop', fontSize: 11, fill: 'hsl(220, 13%, 30%)', fontWeight: 500 }}
+            <>
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Activity className="size-4 text-muted-foreground" />
+                    CPU, Memory &amp; Disk Usage (%)
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={320}>
+                    <LineChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                      <XAxis
+                        dataKey="time"
+                        type="number"
+                        scale="time"
+                        domain={['dataMin', () => Date.now()]}
+                        tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                        tickLine={false}
+                        tickFormatter={(ts: number) => format(new Date(ts), tickFormat)}
+                        interval="preserveStartEnd"
                       />
-                    ))}
-                    <Line
-                      type="monotone"
-                      dataKey="cpu"
-                      name="CPU"
-                      stroke="hsl(221, 83%, 53%)"
-                      dot={false}
-                      strokeWidth={2}
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="memory"
-                      name="Memory"
-                      stroke="hsl(142, 71%, 45%)"
-                      dot={false}
-                      strokeWidth={2}
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="disk"
-                      name="Disk"
-                      stroke="hsl(38, 92%, 50%)"
-                      dot={false}
-                      strokeWidth={2}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
+                      <YAxis
+                        domain={[0, 100]}
+                        tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                        tickLine={false}
+                        tickFormatter={(v: number) => `${v}%`}
+                        width={40}
+                      />
+                      <Tooltip
+                        formatter={(value) => [`${value}%`]}
+                        labelFormatter={(ts) => format(new Date(Number(ts)), 'MMM d HH:mm:ss')}
+                        contentStyle={{
+                          backgroundColor: 'hsl(var(--popover))',
+                          border: '1px solid hsl(var(--border))',
+                          borderRadius: '6px',
+                          color: 'hsl(var(--popover-foreground))',
+                          fontSize: '12px',
+                        }}
+                      />
+                      <Legend
+                        wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }}
+                      />
+                      {offlinePeriods.map((period, i) => (
+                        <ReferenceArea
+                          key={i}
+                          x1={period.start}
+                          x2={period.end ?? Date.now()}
+                          fill="hsl(220, 13%, 60%)"
+                          fillOpacity={0.15}
+                          label={{ value: 'Offline', position: 'insideTop', fontSize: 11, fill: 'hsl(220, 13%, 30%)', fontWeight: 500 }}
+                        />
+                      ))}
+                      <Line
+                        type="monotone"
+                        dataKey="cpu"
+                        name="CPU"
+                        stroke="hsl(221, 83%, 53%)"
+                        dot={false}
+                        strokeWidth={2}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="memory"
+                        name="Memory"
+                        stroke="hsl(142, 71%, 45%)"
+                        dot={false}
+                        strokeWidth={2}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="disk"
+                        name="Disk"
+                        stroke="hsl(38, 92%, 50%)"
+                        dot={false}
+                        strokeWidth={2}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Activity className="size-4 text-muted-foreground" />
+                    Heartbeat Interval
+                    <span className="text-xs font-normal text-muted-foreground">
+                      — seconds between consecutive heartbeats
+                      {metricsRange !== '1h' && ' (max per bucket)'}
+                    </span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {heartbeatData.length === 0 ? (
+                    <p className="text-sm text-muted-foreground text-center py-8">
+                      No heartbeat data for this period.
+                    </p>
+                  ) : (
+                    <ResponsiveContainer width="100%" height={200}>
+                      <BarChart data={heartbeatData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" className="stroke-border" vertical={false} />
+                        <XAxis
+                          dataKey="time"
+                          type="number"
+                          scale="time"
+                          domain={['dataMin', () => Date.now()]}
+                          tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                          tickLine={false}
+                          tickFormatter={(ts: number) => format(new Date(ts), tickFormat)}
+                          interval="preserveStartEnd"
+                        />
+                        <YAxis
+                          tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }}
+                          tickLine={false}
+                          tickFormatter={(v: number) => `${v}s`}
+                          width={40}
+                        />
+                        <Tooltip
+                          formatter={(value) => [`${value}s`, 'Interval']}
+                          labelFormatter={(ts) => format(new Date(Number(ts)), 'MMM d HH:mm:ss')}
+                          contentStyle={{
+                            backgroundColor: 'hsl(var(--popover))',
+                            border: '1px solid hsl(var(--border))',
+                            borderRadius: '6px',
+                            color: 'hsl(var(--popover-foreground))',
+                            fontSize: '12px',
+                          }}
+                        />
+                        {/* Expected heartbeat interval reference line */}
+                        <ReferenceLine
+                          y={30}
+                          stroke="hsl(var(--muted-foreground))"
+                          strokeDasharray="4 2"
+                          strokeOpacity={0.5}
+                          label={{ value: '30s', position: 'insideTopRight', fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                        />
+                        {offlinePeriods.map((period, i) => (
+                          <ReferenceArea
+                            key={i}
+                            x1={period.start}
+                            x2={period.end ?? Date.now()}
+                            fill="hsl(220, 13%, 60%)"
+                            fillOpacity={0.15}
+                          />
+                        ))}
+                        <Bar dataKey="intervalSecs" name="Interval" radius={[2, 2, 0, 0]} maxBarSize={24}>
+                          {heartbeatData.map((entry, i) => (
+                            <Cell
+                              key={i}
+                              fill={
+                                entry.intervalSecs <= 45
+                                  ? 'hsl(142, 71%, 45%)'
+                                  : entry.intervalSecs <= 120
+                                    ? 'hsl(38, 92%, 50%)'
+                                    : 'hsl(0, 84%, 60%)'
+                              }
+                            />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </CardContent>
+              </Card>
+            </>
           )}
         </div>
       )}

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -317,6 +317,94 @@ export async function getAgentOfflinePeriods(
   return periods
 }
 
+export type HeartbeatPoint = { time: number; intervalSecs: number }
+
+export async function getHeartbeatHistory(
+  orgId: string,
+  hostId: string,
+  range: MetricsRange,
+): Promise<HeartbeatPoint[]> {
+  const hours = range === '1h' ? 1 : range === '24h' ? 24 : 168
+  const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000)
+
+  if (range === '1h') {
+    // Individual intervals — LAG() gives the gap between consecutive heartbeats
+    const rows = await db.execute<{ recorded_at: string; interval_secs: number | null }>(sql`
+      SELECT
+        recorded_at,
+        EXTRACT(EPOCH FROM (
+          recorded_at - LAG(recorded_at) OVER (ORDER BY recorded_at)
+        ))::float AS interval_secs
+      FROM host_metrics
+      WHERE organisation_id = ${orgId}
+        AND host_id         = ${hostId}
+        AND recorded_at    >= ${cutoff}
+      ORDER BY recorded_at ASC
+    `)
+    return Array.from(rows)
+      .filter((r) => r.interval_secs != null)
+      .map((r) => ({
+        time: new Date(r.recorded_at).getTime(),
+        intervalSecs: parseFloat(Number(r.interval_secs).toFixed(1)),
+      }))
+  }
+
+  // 24h/7d: bucket by 5-minute or 1-hour windows and take the MAX gap per
+  // bucket so outages are visible even when there are many healthy heartbeats
+  // in the same window. Uses TimescaleDB time_bucket; falls back to raw LAG
+  // on plain PostgreSQL.
+  const bucketInterval = range === '24h' ? sql.raw("'5 minutes'") : sql.raw("'1 hour'")
+  try {
+    const rows = await db.execute<{ bucket: string; max_interval_secs: number | null }>(sql`
+      WITH intervals AS (
+        SELECT
+          recorded_at,
+          EXTRACT(EPOCH FROM (
+            recorded_at - LAG(recorded_at) OVER (ORDER BY recorded_at)
+          ))::float AS interval_secs
+        FROM host_metrics
+        WHERE organisation_id = ${orgId}
+          AND host_id         = ${hostId}
+          AND recorded_at    >= ${cutoff}
+      )
+      SELECT
+        time_bucket(${bucketInterval}::interval, recorded_at) AS bucket,
+        MAX(interval_secs)                                     AS max_interval_secs
+      FROM intervals
+      WHERE interval_secs IS NOT NULL
+      GROUP BY bucket
+      ORDER BY bucket ASC
+    `)
+    return Array.from(rows)
+      .filter((r) => r.max_interval_secs != null)
+      .map((r) => ({
+        time: new Date(r.bucket).getTime(),
+        intervalSecs: parseFloat(Number(r.max_interval_secs).toFixed(1)),
+      }))
+  } catch {
+    // Plain PostgreSQL fallback — raw intervals, capped to avoid massive payloads
+    const rows = await db.execute<{ recorded_at: string; interval_secs: number | null }>(sql`
+      SELECT
+        recorded_at,
+        EXTRACT(EPOCH FROM (
+          recorded_at - LAG(recorded_at) OVER (ORDER BY recorded_at)
+        ))::float AS interval_secs
+      FROM host_metrics
+      WHERE organisation_id = ${orgId}
+        AND host_id         = ${hostId}
+        AND recorded_at    >= ${cutoff}
+      ORDER BY recorded_at ASC
+      LIMIT 500
+    `)
+    return Array.from(rows)
+      .filter((r) => r.interval_secs != null)
+      .map((r) => ({
+        time: new Date(r.recorded_at).getTime(),
+        intervalSecs: parseFloat(Number(r.interval_secs).toFixed(1)),
+      }))
+  }
+}
+
 export async function getHost(orgId: string, hostId: string): Promise<HostWithAgent | null> {
   const rows = await db
     .select()


### PR DESCRIPTION
## Summary

- **Root cause fix**: agent's `*grpc.ClientConn` could get stuck in gRPC's `TRANSIENT_FAILURE` state after a server restart, causing the reconnect loop to spin indefinitely on a broken connection — a manual agent restart (fresh `ClientConn`) was the only recovery. Now `heartbeat.Runner` dials a fresh connection per stream attempt, eliminating stale connection state entirely.
- **TCP keepalive**: added `SO_KEEPALIVE` at 15s via a custom dialer. Linux's default (~2 hours) meant half-open connections caused by NAT expiry or Docker bridge restarts went undetected for hours.
- **Graceful ingest shutdown**: `SIGTERM` now triggers `grpcServer.GracefulStop()` (HTTP/2 `GOAWAY`) so agents reconnect immediately rather than hitting exponential backoff; hard-stops after 30s if streams don't drain.
- **Heartbeat interval chart**: new bar chart on the host metrics tab showing seconds between consecutive agent heartbeats. Colour-coded green/amber/red; dashed 30s reference line; uses `time_bucket` + `MAX` for 24h/7d ranges so gaps remain visible alongside healthy heartbeats.

## Test plan

- [ ] Start ingest, connect agent, run `start.sh` — agent should reconnect without a manual restart, faster than before
- [ ] Verify `docker logs` shows "gRPC server shutting down gracefully" on `docker compose down`
- [ ] Open a host detail page → Metrics tab — heartbeat interval chart appears below the CPU/memory/disk chart
- [ ] Simulate an offline period and confirm red bars appear in the heartbeat chart for that window
- [ ] Confirm 1h / 24h / 7d range selector updates both charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)