### PR TITLE
fix(ldap): cap TLS certificate preview at 5 lines with vertical scroll

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -77,15 +77,11 @@ function CertificateUpload({
   }
 
   if (value) {
-    const lines = value.split('\n')
-    const preview = lines.length > 3
-      ? `${lines[0]}\n...(${lines.length - 2} lines)...\n${lines[lines.length - 1]}`
-      : value
     return (
       <div className="space-y-1.5">
         <Label>TLS Certificate (CA)</Label>
-        <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs font-mono whitespace-pre-wrap break-all text-muted-foreground relative">
-          {preview}
+        <div className="rounded-md border bg-muted/50 px-3 py-2 text-xs font-mono whitespace-pre-wrap break-all overflow-y-auto max-h-24 text-muted-foreground relative">
+          {value}
           <Button
             type="button"
             variant="ghost"


### PR DESCRIPTION
## Summary

- Replaces the old 3-line truncation logic (`lines[0]\n...(N lines)...\nlast line`) with a scrollable box
- Certificate preview div is now capped at `max-h-24` (5 lines of `text-xs` content + padding) with `overflow-y-auto` for vertical scrolling
- Full certificate content is visible by scrolling — no content is hidden

## Test plan

- [ ] Upload a PEM certificate into the TLS Certificate (CA) field
- [ ] Verify the preview box shows ~5 lines then becomes scrollable
- [ ] Verify the full certificate content can be read by scrolling
- [ ] Verify the modal width stays constrained (no horizontal overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)