### PR TITLE
fix(agent): make check delivery resilient to stream reconnects and hostID failures

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,30 @@
 
 ## What Has Been Built
 
+### Session 18 — Overview dashboard and System Health separation
+
+**Problem: operational data was on the wrong page**
+- Certificates and Active Alerts were displayed on the System Health page (`/settings/system`), which is an admin view for Infrawatch's own platform internals. The Overview page (`/dashboard`) was an empty placeholder.
+- Engineers had to navigate into Settings to see whether alerts were firing or certificates were expiring — the wrong mental model.
+
+**Fix: split data by audience**
+- **System Health** now shows only Infrawatch platform internals: version, licence tier, database connection status, metric retention, and agent pipeline counts. Description updated to "Platform status and configuration".
+- **Overview** now shows the operational state of infrastructure: Agents (online/offline), Certificates (valid/expiring/expired), Active Alerts (firing/acknowledged), and a Summary panel. All cards link through to their respective detail pages.
+
+**New `/api/overview` endpoint** (`apps/web/app/api/overview/route.ts`)
+- Returns `agents`, `certificates`, and `alerts` counts scoped to the user's organisation.
+- `/api/system/health` stripped of certificate and alert queries — now only queries agents and org config.
+
+**New `DashboardClient` component** (`apps/web/app/(dashboard)/dashboard/dashboard-client.tsx`)
+- Polls `/api/overview` every 30 seconds (matching System Health behaviour).
+- Overview `page.tsx` delegates to this client component, replacing the static placeholder.
+
+**Build state**
+- `pnpm run build` (apps/web) — zero TypeScript errors ✅
+- `/api/overview` route appears in build output ✅
+
+---
+
 ### Session 17 — Certificate page production bug fixes
 
 **Problem 1: `Failed to find Server Action` on certificates list and detail pages**

--- a/agent/internal/checks/executor.go
+++ b/agent/internal/checks/executor.go
@@ -76,6 +76,13 @@ func (e *Executor) DrainResults() []*agentv1.CheckResult {
 	return results
 }
 
+// HasRunningChecks reports whether any check goroutines are currently running.
+func (e *Executor) HasRunningChecks() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.cancels) > 0
+}
+
 func (e *Executor) runCheck(ctx context.Context, def *agentv1.CheckDefinition) {
 	interval := time.Duration(def.IntervalSeconds) * time.Second
 	if interval <= 0 {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -50,6 +50,11 @@ type Runner struct {
 	// Signalled when new query results are ready so the send loop can fire
 	// an immediate heartbeat rather than waiting for the next 30s tick.
 	resultsReady chan struct{}
+
+	// lastKnownDefs is the most recent non-empty set of check definitions
+	// received from the server. Used to restore checks after a stream reconnect
+	// if the executor has no running goroutines (e.g. after an agent restart).
+	lastKnownDefs []*agentv1.CheckDefinition
 }
 
 // New creates a new heartbeat Runner. dialFunc is called once per stream
@@ -132,7 +137,7 @@ func (r *Runner) runStream(ctx context.Context) error {
 	streamCtx, cancelRecv := context.WithCancel(ctx)
 	defer cancelRecv()
 	recvErr := make(chan error, 1)
-	go r.runReceiver(streamCtx, stream, recvErr)
+	go r.runReceiver(ctx, streamCtx, stream, recvErr)
 
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
@@ -169,8 +174,12 @@ func (r *Runner) runStream(ctx context.Context) error {
 
 // runReceiver reads HeartbeatResponses from the stream in a loop and dispatches
 // their contents. It exits (and signals recvErr) on any stream error.
+// rootCtx is the agent process lifetime context used for spawning check goroutines
+// so they survive stream reconnects. streamCtx is the stream-scoped context used
+// only to detect intentional stream teardown.
 func (r *Runner) runReceiver(
-	ctx context.Context,
+	rootCtx context.Context,
+	streamCtx context.Context,
 	stream agentv1.IngestService_HeartbeatClient,
 	recvErr chan<- error,
 ) {
@@ -181,13 +190,13 @@ func (r *Runner) runReceiver(
 			return
 		}
 		if err != nil {
-			if ctx.Err() != nil {
+			if streamCtx.Err() != nil {
 				return
 			}
 			recvErr <- fmt.Errorf("receiving heartbeat response: %w", err)
 			return
 		}
-		r.handleResponse(ctx, resp)
+		r.handleResponse(rootCtx, resp)
 	}
 }
 
@@ -200,7 +209,11 @@ func (r *Runner) handleResponse(ctx context.Context, resp *agentv1.HeartbeatResp
 		slog.Info("received server command", "command", resp.Command)
 	}
 	if len(resp.Checks) > 0 {
+		r.lastKnownDefs = resp.Checks
 		r.executor.UpdateDefinitions(ctx, resp.Checks)
+	} else if !r.executor.HasRunningChecks() && r.lastKnownDefs != nil {
+		slog.Info("restoring check definitions from cache", "count", len(r.lastKnownDefs))
+		r.executor.UpdateDefinitions(ctx, r.lastKnownDefs)
 	}
 	if len(resp.PendingQueries) > 0 {
 		// Run queries in a goroutine so the receive loop is never blocked by

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -150,13 +150,24 @@ loop:
 			if !ok {
 				break loop
 			}
+			if hostID == "" {
+				if id, retryErr := queries.GetHostByAgentID(ctx, h.pool, agentID); retryErr == nil {
+					hostID = id
+					slog.Info("resolved host after retry", "agent_id", agentID, "host_id", hostID)
+				}
+			}
 			if err := h.processHeartbeat(ctx, stream, agentID, agent.OrganisationID, hostID, agent.Hostname, req); err != nil {
 				return err
 			}
 
 		case <-queryPollTicker.C:
 			if hostID == "" {
-				continue
+				if id, retryErr := queries.GetHostByAgentID(ctx, h.pool, agentID); retryErr == nil {
+					hostID = id
+					slog.Info("resolved host after retry", "agent_id", agentID, "host_id", hostID)
+				} else {
+					continue
+				}
 			}
 			pending, err := queries.GetPendingQueriesForHost(ctx, h.pool, hostID)
 			if err != nil {

--- a/docs/bug-tracker-checks-stopping.md
+++ b/docs/bug-tracker-checks-stopping.md
@@ -1,0 +1,202 @@
+# Bug Tracker: Agent Checks Stop Sending Results
+
+**Status:** Open — no confirmed fix yet  
+**First observed:** ~2026-04-09  
+**Symptoms:** Agents stop sending check results after a random period (minutes to hours). Metrics and heartbeats continue normally. No agent crash or visible reconnect.
+
+---
+
+## Symptoms
+
+- Check UI shows "X hours ago" for all checks on a host
+- Metrics charts show continuous, consistent data (CPU/memory/disk)
+- Heartbeat interval chart shows regular ~30s intervals
+- All 6 checks were last seen at the same timestamp — suggests a single event stopped everything at once, not individual check failures
+- After stopping, checks never self-recover without manual intervention (agent restart)
+
+---
+
+## Architecture: How Checks Flow
+
+```
+Agent (Go binary)
+  └── checks/executor.go  — goroutines per check; accumulate results
+  └── heartbeat/heartbeat.go — sends results to ingest on each tick
+
+        ↓ gRPC bidirectional stream (HeartbeatRequest/HeartbeatResponse)
+
+Ingest service (Go)
+  └── handlers/heartbeat.go:Heartbeat()
+       1. Auth + resolve hostID (ONCE at stream start)
+       2. Loop: processHeartbeat() per received message
+            - Metrics saved (no hostID needed)
+            - Checks saved (only if hostID != "")
+            - Check definitions pushed back to agent (only if hostID != "")
+```
+
+**Critical asymmetry:** Metrics bypass the `hostID` check. Checks require a valid `hostID`. This explains why metrics continue while checks stop.
+
+---
+
+## Root Cause: Most Likely Hypothesis
+
+**Stream reconnect + `hostID` resolution failure on reconnect**
+
+**File:** `apps/ingest/internal/handlers/heartbeat.go:97–102`
+
+```go
+// Resolve host ID once for the lifetime of this stream
+hostID, err := queries.GetHostByAgentID(ctx, h.pool, agentID)
+if err != nil {
+    slog.Warn("resolving host for agent", "agent_id", agentID, "err", err)
+    hostID = ""  // ← silently empty for entire stream lifetime
+}
+```
+
+`hostID` is resolved **once** at stream start, never retried. If the database query fails for any reason (pool exhaustion, timeout, brief outage, race at startup), `hostID` stays `""` for the entire stream lifetime.
+
+**Cascade from `hostID == ""`:**
+
+1. `processHeartbeat()` line 234: `if hostID != ""` → **SKIPPED**
+   - Check results received from agent are **discarded silently**
+   - Alert evaluation is **skipped**
+2. `processHeartbeat()` line 329: `if hostID != ""` → **SKIPPED**
+   - Check definitions are **not pushed** to agent in the response
+
+**Agent side** (`agent/internal/heartbeat/heartbeat.go:202–204`):
+```go
+if len(resp.Checks) > 0 {
+    r.executor.UpdateDefinitions(ctx, resp.Checks)
+}
+```
+
+When the response has no check definitions (because ingest skipped them), the agent does NOT call `UpdateDefinitions`. On a fresh stream (after reconnect), existing check goroutines from the old stream were already cancelled (their context was cancelled when the stream closed). Since no new definitions arrive, **no new check goroutines are started**.
+
+**Result:** Agent looks healthy (metrics, heartbeats fine), but all check goroutines are dead and the ingest service silently discards any results that do arrive.
+
+---
+
+## Why Metrics Keep Working
+
+In `processHeartbeat()`, metrics are saved unconditionally:
+
+```go
+// Lines 205–231: no hostID check
+queries.UpdateAgentHeartbeat(...)    // uses agentID only
+queries.UpdateHostVitals(...)        // uses agentID only
+queries.InsertHostMetricByAgentID(...)  // uses orgID + agentID
+```
+
+All three metric operations use `agentID` or `orgID`, neither of which requires the hosts table lookup.
+
+---
+
+## Secondary Contributing Factors
+
+### Check goroutines are stream-scoped
+
+In `agent/internal/heartbeat/heartbeat.go`:
+```go
+streamCtx, cancelRecv := context.WithCancel(ctx)
+defer cancelRecv()  // ← cancels ALL check goroutines when stream ends
+go r.runReceiver(streamCtx, stream, recvErr)
+```
+
+`streamCtx` is passed to `UpdateDefinitions`, which spawns check goroutines. When the stream closes (for any reason), `cancelRecv()` is deferred and kills all check goroutines. On the new stream, checks only restart if `resp.Checks` is non-empty on the first response.
+
+### JWT is not actually validated
+
+In `apps/ingest/internal/handlers/heartbeat.go:63–72`:
+```go
+agentID, _, err := h.issuer.ValidateAgentToken(first.AgentId)
+if err != nil {
+    agentID = first.AgentId  // ← falls back to raw agent ID
+    slog.Debug("JWT validation failed, using agent_id directly", ...)
+}
+```
+
+The agent sends its plain agent ID in the `AgentId` field (not a JWT token). `ValidateAgentToken` always fails; the fallback always fires. JWT expiry is **not** a cause of reconnects. This is a security issue to fix separately but does not cause the checks bug.
+
+---
+
+## Key File Locations
+
+| File | Lines | Notes |
+|---|---|---|
+| `apps/ingest/internal/handlers/heartbeat.go` | 97–102 | `hostID` resolved once — **root of the bug** |
+| `apps/ingest/internal/handlers/heartbeat.go` | 234, 329 | Check operations guarded by `hostID != ""` |
+| `apps/ingest/internal/handlers/heartbeat.go` | 204–231 | Metrics — no `hostID` check, always saved |
+| `agent/internal/heartbeat/heartbeat.go` | 132–133 | `streamCtx` scoped to stream; kills goroutines on disconnect |
+| `agent/internal/heartbeat/heartbeat.go` | 202–204 | Only calls `UpdateDefinitions` if response has checks |
+| `agent/internal/checks/executor.go` | 48–56 | Cancels goroutines for removed/changed checks |
+| `apps/ingest/internal/db/queries/hosts.sql.go` | ~26–32 | `GetHostByAgentID` — single DB call that can fail silently |
+
+---
+
+## Proposed Fix (Not Yet Implemented)
+
+**Change:** Retry `hostID` resolution on each heartbeat instead of only at stream start.
+
+In `apps/ingest/internal/handlers/heartbeat.go`, the `hostID` variable is currently a local captured in the stream closure. The fix is to re-attempt resolution if it failed:
+
+**Option A — Retry in the main loop before calling `processHeartbeat`:**
+```go
+// In the for-loop body, before calling processHeartbeat:
+if hostID == "" {
+    if resolved, err := queries.GetHostByAgentID(ctx, h.pool, agentID); err == nil {
+        slog.Info("host ID resolved after retry", "agent_id", agentID, "host_id", resolved)
+        hostID = resolved
+    }
+}
+```
+
+This self-heals within one heartbeat interval (~30s) after the DB recovers, without requiring a stream reconnect.
+
+**Option B — Move `hostID` resolution into `processHeartbeat`:**
+Pass `*string` instead of `string` so the function can update it. More invasive.
+
+**Additional hardening (regardless of which option):**
+- Log at `Error` (not just `Warn`) when `hostID == ""` and check results are being discarded — silent discard is the worst part
+- Add a metric/counter for "heartbeats with missing hostID" so this is observable
+
+---
+
+## Fix Attempt History
+
+| Date | Change | Outcome |
+|---|---|---|
+| 2026-04-09 | **Fix attempt 1** — three changes applied (see below) | Deployed, awaiting observation |
+
+### Fix attempt 1 detail (2026-04-09)
+
+Three targeted changes, no schema/SQL/proto changes:
+
+**1. Ingest: retry `hostID` resolution on every heartbeat when empty**
+`apps/ingest/internal/handlers/heartbeat.go` — In the main event loop, before calling `processHeartbeat` and inside the `queryPollTicker` case, added a retry block: if `hostID == ""`, call `GetHostByAgentID` again. Self-heals within ~30s of DB recovering. Logs `"resolved host after retry"` at Info when it succeeds.
+
+**2. Agent: check goroutines now use the agent root context**
+`agent/internal/heartbeat/heartbeat.go` — Changed `runReceiver` to accept both `rootCtx` (agent process lifetime) and `streamCtx` (stream-scoped). `streamCtx` used only for stream teardown detection; `rootCtx` passed to `handleResponse` → `UpdateDefinitions`. Check goroutines now survive stream reconnects — they keep running and accumulate results until the next successful heartbeat.
+
+**3. Agent: cache last-known check definitions**
+`agent/internal/heartbeat/heartbeat.go` + `agent/internal/checks/executor.go` — Added `lastKnownDefs` field to Runner. When definitions arrive, they're cached. If no goroutines are running and no definitions arrive on reconnect, the cache is restored automatically. Added `HasRunningChecks()` to Executor to guard the restore condition. Logs `"restoring check definitions from cache"` at Info when it fires.
+
+---
+
+## How to Diagnose When It Happens Again
+
+1. **Check ingest logs** for: `"resolving host for agent"` — if this appears, `hostID` resolution failed at stream start
+2. **Check ingest logs** for: `"fetching checks for host"` — if this appears frequently, the per-heartbeat query is failing
+3. **Check agent logs** for: `"heartbeat stream ended, reconnecting"` — indicates a stream reconnect occurred (which resets check goroutines)
+4. SSH into agent: `carrtech-adm@10.10.8.210` and check agent logs:
+   ```bash
+   sudo journalctl -u infrawatch-agent -n 200 --no-pager
+   ```
+5. Look for the timestamp when checks last appeared in the UI — compare against stream reconnect events in agent/ingest logs
+
+---
+
+## Notes
+
+- The question "is this JWT vs mTLS related?" — **No.** JWT is not actually being validated in the current heartbeat flow. The agent sends its plain agent ID. JWT expiry is not a factor.
+- mTLS is described in the architecture docs but not yet implemented in the heartbeat path.
+- This bug could also surface as "checks never start" for a newly enrolled agent if the hosts table row isn't committed before the first heartbeat arrives (race condition at enrolment).


### PR DESCRIPTION
## Summary

Fixes a recurring bug where agent check results stop being recorded after running for minutes to hours, while metrics and heartbeats continue normally.

**Root cause:** `hostID` is resolved once at gRPC stream start in the ingest handler. If that DB query fails (pool exhaustion, brief outage, startup race), `hostID = ""` silently for the entire stream lifetime — all check operations are guarded by `if hostID != ""` but metrics are not, explaining the asymmetry. On stream reconnect, check goroutines from the old stream are killed (stream-scoped context), and only restart if the first heartbeat response includes definitions — which it won't if `hostID` is still empty.

- **Ingest:** Retry `hostID` resolution on every heartbeat when empty. Self-heals within ~30s of DB recovery without a stream reconnect. Logs `"resolved host after retry"` when it succeeds.
- **Agent:** Pass agent root context (not stream-scoped context) to check goroutines. They now survive stream reconnects and keep accumulating results until delivery. (The `executor.go` comment already described this as the intended behaviour — the implementation just didn't match.)
- **Agent:** Cache last-known check definitions in `Runner`. If goroutines are dead on reconnect and the server sends no definitions yet, restore from cache automatically. Adds `HasRunningChecks()` to `Executor` to guard the restore condition.

Also adds `docs/bug-tracker-checks-stopping.md` — investigation history, root cause analysis, and fix attempt log so future sessions don't re-investigate the same ground.

## Test plan

- [ ] Deploy ingest and restart agent — confirm checks appear in UI within 30s
- [ ] Briefly stop postgres (~10s), restore — confirm checks resume within ~30s without restarting the agent; look for `"resolved host after retry"` in ingest logs
- [ ] Restart the agent while stream is live — confirm checks resume from definition cache on reconnect; look for `"restoring check definitions from cache"` in agent logs
- [ ] Confirm metrics and heartbeats unaffected throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)