### PR TITLE
feat(phase4): service accounts, LDAP login & identity management

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -7,6 +7,14 @@ import { getRequiredSession } from '@/lib/auth/session'
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const session = await getRequiredSession()
 
+  if (session.user.email.endsWith('@ldap.local')) {
+    redirect('/setup-email')
+  }
+
+  if (session.user.role === 'pending') {
+    redirect('/pending-approval')
+  }
+
   if (!session.user.organisationId) {
     redirect('/onboarding')
   }

--- a/apps/web/app/(dashboard)/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/team/team-client.tsx
@@ -29,8 +29,14 @@ function roleBadgeVariant(role: string): 'destructive' | 'default' | 'secondary'
     case 'super_admin': return 'destructive'
     case 'org_admin': return 'default'
     case 'engineer': return 'secondary'
+    case 'pending': return 'outline'
     default: return 'outline'
   }
+}
+
+function roleBadgeClassName(role: string): string {
+  if (role === 'pending') return 'border-yellow-600 text-yellow-700 dark:border-yellow-500 dark:text-yellow-400'
+  return ''
 }
 
 function formatRole(role: string) {
@@ -194,8 +200,8 @@ export function TeamClient({
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <button className="flex items-center gap-1 focus:outline-none">
-                            <Badge variant={roleBadgeVariant(member.role)}>
-                              {formatRole(member.role)}
+                            <Badge variant={roleBadgeVariant(member.role)} className={roleBadgeClassName(member.role)}>
+                              {member.role === 'pending' ? 'Pending Approval' : formatRole(member.role)}
                             </Badge>
                             <ChevronDown className="size-3 text-muted-foreground" />
                           </button>
@@ -215,8 +221,8 @@ export function TeamClient({
                         </DropdownMenuContent>
                       </DropdownMenu>
                     ) : (
-                      <Badge variant={roleBadgeVariant(member.role)}>
-                        {formatRole(member.role)}
+                      <Badge variant={roleBadgeVariant(member.role)} className={roleBadgeClassName(member.role)}>
+                        {member.role === 'pending' ? 'Pending Approval' : formatRole(member.role)}
                       </Badge>
                     )}
                   </td>

--- a/apps/web/app/(setup)/pending-approval/page.tsx
+++ b/apps/web/app/(setup)/pending-approval/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { db } from '@/lib/db'
+import { users } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { PendingApprovalCard } from './pending-approval-card'
+
+export const metadata: Metadata = {
+  title: 'Account pending approval',
+}
+
+export default async function PendingApprovalPage() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) redirect('/login')
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+  })
+
+  if (!user || user.role !== 'pending') redirect('/dashboard')
+
+  return <PendingApprovalCard />
+}

--- a/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
+++ b/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { signOut } from '@/lib/auth/client'
+
+export function PendingApprovalCard() {
+  const router = useRouter()
+
+  async function handleSignOut() {
+    await signOut()
+    router.push('/login')
+    router.refresh()
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Account pending approval</CardTitle>
+        <CardDescription>
+          Your account has been created but needs to be approved by an administrator.
+          You&apos;ll be able to access the dashboard once a role has been assigned to you.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          If you believe this is an error, please contact your system administrator.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button variant="outline" className="w-full" onClick={handleSignOut}>
+          Sign out
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/app/(setup)/setup-email/page.tsx
+++ b/apps/web/app/(setup)/setup-email/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { auth } from '@/lib/auth'
+import { headers } from 'next/headers'
+import { db } from '@/lib/db'
+import { users } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { SetupEmailForm } from './setup-email-form'
+
+export const metadata: Metadata = {
+  title: 'Set your email address',
+}
+
+export default async function SetupEmailPage() {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) redirect('/login')
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+  })
+
+  if (!user || !user.email.endsWith('@ldap.local')) redirect('/dashboard')
+
+  return <SetupEmailForm userId={user.id} username={user.name} />
+}

--- a/apps/web/app/(setup)/setup-email/setup-email-form.tsx
+++ b/apps/web/app/(setup)/setup-email/setup-email-form.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useRouter } from 'next/navigation'
+import { useMutation } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { updateEmail } from '@/lib/actions/profile'
+
+const emailSchema = z.object({
+  email: z
+    .string()
+    .email('Enter a valid email address')
+    .refine((e) => !e.endsWith('@ldap.local'), 'Please enter a real email address'),
+})
+
+type EmailValues = z.infer<typeof emailSchema>
+
+interface SetupEmailFormProps {
+  userId: string
+  username: string
+}
+
+export function SetupEmailForm({ userId, username }: SetupEmailFormProps) {
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<EmailValues>({
+    resolver: zodResolver(emailSchema),
+  })
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (values: EmailValues) => updateEmail(userId, values.email),
+    onSuccess: (result) => {
+      if ('error' in result) {
+        setServerError(result.error)
+        return
+      }
+      router.push('/dashboard')
+      router.refresh()
+    },
+    onError: (err) => {
+      setServerError(err instanceof Error ? err.message : 'An unexpected error occurred')
+    },
+  })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Set your email address</CardTitle>
+        <CardDescription>
+          Welcome, {username}. Your directory account does not have an email address configured.
+          Please provide one to continue.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit((values) => mutate(values))}>
+        <CardContent className="space-y-4">
+          {serverError && (
+            <p className="text-sm text-destructive">{serverError}</p>
+          )}
+          <div className="space-y-1.5">
+            <Label htmlFor="email">Email address</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              {...register('email')}
+            />
+            {errors.email && (
+              <p className="text-xs text-destructive">{errors.email.message}</p>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending ? 'Saving...' : 'Continue'}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -4,9 +4,10 @@ import { users, accounts, sessions, ldapConfigurations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
-import { randomBytes } from 'crypto'
+import { randomBytes, createHmac } from 'crypto'
 
 export async function POST(request: NextRequest) {
+  try {
   const body = await request.json()
   const { username, password } = body as { username?: string; password?: string }
 
@@ -28,9 +29,14 @@ export async function POST(request: NextRequest) {
   }
 
   // Try each config until one succeeds
+  const errors: string[] = []
   for (const config of configs) {
     const result = await authenticateUser(config, username, password)
-    if ('error' in result) continue
+    if ('error' in result) {
+      console.error(`[LDAP] Auth failed for config "${config.name}" (${config.host}): ${result.error}`)
+      errors.push(`${config.name}: ${result.error}`)
+      continue
+    }
 
     const ldapUser = result.user
     const ldapDn = ldapUser.dn
@@ -70,7 +76,7 @@ export async function POST(request: NextRequest) {
       } else {
         // Create new user
         userId = createId()
-        const email = ldapUser.email ?? `${ldapUser.username}@ldap.local`
+        const email = ldapUser.email || `${ldapUser.username}@ldap.local`
 
         // Find the org from the LDAP config
         await db.insert(users).values({
@@ -79,7 +85,7 @@ export async function POST(request: NextRequest) {
           email,
           emailVerified: true,
           organisationId: config.organisationId,
-          role: 'engineer',
+          role: 'pending',
         })
       }
 
@@ -111,7 +117,13 @@ export async function POST(request: NextRequest) {
       userAgent: request.headers.get('user-agent') ?? null,
     })
 
-    // Set session cookie (matching Better Auth cookie format)
+    // Sign the session token using HMAC-SHA256 to match Better Auth's signed cookie format.
+    // Better Auth uses setSignedCookie which produces: encodeURIComponent(token.base64(HMAC-SHA256(token, secret)))
+    // and getSignedCookie verifies the signature before returning the token.
+    const authSecret = process.env['BETTER_AUTH_SECRET'] ?? ''
+    const signature = createHmac('sha256', authSecret).update(sessionToken).digest('base64')
+    const signedToken = `${sessionToken}.${signature}`
+
     const response = NextResponse.json({
       success: true,
       user: {
@@ -121,7 +133,7 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    response.cookies.set('better-auth.session_token', sessionToken, {
+    response.cookies.set('better-auth.session_token', signedToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
@@ -132,5 +144,11 @@ export async function POST(request: NextRequest) {
     return response
   }
 
+  console.error(`[LDAP] All configs failed for user "${username}":`, errors)
   return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+  } catch (err) {
+    console.error('[LDAP] Unexpected error during login:', err)
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    return NextResponse.json({ error: `Login failed: ${message}` }, { status: 500 })
+  }
 }

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -32,6 +32,42 @@ export async function updateName(
   }
 }
 
+const updateEmailSchema = z.object({
+  email: z
+    .string()
+    .email('Enter a valid email address')
+    .refine((e) => !e.endsWith('@ldap.local'), 'Please enter a real email address'),
+})
+
+export async function updateEmail(
+  userId: string,
+  email: string,
+): Promise<{ success: true } | { error: string }> {
+  const parsed = updateEmailSchema.safeParse({ email })
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid email' }
+  }
+
+  try {
+    const existing = await db.query.users.findFirst({
+      where: eq(users.email, parsed.data.email),
+    })
+    if (existing && existing.id !== userId) {
+      return { error: 'This email address is already in use' }
+    }
+
+    await db
+      .update(users)
+      .set({ email: parsed.data.email, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+
+    return { success: true }
+  } catch (err) {
+    console.error('Failed to update email:', err)
+    return { error: 'An unexpected error occurred' }
+  }
+}
+
 const changePasswordSchema = z.object({
   currentPassword: z.string().min(1, 'Current password is required'),
   newPassword: z.string().min(8, 'New password must be at least 8 characters'),

--- a/apps/web/lib/ldap/client.ts
+++ b/apps/web/lib/ldap/client.ts
@@ -44,6 +44,14 @@ async function connectAndBind(config: LdapConfiguration, dn: string, password: s
   return client
 }
 
+/** Resolve a search base: if it already ends with baseDn, use as-is; otherwise append baseDn. */
+function resolveSearchBase(subBase: string | null | undefined, baseDn: string): string {
+  if (!subBase) return baseDn
+  // If the sub-base already contains the base DN (case-insensitive), use it directly
+  if (subBase.toLowerCase().endsWith(baseDn.toLowerCase())) return subBase
+  return `${subBase},${baseDn}`
+}
+
 function getBindPassword(config: LdapConfiguration): string {
   try {
     return decrypt(config.bindPassword)
@@ -74,9 +82,7 @@ export async function searchUsers(
   try {
     client = await connectAndBind(config, config.bindDn, getBindPassword(config))
 
-    const searchBase = config.userSearchBase
-      ? `${config.userSearchBase},${config.baseDn}`
-      : config.baseDn
+    const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
 
     const searchFilter = filter ?? config.userSearchFilter.replace('{{username}}', '*')
 
@@ -111,8 +117,8 @@ export async function searchUsers(
     return searchEntries.map((entry) => ({
       dn: entry.dn,
       username: String(entry[config.usernameAttribute] ?? ''),
-      email: entry[config.emailAttribute] ? String(entry[config.emailAttribute]) : null,
-      displayName: entry[config.displayNameAttribute] ? String(entry[config.displayNameAttribute]) : null,
+      email: entry[config.emailAttribute] ? String(entry[config.emailAttribute]) || null : null,
+      displayName: entry[config.displayNameAttribute] ? String(entry[config.displayNameAttribute]) || null : null,
       groups: Array.isArray(entry.memberOf)
         ? entry.memberOf.map(String)
         : entry.memberOf
@@ -209,9 +215,7 @@ export async function authenticateUser(
     // First bind as service account to search for the user
     client = await connectAndBind(config, config.bindDn, getBindPassword(config))
 
-    const searchBase = config.userSearchBase
-      ? `${config.userSearchBase},${config.baseDn}`
-      : config.baseDn
+    const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
 
     const searchFilter = config.userSearchFilter.replace('{{username}}', username)
 
@@ -252,8 +256,8 @@ export async function authenticateUser(
       user: {
         dn: userDn,
         username: String(entry[config.usernameAttribute] ?? username),
-        email: entry[config.emailAttribute] ? String(entry[config.emailAttribute]) : null,
-        displayName: entry[config.displayNameAttribute] ? String(entry[config.displayNameAttribute]) : null,
+        email: entry[config.emailAttribute] ? String(entry[config.emailAttribute]) || null : null,
+        displayName: entry[config.displayNameAttribute] ? String(entry[config.displayNameAttribute]) || null : null,
         groups: Array.isArray(entry.memberOf)
           ? entry.memberOf.map(String)
           : entry.memberOf


### PR DESCRIPTION
## Summary

- **Service account & SSH key discovery**: Agent-side checks to discover local users and SSH keys on hosts, with ingest handlers and database schema to store them
- **LDAP authentication**: Full LDAP login flow with configurable directory connections, TLS certificate support, and admin UI for managing LDAP configurations
- **Post-login onboarding**: LDAP users without a real email are redirected to set one; new LDAP users are assigned a "pending" role requiring admin approval before dashboard access
- **Session cookie signing**: LDAP login now signs session tokens with HMAC-SHA256 to match Better Auth's signed cookie format
- **Host settings & local user management**: Per-host settings tab and detail views for local user accounts discovered by agents
- **Directory account views**: Browse and manage domain/directory-sourced service accounts across the organisation
- **Migration safety**: Added timestamp validation script to prevent misordered migrations

## Test plan

- [ ] Verify LDAP login works with a test directory (e.g. OpenLDAP)
- [ ] Confirm new LDAP users are created with "pending" role and see the approval page
- [ ] Confirm LDAP users without email see the email setup form and can submit a real address
- [ ] Verify admin can change a "pending" user's role from the team page
- [ ] Test service account and SSH key discovery via agent checks
- [ ] Verify host settings tab renders and saves correctly
- [ ] Confirm directory account listing and detail pages load

🤖 Generated with [Claude Code](https://claude.com/claude-code)