### PR TITLE
fix: session 17 — certificate page bugs, CI fixes, cert_file check type

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,14 +6,38 @@
 ---
 
 ## Current Phase
-**Phase 3 — Certificate Management**
+**Phase 3 — Certificate Management (bug fixes)**
 
 ## Current Status
-🟢 Phase 3 complete — Certificate lifecycle management fully built. Agent performs TLS certificate checks via a new `certificate` check type, reports a structured JSON `CertificateReport` payload. Ingest persists certificates to the DB with upsert semantics, renewal detection, and event history. Web UI provides an inventory page at `/certificates` with summary cards and sortable/filterable table, plus a detail page showing SANs, chain, fingerprint, and event timeline. Alert system extended with `cert_expiry` condition type; per-org evaluator fires/resolves on every cert scan and a background sweeper runs every 15 minutes.
+🟢 Phase 3 complete and stable — Certificate lifecycle management fully built and production bugs resolved. Agent performs TLS certificate checks via a new `certificate` check type, reports a structured JSON `CertificateReport` payload. Ingest persists certificates to the DB with upsert semantics, renewal detection, and event history. Web UI provides an inventory page at `/certificates` with summary cards and sortable/filterable table, plus a detail page showing SANs, chain, fingerprint, and event timeline. Alert system extended with `cert_expiry` condition type; per-org evaluator fires/resolves on every cert scan and a background sweeper runs every 15 minutes. Production Docker deployment bugs fixed: server action mismatches on certificate pages resolved via proper API routes; certificate chain date rendering crash fixed.
 
 ---
 
 ## What Has Been Built
+
+### Session 17 — Certificate page production bug fixes
+
+**Problem 1: `Failed to find Server Action` on certificates list and detail pages**
+- Root cause: `getCertificates`, `getCertificateCounts`, and `getCertificate` were all called from TanStack Query `queryFn` inside client components. Server actions use POST and are identified by a build-time hash; in production standalone Docker builds, client and server bundles can have drifted action IDs across deployments, causing Next.js to reject the requests.
+- Fix (list page): added `GET /api/certificates` and `GET /api/certificates/counts` route handlers (`apps/web/app/api/certificates/route.ts`, `apps/web/app/api/certificates/counts/route.ts`). `CertificatesClient` `queryFn` now uses `fetch()` against these routes. Added `initialData` and `staleTime: 30s` so SSR data is used on first render without an immediate refetch.
+- Fix (detail page): removed `useQuery` from `CertificateDetailClient` entirely — the server page already SSR-fetches the certificate and passes it as props, so no client-side refetch was needed.
+- `deleteCertificate` mutation continues to use the server action (correct pattern — mutations are the intended use case for server actions).
+
+**Problem 2: `RangeError: Invalid time value` crash on certificate chain table**
+- Root cause: `CertificateChainEntry` TypeScript interface in `apps/web/lib/db/schema/certificates.ts` declared fields as camelCase (`notAfter`, `notBefore`, `fingerprintSha256`) but the Go ingest handler serialises `certChainEntry` with snake_case JSON tags (`not_after`, `not_before`, `fingerprint_sha256`). Every read of `entry.notAfter` in the chain table returned `undefined` → `new Date(undefined)` → Invalid Date → `date-fns format()` threw `RangeError: Invalid time value` during SSR, crashing the detail page.
+- Fix: corrected `CertificateChainEntry` to use snake_case keys matching the Go JSON output; updated the chain table in `certificate-detail-client.tsx` to use `entry.not_after` and `entry.fingerprint_sha256`.
+
+**Other fixes on this branch (not yet merged to main at session start)**
+- `fix(ci)`: tracked `agent-dist` directory so Docker `COPY` succeeds in CI (`288291d`)
+- `feat(checks)`: added `cert_file` check type to Add Check dialog and fixed cert JSON display (`9ad2882`)
+- `fix(ci)`: bumped ingest Dockerfile to `golang:1.25-alpine` (`3c5ef71`)
+- `fix(web)`: fixed EACCES on `agent-dist` volume mount by switching to root entrypoint with `su-exec` privilege drop (`909494d`)
+
+**Build state**
+- `pnpm run build` (apps/web) — zero TypeScript errors ✅
+- `GET /api/certificates` and `GET /api/certificates/counts` routes appear in build output ✅
+
+---
 
 ### Session 16 — Phase 3 Certificate Management
 


### PR DESCRIPTION
## Summary

**Session 17 — Certificate page bug fixes:**
- **fix(web)**: Replace server action `queryFn` calls with API routes on certificates pages — eliminates `Failed to find Server Action` in production
- **fix(web)**: Correct `CertificateChainEntry` interface to snake_case keys matching Go JSON — fixes `RangeError: Invalid time value` crash on certificate detail page
- **fix(web)**: Stop calling server action from `useQuery` on certificate detail page (SSR already provides data as props)
- **fix(web)**: Fix EACCES on `agent-dist` volume mount via root entrypoint + `su-exec` privilege drop
- **fix(ci)**: Track `agent-dist` directory so Docker `COPY` succeeds in CI
- **fix(ci)**: Bump ingest Dockerfile to `golang:1.25-alpine`
- **feat(checks)**: Add `cert_file` check type to Add Check dialog; fix cert JSON display

**Technical debt clearance:**
- **ci**: Add `pr-checks.yml` — lint, type-check, build (web) + test, build (Go) on every PR
- **feat(web)**: Add `GET /api/system/health` route — returns agent/cert/alert/db/retention counts
- **feat(web)**: Add `/settings/system` System Health page with auto-refreshing status cards (30s)
- **feat(web)**: Add System Health nav item to Administration sidebar group
- **fix(ingest)**: Remove `gen_cuid()` fallback in `InsertAgent` — always generate ID via `newCUID()`, eliminating a failed DB round-trip on every agent registration
- **docs**: Mark all resolved debt items ✅ in PROGRESS.md; update Phase 0 and Phase 3 checklists

## Test plan

- [ ] Deploy to Docker; verify `/certificates` loads without `Failed to find Server Action`
- [ ] Open a certificate detail page; verify chain table renders dates (no `RangeError`)
- [ ] Verify `agent-dist` volume mount has no permission errors on container start
- [ ] Navigate to `/settings/system` — health cards load with real data, refresh every 30s
- [ ] Verify sidebar shows "System Health" under Administration
- [ ] Register a new agent and confirm it gets a CUID (no double round-trip error in ingest logs)
- [ ] Open a PR against this branch; confirm `PR Checks` workflow runs (lint, type-check, build, go test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)