### PR TITLE
feat(tasks): add task cancellation with agent-side process kill and UI

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -66,6 +66,10 @@ type Runner struct {
 	// re-sends the same task before the agent has reported a result.
 	seenTaskIDs map[string]struct{}
 
+	// taskCancelFuncs maps task_run_host_id → context.CancelFunc for every
+	// task currently running on this agent. Used to stop tasks on server request.
+	taskCancelFuncs sync.Map
+
 	// Signalled when new query results are ready so the send loop can fire
 	// an immediate heartbeat rather than waiting for the next 30s tick.
 	resultsReady chan struct{}
@@ -262,6 +266,16 @@ func (r *Runner) handleResponse(ctx context.Context, resp *agentv1.HeartbeatResp
 			go r.executeTask(ctx, resp.PendingTask)
 		}
 	}
+	if len(resp.CancelTaskIds) > 0 {
+		for _, id := range resp.CancelTaskIds {
+			if fn, ok := r.taskCancelFuncs.Load(id); ok {
+				slog.Info("cancelling task on server request", "task_id", id)
+				fn.(context.CancelFunc)()
+			} else {
+				slog.Debug("cancel request for task not in flight (may have already completed)", "task_id", id)
+			}
+		}
+	}
 	if resp.UpdateAvailable && resp.DownloadUrl != "" {
 		slog.Info("agent update available, downloading",
 			"current", r.version,
@@ -323,7 +337,16 @@ func (r *Runner) drainQueryResults() []*agentv1.AgentQueryResult {
 
 // executeTask runs the task in the background, forwarding incremental output
 // chunks via progressFn and buffering the final result for the next heartbeat.
+// Each task gets its own derived context so it can be cancelled independently
+// via handleResponse without tearing down the whole heartbeat stream.
 func (r *Runner) executeTask(ctx context.Context, task *agentv1.AgentTask) {
+	taskCtx, taskCancel := context.WithCancel(ctx)
+	r.taskCancelFuncs.Store(task.TaskId, taskCancel)
+	defer func() {
+		taskCancel() // always release the context resources
+		r.taskCancelFuncs.Delete(task.TaskId)
+	}()
+
 	progressFn := func(chunk string) {
 		r.taskProgressMu.Lock()
 		r.taskProgress = append(r.taskProgress, &agentv1.AgentTaskProgress{
@@ -338,7 +361,7 @@ func (r *Runner) executeTask(ctx context.Context, task *agentv1.AgentTask) {
 		}
 	}
 
-	result := tasks.Dispatch(ctx, task, progressFn)
+	result := tasks.Dispatch(taskCtx, task, progressFn)
 
 	r.taskResultsMu.Lock()
 	r.taskResults = append(r.taskResults, result)

--- a/agent/internal/tasks/patch.go
+++ b/agent/internal/tasks/patch.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -61,9 +62,26 @@ func RunPatch(ctx context.Context, configJSON string, progressFn func(chunk stri
 	}
 
 	exitCode, rawOutput, runErr := runCommandStreaming(ctx, cmd, progressFn)
-	if runErr != nil && exitCode == 0 {
-		// command couldn't start at all
-		return errorResult(runErr.Error())
+	if runErr != nil {
+		if exitCode == 0 {
+			// Command couldn't start at all.
+			return errorResult(runErr.Error())
+		}
+		// Process was killed via context — report the reason clearly.
+		if errors.Is(runErr, context.Canceled) {
+			return &agentv1.AgentTaskResult{
+				ExitCode: int32(exitCode),
+				Error:    "cancelled by user",
+			}
+		}
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			return &agentv1.AgentTaskResult{
+				ExitCode: int32(exitCode),
+				Error:    "task timed out (exceeded 45 minutes)",
+			}
+		}
+		// Other kill (e.g. SIGKILL from outside): fall through and return the
+		// partial result so the output is preserved.
 	}
 
 	result := patchResult{

--- a/apps/ingest/internal/db/queries/task_runs.sql.go
+++ b/apps/ingest/internal/db/queries/task_runs.sql.go
@@ -64,6 +64,34 @@ func GetPendingTasksForHost(ctx context.Context, pool *pgxpool.Pool, hostID stri
 	return result, rows.Err()
 }
 
+// GetCancellingTasksForHost returns the task_run_hosts IDs for a given host
+// that are in 'cancelling' status. These IDs are sent to the agent so it can
+// stop the corresponding in-flight processes.
+func GetCancellingTasksForHost(ctx context.Context, pool *pgxpool.Pool, hostID string) ([]string, error) {
+	const q = `
+		SELECT id
+		FROM task_run_hosts
+		WHERE host_id    = $1
+		  AND status     = 'cancelling'
+		  AND deleted_at IS NULL
+	`
+	rows, err := pool.Query(ctx, q, hostID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // MarkTaskRunHostRunning transitions a task_run_hosts row to 'running' and
 // also transitions the parent task_run to 'running' if it is still 'pending'.
 // This is done atomically so that a concurrent ingest instance cannot dispatch
@@ -121,9 +149,11 @@ func CompleteTaskRunHost(
 	if resultJSON != "" {
 		resultArg = resultJSON
 	}
+	// If the row is currently 'cancelling', persist 'cancelled' regardless of
+	// the agent-reported outcome — the user requested the stop.
 	const q = `
 		UPDATE task_run_hosts
-		SET status       = $2,
+		SET status       = CASE WHEN status = 'cancelling' THEN 'cancelled' ELSE $2 END,
 		    exit_code    = $3,
 		    result       = $4::jsonb,
 		    completed_at = NOW(),
@@ -141,11 +171,11 @@ func TimeoutStuckTaskRunHosts(ctx context.Context, pool *pgxpool.Pool, maxAge ti
 	const q = `
 		WITH timed_out AS (
 		  UPDATE task_run_hosts
-		  SET status       = 'failed',
+		  SET status       = CASE WHEN status = 'cancelling' THEN 'cancelled' ELSE 'failed' END,
 		      exit_code    = -1,
 		      completed_at = NOW(),
 		      updated_at   = NOW()
-		  WHERE status     = 'running'
+		  WHERE status     IN ('running', 'cancelling')
 		    AND deleted_at IS NULL
 		    AND started_at < NOW() - ($1 || ' seconds')::interval
 		  RETURNING task_run_id
@@ -156,21 +186,26 @@ func TimeoutStuckTaskRunHosts(ctx context.Context, pool *pgxpool.Pool, maxAge ti
 		run_counts AS (
 		  SELECT
 		    a.task_run_id,
-		    COUNT(*) FILTER (WHERE trh.status NOT IN ('success','failed','skipped')) AS still_active,
-		    COUNT(*) FILTER (WHERE trh.status = 'failed')                           AS failed_count
+		    COUNT(*) FILTER (WHERE trh.status NOT IN ('success','failed','skipped','cancelled')) AS still_active,
+		    COUNT(*) FILTER (WHERE trh.status = 'failed')                                       AS failed_count,
+		    COUNT(*) FILTER (WHERE trh.status = 'cancelled')                                    AS cancelled_count
 		  FROM affected a
 		  JOIN task_run_hosts trh
 		    ON trh.task_run_id = a.task_run_id AND trh.deleted_at IS NULL
 		  GROUP BY a.task_run_id
 		)
 		UPDATE task_runs tr
-		SET status       = CASE WHEN rc.failed_count > 0 THEN 'failed' ELSE 'completed' END,
+		SET status       = CASE
+		                     WHEN rc.failed_count    > 0 THEN 'failed'
+		                     WHEN rc.cancelled_count > 0 THEN 'cancelled'
+		                     ELSE 'completed'
+		                   END,
 		    completed_at = NOW(),
 		    updated_at   = NOW()
 		FROM run_counts rc
 		WHERE tr.id             = rc.task_run_id
 		  AND rc.still_active   = 0
-		  AND tr.status NOT IN ('completed', 'failed')
+		  AND tr.status NOT IN ('completed', 'failed', 'cancelled')
 	`
 	secs := int64(maxAge.Seconds())
 	_, err := pool.Exec(ctx, q, secs)
@@ -188,19 +223,24 @@ func MaybeCompleteTaskRun(ctx context.Context, pool *pgxpool.Pool, taskRunHostID
 		),
 		counts AS (
 		  SELECT
-		    COUNT(*) FILTER (WHERE status NOT IN ('success','failed','skipped')) AS active,
-		    COUNT(*) FILTER (WHERE status = 'failed')                           AS failed
+		    COUNT(*) FILTER (WHERE status NOT IN ('success','failed','skipped','cancelled')) AS active,
+		    COUNT(*) FILTER (WHERE status = 'failed')                                       AS failed,
+		    COUNT(*) FILTER (WHERE status = 'cancelled')                                    AS cancelled
 		  FROM task_run_hosts
 		  WHERE task_run_id = (SELECT task_run_id FROM run)
 		    AND deleted_at  IS NULL
 		)
 		UPDATE task_runs
-		SET status       = CASE WHEN (SELECT failed FROM counts) > 0 THEN 'failed' ELSE 'completed' END,
+		SET status       = CASE
+		                     WHEN (SELECT failed    FROM counts) > 0 THEN 'failed'
+		                     WHEN (SELECT cancelled FROM counts) > 0 THEN 'cancelled'
+		                     ELSE 'completed'
+		                   END,
 		    completed_at = NOW(),
 		    updated_at   = NOW()
 		WHERE id         = (SELECT task_run_id FROM run)
 		  AND (SELECT active FROM counts) = 0
-		  AND status NOT IN ('completed', 'failed')
+		  AND status NOT IN ('completed', 'failed', 'cancelled')
 	`
 	_, err := pool.Exec(ctx, q, taskRunHostID)
 	return err

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -239,6 +239,21 @@ loop:
 				slog.Info("dispatched task to agent", "host_id", hostID, "task_run_host_id", t.ID, "task_type", t.TaskType)
 			}
 		}
+
+			// Send cancellation signals for any tasks the user has stopped.
+			cancelIDs, err := queries.GetCancellingTasksForHost(ctx, h.pool, hostID)
+			if err != nil {
+				slog.Warn("fetching cancelling tasks", "host_id", hostID, "err", err)
+			} else if len(cancelIDs) > 0 {
+				if err := stream.Send(&agentv1.HeartbeatResponse{
+					Ok:            true,
+					CancelTaskIds: cancelIDs,
+				}); err != nil {
+					slog.Warn("pushing cancel task IDs to agent", "host_id", hostID, "err", err)
+					return err
+				}
+				slog.Info("pushed cancel task IDs to agent", "host_id", hostID, "count", len(cancelIDs))
+			}
 	}
 
 	// Mark agent and host offline on stream close

--- a/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow, format, formatDuration, intervalToDuration } from 'date-fns'
 import {
   ArrowLeft,
+  Ban,
   CheckCircle2,
   XCircle,
   Clock,
@@ -16,7 +17,19 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { Badge } from '@/components/ui/badge'
-import { getTaskRun } from '@/lib/actions/task-runs'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { cancelTaskRun, getTaskRun } from '@/lib/actions/task-runs'
 import type { TaskRunWithHosts, TaskRunHostWithHost } from '@/lib/actions/task-runs'
 import type { PatchTaskResult, PatchTaskConfig } from '@/lib/db/schema'
 
@@ -25,8 +38,8 @@ interface Props {
   initialTaskRun: TaskRunWithHosts
 }
 
-const TERMINAL_STATUSES = new Set(['success', 'failed', 'skipped'])
-const RUN_TERMINAL_STATUSES = new Set(['completed', 'failed'])
+const TERMINAL_STATUSES = new Set(['success', 'failed', 'skipped', 'cancelled'])
+const RUN_TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled'])
 
 function isHostTerminal(status: string) {
   return TERMINAL_STATUSES.has(status)
@@ -46,6 +59,10 @@ function HostStatusIcon({ status }: { status: string }) {
       return <XCircle className="size-4 text-red-500 shrink-0" />
     case 'running':
       return <Loader2 className="size-4 text-blue-500 animate-spin shrink-0" />
+    case 'cancelling':
+      return <Loader2 className="size-4 text-orange-400 animate-spin shrink-0" />
+    case 'cancelled':
+      return <Ban className="size-4 text-orange-500 shrink-0" />
     case 'skipped':
       return <SkipForward className="size-4 text-gray-400 shrink-0" />
     default:
@@ -61,6 +78,10 @@ function RunStatusBadge({ status }: { status: string }) {
       return <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">Failed</Badge>
     case 'running':
       return <Badge className="bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100"><Loader2 className="size-3 mr-1 animate-spin" />Running</Badge>
+    case 'cancelling':
+      return <Badge className="bg-orange-100 text-orange-700 border-orange-200 hover:bg-orange-100"><Loader2 className="size-3 mr-1 animate-spin" />Cancelling…</Badge>
+    case 'cancelled':
+      return <Badge className="bg-orange-100 text-orange-800 border-orange-200 hover:bg-orange-100"><Ban className="size-3 mr-1" />Cancelled</Badge>
     default:
       return <Badge className="bg-gray-100 text-gray-600 border-gray-200 hover:bg-gray-100"><Clock className="size-3 mr-1" />Pending</Badge>
   }
@@ -144,6 +165,16 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
       >
         {hostRow.status === 'skipped' ? (
           <p className="text-zinc-500 italic">Skipped: {hostRow.skipReason ?? 'no reason given'}</p>
+        ) : hostRow.status === 'cancelling' ? (
+          <p className="text-zinc-500 italic">
+            <Loader2 className="inline size-3.5 mr-1 -mt-0.5 animate-spin text-orange-400" />
+            Cancellation requested — waiting for agent to stop the process…
+          </p>
+        ) : hostRow.status === 'cancelled' && !hostRow.rawOutput ? (
+          <p className="text-orange-400 italic">
+            <Ban className="inline size-3.5 mr-1 -mt-0.5" />
+            Task was cancelled.
+          </p>
         ) : hostRow.status === 'pending' ? (
           <p className="text-zinc-500 italic">
             <Clock className="inline size-3.5 mr-1 -mt-0.5" />
@@ -191,9 +222,71 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
   )
 }
 
+// ── Stop button ───────────────────────────────────────────────────────────────
+
+function StopButton({
+  orgId,
+  taskRunId,
+  onCancelled,
+}: {
+  orgId: string
+  taskRunId: string
+  onCancelled: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const mutation = useMutation({
+    mutationFn: () => cancelTaskRun(orgId, taskRunId),
+    onSuccess: (result) => {
+      if ('error' in result) return
+      setOpen(false)
+      onCancelled()
+    },
+  })
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-orange-600 border-orange-200 hover:bg-orange-50 hover:text-orange-700"
+        >
+          <Ban className="size-3.5 mr-1.5" />
+          Stop
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop this task run?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Running hosts will receive a cancellation signal and their processes
+            will be stopped. Pending hosts will be cancelled immediately. This
+            cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep running</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={(e) => {
+              e.preventDefault()
+              mutation.mutate()
+            }}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending && <Loader2 className="size-3.5 mr-1.5 animate-spin" />}
+            Stop task
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
+  const queryClient = useQueryClient()
   const [selectedHostId, setSelectedHostId] = useState<string | null>(
     initialTaskRun.hosts[0]?.hostId ?? null,
   )
@@ -225,6 +318,10 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
   const successHosts = taskRun.hosts.filter((h) => h.status === 'success').length
   const failedHosts = taskRun.hosts.filter((h) => h.status === 'failed').length
   const skippedHosts = taskRun.hosts.filter((h) => h.status === 'skipped').length
+  const cancelledHosts = taskRun.hosts.filter(
+    (h) => h.status === 'cancelled' || h.status === 'cancelling',
+  ).length
+  const canStop = taskRun.status === 'pending' || taskRun.status === 'running'
   const rebootRequired = taskRun.hosts.some(
     (h) => (h.result as PatchTaskResult | null)?.reboot_required,
   )
@@ -274,6 +371,17 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
               </Badge>
             )}
             <RunStatusBadge status={taskRun.status} />
+            {canStop && (
+              <StopButton
+                orgId={orgId}
+                taskRunId={taskRun.id}
+                onCancelled={() =>
+                  queryClient.invalidateQueries({
+                    queryKey: ['task-run', orgId, taskRun.id],
+                  })
+                }
+              />
+            )}
           </div>
         </div>
 
@@ -285,6 +393,7 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
               {successHosts > 0 && ` · ${successHosts} succeeded`}
               {failedHosts > 0 && ` · ${failedHosts} failed`}
               {skippedHosts > 0 && ` · ${skippedHosts} skipped`}
+              {cancelledHosts > 0 && ` · ${cancelledHosts} cancelled`}
             </span>
             <span>{progressPct}%</span>
           </div>

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -7,7 +7,7 @@ import {
   hosts,
   hostGroupMembers,
 } from '@/lib/db/schema'
-import { eq, and, isNull, desc, inArray } from 'drizzle-orm'
+import { eq, and, isNull, desc, inArray, or } from 'drizzle-orm'
 import type {
   TaskRun,
   TaskRunHost,
@@ -193,6 +193,83 @@ export async function listTaskRunsForGroup(
   })
 
   return Promise.all(runs.map((run) => getTaskRun(orgId, run.id).then((r) => r!)))
+}
+
+// ── Cancellation ──────────────────────────────────────────────────────────────
+
+/**
+ * Cancels an active task run.
+ * - Pending hosts (not yet started) are marked 'cancelled' immediately.
+ * - Running hosts are moved to 'cancelling'; the ingest service will signal
+ *   the agent to stop the process and the row will transition to 'cancelled'
+ *   once the agent acknowledges.
+ * - The parent task_run is marked 'cancelling'.
+ */
+export async function cancelTaskRun(
+  orgId: string,
+  taskRunId: string,
+): Promise<{ success: true } | { error: string }> {
+  try {
+    return await db.transaction(async (tx) => {
+      // Verify ownership and that the run is still active.
+      const run = await tx.query.taskRuns.findFirst({
+        where: and(
+          eq(taskRuns.id, taskRunId),
+          eq(taskRuns.organisationId, orgId),
+          isNull(taskRuns.deletedAt),
+        ),
+      })
+      if (!run) return { error: 'Task run not found' }
+      if (['completed', 'failed', 'cancelled', 'cancelling'].includes(run.status)) {
+        return { error: 'Task run is already finished or being cancelled' }
+      }
+
+      const now = new Date()
+
+      // Cancel hosts that haven't started yet — no agent signal needed.
+      await tx
+        .update(taskRunHosts)
+        .set({ status: 'cancelled', completedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(taskRunHosts.taskRunId, taskRunId),
+            eq(taskRunHosts.organisationId, orgId),
+            eq(taskRunHosts.status, 'pending'),
+            isNull(taskRunHosts.deletedAt),
+          ),
+        )
+
+      // Signal running hosts to stop — the agent will acknowledge on the
+      // next heartbeat and the status will transition to 'cancelled'.
+      await tx
+        .update(taskRunHosts)
+        .set({ status: 'cancelling', updatedAt: now })
+        .where(
+          and(
+            eq(taskRunHosts.taskRunId, taskRunId),
+            eq(taskRunHosts.organisationId, orgId),
+            eq(taskRunHosts.status, 'running'),
+            isNull(taskRunHosts.deletedAt),
+          ),
+        )
+
+      // Move the parent run to 'cancelling' so the UI reflects the intent.
+      await tx
+        .update(taskRuns)
+        .set({ status: 'cancelling', updatedAt: now })
+        .where(
+          and(
+            eq(taskRuns.id, taskRunId),
+            isNull(taskRuns.deletedAt),
+          ),
+        )
+
+      return { success: true }
+    })
+  } catch (err) {
+    console.error('Failed to cancel task run:', err)
+    return { error: 'Failed to cancel task run' }
+  }
 }
 
 // ── Patch-specific actions ────────────────────────────────────────────────────

--- a/apps/web/lib/db/schema/task-runs.ts
+++ b/apps/web/lib/db/schema/task-runs.ts
@@ -5,8 +5,8 @@ import { hosts } from './hosts'
 import { users } from './auth'
 
 export type TaskType = 'patch' | 'custom_script'
-export type TaskRunStatus = 'pending' | 'running' | 'completed' | 'failed'
-export type TaskRunHostStatus = 'pending' | 'running' | 'success' | 'failed' | 'skipped'
+export type TaskRunStatus = 'pending' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed'
+export type TaskRunHostStatus = 'pending' | 'running' | 'cancelling' | 'cancelled' | 'success' | 'failed' | 'skipped'
 
 // Config shapes — discriminated by task_type
 export interface PatchTaskConfig { mode: 'security' | 'all' }

--- a/proto/agent/v1/heartbeat.proto
+++ b/proto/agent/v1/heartbeat.proto
@@ -120,5 +120,6 @@ message HeartbeatResponse {
   string download_url = 6;    // base URL to fetch the updated binary from
   repeated CheckDefinition checks = 7;
   repeated AgentQuery pending_queries = 8;
-  AgentTask pending_task = 9;  // current pending task (one at a time; absent = none)
+  AgentTask pending_task = 9;          // current pending task (one at a time; absent = none)
+  repeated string cancel_task_ids = 10; // task_run_hosts.id values the agent must cancel immediately
 }

--- a/proto/gen/go/agent/v1/heartbeat.pb.go
+++ b/proto/gen/go/agent/v1/heartbeat.pb.go
@@ -954,7 +954,8 @@ type HeartbeatResponse struct {
 	DownloadUrl     string                 `protobuf:"bytes,6,opt,name=download_url,json=downloadUrl,proto3" json:"download_url,omitempty"`              // base URL to fetch the updated binary from
 	Checks          []*CheckDefinition     `protobuf:"bytes,7,rep,name=checks,proto3" json:"checks,omitempty"`
 	PendingQueries  []*AgentQuery          `protobuf:"bytes,8,rep,name=pending_queries,json=pendingQueries,proto3" json:"pending_queries,omitempty"`
-	PendingTask     *AgentTask             `protobuf:"bytes,9,opt,name=pending_task,json=pendingTask,proto3" json:"pending_task,omitempty"` // current pending task (one at a time; absent = none)
+	PendingTask     *AgentTask             `protobuf:"bytes,9,opt,name=pending_task,json=pendingTask,proto3" json:"pending_task,omitempty"`          // current pending task (one at a time; absent = none)
+	CancelTaskIds   []string               `protobuf:"bytes,10,rep,name=cancel_task_ids,json=cancelTaskIds,proto3" json:"cancel_task_ids,omitempty"` // task_run_hosts.id values the agent must cancel immediately
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1048,6 +1049,13 @@ func (x *HeartbeatResponse) GetPendingQueries() []*AgentQuery {
 func (x *HeartbeatResponse) GetPendingTask() *AgentTask {
 	if x != nil {
 		return x.PendingTask
+	}
+	return nil
+}
+
+func (x *HeartbeatResponse) GetCancelTaskIds() []string {
+	if x != nil {
+		return x.CancelTaskIds
 	}
 	return nil
 }
@@ -1146,7 +1154,7 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\rcheck_results\x18\r \x03(\v2\x15.agent.v1.CheckResultR\fcheckResults\x12?\n" +
 	"\rquery_results\x18\x0e \x03(\v2\x1a.agent.v1.AgentQueryResultR\fqueryResults\x12@\n" +
 	"\rtask_progress\x18\x0f \x03(\v2\x1b.agent.v1.AgentTaskProgressR\ftaskProgress\x12<\n" +
-	"\ftask_results\x18\x10 \x03(\v2\x19.agent.v1.AgentTaskResultR\vtaskResults\"\x85\x03\n" +
+	"\ftask_results\x18\x10 \x03(\v2\x19.agent.v1.AgentTaskResultR\vtaskResults\"\xad\x03\n" +
 	"\x11HeartbeatResponse\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x18\n" +
 	"\acommand\x18\x02 \x01(\tR\acommand\x12'\n" +
@@ -1156,7 +1164,9 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\fdownload_url\x18\x06 \x01(\tR\vdownloadUrl\x121\n" +
 	"\x06checks\x18\a \x03(\v2\x19.agent.v1.CheckDefinitionR\x06checks\x12=\n" +
 	"\x0fpending_queries\x18\b \x03(\v2\x14.agent.v1.AgentQueryR\x0ependingQueries\x126\n" +
-	"\fpending_task\x18\t \x01(\v2\x13.agent.v1.AgentTaskR\vpendingTaskB.Z,github.com/infrawatch/proto/agent/v1;agentv1b\x06proto3"
+	"\fpending_task\x18\t \x01(\v2\x13.agent.v1.AgentTaskR\vpendingTask\x12&\n" +
+	"\x0fcancel_task_ids\x18\n" +
+	" \x03(\tR\rcancelTaskIdsB.Z,github.com/infrawatch/proto/agent/v1;agentv1b\x06proto3"
 
 var (
 	file_agent_v1_heartbeat_proto_rawDescOnce sync.Once


### PR DESCRIPTION
## Summary

- **Protocol**: New `cancel_task_ids` field (repeated string, field 10) on `HeartbeatResponse` lets the ingest service push cancel signals to the agent on its existing 2-second poll cycle — no new RPC or connection needed.
- **Agent**: Each task now runs with its own derived `context` (stored in `taskCancelFuncs sync.Map`). When `cancel_task_ids` arrives, the matching `CancelFunc` is called, which propagates to `runCommandStreaming`'s context watcher goroutine that kills the OS process. The agent then reports back `AgentTaskResult{Error: "cancelled by user"}` on the next heartbeat.
- **Ingest**: `CompleteTaskRunHost` SQL uses `CASE WHEN status = 'cancelling' THEN 'cancelled' ELSE $2 END` so the DB always wins — even if the agent reports success in a race. `MaybeCompleteTaskRun` and `TimeoutStuckTaskRunHosts` both treat `cancelled` as terminal with priority: `failed > cancelled > completed`.
- **Server action**: `cancelTaskRun` marks `pending` hosts as `cancelled` immediately, `running` hosts as `cancelling`, and the parent `task_run` as `cancelling` in a single transaction.
- **UI**: Stop button (with confirmation dialog) appears in the task monitor header while the run is `pending` or `running`. New `cancelling` (orange spinner) and `cancelled` (ban icon) states throughout the status icons, badges, output panel, and progress summary.

## Test plan

- [ ] Trigger a patch run on a Linux host, click **Stop** — confirm the "Cancellation requested…" state appears in the output panel within ~2 seconds (next heartbeat poll)
- [ ] After cancellation, confirm the agent process is killed and the host row transitions to `cancelled`
- [ ] Confirm the parent task run transitions to `cancelled` once all hosts finish
- [ ] Trigger a group patch run with multiple hosts, cancel while some are `pending` — confirm pending hosts skip to `cancelled` immediately while running hosts wait for agent ack
- [ ] Verify the Stop button disappears once the run is in a terminal state (`completed`, `failed`, `cancelled`)
- [ ] Confirm re-triggering a new patch after cancellation works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)