### PR TITLE
fix(web): fix certificate page crashes — server action mismatches and invalid date RangeError

### DIFF
--- a/apps/web/app/(dashboard)/certificates/[id]/certificate-detail-client.tsx
+++ b/apps/web/app/(dashboard)/certificates/[id]/certificate-detail-client.tsx
@@ -192,12 +192,12 @@ export function CertificateDetailClient({ orgId: _orgId, initialCertificate, ini
                 </TableHeader>
                 <TableBody>
                   {details.chain.map((entry, i) => (
-                    <TableRow key={entry.fingerprintSha256}>
+                    <TableRow key={entry.fingerprint_sha256}>
                       <TableCell className="text-muted-foreground">{i + 1}</TableCell>
                       <TableCell className="font-mono text-xs max-w-52 truncate">{entry.subject}</TableCell>
                       <TableCell className="font-mono text-xs max-w-52 truncate">{entry.issuer}</TableCell>
                       <TableCell className="text-sm">
-                        {format(new Date(entry.notAfter), 'MMM d, yyyy')}
+                        {format(new Date(entry.not_after), 'MMM d, yyyy')}
                       </TableCell>
                     </TableRow>
                   ))}

--- a/apps/web/lib/db/schema/certificates.ts
+++ b/apps/web/lib/db/schema/certificates.ts
@@ -7,9 +7,9 @@ import { checks } from './checks'
 export interface CertificateChainEntry {
   subject: string
   issuer: string
-  notBefore: string      // ISO
-  notAfter: string
-  fingerprintSha256: string
+  not_before: string      // ISO — matches Go json:"not_before" tag
+  not_after: string       // ISO — matches Go json:"not_after" tag
+  fingerprint_sha256: string  // matches Go json:"fingerprint_sha256" tag
 }
 
 export interface CertificateDetails {


### PR DESCRIPTION
## Summary

Three bugs fixed that together caused the certificate pages to crash in production Docker deployments:

- **`Failed to find Server Action` on certificates list** — `getCertificates` and `getCertificateCounts` were called from TanStack Query `queryFn` as server actions (POST-based). Replaced with proper `GET /api/certificates` and `GET /api/certificates/counts` route handlers. Added `initialData` and `staleTime` so SSR data is used on first render.
- **`Failed to find Server Action` on certificate detail** — `getCertificate` was wrapped in `useQuery` unnecessarily. The page already SSR-fetches and passes data as props; the client component now uses those props directly.
- **`RangeError: Invalid time value` in certificate chain table** — `CertificateChainEntry` TypeScript interface used camelCase field names (`notAfter`, `fingerprintSha256`) but the Go ingest handler serialises chain entries with snake_case JSON tags (`not_after`, `fingerprint_sha256`). Every chain date read returned `undefined`, causing `date-fns` to throw during SSR. Interface and component updated to match the actual JSON keys.

## Changes

- `app/api/certificates/route.ts` — new `GET` handler for certificate list with filter params
- `app/api/certificates/counts/route.ts` — new `GET` handler for certificate counts
- `app/(dashboard)/certificates/certificates-client.tsx` — use fetch-based `queryFn` for both queries
- `app/(dashboard)/certificates/[id]/certificate-detail-client.tsx` — remove `useQuery`, use SSR props directly; fix chain entry field names
- `lib/db/schema/certificates.ts` — correct `CertificateChainEntry` interface to snake_case

## Test plan

- [ ] Certificates list page loads without console errors
- [ ] Filtering by status, host, and sort triggers a refetch via the new API route
- [ ] Clicking a certificate navigates to the detail page without crashing
- [ ] Certificate chain table renders with correct expiry dates
- [ ] Deleting a certificate works (mutation unchanged)
- [ ] No `Failed to find Server Action` or `RangeError` in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)