### PR TITLE
fix(ldap): properly constrain TLS certificate preview within modal

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -84,7 +84,7 @@ function CertificateUpload({
     return (
       <div className="space-y-1.5">
         <Label>TLS Certificate (CA)</Label>
-        <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs font-mono whitespace-pre overflow-x-auto w-full text-muted-foreground relative">
+        <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs font-mono whitespace-pre-wrap break-all text-muted-foreground relative">
           {preview}
           <Button
             type="button"
@@ -258,7 +258,7 @@ export function LdapSettingsClient({
               Add Configuration
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+          <DialogContent className="max-w-lg max-h-[80vh] overflow-x-hidden overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Add LDAP Configuration</DialogTitle>
               <DialogDescription>
@@ -487,7 +487,7 @@ export function LdapSettingsClient({
 
       {/* Edit LDAP Configuration Dialog */}
       <Dialog open={editingConfig !== null} onOpenChange={(open) => { if (!open) setEditingConfig(null) }}>
-        <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+        <DialogContent className="max-w-lg max-h-[80vh] overflow-x-hidden overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit LDAP Configuration</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
## Summary

The first fix in #95 was incomplete — it added `overflow-x-auto w-full` to the certificate div, but the parent dialog had no hard width constraint so the div still grew to fit content.

This PR contains the proper fix:

- **Certificate preview div**: `whitespace-pre` → `whitespace-pre-wrap break-all` so long certificate lines wrap within the container instead of pushing the dialog wider
- **Both LDAP `DialogContent` elements**: add `overflow-x-hidden` to hard-clamp the dialog at `max-w-lg` regardless of content width

## Root Cause

`whitespace-pre` never wraps text. A certificate pasted as a single long line would cause the preview `div` to grow indefinitely. The `max-w-lg` on the `DialogContent` sets a _maximum_ width, but without `overflow-x-hidden` the dialog still expands when children are wider.

## Test plan

- [ ] Open Settings → LDAP / Active Directory
- [ ] Edit an existing LDAP configuration with TLS enabled
- [ ] Upload a PEM certificate into the TLS Certificate (CA) field
- [ ] Verify the modal stays within its fixed width
- [ ] Verify certificate content wraps inside its preview box
- [ ] Verify Cancel and Save Changes buttons are always visible without horizontal scrolling

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)