### PR TITLE
fix(ldap): constrain TLS certificate preview to modal width

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -84,7 +84,7 @@ function CertificateUpload({
     return (
       <div className="space-y-1.5">
         <Label>TLS Certificate (CA)</Label>
-        <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs font-mono whitespace-pre text-muted-foreground relative">
+        <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs font-mono whitespace-pre overflow-x-auto w-full text-muted-foreground relative">
           {preview}
           <Button
             type="button"


### PR DESCRIPTION
## Summary

- Adds `overflow-x-auto` and `w-full` to the TLS Certificate preview `div` in the LDAP configuration modal
- The `whitespace-pre` class was causing long single-line certificate content to expand the modal horizontally beyond the viewport
- The preview div now scrolls internally rather than expanding the modal
- No other `whitespace-pre` usages or raw `<textarea>` elements exist in modal components

## Test plan

- [ ] Open Settings → LDAP / Active Directory
- [ ] Edit an existing LDAP configuration (or create new one with TLS enabled)
- [ ] Upload a PEM certificate into the TLS Certificate (CA) field
- [ ] Verify the modal does not expand horizontally
- [ ] Verify Cancel and Save Changes buttons remain visible without horizontal scrolling
- [ ] Verify the certificate preview scrolls horizontally within its own container if content is wide

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)