### PR TITLE
feat(agent): add -uninstall flag

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -30,6 +30,7 @@ func main() {
 	tokenFlag := flag.String("token", "", "Enrolment token (overrides config file and INFRAWATCH_ORG_TOKEN)")
 	addressFlag := flag.String("address", "", "Ingest address host:port (overrides config file and INFRAWATCH_INGEST_ADDRESS)")
 	installFlag := flag.Bool("install", false, "Install agent as a system service and exit (requires --token)")
+	uninstallFlag := flag.Bool("uninstall", false, "Stop and remove the agent service, binary, config, and data files")
 	tlsSkipVerifyFlag := flag.Bool("tls-skip-verify", false, "Skip TLS certificate verification — use when ingest uses a self-signed cert (insecure)")
 	versionFlag := flag.Bool("version", false, "Print agent version and exit")
 	versionFlagShort := flag.Bool("v", false, "Print agent version and exit (shorthand)")
@@ -52,6 +53,15 @@ func main() {
 		}
 		if err := install.Run(*tokenFlag, strings.TrimSpace(*addressFlag), *tlsSkipVerifyFlag); err != nil {
 			slog.Error("install failed", "err", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// ── Uninstall mode: stop service, remove all agent files, then exit ───────
+	if *uninstallFlag {
+		if err := install.Uninstall(); err != nil {
+			slog.Error("uninstall failed", "err", err)
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/agent/internal/install/uninstall.go
+++ b/agent/internal/install/uninstall.go
@@ -1,0 +1,136 @@
+package install
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// Uninstall stops the agent service, removes the binary, service files,
+// configuration, and data files for the current OS.
+// It must be called as root (Linux/macOS) or Administrator (Windows).
+func Uninstall() error {
+	switch runtime.GOOS {
+	case "linux":
+		return uninstallLinux()
+	case "darwin":
+		return uninstallDarwin()
+	case "windows":
+		return uninstallWindows()
+	default:
+		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+}
+
+// ── Linux / systemd ───────────────────────────────────────────────────────────
+
+func uninstallLinux() error {
+	if os.Getuid() != 0 {
+		return fmt.Errorf("uninstall must be run as root (try: sudo ./infrawatch-agent -uninstall)")
+	}
+
+	const serviceName = "infrawatch-agent"
+	const unitPath = "/etc/systemd/system/infrawatch-agent.service"
+	const binaryPath = "/usr/local/bin/infrawatch-agent"
+	const cfgDir = "/etc/infrawatch"
+	const dataDir = "/var/lib/infrawatch"
+
+	// Stop and disable the service (ignore errors — it may not be running)
+	slog.Info("stopping service", "name", serviceName)
+	_ = run("systemctl", "stop", serviceName)
+	_ = run("systemctl", "disable", serviceName)
+
+	// Remove systemd unit and reload
+	removeFile(unitPath)
+	slog.Info("reloading systemd daemon")
+	_ = run("systemctl", "daemon-reload")
+
+	// Remove binary, config, and data
+	removeFile(binaryPath)
+	removeDir(cfgDir)
+	removeDir(dataDir)
+
+	printUninstallSuccess()
+	return nil
+}
+
+// ── macOS / launchd ───────────────────────────────────────────────────────────
+
+func uninstallDarwin() error {
+	if os.Getuid() != 0 {
+		return fmt.Errorf("uninstall must be run as root (try: sudo ./infrawatch-agent -uninstall)")
+	}
+
+	const plistPath = "/Library/LaunchDaemons/com.infrawatch.agent.plist"
+	const binaryPath = "/usr/local/bin/infrawatch-agent"
+	const cfgDir = "/etc/infrawatch"
+	const dataDir = "/var/lib/infrawatch"
+	const logFile = "/var/log/infrawatch-agent.log"
+
+	// Unload the launchd service (ignore errors — it may not be loaded)
+	slog.Info("unloading launchd service")
+	_ = run("launchctl", "unload", plistPath)
+
+	// Remove plist, binary, config, data, and log
+	removeFile(plistPath)
+	removeFile(binaryPath)
+	removeDir(cfgDir)
+	removeDir(dataDir)
+	removeFile(logFile)
+
+	printUninstallSuccess()
+	return nil
+}
+
+// ── Windows / Service Control Manager ────────────────────────────────────────
+
+func uninstallWindows() error {
+	if !isAdmin() {
+		return fmt.Errorf("uninstall must be run as Administrator")
+	}
+
+	binDir := filepath.Join(`C:\Program Files`, "infrawatch")
+	cfgDir := filepath.Join(`C:\ProgramData`, "infrawatch")
+
+	// Stop and delete the Windows service (ignore errors — it may not exist)
+	slog.Info("stopping Windows service", "name", "InfrawatchAgent")
+	_ = run("sc.exe", "stop", "InfrawatchAgent")
+	_ = run("sc.exe", "delete", "InfrawatchAgent")
+
+	// Remove binary directory and config/data directory
+	removeDir(binDir)
+	removeDir(cfgDir)
+
+	printUninstallSuccess()
+	return nil
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+func removeFile(path string) {
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			slog.Info("file not found, skipping", "path", path)
+		} else {
+			slog.Warn("failed to remove file", "path", path, "err", err)
+		}
+		return
+	}
+	slog.Info("removed", "path", path)
+}
+
+func removeDir(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		slog.Warn("failed to remove directory", "path", path, "err", err)
+		return
+	}
+	slog.Info("removed", "path", path)
+}
+
+func printUninstallSuccess() {
+	fmt.Println()
+	fmt.Println("Infrawatch agent has been uninstalled.")
+	fmt.Println("All service files, configuration, and data have been removed.")
+}


### PR DESCRIPTION
## Summary
- Adds a `-uninstall` CLI flag to the agent that cleanly removes all traces of the agent from the system
- Stops and disables the service (systemd on Linux, launchd on macOS, SCM on Windows)
- Removes the binary, service files, configuration directory, and data directory
- Requires root/Administrator privileges, matching the install flow

## Usage
```bash
sudo ./infrawatch-agent -uninstall
```

## Test plan
- [ ] Verify `-uninstall` appears in `-help` output
- [ ] Test on Linux: install agent, run `-uninstall`, confirm systemd unit, binary, `/etc/infrawatch/`, and `/var/lib/infrawatch/` are removed
- [ ] Test on macOS: install agent, run `-uninstall`, confirm launchd plist, binary, config, data, and log file are removed
- [ ] Test on Windows: install agent, run `-uninstall`, confirm SCM service deleted and `Program Files\infrawatch` and `ProgramData\infrawatch` are removed
- [ ] Verify uninstall handles already-stopped or non-existent service gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)