### PR TITLE
feat(tasks): add custom script runner and service management task types

### DIFF
--- a/agent/internal/tasks/script.go
+++ b/agent/internal/tasks/script.go
@@ -1,0 +1,111 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+func init() {
+	Register("custom_script", RunCustomScript)
+}
+
+// scriptConfig is the JSON structure stored in task_runs.config for custom_script tasks.
+type scriptConfig struct {
+	Script         string `json:"script"`          // script body to execute
+	Interpreter    string `json:"interpreter"`     // "sh" | "bash" | "python3" (default: "sh")
+	TimeoutSeconds int    `json:"timeout_seconds"` // 0 = inherit parent context (45 min agent default)
+}
+
+// scriptResult is the JSON structure stored in task_run_hosts.result for custom_script tasks.
+type scriptResult struct {
+	ExitCode int `json:"exit_code"`
+}
+
+// RunCustomScript writes the script to a temp file and executes it with the
+// specified interpreter, streaming stdout+stderr back in real time.
+func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chunk string)) *agentv1.AgentTaskResult {
+	var cfg scriptConfig
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		return errorResult(fmt.Sprintf("invalid script config: %v", err))
+	}
+	if cfg.Script == "" {
+		return errorResult("script body is required")
+	}
+	if cfg.Interpreter == "" {
+		cfg.Interpreter = "sh"
+	}
+
+	// Apply an explicit timeout if requested, capped at 1 hour.
+	if cfg.TimeoutSeconds > 0 {
+		timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+		if timeout > time.Hour {
+			timeout = time.Hour
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	// Verify the interpreter is available before writing the temp file.
+	if _, err := exec.LookPath(cfg.Interpreter); err != nil {
+		return errorResult(fmt.Sprintf("interpreter %q not found on this host: %v", cfg.Interpreter, err))
+	}
+
+	// Write the script body to a temp file and make it executable.
+	tmpFile, err := os.CreateTemp("", "infrawatch-script-*")
+	if err != nil {
+		return errorResult(fmt.Sprintf("failed to create temp file: %v", err))
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath) // clean up regardless of outcome
+
+	if _, err := tmpFile.WriteString(cfg.Script); err != nil {
+		_ = tmpFile.Close()
+		return errorResult(fmt.Sprintf("failed to write script: %v", err))
+	}
+	if err := tmpFile.Close(); err != nil {
+		return errorResult(fmt.Sprintf("failed to finalise temp file: %v", err))
+	}
+	if err := os.Chmod(tmpPath, 0o700); err != nil {
+		return errorResult(fmt.Sprintf("failed to set script permissions: %v", err))
+	}
+
+	progressFn(fmt.Sprintf("Running script with interpreter: %s\n\n", cfg.Interpreter))
+
+	cmd := exec.CommandContext(ctx, cfg.Interpreter, tmpPath)
+	exitCode, _, runErr := runCommandStreaming(ctx, cmd, progressFn)
+
+	if runErr != nil {
+		if errors.Is(runErr, context.Canceled) {
+			return &agentv1.AgentTaskResult{
+				ExitCode: int32(exitCode),
+				Error:    "cancelled by user",
+			}
+		}
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			return &agentv1.AgentTaskResult{
+				ExitCode: int32(exitCode),
+				Error:    fmt.Sprintf("task timed out (exceeded %d seconds)", cfg.TimeoutSeconds),
+			}
+		}
+		if exitCode == -1 {
+			// Command could not start.
+			return errorResult(runErr.Error())
+		}
+	}
+
+	result := scriptResult{ExitCode: exitCode}
+	resultJSON, _ := json.Marshal(result)
+
+	return &agentv1.AgentTaskResult{
+		ExitCode:   int32(exitCode),
+		ResultJson: string(resultJSON),
+	}
+}

--- a/agent/internal/tasks/service.go
+++ b/agent/internal/tasks/service.go
@@ -1,0 +1,97 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+func init() {
+	Register("service", RunServiceAction)
+}
+
+// serviceConfig is the JSON structure stored in task_runs.config for service tasks.
+type serviceConfig struct {
+	ServiceName string `json:"service_name"`
+	Action      string `json:"action"` // "start" | "stop" | "restart" | "status"
+}
+
+// serviceResult is the JSON structure stored in task_run_hosts.result for service tasks.
+type serviceResult struct {
+	ServiceName string `json:"service_name"`
+	Action      string `json:"action"`
+	IsActive    bool   `json:"is_active"`
+}
+
+var validServiceActions = map[string]bool{
+	"start":   true,
+	"stop":    true,
+	"restart": true,
+	"status":  true,
+}
+
+// RunServiceAction runs a systemctl action against the named service and reports
+// the service's active state after the action completes.
+func RunServiceAction(ctx context.Context, configJSON string, progressFn func(chunk string)) *agentv1.AgentTaskResult {
+	var cfg serviceConfig
+	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
+		return errorResult(fmt.Sprintf("invalid service config: %v", err))
+	}
+	if cfg.ServiceName == "" {
+		return errorResult("service_name is required")
+	}
+	if !validServiceActions[cfg.Action] {
+		return errorResult(fmt.Sprintf("invalid action %q: must be one of start, stop, restart, status", cfg.Action))
+	}
+
+	// Service operations should be fast; cap at 60 seconds.
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	progressFn(fmt.Sprintf("Running: systemctl %s %s\n\n", cfg.Action, cfg.ServiceName))
+
+	cmd := exec.CommandContext(ctx, "systemctl", cfg.Action, cfg.ServiceName)
+	exitCode, _, runErr := runCommandStreaming(ctx, cmd, progressFn)
+
+	if runErr != nil {
+		if exitCode == -1 {
+			// Command could not start — systemctl not available or similar.
+			return errorResult(runErr.Error())
+		}
+	}
+
+	// Check whether the service is currently active regardless of the action
+	// result, so the UI can reflect the live state.
+	isActive := checkServiceActive(cfg.ServiceName)
+
+	if isActive {
+		progressFn(fmt.Sprintf("\nService %s is active (running).\n", cfg.ServiceName))
+	} else {
+		progressFn(fmt.Sprintf("\nService %s is inactive (dead).\n", cfg.ServiceName))
+	}
+
+	result := serviceResult{
+		ServiceName: cfg.ServiceName,
+		Action:      cfg.Action,
+		IsActive:    isActive,
+	}
+	resultJSON, _ := json.Marshal(result)
+
+	return &agentv1.AgentTaskResult{
+		ExitCode:   int32(exitCode),
+		ResultJson: string(resultJSON),
+	}
+}
+
+// checkServiceActive returns true if the named service is currently active
+// according to systemctl is-active.
+func checkServiceActive(serviceName string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", serviceName)
+	return cmd.Run() == nil
+}

--- a/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
@@ -12,10 +12,15 @@ import {
   CheckCircle2,
   XCircle,
   Clock,
+  Terminal,
+  Power,
+  AlertTriangle,
 } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Dialog,
   DialogContent,
@@ -33,9 +38,20 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Label } from '@/components/ui/label'
-import { triggerPatchRun, listTaskRunsForHost } from '@/lib/actions/task-runs'
+import {
+  triggerPatchRun,
+  triggerCustomScriptRun,
+  triggerServiceAction,
+  listTaskRunsForHost,
+} from '@/lib/actions/task-runs'
 import type { TaskRunWithHosts } from '@/lib/actions/task-runs'
-import type { PatchTaskConfig, PatchTaskResult } from '@/lib/db/schema'
+import type {
+  PatchTaskConfig,
+  PatchTaskResult,
+  CustomScriptTaskConfig,
+  ServiceTaskConfig,
+  ServiceTaskResult,
+} from '@/lib/db/schema'
 import type { HostWithAgent } from '@/lib/actions/agents'
 import { useRouter } from 'next/navigation'
 
@@ -84,12 +100,84 @@ function RunStatusBadge({ status }: { status: string }) {
   }
 }
 
+function taskTypeLabel(taskType: string): string {
+  switch (taskType) {
+    case 'patch': return 'Patch'
+    case 'custom_script': return 'Script'
+    case 'service': return 'Service'
+    default: return taskType
+  }
+}
+
+function TaskDetailsCell({ run, hostId }: { run: TaskRunWithHosts; hostId: string }) {
+  const thisHost = run.hosts.find((h) => h.hostId === hostId)
+
+  if (run.taskType === 'patch') {
+    const config = run.config as PatchTaskConfig
+    const result = thisHost?.result as PatchTaskResult | null
+    return (
+      <div className="space-y-1">
+        <p className="text-sm text-muted-foreground">
+          {config.mode === 'security' ? 'Security only' : 'All updates'}
+        </p>
+        {result?.reboot_required && (
+          <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">
+            <RotateCcw className="size-3 mr-1" />
+            Reboot req.
+          </Badge>
+        )}
+      </div>
+    )
+  }
+
+  if (run.taskType === 'custom_script') {
+    const config = run.config as CustomScriptTaskConfig
+    return <span className="text-sm text-muted-foreground">{config.interpreter}</span>
+  }
+
+  if (run.taskType === 'service') {
+    const config = run.config as ServiceTaskConfig
+    const result = thisHost?.result as ServiceTaskResult | null
+    return (
+      <div className="space-y-1">
+        <p className="text-sm text-muted-foreground capitalize">
+          {config.action} · {config.service_name}
+        </p>
+        {result !== null && result !== undefined && (
+          <Badge
+            className={
+              result.is_active
+                ? 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100 text-xs'
+                : 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100 text-xs'
+            }
+          >
+            {result.is_active ? 'Active' : 'Inactive'}
+          </Badge>
+        )}
+      </div>
+    )
+  }
+
+  return <span className="text-sm text-muted-foreground">—</span>
+}
+
 export function TasksTab({ orgId, host, userId }: Props) {
   const router = useRouter()
+  const isLinux = host.os?.toLowerCase() === 'linux'
+
+  // Patch dialog state
   const [patchOpen, setPatchOpen] = useState(false)
   const [patchMode, setPatchMode] = useState<'all' | 'security'>('all')
 
-  const isLinux = host.os?.toLowerCase() === 'linux'
+  // Script dialog state
+  const [scriptOpen, setScriptOpen] = useState(false)
+  const [scriptBody, setScriptBody] = useState('')
+  const [interpreter, setInterpreter] = useState<'sh' | 'bash' | 'python3'>('sh')
+
+  // Service dialog state
+  const [serviceOpen, setServiceOpen] = useState(false)
+  const [serviceName, setServiceName] = useState('')
+  const [serviceAction, setServiceAction] = useState<'start' | 'stop' | 'restart' | 'status'>('restart')
 
   const { data: taskRuns = [] } = useQuery({
     queryKey: ['task-runs-host', orgId, host.id],
@@ -104,9 +192,23 @@ export function TasksTab({ orgId, host, userId }: Props) {
     mutationFn: () => triggerPatchRun(orgId, userId, host.id, patchMode),
     onSuccess: (result) => {
       setPatchOpen(false)
-      if ('taskRunId' in result) {
-        router.push(`/tasks/${result.taskRunId}`)
-      }
+      if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
+    },
+  })
+
+  const { mutate: doScriptRun, isPending: isScripting } = useMutation({
+    mutationFn: () => triggerCustomScriptRun(orgId, userId, host.id, scriptBody, interpreter),
+    onSuccess: (result) => {
+      setScriptOpen(false)
+      if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
+    },
+  })
+
+  const { mutate: doServiceAction, isPending: isServicing } = useMutation({
+    mutationFn: () => triggerServiceAction(orgId, userId, host.id, serviceName, serviceAction),
+    onSuccess: (result) => {
+      setServiceOpen(false)
+      if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
     },
   })
 
@@ -117,102 +219,80 @@ export function TasksTab({ orgId, host, userId }: Props) {
         <div>
           <h3 className="text-base font-semibold text-foreground">Task Runs</h3>
           <p className="text-sm text-muted-foreground mt-0.5">
-            Run built-in operations against this host.
+            Run operations against this host.
           </p>
         </div>
-        {isLinux && (
-          <Button onClick={() => setPatchOpen(true)} size="sm">
-            <Shield className="size-4 mr-1.5" />
-            Run Patch
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setScriptOpen(true)}>
+            <Terminal className="size-4 mr-1.5" />
+            Run Script
           </Button>
-        )}
+          {isLinux && (
+            <>
+              <Button variant="outline" size="sm" onClick={() => setServiceOpen(true)}>
+                <Power className="size-4 mr-1.5" />
+                Service
+              </Button>
+              <Button size="sm" onClick={() => setPatchOpen(true)}>
+                <Shield className="size-4 mr-1.5" />
+                Run Patch
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
-      {/* Non-Linux notice */}
-      {!isLinux && (
-        <div className="rounded-lg border border-dashed p-8 text-center">
-          <Shield className="size-7 mx-auto text-muted-foreground mb-3" />
-          <p className="text-sm font-medium text-foreground">Task execution not supported</p>
+      {/* Task run history */}
+      {taskRuns.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-10 text-center">
+          <RefreshCw className="size-7 mx-auto text-muted-foreground mb-3" />
+          <p className="text-sm font-medium text-foreground">No task runs yet</p>
           <p className="text-xs text-muted-foreground mt-1">
-            Built-in tasks such as patching are only available on Linux hosts.
-            {host.os ? ` This host is running ${host.os}.` : ''}
+            Use the buttons above to run a task on this host.
           </p>
         </div>
-      )}
-
-      {/* Task run history */}
-      {isLinux && (
-        <>
-          {taskRuns.length === 0 ? (
-            <div className="rounded-lg border border-dashed p-10 text-center">
-              <RefreshCw className="size-7 mx-auto text-muted-foreground mb-3" />
-              <p className="text-sm font-medium text-foreground">No task runs yet</p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Run Patch to start the first task run on this host.
-              </p>
-            </div>
-          ) : (
-            <div className="rounded-lg border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Task</TableHead>
-                    <TableHead>Mode</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Reboot</TableHead>
-                    <TableHead>Started</TableHead>
-                    <TableHead className="w-20" />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {taskRuns.map((run) => {
-                    const config = run.config as PatchTaskConfig
-                    const thisHost = run.hosts.find((h) => h.hostId === host.id)
-                    const result = thisHost?.result as PatchTaskResult | null
-                    const rebootRequired = result?.reboot_required ?? false
-
-                    return (
-                      <TableRow key={run.id}>
-                        <TableCell className="font-medium capitalize">
-                          {run.taskType === 'patch' ? 'Patch' : run.taskType}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground capitalize">
-                          {config.mode === 'security' ? 'Security only' : 'All updates'}
-                        </TableCell>
-                        <TableCell>
-                          <RunStatusBadge status={run.status} />
-                        </TableCell>
-                        <TableCell>
-                          {rebootRequired ? (
-                            <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">
-                              <RotateCcw className="size-3 mr-1" />
-                              Required
-                            </Badge>
-                          ) : (
-                            <span className="text-xs text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {run.startedAt
-                            ? formatDistanceToNow(new Date(run.startedAt), { addSuffix: true })
-                            : formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}
-                        </TableCell>
-                        <TableCell>
-                          <Link href={`/tasks/${run.id}`}>
-                            <Button variant="ghost" size="sm" className="h-7 px-2 text-xs gap-1">
-                              {isRunActive(run.status) ? 'View live' : 'View'}
-                              <ExternalLink className="size-3" />
-                            </Button>
-                          </Link>
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Task</TableHead>
+                <TableHead>Details</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Started</TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {taskRuns.map((run) => (
+                <TableRow key={run.id}>
+                  <TableCell className="font-medium">
+                    {taskTypeLabel(run.taskType)}
+                  </TableCell>
+                  <TableCell>
+                    <TaskDetailsCell run={run} hostId={host.id} />
+                  </TableCell>
+                  <TableCell>
+                    <RunStatusBadge status={run.status} />
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {run.startedAt
+                      ? formatDistanceToNow(new Date(run.startedAt), { addSuffix: true })
+                      : formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}
+                  </TableCell>
+                  <TableCell>
+                    <Link href={`/tasks/${run.id}`}>
+                      <Button variant="ghost" size="sm" className="h-7 px-2 text-xs gap-1">
+                        {isRunActive(run.status) ? 'View live' : 'View'}
+                        <ExternalLink className="size-3" />
+                      </Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       )}
 
       {/* Patch dialog */}
@@ -252,12 +332,127 @@ export function TasksTab({ orgId, host, userId }: Props) {
           </div>
 
           <DialogFooter>
-            <Button variant="outline" onClick={() => setPatchOpen(false)}>
-              Cancel
-            </Button>
+            <Button variant="outline" onClick={() => setPatchOpen(false)}>Cancel</Button>
             <Button onClick={() => doPatchRun()} disabled={isPatching}>
               {isPatching && <Loader2 className="size-4 mr-1 animate-spin" />}
               Run Patch
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Script dialog */}
+      <Dialog open={scriptOpen} onOpenChange={setScriptOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Run Script</DialogTitle>
+            <DialogDescription>
+              Write a script to execute on this host. Output is streamed in real time.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Interpreter</Label>
+              <div className="flex gap-2">
+                {(['sh', 'bash', 'python3'] as const).map((i) => (
+                  <button
+                    key={i}
+                    onClick={() => setInterpreter(i)}
+                    className={`rounded-md border px-3 py-1.5 text-sm font-mono transition-colors ${
+                      interpreter === i
+                        ? 'border-primary bg-primary/5 text-foreground font-medium'
+                        : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+                    }`}
+                  >
+                    {i}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Script</Label>
+              <Textarea
+                placeholder={`#!/bin/${interpreter}\necho "Hello from $(hostname)"`}
+                value={scriptBody}
+                onChange={(e) => setScriptBody(e.target.value)}
+                className="font-mono text-xs min-h-36 resize-y"
+                rows={8}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setScriptOpen(false)}>Cancel</Button>
+            <Button onClick={() => doScriptRun()} disabled={isScripting || !scriptBody.trim()}>
+              {isScripting && <Loader2 className="size-4 mr-1 animate-spin" />}
+              Run Script
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Service dialog */}
+      <Dialog open={serviceOpen} onOpenChange={setServiceOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Service Action</DialogTitle>
+            <DialogDescription>
+              Run a systemctl command against a service on this host.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Service name</Label>
+              <Input
+                placeholder="e.g. nginx, postgresql, ssh"
+                value={serviceName}
+                onChange={(e) => setServiceName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Action</Label>
+              <div className="grid grid-cols-2 gap-2">
+                {(
+                  [
+                    { value: 'start', desc: 'Start the service' },
+                    { value: 'stop', desc: 'Stop the service' },
+                    { value: 'restart', desc: 'Restart the service' },
+                    { value: 'status', desc: 'Check current status' },
+                  ] as const
+                ).map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setServiceAction(opt.value)}
+                    className={`text-left rounded-lg border px-3 py-2.5 transition-colors ${
+                      serviceAction === opt.value
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:border-muted-foreground/40'
+                    }`}
+                  >
+                    <p className="text-sm font-medium text-foreground capitalize">{opt.value}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{opt.desc}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
+            {!isLinux && (
+              <div className="rounded-md bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800">
+                <AlertTriangle className="size-3.5 inline mr-1" />
+                Service management requires systemctl (Linux only).
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setServiceOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => doServiceAction()}
+              disabled={isServicing || !serviceName.trim()}
+            >
+              {isServicing && <Loader2 className="size-4 mr-1 animate-spin" />}
+              Run Action
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -20,11 +20,14 @@ import {
   ExternalLink,
   RotateCcw,
   SkipForward,
+  Terminal,
+  Power,
 } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
 import { Label } from '@/components/ui/label'
 import {
@@ -59,11 +62,22 @@ import {
   removeHostFromGroup,
 } from '@/lib/actions/host-groups'
 import { listHosts } from '@/lib/actions/agents'
-import { triggerGroupPatchRun, listTaskRunsForGroup } from '@/lib/actions/task-runs'
+import {
+  triggerGroupPatchRun,
+  triggerGroupCustomScriptRun,
+  triggerGroupServiceAction,
+  listTaskRunsForGroup,
+} from '@/lib/actions/task-runs'
 import type { HostGroupWithMembers } from '@/lib/actions/host-groups'
 import type { HostWithAgent } from '@/lib/actions/agents'
 import type { TaskRunWithHosts } from '@/lib/actions/task-runs'
-import type { Host, PatchTaskConfig } from '@/lib/db/schema'
+import type {
+  Host,
+  PatchTaskConfig,
+  CustomScriptTaskConfig,
+  ServiceTaskConfig,
+  ServiceTaskResult,
+} from '@/lib/db/schema'
 
 const PARALLEL_OPTIONS = [
   { value: 1, label: '1 (sequential)' },
@@ -164,6 +178,18 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
   const [patchMode, setPatchMode] = useState<'all' | 'security'>('all')
   const [maxParallel, setMaxParallel] = useState(1)
 
+  // Script dialog state
+  const [scriptOpen, setScriptOpen] = useState(false)
+  const [scriptBody, setScriptBody] = useState('')
+  const [interpreter, setInterpreter] = useState<'sh' | 'bash' | 'python3'>('sh')
+  const [scriptMaxParallel, setScriptMaxParallel] = useState(1)
+
+  // Service dialog state
+  const [serviceOpen, setServiceOpen] = useState(false)
+  const [serviceName, setServiceName] = useState('')
+  const [serviceAction, setServiceAction] = useState<'start' | 'stop' | 'restart' | 'status'>('restart')
+  const [serviceMaxParallel, setServiceMaxParallel] = useState(1)
+
   const { data: group } = useQuery({
     queryKey: ['host-group', orgId, initialGroup.id],
     queryFn: () => getGroup(orgId, initialGroup.id),
@@ -209,9 +235,25 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
       triggerGroupPatchRun(orgId, userId, initialGroup.id, patchMode, maxParallel),
     onSuccess: (result) => {
       setPatchOpen(false)
-      if ('taskRunId' in result) {
-        router.push(`/tasks/${result.taskRunId}`)
-      }
+      if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
+    },
+  })
+
+  const { mutate: doGroupScript, isPending: isScripting } = useMutation({
+    mutationFn: () =>
+      triggerGroupCustomScriptRun(orgId, userId, initialGroup.id, scriptBody, interpreter, scriptMaxParallel),
+    onSuccess: (result) => {
+      setScriptOpen(false)
+      if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
+    },
+  })
+
+  const { mutate: doGroupService, isPending: isServicing } = useMutation({
+    mutationFn: () =>
+      triggerGroupServiceAction(orgId, userId, initialGroup.id, serviceName, serviceAction, serviceMaxParallel),
+    onSuccess: (result) => {
+      setServiceOpen(false)
+      if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
     },
   })
 
@@ -219,6 +261,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
 
   const memberIds = new Set(group.members.map((h) => h.id))
   const nonLinuxCount = group.members.filter((h) => h.os?.toLowerCase() !== 'linux').length
+  const linuxCount = group.members.length - nonLinuxCount
 
   const filteredSearch = allHosts.filter((h) => {
     if (memberIds.has(h.id)) return false
@@ -250,6 +293,14 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
             )}
           </div>
           <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={() => setScriptOpen(true)}>
+              <Terminal className="size-4 mr-1" />
+              Run Script
+            </Button>
+            <Button variant="outline" onClick={() => setServiceOpen(true)}>
+              <Power className="size-4 mr-1" />
+              Service Action
+            </Button>
             <Button variant="outline" onClick={() => setPatchOpen(true)}>
               <Shield className="size-4 mr-1" />
               Patch Group
@@ -334,10 +385,10 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
         <h2 className="text-base font-semibold text-foreground">Task History</h2>
         {taskRuns.length === 0 ? (
           <div className="rounded-lg border border-dashed p-8 text-center">
-            <Shield className="size-7 mx-auto text-muted-foreground mb-3" />
+            <Terminal className="size-7 mx-auto text-muted-foreground mb-3" />
             <p className="text-sm font-medium text-foreground">No task runs yet</p>
             <p className="text-xs text-muted-foreground mt-1">
-              Use &quot;Patch Group&quot; to start the first task run on this group.
+              Use the buttons above to run a task on this group.
             </p>
           </div>
         ) : (
@@ -346,33 +397,72 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
               <TableHeader>
                 <TableRow>
                   <TableHead>Task</TableHead>
-                  <TableHead>Mode</TableHead>
+                  <TableHead>Details</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Hosts</TableHead>
-                  <TableHead>Reboot</TableHead>
                   <TableHead>Started</TableHead>
                   <TableHead className="w-24" />
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {taskRuns.map((run) => {
-                  const config = run.config as PatchTaskConfig
                   const successCount = run.hosts.filter((h) => h.status === 'success').length
                   const failedCount = run.hosts.filter((h) => h.status === 'failed').length
                   const skippedCount = run.hosts.filter((h) => h.status === 'skipped').length
                   const runningCount = run.hosts.filter((h) => h.status === 'running').length
                   const pendingCount = run.hosts.filter((h) => h.status === 'pending').length
-                  const rebootCount = run.hosts.filter(
-                    (h) => (h.result as { reboot_required?: boolean } | null)?.reboot_required,
-                  ).length
 
                   return (
                     <TableRow key={run.id}>
-                      <TableCell className="font-medium capitalize">
-                        {run.taskType === 'patch' ? 'Patch' : run.taskType}
+                      <TableCell className="font-medium">
+                        {run.taskType === 'patch' ? 'Patch'
+                          : run.taskType === 'custom_script' ? 'Script'
+                          : run.taskType === 'service' ? 'Service'
+                          : run.taskType}
                       </TableCell>
-                      <TableCell className="text-sm text-muted-foreground capitalize">
-                        {config.mode === 'security' ? 'Security only' : 'All updates'}
+                      <TableCell className="text-sm text-muted-foreground">
+                        {run.taskType === 'patch' && (() => {
+                          const config = run.config as PatchTaskConfig
+                          const rebootCount = run.hosts.filter(
+                            (h) => (h.result as { reboot_required?: boolean } | null)?.reboot_required,
+                          ).length
+                          return (
+                            <div className="space-y-1">
+                              <p>{config.mode === 'security' ? 'Security only' : 'All updates'}</p>
+                              {rebootCount > 0 && (
+                                <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">
+                                  <RotateCcw className="size-3 mr-1" />
+                                  {rebootCount} reboot{rebootCount !== 1 ? 's' : ''}
+                                </Badge>
+                              )}
+                            </div>
+                          )
+                        })()}
+                        {run.taskType === 'custom_script' && (
+                          (run.config as CustomScriptTaskConfig).interpreter
+                        )}
+                        {run.taskType === 'service' && (() => {
+                          const config = run.config as ServiceTaskConfig
+                          const activeCount = run.hosts.filter(
+                            (h) => (h.result as ServiceTaskResult | null)?.is_active,
+                          ).length
+                          const doneCount = run.hosts.filter(
+                            (h) => h.status === 'success' || h.status === 'failed',
+                          ).length
+                          return (
+                            <div className="space-y-1">
+                              <p className="capitalize">{config.action} · {config.service_name}</p>
+                              {doneCount > 0 && (
+                                <p className="text-xs">
+                                  <span className="text-green-700">{activeCount} active</span>
+                                  {doneCount - activeCount > 0 && (
+                                    <span className="text-muted-foreground"> · {doneCount - activeCount} inactive</span>
+                                  )}
+                                </p>
+                              )}
+                            </div>
+                          )
+                        })()}
                       </TableCell>
                       <TableCell>
                         <RunStatusBadge status={run.status} />
@@ -399,16 +489,6 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
                           )}
                         </div>
                       </TableCell>
-                      <TableCell>
-                        {rebootCount > 0 ? (
-                          <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">
-                            <RotateCcw className="size-3 mr-1" />
-                            {rebootCount} host{rebootCount !== 1 ? 's' : ''}
-                          </Badge>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">—</span>
-                        )}
-                      </TableCell>
                       <TableCell className="text-sm text-muted-foreground">
                         {run.startedAt
                           ? formatDistanceToNow(new Date(run.startedAt), { addSuffix: true })
@@ -430,6 +510,160 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
           </div>
         )}
       </div>
+
+      {/* Script Group Dialog */}
+      <Dialog open={scriptOpen} onOpenChange={setScriptOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Run Script on &quot;{group.name}&quot;</DialogTitle>
+            <DialogDescription>
+              Execute a script on all hosts in this group. Output is streamed in real time.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Interpreter</Label>
+              <div className="flex gap-2">
+                {(['sh', 'bash', 'python3'] as const).map((i) => (
+                  <button
+                    key={i}
+                    onClick={() => setInterpreter(i)}
+                    className={`rounded-md border px-3 py-1.5 text-sm font-mono transition-colors ${
+                      interpreter === i
+                        ? 'border-primary bg-primary/5 text-foreground font-medium'
+                        : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+                    }`}
+                  >
+                    {i}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Script</Label>
+              <Textarea
+                placeholder={`#!/bin/${interpreter}\necho "Hello from $(hostname)"`}
+                value={scriptBody}
+                onChange={(e) => setScriptBody(e.target.value)}
+                className="font-mono text-xs min-h-36 resize-y"
+                rows={8}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Max parallel hosts</Label>
+              <div className="flex flex-wrap gap-2">
+                {PARALLEL_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setScriptMaxParallel(opt.value)}
+                    className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                      scriptMaxParallel === opt.value
+                        ? 'border-primary bg-primary/5 text-foreground font-medium'
+                        : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setScriptOpen(false)}>Cancel</Button>
+            <Button onClick={() => doGroupScript()} disabled={isScripting || !scriptBody.trim()}>
+              {isScripting && <Loader2 className="size-4 mr-1 animate-spin" />}
+              Run Script
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Service Group Dialog */}
+      <Dialog open={serviceOpen} onOpenChange={setServiceOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Service Action on &quot;{group.name}&quot;</DialogTitle>
+            <DialogDescription>
+              Run a systemctl command against Linux hosts in this group.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Service name</Label>
+              <Input
+                placeholder="e.g. nginx, postgresql, ssh"
+                value={serviceName}
+                onChange={(e) => setServiceName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Action</Label>
+              <div className="grid grid-cols-2 gap-2">
+                {(
+                  [
+                    { value: 'start', desc: 'Start the service' },
+                    { value: 'stop', desc: 'Stop the service' },
+                    { value: 'restart', desc: 'Restart the service' },
+                    { value: 'status', desc: 'Check current status' },
+                  ] as const
+                ).map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setServiceAction(opt.value)}
+                    className={`text-left rounded-lg border px-3 py-2.5 transition-colors ${
+                      serviceAction === opt.value
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:border-muted-foreground/40'
+                    }`}
+                  >
+                    <p className="text-sm font-medium text-foreground capitalize">{opt.value}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{opt.desc}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">Max parallel hosts</Label>
+              <div className="flex flex-wrap gap-2">
+                {PARALLEL_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setServiceMaxParallel(opt.value)}
+                    className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
+                      serviceMaxParallel === opt.value
+                        ? 'border-primary bg-primary/5 text-foreground font-medium'
+                        : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {nonLinuxCount > 0 && (
+              <div className="rounded-md bg-amber-50 border border-amber-200 px-3 py-2.5 text-xs text-amber-800">
+                <AlertTriangle className="size-3.5 inline mr-1" />
+                {nonLinuxCount} non-Linux host{nonLinuxCount !== 1 ? 's' : ''} will be skipped.
+                {linuxCount === 0 && ' No Linux hosts in this group.'}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setServiceOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => doGroupService()}
+              disabled={isServicing || !serviceName.trim() || linuxCount === 0}
+            >
+              {isServicing && <Loader2 className="size-4 mr-1 animate-spin" />}
+              Run Action
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Add Hosts Dialog */}
       <Dialog open={addOpen} onOpenChange={setAddOpen}>

--- a/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
@@ -31,7 +31,13 @@ import {
 } from '@/components/ui/alert-dialog'
 import { cancelTaskRun, getTaskRun } from '@/lib/actions/task-runs'
 import type { TaskRunWithHosts, TaskRunHostWithHost } from '@/lib/actions/task-runs'
-import type { PatchTaskResult, PatchTaskConfig } from '@/lib/db/schema'
+import type {
+  PatchTaskResult,
+  PatchTaskConfig,
+  CustomScriptTaskConfig,
+  ServiceTaskConfig,
+  ServiceTaskResult,
+} from '@/lib/db/schema'
 
 interface Props {
   orgId: string
@@ -102,7 +108,15 @@ function useElapsedSeconds(startedAt: Date | null | string | undefined, active: 
 
 // ── Output panel ──────────────────────────────────────────────────────────────
 
-function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive: boolean }) {
+function OutputPanel({
+  hostRow,
+  isLive,
+  taskType,
+}: {
+  hostRow: TaskRunHostWithHost
+  isLive: boolean
+  taskType: string
+}) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState(true)
@@ -130,7 +144,8 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
     setAutoScroll(atBottom)
   }
 
-  const result = hostRow.result as PatchTaskResult | null
+  const patchResult = taskType === 'patch' ? (hostRow.result as PatchTaskResult | null) : null
+  const serviceResult = taskType === 'service' ? (hostRow.result as ServiceTaskResult | null) : null
 
   const elapsedLabel =
     elapsedSecs > 0
@@ -149,10 +164,21 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
           <span className="text-zinc-500 ml-1">({elapsedLabel})</span>
         )}
         {isLive && <span className="ml-auto text-blue-400 animate-pulse">● live</span>}
-        {result?.reboot_required && (
+        {patchResult?.reboot_required && (
           <Badge className="ml-auto bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100 text-xs">
             <RotateCcw className="size-3 mr-1" />
             Reboot required
+          </Badge>
+        )}
+        {serviceResult !== null && serviceResult !== undefined && (
+          <Badge
+            className={`ml-auto text-xs ${
+              serviceResult.is_active
+                ? 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100'
+                : 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100'
+            }`}
+          >
+            {serviceResult.is_active ? 'Active' : 'Inactive'}
           </Badge>
         )}
       </div>
@@ -211,10 +237,10 @@ function OutputPanel({ hostRow, isLive }: { hostRow: TaskRunHostWithHost; isLive
       </div>
 
       {/* Result summary */}
-      {result && result.packages_updated && result.packages_updated.length > 0 && (
+      {patchResult && patchResult.packages_updated && patchResult.packages_updated.length > 0 && (
         <div className="border-t px-3 py-2 bg-muted text-xs">
           <span className="text-muted-foreground">
-            {result.packages_updated.length} package{result.packages_updated.length !== 1 ? 's' : ''} updated
+            {patchResult.packages_updated.length} package{patchResult.packages_updated.length !== 1 ? 's' : ''} updated
           </span>
         </div>
       )}
@@ -312,7 +338,6 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
 
   if (!taskRun) return null
 
-  const config = taskRun.config as PatchTaskConfig
   const totalHosts = taskRun.hosts.length
   const doneHosts = taskRun.hosts.filter((h) => isHostTerminal(h.status)).length
   const successHosts = taskRun.hosts.filter((h) => h.status === 'success').length
@@ -322,9 +347,9 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
     (h) => h.status === 'cancelled' || h.status === 'cancelling',
   ).length
   const canStop = taskRun.status === 'pending' || taskRun.status === 'running'
-  const rebootRequired = taskRun.hosts.some(
-    (h) => (h.result as PatchTaskResult | null)?.reboot_required,
-  )
+  const rebootRequired =
+    taskRun.taskType === 'patch' &&
+    taskRun.hosts.some((h) => (h.result as PatchTaskResult | null)?.reboot_required)
   const progressPct = totalHosts > 0 ? Math.round((doneHosts / totalHosts) * 100) : 0
 
   // Determine back link based on target type.
@@ -334,10 +359,21 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
       : `/hosts/${taskRun.targetId}`
   const backLabel = taskRun.targetType === 'group' ? 'Back to group' : 'Back to host'
 
-  const taskLabel =
-    taskRun.taskType === 'patch'
-      ? `Patch — ${config.mode === 'security' ? 'security updates' : 'all updates'}`
-      : taskRun.taskType
+  const taskLabel = (() => {
+    if (taskRun.taskType === 'patch') {
+      const config = taskRun.config as PatchTaskConfig
+      return `Patch — ${config.mode === 'security' ? 'security updates' : 'all updates'}`
+    }
+    if (taskRun.taskType === 'custom_script') {
+      const config = taskRun.config as CustomScriptTaskConfig
+      return `Script — ${config.interpreter}`
+    }
+    if (taskRun.taskType === 'service') {
+      const config = taskRun.config as ServiceTaskConfig
+      return `Service — ${config.action} ${config.service_name}`
+    }
+    return taskRun.taskType
+  })()
 
   return (
     <div className="flex flex-col h-full gap-4">
@@ -417,7 +453,8 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
           </div>
           <div className="flex-1 overflow-y-auto divide-y">
             {taskRun.hosts.map((h) => {
-              const patchResult = h.result as PatchTaskResult | null
+              const hostPatchResult = taskRun.taskType === 'patch' ? (h.result as PatchTaskResult | null) : null
+              const hostServiceResult = taskRun.taskType === 'service' ? (h.result as ServiceTaskResult | null) : null
               const isSelected = h.hostId === selectedHost?.hostId
               return (
                 <button
@@ -435,10 +472,15 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
                     {h.host.displayName && (
                       <p className="text-xs text-muted-foreground truncate">{h.host.hostname}</p>
                     )}
-                    {patchResult?.reboot_required && (
+                    {hostPatchResult?.reboot_required && (
                       <p className="text-xs text-amber-600 flex items-center gap-0.5 mt-0.5">
                         <RotateCcw className="size-2.5" />
                         Reboot required
+                      </p>
+                    )}
+                    {hostServiceResult !== null && hostServiceResult !== undefined && (
+                      <p className={`text-xs mt-0.5 ${hostServiceResult.is_active ? 'text-green-600' : 'text-red-500'}`}>
+                        {hostServiceResult.is_active ? 'Active' : 'Inactive'}
                       </p>
                     )}
                     {h.status === 'skipped' && (
@@ -460,6 +502,7 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
             <OutputPanel
               hostRow={selectedHost}
               isLive={!isHostTerminal(selectedHost.status) && active}
+              taskType={taskRun.taskType}
             />
           ) : (
             <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -14,6 +14,8 @@ import type {
   TaskType,
   TaskConfig,
   PatchTaskConfig,
+  CustomScriptTaskConfig,
+  ServiceTaskConfig,
   Host,
 } from '@/lib/db/schema'
 
@@ -162,7 +164,7 @@ export async function listTaskRunsForHost(
       inArray(taskRuns.id, runIds),
       eq(taskRuns.organisationId, orgId),
       isNull(taskRuns.deletedAt),
-      ...(taskType ? [eq(taskRuns.taskType, taskType as 'patch' | 'custom_script')] : []),
+      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
     ),
     orderBy: [desc(taskRuns.createdAt)],
     limit: 50,
@@ -186,7 +188,7 @@ export async function listTaskRunsForGroup(
       eq(taskRuns.targetType, 'group'),
       eq(taskRuns.targetId, groupId),
       isNull(taskRuns.deletedAt),
-      ...(taskType ? [eq(taskRuns.taskType, taskType as 'patch' | 'custom_script')] : []),
+      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
     ),
     orderBy: [desc(taskRuns.createdAt)],
     limit: 50,
@@ -269,6 +271,148 @@ export async function cancelTaskRun(
   } catch (err) {
     console.error('Failed to cancel task run:', err)
     return { error: 'Failed to cancel task run' }
+  }
+}
+
+// ── Custom script actions ─────────────────────────────────────────────────────
+
+/**
+ * Triggers a custom script run against a single host.
+ * Works on any OS — the agent will return an error if the interpreter is absent.
+ */
+export async function triggerCustomScriptRun(
+  orgId: string,
+  userId: string,
+  hostId: string,
+  script: string,
+  interpreter: 'sh' | 'bash' | 'python3',
+  timeoutSeconds?: number,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const host = await db.query.hosts.findFirst({
+    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { error: 'Host not found' }
+
+  const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
+  return createTaskRun(orgId, userId, 'host', hostId, 'custom_script', config, 1, [hostId], [])
+}
+
+/**
+ * Triggers a custom script run against all hosts in a group.
+ * All hosts are targeted regardless of OS — the agent handles interpreter availability.
+ */
+export async function triggerGroupCustomScriptRun(
+  orgId: string,
+  userId: string,
+  groupId: string,
+  script: string,
+  interpreter: 'sh' | 'bash' | 'python3',
+  maxParallel: number,
+  timeoutSeconds?: number,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const members = await db.query.hostGroupMembers.findMany({
+    where: and(
+      eq(hostGroupMembers.groupId, groupId),
+      eq(hostGroupMembers.organisationId, orgId),
+      isNull(hostGroupMembers.deletedAt),
+    ),
+    columns: { hostId: true },
+  })
+  if (members.length === 0) return { error: 'Group has no members' }
+
+  const hostIds = members.map((m) => m.hostId)
+  const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
+  return createTaskRun(orgId, userId, 'group', groupId, 'custom_script', config, maxParallel, hostIds, [])
+}
+
+// ── Service management actions ────────────────────────────────────────────────
+
+/**
+ * Triggers a systemctl service action against a single Linux host.
+ * Returns an error for non-Linux hosts.
+ */
+export async function triggerServiceAction(
+  orgId: string,
+  userId: string,
+  hostId: string,
+  serviceName: string,
+  action: 'start' | 'stop' | 'restart' | 'status',
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const host = await db.query.hosts.findFirst({
+    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { error: 'Host not found' }
+  if (host.os?.toLowerCase() !== 'linux') {
+    return { error: 'Service management is only supported on Linux hosts' }
+  }
+
+  const config: ServiceTaskConfig = { service_name: serviceName, action }
+  return createTaskRun(orgId, userId, 'host', hostId, 'service', config, 1, [hostId], [])
+}
+
+/**
+ * Triggers a systemctl service action against all Linux hosts in a group.
+ * Non-Linux hosts are immediately recorded as 'skipped'.
+ */
+export async function triggerGroupServiceAction(
+  orgId: string,
+  userId: string,
+  groupId: string,
+  serviceName: string,
+  action: 'start' | 'stop' | 'restart' | 'status',
+  maxParallel: number,
+): Promise<
+  { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
+> {
+  const members = await db.query.hostGroupMembers.findMany({
+    where: and(
+      eq(hostGroupMembers.groupId, groupId),
+      eq(hostGroupMembers.organisationId, orgId),
+      isNull(hostGroupMembers.deletedAt),
+    ),
+    columns: { hostId: true },
+  })
+  if (members.length === 0) return { error: 'Group has no members' }
+
+  const hostIds = members.map((m) => m.hostId)
+  const groupHosts = await db.query.hosts.findMany({
+    where: and(
+      inArray(hosts.id, hostIds),
+      eq(hosts.organisationId, orgId),
+      isNull(hosts.deletedAt),
+    ),
+  })
+
+  const pendingHostIds: string[] = []
+  const skipHosts: { hostId: string; reason: string }[] = []
+
+  for (const host of groupHosts) {
+    if (host.os?.toLowerCase() === 'linux') {
+      pendingHostIds.push(host.id)
+    } else {
+      skipHosts.push({
+        hostId: host.id,
+        reason: `non-Linux host (os: ${host.os ?? 'unknown'})`,
+      })
+    }
+  }
+
+  if (pendingHostIds.length === 0 && skipHosts.length === 0) {
+    return { error: 'No hosts found in group' }
+  }
+
+  const config: ServiceTaskConfig = { service_name: serviceName, action }
+  const result = await createTaskRun(
+    orgId, userId, 'group', groupId, 'service', config, maxParallel, pendingHostIds, skipHosts,
+  )
+
+  if ('error' in result) return result
+
+  return {
+    success: true,
+    taskRunId: result.taskRunId,
+    targetedCount: pendingHostIds.length,
+    skippedCount: skipHosts.length,
   }
 }
 

--- a/apps/web/lib/db/schema/task-runs.ts
+++ b/apps/web/lib/db/schema/task-runs.ts
@@ -4,13 +4,22 @@ import { organisations } from './organisations'
 import { hosts } from './hosts'
 import { users } from './auth'
 
-export type TaskType = 'patch' | 'custom_script'
+export type TaskType = 'patch' | 'custom_script' | 'service'
 export type TaskRunStatus = 'pending' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed'
 export type TaskRunHostStatus = 'pending' | 'running' | 'cancelling' | 'cancelled' | 'success' | 'failed' | 'skipped'
 
 // Config shapes — discriminated by task_type
 export interface PatchTaskConfig { mode: 'security' | 'all' }
-export type TaskConfig = PatchTaskConfig // union extended when new types added
+export interface CustomScriptTaskConfig {
+  script: string
+  interpreter: 'sh' | 'bash' | 'python3'
+  timeout_seconds?: number
+}
+export interface ServiceTaskConfig {
+  service_name: string
+  action: 'start' | 'stop' | 'restart' | 'status'
+}
+export type TaskConfig = PatchTaskConfig | CustomScriptTaskConfig | ServiceTaskConfig
 
 // Result shapes
 export interface PackageUpdate {
@@ -22,7 +31,15 @@ export interface PatchTaskResult {
   packages_updated: PackageUpdate[]
   reboot_required: boolean
 }
-export type TaskResult = PatchTaskResult // union extended when new types added
+export interface CustomScriptTaskResult {
+  exit_code: number
+}
+export interface ServiceTaskResult {
+  service_name: string
+  action: string
+  is_active: boolean
+}
+export type TaskResult = PatchTaskResult | CustomScriptTaskResult | ServiceTaskResult
 
 export const taskRuns = pgTable('task_runs', {
   id: text('id').primaryKey().$defaultFn(() => createId()),


### PR DESCRIPTION
## Summary

- **Custom Script Runner** (`custom_script`): Run arbitrary shell scripts (sh/bash/python3) on any host with real-time output streaming and optional timeout. Available from host detail Tasks tab and group detail page.
- **Service Management** (`service`): Run `systemctl start/stop/restart/status` against a named service on Linux hosts, with live active/inactive result reported in the UI. Available on host Tasks tab and group detail page.
- Both task types work end-to-end through the existing gRPC heartbeat dispatch pipeline, supporting per-task cancellation and the task monitor page.

## Changes

**Agent (Go)**
- `agent/internal/tasks/script.go` — writes script to temp file, executes with chosen interpreter, streams stdout/stderr
- `agent/internal/tasks/service.go` — runs systemctl action, checks `is-active`, returns structured result

**Web (TypeScript)**
- Schema: `TaskType` extended with `'service'`; new config/result interfaces for both task types
- Actions: `triggerCustomScriptRun`, `triggerGroupCustomScriptRun`, `triggerServiceAction`, `triggerGroupServiceAction`
- Host tasks tab: "Run Script" button (all OS) + "Service" button (Linux only) with dialogs and updated history table
- Group detail: "Run Script" and "Service Action" group buttons with parallel host selector
- Task monitor: label/result rendering extended for all three task types

## Test plan

- [ ] Single host → Run Script → sh → `echo "hello"` → monitor shows output, status → completed
- [ ] Single host → Service → status nginx → monitor shows Active/Inactive badge in result
- [ ] Group → Run Script on Group → 2+ hosts → per-host output visible in monitor
- [ ] Group → Service Action → mixed OS group → non-Linux hosts skipped, Linux hosts execute
- [ ] Cancel a running script → agent stops, monitor shows cancelled
- [ ] `go build ./agent/...` and `pnpm run build` pass with zero errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)