### PR TITLE
fix(db): bump migration 0014 timestamp to be monotonically after 0013

### DIFF
--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -103,7 +103,7 @@
     {
       "idx": 14,
       "version": "7",
-      "when": 1775743793381,
+      "when": 1775900000006,
       "tag": "0014_mean_dragon_lord",
       "breakpoints": true
     }


### PR DESCRIPTION
The drizzle-kit generated timestamp (1775743793381) was lower than 0013's manually set value (1775900000005), causing the migrator to silently skip 0014 — the same root cause documented in Session 13.