### PR TITLE
fix(tasks): resolve patch output deadlock, add timeouts and debug UI

### DIFF
--- a/agent/internal/tasks/patch.go
+++ b/agent/internal/tasks/patch.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	agentv1 "github.com/infrawatch/proto/agent/v1"
 )
@@ -44,6 +45,10 @@ func RunPatch(ctx context.Context, configJSON string, progressFn func(chunk stri
 	if cfg.Mode == "" {
 		cfg.Mode = "all"
 	}
+
+	// Apply a hard 45-minute timeout so the task cannot hang indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Minute)
+	defer cancel()
 
 	pm, err := detectPackageManager()
 	if err != nil {
@@ -128,6 +133,11 @@ func buildPatchCommand(pm, mode string) (*exec.Cmd, error) {
 
 // runCommandStreaming runs cmd, streaming stdout+stderr to progressFn in line
 // batches. Returns the exit code and the full combined output.
+//
+// The scanner runs in a separate goroutine so the command can write output
+// without blocking (io.Pipe is synchronous). After the process exits we close
+// the write-end of the pipe to signal EOF to the scanner, then wait for it to
+// flush any remaining lines before returning.
 func runCommandStreaming(ctx context.Context, cmd *exec.Cmd, progressFn func(chunk string)) (exitCode int, rawOutput string, err error) {
 	cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 
@@ -136,34 +146,61 @@ func runCommandStreaming(ctx context.Context, cmd *exec.Cmd, progressFn func(chu
 	cmd.Stderr = pw
 
 	if err := cmd.Start(); err != nil {
+		_ = pr.CloseWithError(err)
+		_ = pw.CloseWithError(err)
 		return -1, "", fmt.Errorf("starting command: %w", err)
 	}
 
-	// Collect output line-by-line, forwarding batches to progressFn.
+	// Scanner goroutine: reads lines and forwards batches to progressFn.
+	// Must run concurrently with the command (io.Pipe has no internal buffer —
+	// the command's writes block until we read).
 	var sb strings.Builder
-	scanner := bufio.NewScanner(pr)
-	var batch strings.Builder
-	lineCount := 0
-
-	for scanner.Scan() {
-		line := scanner.Text() + "\n"
-		sb.WriteString(line)
-		batch.WriteString(line)
-		lineCount++
-		if lineCount >= 10 {
-			progressFn(batch.String())
-			batch.Reset()
-			lineCount = 0
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		scanner := bufio.NewScanner(pr)
+		// Use a 1 MB line buffer to handle long package manager output lines.
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		var batch strings.Builder
+		lineCount := 0
+		for scanner.Scan() {
+			line := scanner.Text() + "\n"
+			sb.WriteString(line)
+			batch.WriteString(line)
+			lineCount++
+			if lineCount >= 10 {
+				progressFn(batch.String())
+				batch.Reset()
+				lineCount = 0
+			}
 		}
-	}
-	// Flush remaining lines
-	if batch.Len() > 0 {
-		progressFn(batch.String())
+		if batch.Len() > 0 {
+			progressFn(batch.String())
+		}
+	}()
+
+	// Context watcher: kill the process if the context is cancelled (timeout).
+	go func() {
+		select {
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+		case <-scanDone:
+			// Completed normally — nothing to kill.
+		}
+	}()
+
+	// Wait for the process to exit, then close pw to signal EOF to the scanner.
+	waitErr := cmd.Wait()
+	_ = pw.Close()
+	<-scanDone // Wait for all buffered output to be flushed.
+
+	if ctx.Err() != nil {
+		return -1, sb.String(), fmt.Errorf("command cancelled: %w", ctx.Err())
 	}
 
-	pw.Close()
-
-	if waitErr := cmd.Wait(); waitErr != nil {
+	if waitErr != nil {
 		if exitErr, ok := waitErr.(*exec.ExitError); ok {
 			return exitErr.ExitCode(), sb.String(), nil
 		}

--- a/apps/ingest/internal/db/queries/task_runs.sql.go
+++ b/apps/ingest/internal/db/queries/task_runs.sql.go
@@ -2,6 +2,7 @@ package queries
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -130,6 +131,49 @@ func CompleteTaskRunHost(
 		WHERE id = $1
 	`
 	_, err := pool.Exec(ctx, q, taskRunHostID, hostStatus, exitCode, resultArg)
+	return err
+}
+
+// TimeoutStuckTaskRunHosts marks any task_run_hosts rows that have been in
+// 'running' status for longer than maxAge as 'failed', then closes any parent
+// task_run whose all hosts are now in a terminal state.
+func TimeoutStuckTaskRunHosts(ctx context.Context, pool *pgxpool.Pool, maxAge time.Duration) error {
+	const q = `
+		WITH timed_out AS (
+		  UPDATE task_run_hosts
+		  SET status       = 'failed',
+		      exit_code    = -1,
+		      completed_at = NOW(),
+		      updated_at   = NOW()
+		  WHERE status     = 'running'
+		    AND deleted_at IS NULL
+		    AND started_at < NOW() - ($1 || ' seconds')::interval
+		  RETURNING task_run_id
+		),
+		affected AS (
+		  SELECT DISTINCT task_run_id FROM timed_out
+		),
+		run_counts AS (
+		  SELECT
+		    a.task_run_id,
+		    COUNT(*) FILTER (WHERE trh.status NOT IN ('success','failed','skipped')) AS still_active,
+		    COUNT(*) FILTER (WHERE trh.status = 'failed')                           AS failed_count
+		  FROM affected a
+		  JOIN task_run_hosts trh
+		    ON trh.task_run_id = a.task_run_id AND trh.deleted_at IS NULL
+		  GROUP BY a.task_run_id
+		)
+		UPDATE task_runs tr
+		SET status       = CASE WHEN rc.failed_count > 0 THEN 'failed' ELSE 'completed' END,
+		    completed_at = NOW(),
+		    updated_at   = NOW()
+		FROM run_counts rc
+		WHERE tr.id             = rc.task_run_id
+		  AND rc.still_active   = 0
+		  AND tr.status NOT IN ('completed', 'failed')
+	`
+	secs := int64(maxAge.Seconds())
+	_, err := pool.Exec(ctx, q, secs)
 	return err
 }
 

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -140,6 +140,12 @@ func (h *HeartbeatHandler) Heartbeat(stream agentv1.IngestService_HeartbeatServe
 	agentCheckTicker := time.NewTicker(30 * time.Second)
 	defer agentCheckTicker.Stop()
 
+	// Scan for task_run_hosts rows that have been 'running' for more than
+	// 60 minutes with no completion signal. This catches cases where the agent
+	// dies mid-task or a bug prevents the result from being reported.
+	taskTimeoutTicker := time.NewTicker(5 * time.Minute)
+	defer taskTimeoutTicker.Stop()
+
 loop:
 	for {
 		select {
@@ -165,6 +171,11 @@ loop:
 			}
 			if err := h.processHeartbeat(ctx, stream, agentID, agent.OrganisationID, hostID, agent.Hostname, req); err != nil {
 				return err
+			}
+
+		case <-taskTimeoutTicker.C:
+			if err := queries.TimeoutStuckTaskRunHosts(ctx, h.pool, 60*time.Minute); err != nil {
+				slog.Warn("timing out stuck task run hosts", "err", err)
 			}
 
 		case <-agentCheckTicker.C:

--- a/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { formatDistanceToNow, format } from 'date-fns'
+import { formatDistanceToNow, format, formatDuration, intervalToDuration } from 'date-fns'
 import {
   ArrowLeft,
   CheckCircle2,
@@ -12,6 +12,7 @@ import {
   RotateCcw,
   SkipForward,
   Terminal,
+  AlertTriangle,
 } from 'lucide-react'
 import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
@@ -65,6 +66,19 @@ function RunStatusBadge({ status }: { status: string }) {
   }
 }
 
+// ── Elapsed time hook ─────────────────────────────────────────────────────────
+
+function useElapsedSeconds(startedAt: Date | null | string | undefined, active: boolean): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!active || !startedAt) return
+    const id = setInterval(() => setNow(Date.now()), 5_000)
+    return () => clearInterval(id)
+  }, [active, startedAt])
+  if (!startedAt) return 0
+  return Math.max(0, Math.floor((now - new Date(startedAt).getTime()) / 1000))
+}
+
 // ── Output panel ──────────────────────────────────────────────────────────────
 
 function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive: boolean }) {
@@ -72,6 +86,12 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
   const scrollRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
   const prevOutputLen = useRef(0)
+
+  const elapsedSecs = useElapsedSeconds(hostRow.startedAt, isLive && hostRow.status === 'running')
+  const elapsedMins = Math.floor(elapsedSecs / 60)
+  const hasNoOutput = !hostRow.rawOutput
+  // Warn if running for > 5 minutes with no output from the command
+  const isStuck = isLive && hostRow.status === 'running' && hasNoOutput && elapsedMins >= 5
 
   // Auto-scroll to bottom when new output arrives and the user hasn't scrolled up.
   useEffect(() => {
@@ -91,12 +111,22 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
 
   const result = hostRow.result as PatchTaskResult | null
 
+  const elapsedLabel =
+    elapsedSecs > 0
+      ? formatDuration(intervalToDuration({ start: 0, end: elapsedSecs * 1000 }), {
+          format: elapsedSecs < 60 ? ['seconds'] : elapsedSecs < 3600 ? ['minutes', 'seconds'] : ['hours', 'minutes'],
+        })
+      : null
+
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* Output header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b bg-zinc-900 text-zinc-300 text-xs rounded-t-md">
         <Terminal className="size-3.5" />
         <span className="font-mono">{hostRow.host.displayName ?? hostRow.host.hostname}</span>
+        {isLive && elapsedLabel && (
+          <span className="text-zinc-500 ml-1">({elapsedLabel})</span>
+        )}
         {isLive && <span className="ml-auto text-blue-400 animate-pulse">● live</span>}
         {result?.reboot_required && (
           <Badge className="ml-auto bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">
@@ -114,13 +144,38 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
       >
         {hostRow.status === 'skipped' ? (
           <p className="text-zinc-500 italic">Skipped: {hostRow.skipReason ?? 'no reason given'}</p>
+        ) : hostRow.status === 'pending' ? (
+          <p className="text-zinc-500 italic">
+            <Clock className="inline size-3.5 mr-1 -mt-0.5" />
+            Waiting for agent to pick up task…
+          </p>
+        ) : hostRow.status === 'running' && hasNoOutput ? (
+          <div className="space-y-3">
+            <p className="text-zinc-500 italic">
+              <Loader2 className="inline size-3.5 mr-1 -mt-0.5 animate-spin" />
+              Agent connected — waiting for command output…
+              {elapsedLabel && <span className="text-zinc-600"> ({elapsedLabel} elapsed)</span>}
+            </p>
+            {isStuck && (
+              <div className="border border-amber-700 rounded p-2 text-amber-400 not-italic space-y-1">
+                <p className="flex items-center gap-1.5 font-semibold">
+                  <AlertTriangle className="size-3.5 shrink-0" />
+                  No output received for {elapsedMins} minutes
+                </p>
+                <p className="text-amber-500 text-xs">
+                  The patch command may still be starting up, or the agent may have lost its connection.
+                  The task will be automatically failed after 60 minutes if no response is received.
+                </p>
+              </div>
+            )}
+          </div>
         ) : hostRow.rawOutput ? (
           <>
             {hostRow.rawOutput}
             <div ref={bottomRef} />
           </>
         ) : (
-          <p className="text-zinc-500 italic">Waiting for output…</p>
+          <p className="text-zinc-500 italic">No output captured.</p>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- **Fix io.Pipe deadlock in `runCommandStreaming`**: the output scanner was running in the same goroutine as `cmd.Wait()`, causing a deadlock — the scanner blocked waiting for EOF, and EOF only came after `pw.Close()` which was placed after the scanner loop. Fixed by moving the scanner to a goroutine, calling `cmd.Wait()` first, then closing `pw` to signal EOF, then draining via `<-scanDone`.
- **Add 45-minute context timeout** in `RunPatch` so a hanging patch command is automatically killed and reported as failed.
- **Add context-cancellation watcher goroutine** to `SIGKILL` the process if the context deadline is exceeded.
- **Add `TimeoutStuckTaskRunHosts`** SQL query that marks `task_run_hosts` rows stuck in `running` for >N minutes as `failed`, and closes the parent `task_run` if all hosts are now terminal.
- **Fire timeout scan every 5 minutes** from the heartbeat handler with a 60-minute age threshold.
- **Improve task monitor UI**: distinct messages for `pending` ("Waiting for agent to pick up task…") vs `running` with no output ("Agent connected — waiting for command output…"), live elapsed timer in the output panel header, and an amber warning block after 5 minutes with no output.

## Test plan

- [ ] Trigger a patch run on a Linux host; confirm output streams live to the monitor page within seconds
- [ ] Verify the elapsed timer ticks in the output panel header while running
- [ ] For a pending host, confirm "Waiting for agent to pick up task…" is shown instead of the old generic message
- [ ] Confirm the 45-minute timeout is reflected in agent logs if a command hangs
- [ ] Confirm `TimeoutStuckTaskRunHosts` marks old running rows as failed (can be tested by manually setting a `started_at` in the past)

🤖 Generated with [Claude Code](https://claude.com/claude-code)