### PR TITLE
fix(ingest): close heartbeat stream within 30s when agent is deleted

### DIFF
--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -133,6 +133,13 @@ func (h *HeartbeatHandler) Heartbeat(stream agentv1.IngestService_HeartbeatServe
 	queryPollTicker := time.NewTicker(2 * time.Second)
 	defer queryPollTicker.Stop()
 
+	// Re-validate the agent exists every 30s. If it was deleted (e.g. the host
+	// was removed in the UI), close the stream with NotFound so the agent
+	// detects the rejection and re-registers cleanly rather than heartbeating
+	// into the void for the lifetime of the stream.
+	agentCheckTicker := time.NewTicker(30 * time.Second)
+	defer agentCheckTicker.Stop()
+
 loop:
 	for {
 		select {
@@ -158,6 +165,15 @@ loop:
 			}
 			if err := h.processHeartbeat(ctx, stream, agentID, agent.OrganisationID, hostID, agent.Hostname, req); err != nil {
 				return err
+			}
+
+		case <-agentCheckTicker.C:
+			if _, err := queries.GetAgentByID(ctx, h.pool, agentID); err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					slog.Info("agent deleted, closing stream for re-registration", "agent_id", agentID)
+					return status.Error(codes.NotFound, "agent not found")
+				}
+				slog.Warn("re-validating agent", "agent_id", agentID, "err", err)
 			}
 
 		case <-queryPollTicker.C:


### PR DESCRIPTION
## Problem

When a host is deleted from the UI, the agent record is removed from the database. However, the ingest service only validates the agent **once** at stream open time — so any already-connected agent would continue heartbeating indefinitely against a deleted record, never triggering re-registration.

## Fix

Add a 30-second ticker inside the heartbeat stream loop that calls `GetAgentByID`. If the agent no longer exists (`pgx.ErrNoRows`), the stream is closed with `codes.NotFound`.

The agent (v0.16.0+, from simonjcarr/infrawatch#87) already handles this: `isFatalAgentError()` detects `NotFound`, returns `ErrAgentDeregistered`, `runAgent` clears `agent_state.json`, and the agent re-registers with the same keypair — creating a new host record in the UI automatically.

## End-to-end flow after this fix

1. Admin deletes host in UI → host + agent records deleted in DB transaction
2. Ingest liveness ticker fires (within 30s) → `GetAgentByID` returns `ErrNoRows` → stream closed with `NotFound`
3. Agent detects `ErrAgentDeregistered` → clears local state → re-registers
4. New pending host appears in UI (auto-approved if token has `auto_approve`)

## Test plan

- [ ] Delete a host from the UI while the agent is running; confirm the agent re-registers within ~30 seconds without manual intervention
- [ ] `go build ./...` in `apps/ingest/` passes
- [ ] Confirm a non-deleted agent's stream is not affected by the ticker

🤖 Generated with [Claude Code](https://claude.com/claude-code)