### PR TITLE
fix(web): fix EACCES on agent-dist volume mount

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -54,7 +54,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN addgroup --system --gid 1001 nodejs && \
+RUN apk add --no-cache su-exec && \
+    addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # In a pnpm monorepo, Next.js standalone mirrors the full workspace structure.
@@ -88,7 +89,9 @@ COPY --chown=nextjs:nodejs apps/web/lib/db/migrations ./apps/web/lib/db/migratio
 COPY --from=deps --chown=nextjs:nodejs /migrate-deps/drizzle-orm ./node_modules/drizzle-orm
 COPY --from=deps --chown=nextjs:nodejs /migrate-deps/postgres ./node_modules/postgres
 
-USER nextjs
+# Entrypoint: runs as root, fixes agent-dist volume ownership, then drops to nextjs
+COPY apps/web/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 3000
 
@@ -97,4 +100,4 @@ ENV HOSTNAME="0.0.0.0"
 
 # server.js is at /app/apps/web/server.js after the standalone copy
 WORKDIR /app/apps/web
-CMD ["sh", "-c", "node migrate.js && node server.js"]
+CMD ["/entrypoint.sh"]

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Ensure the agent-dist volume mount is writable by the nextjs user.
+# Docker named volumes are created as root; this fixes ownership on each start.
+if [ -d "/var/lib/infrawatch/agent-dist" ]; then
+  chown -R nextjs:nodejs /var/lib/infrawatch/agent-dist
+fi
+
+exec su-exec nextjs sh -c "node migrate.js && node server.js"


### PR DESCRIPTION
## Summary

- Docker named volumes are created owned by `root`, causing the `nextjs` user (uid 1001) to get `EACCES: permission denied` when writing downloaded agent binaries to `/var/lib/infrawatch/agent-dist`
- Adds `apps/web/entrypoint.sh` — runs as root on startup, `chown`s the volume to `nextjs:nodejs`, then uses `su-exec` to drop privileges before handing off to `node migrate.js && node server.js`
- Installs `su-exec` in the runner stage and removes the `USER nextjs` Dockerfile directive (privilege drop is now handled by the entrypoint instead)

The app still runs as `nextjs` — only the thin startup script runs as root.

## Test plan

- [ ] Rebuild image: `docker compose -f docker-compose.single.yml up --build -d web`
- [ ] Check logs — no more `EACCES` errors on agent-dist downloads
- [ ] Verify agent binaries are downloaded and cached successfully
- [ ] Confirm the running process is `nextjs` (not root): `docker exec <container> ps aux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)