### PR TITLE
fix(web): resolve Failed to find Server Action errors on certificates pages

### DIFF
--- a/apps/web/app/(dashboard)/certificates/certificates-client.tsx
+++ b/apps/web/app/(dashboard)/certificates/certificates-client.tsx
@@ -25,8 +25,6 @@ import {
 } from '@/components/ui/table'
 import { CertificateStatusBadge } from '@/components/certificates/certificate-status-badge'
 import {
-  getCertificates,
-  getCertificateCounts,
   deleteCertificate,
   type CertificateCounts,
   type CertificateListFilters,
@@ -101,12 +99,31 @@ export function CertificatesClient({
 
   const { data: certs = initialCertificates } = useQuery({
     queryKey: ['certificates', orgId, filters],
-    queryFn: () => getCertificates(orgId, filters),
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        ...(filters.status ? { status: filters.status } : {}),
+        ...(filters.host ? { host: filters.host } : {}),
+        sortBy: filters.sortBy ?? 'not_after',
+        sortDir: filters.sortDir ?? 'asc',
+        limit: String(filters.limit ?? 100),
+      })
+      const res = await fetch(`/api/certificates?${params}`)
+      if (!res.ok) throw new Error('Failed to fetch certificates')
+      return res.json() as Promise<Certificate[]>
+    },
+    initialData: initialCertificates,
+    staleTime: 30_000,
   })
 
   const { data: counts = initialCounts } = useQuery({
     queryKey: ['certificate-counts', orgId],
-    queryFn: () => getCertificateCounts(orgId),
+    queryFn: async () => {
+      const res = await fetch('/api/certificates/counts')
+      if (!res.ok) throw new Error('Failed to fetch certificate counts')
+      return res.json() as Promise<CertificateCounts>
+    },
+    initialData: initialCounts,
+    staleTime: 30_000,
   })
 
   const deleteMutation = useMutation({

--- a/apps/web/app/api/certificates/counts/route.ts
+++ b/apps/web/app/api/certificates/counts/route.ts
@@ -1,0 +1,26 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { db } from '@/lib/db'
+import { users } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { getCertificateCounts } from '@/lib/actions/certificates'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/certificates/counts
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+  })
+  if (!user?.organisationId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const counts = await getCertificateCounts(user.organisationId)
+  return Response.json(counts)
+}

--- a/apps/web/app/api/certificates/route.ts
+++ b/apps/web/app/api/certificates/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server'
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { db } from '@/lib/db'
+import { users } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { getCertificates } from '@/lib/actions/certificates'
+import type { CertificateListFilters } from '@/lib/actions/certificates'
+import type { CertificateStatus } from '@/lib/db/schema'
+
+export const dynamic = 'force-dynamic'
+
+// GET /api/certificates?status=valid&host=foo&sortBy=not_after&sortDir=asc&limit=100&offset=0
+export async function GET(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+  })
+  if (!user?.organisationId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { searchParams } = request.nextUrl
+  const filters: CertificateListFilters = {
+    status: (searchParams.get('status') as CertificateStatus) ?? undefined,
+    host: searchParams.get('host') ?? undefined,
+    sortBy: (searchParams.get('sortBy') as CertificateListFilters['sortBy']) ?? undefined,
+    sortDir: (searchParams.get('sortDir') as 'asc' | 'desc') ?? undefined,
+    limit: searchParams.has('limit') ? Number(searchParams.get('limit')) : undefined,
+    offset: searchParams.has('offset') ? Number(searchParams.get('offset')) : undefined,
+  }
+
+  const certificates = await getCertificates(user.organisationId, filters)
+  return Response.json(certificates)
+}


### PR DESCRIPTION
## Summary

- Fixes consistent `Failed to find Server Action` errors when navigating to the certificates list and detail pages
- Root cause: server actions (`use server`) are POST-only and identified by a build-time hash; calling them from TanStack Query's `queryFn` fails in production standalone Docker builds when client/server bundles drift between deployments
- Replaces server action `queryFn` calls with proper `GET` API routes that TanStack Query can fetch reliably

## Changes

- **`/certificates/[id]`** — remove `useQuery` wrapping `getCertificate`; page already SSR-fetches and passes data as props so no client refetch is needed
- **`/certificates`** — replace `getCertificates` and `getCertificateCounts` server action calls in `queryFn` with `fetch()` calls to two new route handlers:
  - `GET /api/certificates` — accepts filter/sort/pagination query params
  - `GET /api/certificates/counts` — returns status counts
- Add `initialData` and `staleTime: 30s` to prevent unnecessary refetches on mount
- Mutations (`deleteCertificate`) continue using server actions, which is the correct pattern

## Test plan

- [ ] Certificates list page loads and displays certificates without console errors
- [ ] Filtering by status, host, and sort order triggers a clean refetch via the new API route
- [ ] Clicking a certificate navigates to the detail page without error
- [ ] Deleting a certificate still works (mutation path unchanged)
- [ ] No `Failed to find Server Action` errors in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)