### PR TITLE
fix(agents): decrement enrolment token usage count on host deletion

### DIFF
--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -578,6 +578,23 @@ export async function deleteHost(
       //     can no longer connect; without this the agent keeps heartbeating
       //     against a host row that no longer exists)
       if (host.agentId) {
+        // Fetch the enrolment token ID before deleting the agent so we can
+        // decrement the usage counter — keeping it in sync with live registrations
+        const agent = await tx.query.agents.findFirst({
+          where: eq(agents.id, host.agentId),
+          columns: { enrolmentTokenId: true },
+        })
+
+        if (agent?.enrolmentTokenId) {
+          await tx
+            .update(agentEnrolmentTokens)
+            .set({
+              usageCount: sql`GREATEST(usage_count - 1, 0)`,
+              updatedAt: new Date(),
+            })
+            .where(eq(agentEnrolmentTokens.id, agent.enrolmentTokenId))
+        }
+
         await tx
           .delete(agentStatusHistory)
           .where(eq(agentStatusHistory.agentId, host.agentId))


### PR DESCRIPTION
## Summary

- Enrollment token `usage_count` was incremented on agent registration but never decremented on host deletion, leaving the counter permanently inflated
- Tokens with a `maxUses` limit would appear exhausted even after all their registered hosts were deleted
- Fix reads the agent's `enrolmentTokenId` inside the deletion transaction and decrements `usage_count` via `GREATEST(usage_count - 1, 0)` before the agent row is removed

## Test plan

- [ ] Register a host using an enrolment token — confirm usage count increments
- [ ] Delete the host from the UI — confirm usage count decrements back
- [ ] Confirm usage count never goes below 0
- [ ] Confirm tokens with `maxUses` become available again after their hosts are deleted

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)