### PR TITLE
refactor(web): move operational data from System Health to Overview dashboard

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Server,
+  ShieldCheck,
+  Bell,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Loader2,
+} from 'lucide-react'
+
+interface OverviewData {
+  agents: { online: number; offline: number; total: number }
+  certificates: { valid: number; expiringSoon: number; expired: number }
+  alerts: { firing: number; acknowledged: number }
+}
+
+function StatRow({
+  label,
+  value,
+  className,
+}: {
+  label: string
+  value: number | string
+  className?: string
+}) {
+  return (
+    <div className="flex items-center justify-between py-1.5 border-b border-border last:border-0">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className={`text-sm font-medium tabular-nums ${className ?? 'text-foreground'}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+export function DashboardClient() {
+  const { data, isLoading, error } = useQuery<OverviewData>({
+    queryKey: ['overview'],
+    queryFn: () => fetch('/api/overview').then((r) => r.json()),
+    refetchInterval: 30_000,
+    staleTime: 20_000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground py-8">
+        <Loader2 className="size-4 animate-spin" />
+        <span className="text-sm">Loading overview…</span>
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 text-destructive py-8">
+        <XCircle className="size-4" />
+        <span className="text-sm">Failed to load overview data.</span>
+      </div>
+    )
+  }
+
+  const hasIssues =
+    data.alerts.firing > 0 || data.certificates.expired > 0 || data.agents.offline > 0
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">Overview</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Current state of your infrastructure
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Agents */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Server className="size-4 text-muted-foreground" />
+              <Link href="/agents" className="hover:underline">
+                Agents
+              </Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <StatRow label="Total enrolled" value={data.agents.total} />
+            <StatRow
+              label="Online"
+              value={data.agents.online}
+              className={data.agents.online > 0 ? 'text-green-700' : 'text-foreground'}
+            />
+            <StatRow
+              label="Offline"
+              value={data.agents.offline}
+              className={data.agents.offline > 0 ? 'text-amber-600' : 'text-foreground'}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Certificates */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <ShieldCheck className="size-4 text-muted-foreground" />
+              <Link href="/certificates" className="hover:underline">
+                Certificates
+              </Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <StatRow
+              label="Valid"
+              value={data.certificates.valid}
+              className={data.certificates.valid > 0 ? 'text-green-700' : 'text-foreground'}
+            />
+            <StatRow
+              label="Expiring soon"
+              value={data.certificates.expiringSoon}
+              className={data.certificates.expiringSoon > 0 ? 'text-amber-600' : 'text-foreground'}
+            />
+            <StatRow
+              label="Expired"
+              value={data.certificates.expired}
+              className={data.certificates.expired > 0 ? 'text-destructive' : 'text-foreground'}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Active Alerts */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Bell className="size-4 text-muted-foreground" />
+              <Link href="/alerts" className="hover:underline">
+                Active Alerts
+              </Link>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <StatRow
+              label="Firing"
+              value={data.alerts.firing}
+              className={data.alerts.firing > 0 ? 'text-destructive' : 'text-foreground'}
+            />
+            <StatRow
+              label="Acknowledged"
+              value={data.alerts.acknowledged}
+              className={data.alerts.acknowledged > 0 ? 'text-amber-600' : 'text-foreground'}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Summary */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <AlertTriangle className="size-4 text-muted-foreground" />
+              Summary
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {!hasIssues ? (
+              <div className="flex items-center gap-2 text-green-700 py-1">
+                <CheckCircle2 className="size-4" />
+                <span className="text-sm font-medium">All systems nominal</span>
+              </div>
+            ) : (
+              <ul className="space-y-1.5">
+                {data.alerts.firing > 0 && (
+                  <li className="flex items-center gap-2 text-destructive text-sm">
+                    <XCircle className="size-4 shrink-0" />
+                    {data.alerts.firing} alert{data.alerts.firing !== 1 ? 's' : ''} firing
+                  </li>
+                )}
+                {data.certificates.expired > 0 && (
+                  <li className="flex items-center gap-2 text-destructive text-sm">
+                    <XCircle className="size-4 shrink-0" />
+                    {data.certificates.expired} certificate
+                    {data.certificates.expired !== 1 ? 's' : ''} expired
+                  </li>
+                )}
+                {data.agents.offline > 0 && (
+                  <li className="flex items-center gap-2 text-amber-600 text-sm">
+                    <AlertTriangle className="size-4 shrink-0" />
+                    {data.agents.offline} agent{data.agents.offline !== 1 ? 's' : ''} offline
+                  </li>
+                )}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,17 +1,10 @@
 import type { Metadata } from 'next'
+import { DashboardClient } from './dashboard-client'
 
 export const metadata: Metadata = {
   title: 'Overview',
 }
 
 export default function DashboardPage() {
-  return (
-    <div>
-      <h1 className="text-2xl font-semibold text-foreground mb-2">Overview</h1>
-      <p className="text-muted-foreground">
-        Welcome to Infrawatch. Your infrastructure monitoring dashboard will appear here once
-        agents are connected and data is flowing.
-      </p>
-    </div>
-  )
+  return <DashboardClient />
 }

--- a/apps/web/app/(dashboard)/settings/system/system-client.tsx
+++ b/apps/web/app/(dashboard)/settings/system/system-client.tsx
@@ -1,18 +1,14 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import {
   Server,
-  ShieldCheck,
-  Bell,
   Database,
   Tag,
   CheckCircle2,
   XCircle,
-  AlertTriangle,
   Loader2,
 } from 'lucide-react'
 
@@ -22,8 +18,6 @@ interface HealthData {
   metricRetentionDays: number
   database: { connected: boolean }
   agents: { online: number; offline: number; total: number }
-  certificates: { valid: number; expiringSoon: number; expired: number }
-  alerts: { active: number; acknowledged: number }
 }
 
 function tierBadgeVariant(tier: string): 'outline' | 'default' | 'secondary' {
@@ -75,7 +69,7 @@ export function SystemHealthClient() {
     <div className="space-y-6 max-w-3xl">
       <div>
         <h1 className="text-2xl font-semibold text-foreground">System Health</h1>
-        <p className="text-sm text-muted-foreground mt-1">Overview of platform status and resource counts</p>
+        <p className="text-sm text-muted-foreground mt-1">Platform status and configuration</p>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -130,7 +124,7 @@ export function SystemHealthClient() {
           <CardHeader className="pb-3">
             <CardTitle className="text-base flex items-center gap-2">
               <Server className="size-4 text-muted-foreground" />
-              Agents
+              Agent Pipeline
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-1">
@@ -145,98 +139,6 @@ export function SystemHealthClient() {
               value={data.agents.offline}
               className={data.agents.offline > 0 ? 'text-amber-600' : 'text-foreground'}
             />
-          </CardContent>
-        </Card>
-
-        {/* Certificates */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <ShieldCheck className="size-4 text-muted-foreground" />
-              <Link href="/certificates" className="hover:underline">
-                Certificates
-              </Link>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-1">
-            <StatRow
-              label="Valid"
-              value={data.certificates.valid}
-              className={data.certificates.valid > 0 ? 'text-green-700' : 'text-foreground'}
-            />
-            <StatRow
-              label="Expiring soon"
-              value={data.certificates.expiringSoon}
-              className={data.certificates.expiringSoon > 0 ? 'text-amber-600' : 'text-foreground'}
-            />
-            <StatRow
-              label="Expired"
-              value={data.certificates.expired}
-              className={data.certificates.expired > 0 ? 'text-destructive' : 'text-foreground'}
-            />
-          </CardContent>
-        </Card>
-
-        {/* Alerts */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <Bell className="size-4 text-muted-foreground" />
-              <Link href="/alerts" className="hover:underline">
-                Active Alerts
-              </Link>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-1">
-            <StatRow
-              label="Firing"
-              value={data.alerts.active}
-              className={data.alerts.active > 0 ? 'text-destructive' : 'text-foreground'}
-            />
-            <StatRow
-              label="Acknowledged"
-              value={data.alerts.acknowledged}
-              className={data.alerts.acknowledged > 0 ? 'text-amber-600' : 'text-foreground'}
-            />
-          </CardContent>
-        </Card>
-
-        {/* Status summary */}
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <AlertTriangle className="size-4 text-muted-foreground" />
-              Summary
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {data.alerts.active === 0 && data.certificates.expired === 0 && data.agents.offline === 0 ? (
-              <div className="flex items-center gap-2 text-green-700 py-1">
-                <CheckCircle2 className="size-4" />
-                <span className="text-sm font-medium">All systems nominal</span>
-              </div>
-            ) : (
-              <ul className="space-y-1.5">
-                {data.alerts.active > 0 && (
-                  <li className="flex items-center gap-2 text-destructive text-sm">
-                    <XCircle className="size-4 shrink-0" />
-                    {data.alerts.active} alert{data.alerts.active !== 1 ? 's' : ''} firing
-                  </li>
-                )}
-                {data.certificates.expired > 0 && (
-                  <li className="flex items-center gap-2 text-destructive text-sm">
-                    <XCircle className="size-4 shrink-0" />
-                    {data.certificates.expired} certificate{data.certificates.expired !== 1 ? 's' : ''} expired
-                  </li>
-                )}
-                {data.agents.offline > 0 && (
-                  <li className="flex items-center gap-2 text-amber-600 text-sm">
-                    <AlertTriangle className="size-4 shrink-0" />
-                    {data.agents.offline} agent{data.agents.offline !== 1 ? 's' : ''} offline
-                  </li>
-                )}
-              </ul>
-            )}
           </CardContent>
         </Card>
       </div>

--- a/apps/web/app/api/overview/route.ts
+++ b/apps/web/app/api/overview/route.ts
@@ -1,0 +1,64 @@
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { db } from '@/lib/db'
+import { users, agents, certificates, alertInstances } from '@/lib/db/schema'
+import { eq, and, isNull, count } from 'drizzle-orm'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+  })
+  if (!user?.organisationId) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const orgId = user.organisationId
+
+  const [agentRows, certRows, alertRows] = await Promise.all([
+    db
+      .select({ status: agents.status, count: count() })
+      .from(agents)
+      .where(and(eq(agents.organisationId, orgId), isNull(agents.deletedAt)))
+      .groupBy(agents.status),
+
+    db
+      .select({ status: certificates.status, count: count() })
+      .from(certificates)
+      .where(and(eq(certificates.organisationId, orgId), isNull(certificates.deletedAt)))
+      .groupBy(certificates.status),
+
+    db
+      .select({ status: alertInstances.status, count: count() })
+      .from(alertInstances)
+      .where(eq(alertInstances.organisationId, orgId))
+      .groupBy(alertInstances.status),
+  ])
+
+  const agentMap = Object.fromEntries(agentRows.map((r) => [r.status, r.count]))
+  const certMap = Object.fromEntries(certRows.map((r) => [r.status, r.count]))
+  const alertMap = Object.fromEntries(alertRows.map((r) => [r.status, r.count]))
+
+  return Response.json({
+    agents: {
+      online: agentMap['active'] ?? 0,
+      offline: agentMap['offline'] ?? 0,
+      total: Object.values(agentMap).reduce((s, n) => s + n, 0),
+    },
+    certificates: {
+      valid: certMap['valid'] ?? 0,
+      expiringSoon: certMap['expiring_soon'] ?? 0,
+      expired: certMap['expired'] ?? 0,
+    },
+    alerts: {
+      firing: alertMap['firing'] ?? 0,
+      acknowledged: alertMap['acknowledged'] ?? 0,
+    },
+  })
+}

--- a/apps/web/app/api/system/health/route.ts
+++ b/apps/web/app/api/system/health/route.ts
@@ -1,7 +1,7 @@
 import { auth } from '@/lib/auth'
 import { headers } from 'next/headers'
 import { db } from '@/lib/db'
-import { users, agents, certificates, alertInstances, organisations } from '@/lib/db/schema'
+import { users, agents, organisations } from '@/lib/db/schema'
 import { eq, and, isNull, count } from 'drizzle-orm'
 import pkg from '../../../../package.json'
 
@@ -22,24 +22,12 @@ export async function GET() {
 
   const orgId = user.organisationId
 
-  const [agentRows, certRows, alertRows, org] = await Promise.all([
+  const [agentRows, org] = await Promise.all([
     db
       .select({ status: agents.status, count: count() })
       .from(agents)
       .where(and(eq(agents.organisationId, orgId), isNull(agents.deletedAt)))
       .groupBy(agents.status),
-
-    db
-      .select({ status: certificates.status, count: count() })
-      .from(certificates)
-      .where(and(eq(certificates.organisationId, orgId), isNull(certificates.deletedAt)))
-      .groupBy(certificates.status),
-
-    db
-      .select({ status: alertInstances.status, count: count() })
-      .from(alertInstances)
-      .where(eq(alertInstances.organisationId, orgId))
-      .groupBy(alertInstances.status),
 
     db.query.organisations.findFirst({
       where: eq(organisations.id, orgId),
@@ -47,9 +35,6 @@ export async function GET() {
   ])
 
   const agentMap = Object.fromEntries(agentRows.map((r) => [r.status, r.count]))
-  const certMap = Object.fromEntries(certRows.map((r) => [r.status, r.count]))
-  const alertMap = Object.fromEntries(alertRows.map((r) => [r.status, r.count]))
-
   const agentOnline = agentMap['active'] ?? 0
   const agentOffline = agentMap['offline'] ?? 0
   const agentTotal = Object.values(agentMap).reduce((s, n) => s + n, 0)
@@ -63,15 +48,6 @@ export async function GET() {
       online: agentOnline,
       offline: agentOffline,
       total: agentTotal,
-    },
-    certificates: {
-      valid: certMap['valid'] ?? 0,
-      expiringSoon: certMap['expiring_soon'] ?? 0,
-      expired: certMap['expired'] ?? 0,
-    },
-    alerts: {
-      active: alertMap['firing'] ?? 0,
-      acknowledged: alertMap['acknowledged'] ?? 0,
     },
   })
 }


### PR DESCRIPTION
## Summary

- **System Health** (`/settings/system`) now shows only platform internals: version, licence tier, database connection, and agent pipeline status — things that tell an admin whether Infrawatch itself is running correctly
- **Overview** (`/dashboard`) now shows the operational state of your infrastructure: agents online/offline, certificate validity, active alerts, and a summary — things an engineer checks day-to-day
- New `/api/overview` endpoint serves the operational data; `/api/system/health` is stripped back to platform-only queries

## Why

Certificates and active alerts were previously on the System Health page (an admin view under Settings) and nothing was on the Overview page. This was the wrong information in the wrong place — engineers shouldn't have to navigate into Settings to see whether alerts are firing or certs are expiring.

## Test plan

- [ ] Navigate to `/dashboard` — verify Agents, Certificates, Active Alerts, and Summary cards appear with live data
- [ ] Navigate to `/settings/system` — verify only Platform, Database, and Agent Pipeline cards remain (no Certificates or Alerts cards)
- [ ] Verify `/api/overview` returns `agents`, `certificates`, and `alerts` fields
- [ ] Verify `/api/system/health` no longer returns `certificates` or `alerts` fields
- [ ] Confirm build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)