### PR TITLE
fix(agents): derive enrolment token usage count from live agent query

### DIFF
--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -21,7 +21,7 @@ import {
   agentQueries,
   resourceTags,
 } from '@/lib/db/schema'
-import { eq, and, isNull, gt, gte, asc, sql, inArray } from 'drizzle-orm'
+import { eq, and, isNull, isNotNull, gt, gte, asc, sql, inArray } from 'drizzle-orm'
 import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
 import { applyGlobalDefaultsToHost } from '@/lib/actions/alerts'
 import { getOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
@@ -191,12 +191,39 @@ export async function createEnrolmentToken(
 }
 
 export async function listEnrolmentTokens(orgId: string): Promise<AgentEnrolmentToken[]> {
-  return db.query.agentEnrolmentTokens.findMany({
+  const tokens = await db.query.agentEnrolmentTokens.findMany({
     where: and(
       eq(agentEnrolmentTokens.organisationId, orgId),
       isNull(agentEnrolmentTokens.deletedAt),
     ),
   })
+
+  if (tokens.length === 0) return tokens
+
+  // Derive live usage count from active agents — the stored counter can drift
+  // if hosts are deleted, so we always compute it fresh
+  const liveCounts = await db
+    .select({
+      enrolmentTokenId: agents.enrolmentTokenId,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.organisationId, orgId),
+        isNull(agents.deletedAt),
+        isNotNull(agents.enrolmentTokenId),
+        inArray(agents.enrolmentTokenId, tokens.map((t) => t.id)),
+      ),
+    )
+    .groupBy(agents.enrolmentTokenId)
+
+  const countMap = new Map(liveCounts.map((r) => [r.enrolmentTokenId, r.count]))
+
+  return tokens.map((token) => ({
+    ...token,
+    usageCount: countMap.get(token.id) ?? 0,
+  }))
 }
 
 export async function revokeEnrolmentToken(


### PR DESCRIPTION
## Summary

- The stored `usage_count` column was already out of sync before the decrement fix (PR #93) landed
- `listEnrolmentTokens` was reading the stale stored value, so the enrollment screen still showed 3 even with only 2 active hosts
- This PR replaces the stored counter read with a live `GROUP BY` query on the `agents` table, so the count is always accurate regardless of what the column contains

## How it works

`listEnrolmentTokens` now runs a second query that counts active (non-deleted) agents grouped by `enrolment_token_id`, then overlays those live counts onto the returned tokens. Tokens with no active agents get `0`.

## Test plan

- [ ] Enrollment screen shows correct usage count matching actual registered hosts
- [ ] Deleting a host immediately reflects the correct (decremented) count on refresh
- [ ] Tokens with `maxUses` correctly show as exhausted / available based on live count

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)