### PR TITLE
fix(web): agent self-update 503 — baked fallback + manifest version sync

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -71,6 +71,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/
 # Release-please manifest — read at runtime to determine the required agent version
 COPY --from=builder --chown=nextjs:nodejs /app/.release-please-manifest.json /app/.release-please-manifest.json
 
+# Agent binaries — baked into the image as a bootstrap fallback for air-gapped
+# deployments where the operator-managed agent_dist volume starts empty and
+# GitHub is unreachable. The download route checks this directory last.
+COPY --chown=nextjs:nodejs apps/web/data/agent-dist ./apps/web/data/agent-dist
+
 # Migration script — from builder stage (same source, no caching concern)
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/migrate.js ./apps/web/migrate.js
 # Migration SQL files — copied DIRECTLY from the build context so this layer is always

--- a/apps/web/app/api/agent/download/route.ts
+++ b/apps/web/app/api/agent/download/route.ts
@@ -24,10 +24,11 @@ const SUPPORTED_ARCH = ['amd64', 'arm64']
  * Serves the agent binary for the required version (pinned in lib/agent/version.ts).
  *
  * Resolution order:
- *   1. Versioned local file (infrawatch-agent-linux-amd64-v0.1.0) — served immediately if cached
+ *   1. Versioned local file in AGENT_DIST_DIR — served immediately if cached
  *   2. GitHub Release for the required version — downloads, caches, then serves
- *   3. Unversioned fallback (manually built via `make agent`) — for local dev without releases
- *   4. 503 if nothing available
+ *   3. Unversioned file in AGENT_DIST_DIR — operator-managed volume / local dev
+ *   4. Unversioned file baked into image (data/agent-dist/) — air-gap bootstrap
+ *   5. 503 if nothing available
  *
  * Query params: os (linux|darwin|windows), arch (amd64|arm64)
  */
@@ -73,18 +74,31 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // ── 3: Unversioned fallback (locally built via `make agent`) ──────────────
+  // ── 3: Unversioned fallback (operator-managed volume / AGENT_DIST_DIR) ────
   const unversionedPath = path.join(AGENT_DIST_DIR, baseName)
   if (fs.existsSync(unversionedPath)) {
     return streamFile(unversionedPath, baseName)
   }
 
-  // ── 4: Nothing available ──────────────────────────────────────────────────
+  // ── 4: Baked-in fallback (copied into image at build time) ────────────────
+  // Essential for air-gapped deployments where GitHub is unreachable and the
+  // operator-managed volume hasn't been seeded yet. AGENT_DIST_DIR may point
+  // to a named Docker volume that starts empty; this directory is always present.
+  const bakedDistDir = path.join(process.cwd(), 'data/agent-dist')
+  if (path.resolve(bakedDistDir) !== path.resolve(AGENT_DIST_DIR)) {
+    const bakedPath = path.join(bakedDistDir, baseName)
+    if (fs.existsSync(bakedPath)) {
+      return streamFile(bakedPath, baseName)
+    }
+  }
+
+  // ── 5: Nothing available ──────────────────────────────────────────────────
   return NextResponse.json(
     {
       error:
         `No binary available for ${os}/${arch} (required version: ${REQUIRED_AGENT_VERSION}). ` +
-        `Ensure a GitHub release exists for tag "agent/${REQUIRED_AGENT_VERSION}" in ${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}.`,
+        `Either place a binary in AGENT_DIST_DIR (${AGENT_DIST_DIR}) or ensure a GitHub release ` +
+        `exists for tag "agent/${REQUIRED_AGENT_VERSION}" in ${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}.`,
     },
     { status: 503 }
   )


### PR DESCRIPTION
## Summary

- **Manifest stale**: `.release-please-manifest.json` had agent `0.11.1` while GitHub reported `0.12.0` as latest — the download route was fetching `agent/v0.11.1` from GitHub (no binary assets), causing step 2 to silently fail
- **Empty volume, no fallback**: `docker-compose.single.yml` points `AGENT_DIST_DIR` to a named Docker volume that starts empty; the Dockerfile never baked `data/agent-dist/` into the image, so the unversioned fallback also found nothing → 503
- **Fix**: bump manifest to `0.12.0`, COPY agent binaries into the runner image stage, and add a step 4 to the download route that checks the baked-in `data/agent-dist/` when it differs from `AGENT_DIST_DIR`

## Test plan

- [ ] Restart the web container and confirm `/api/agent/download?os=linux&arch=amd64` returns 200 with a binary
- [ ] Confirm agent on almalinux9 successfully updates from v0.11.3 → v0.12.0 (no more `download returned HTTP 503` in logs)
- [ ] Confirm behaviour with an empty `agent_dist` volume (baked-in fallback should serve the binary)
- [ ] Confirm behaviour when GitHub is unreachable (air-gap simulation) — baked-in fallback should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)