### PR TITLE
fix(db): add migration timestamp validation

### DIFF
--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -124,7 +124,7 @@
     {
       "idx": 17,
       "version": "7",
-      "when": 1775809691885,
+      "when": 1775900000009,
       "tag": "0017_chilly_slyde",
       "breakpoints": true
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "type-check": "tsc --noEmit",
-    "build": "next build",
+    "build": "node scripts/validate-migrations.js && next build",
     "start": "next start",
     "lint": "eslint",
-    "db:generate": "drizzle-kit generate",
+    "db:generate": "drizzle-kit generate && node scripts/validate-migrations.js",
+    "db:validate": "node scripts/validate-migrations.js",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"

--- a/apps/web/scripts/validate-migrations.js
+++ b/apps/web/scripts/validate-migrations.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Validates that migration journal timestamps are strictly monotonic.
+ *
+ * Drizzle's migrator skips migrations whose `when` timestamp is earlier than
+ * an already-applied migration. This script catches that before it reaches
+ * a running container.
+ *
+ * Usage:
+ *   node scripts/validate-migrations.js          # exits 0 on success, 1 on failure
+ *   pnpm run db:validate                          # via package.json script
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const JOURNAL_PATH = path.resolve(
+  __dirname,
+  '../lib/db/migrations/meta/_journal.json'
+)
+
+function validate() {
+  if (!fs.existsSync(JOURNAL_PATH)) {
+    console.error('Migration journal not found at', JOURNAL_PATH)
+    process.exit(1)
+  }
+
+  const journal = JSON.parse(fs.readFileSync(JOURNAL_PATH, 'utf-8'))
+  const entries = journal.entries
+
+  if (!entries || entries.length === 0) {
+    console.log('No migration entries found.')
+    return
+  }
+
+  const errors = []
+
+  for (let i = 1; i < entries.length; i++) {
+    const prev = entries[i - 1]
+    const curr = entries[i]
+
+    if (curr.when <= prev.when) {
+      errors.push(
+        `Migration ${curr.idx} "${curr.tag}" (when: ${curr.when}) has a timestamp <= ` +
+          `migration ${prev.idx} "${prev.tag}" (when: ${prev.when}). ` +
+          `The migrator will skip it.`
+      )
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('Migration journal validation FAILED:\n')
+    errors.forEach((e) => console.error(`  - ${e}`))
+    console.error(
+      '\nFix: update the "when" field in _journal.json so timestamps are strictly increasing.'
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `Migration journal OK: ${entries.length} entries, timestamps strictly increasing.`
+  )
+}
+
+validate()


### PR DESCRIPTION
## Summary
- Fixes migration 0017 timestamp to be monotonically after 0016 (was causing `tls_certificate` column to be silently skipped)
- Adds `scripts/validate-migrations.js` that checks journal timestamps are strictly increasing
- Wired into `db:generate` (catches on create) and `build` (catches before deploy) — also available standalone via `pnpm run db:validate`

## Test plan
- [x] Verified script passes on current journal
- [x] Verified script detects bad timestamps and exits non-zero
- [x] Rebuilt Docker container — `/settings/ldap` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)