### PR TITLE
feat(tasks): service autocomplete, interactive terminal, and task history management

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -52,6 +52,7 @@ import { AlertsTab } from './alerts-tab'
 import { SettingsTab } from './settings-tab'
 import { LocalUsersTab } from './local-users-tab'
 import { TasksTab } from './tasks-tab'
+import { TerminalTab } from './terminal-tab'
 import { getAlertInstances } from '@/lib/actions/alerts'
 import { getHostCollectionSettings } from '@/lib/actions/host-settings'
 import { getServiceAccounts } from '@/lib/actions/service-accounts'
@@ -59,7 +60,7 @@ import { listGroupsForHost, listGroups, addHostToGroup, removeHostFromGroup } fr
 import type { HostGroup } from '@/lib/db/schema'
 import type { HostGroupWithCount } from '@/lib/actions/host-groups'
 
-type Tab = 'overview' | 'storage' | 'network' | 'metrics' | 'checks' | 'alerts' | 'users' | 'settings' | 'groups' | 'tasks'
+type Tab = 'overview' | 'storage' | 'network' | 'metrics' | 'checks' | 'alerts' | 'users' | 'settings' | 'groups' | 'tasks' | 'terminal'
 
 interface Props {
   host: HostWithAgent
@@ -447,6 +448,9 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, late
         </TabButton>
         <TabButton active={activeTab === 'tasks'} onClick={() => setActiveTab('tasks')}>
           Tasks
+        </TabButton>
+        <TabButton active={activeTab === 'terminal'} onClick={() => setActiveTab('terminal')}>
+          Terminal
         </TabButton>
       </div>
 
@@ -910,6 +914,11 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, late
       {/* Tasks Tab */}
       {activeTab === 'tasks' && (
         <TasksTab orgId={orgId} host={host} userId={currentUserId} />
+      )}
+
+      {/* Terminal Tab */}
+      {activeTab === 'terminal' && (
+        <TerminalTab orgId={orgId} host={host} userId={currentUserId} />
       )}
 
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
   Shield,
@@ -15,12 +15,15 @@ import {
   Terminal,
   Power,
   AlertTriangle,
+  Trash2,
+  Search,
 } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -43,6 +46,7 @@ import {
   triggerCustomScriptRun,
   triggerServiceAction,
   listTaskRunsForHost,
+  deleteTaskRuns,
 } from '@/lib/actions/task-runs'
 import type { TaskRunWithHosts } from '@/lib/actions/task-runs'
 import type {
@@ -51,6 +55,8 @@ import type {
   CustomScriptTaskConfig,
   ServiceTaskConfig,
   ServiceTaskResult,
+  AgentQueryStatus,
+  ServiceInfoResult,
 } from '@/lib/db/schema'
 import type { HostWithAgent } from '@/lib/actions/agents'
 import { useRouter } from 'next/navigation'
@@ -59,6 +65,12 @@ interface Props {
   orgId: string
   host: HostWithAgent
   userId: string
+}
+
+type AgentQueryPollResponse = {
+  status: AgentQueryStatus
+  result?: { services?: ServiceInfoResult[] }
+  error?: string
 }
 
 const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed'])
@@ -163,6 +175,7 @@ function TaskDetailsCell({ run, hostId }: { run: TaskRunWithHosts; hostId: strin
 
 export function TasksTab({ orgId, host, userId }: Props) {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const isLinux = host.os?.toLowerCase() === 'linux'
 
   // Patch dialog state
@@ -178,6 +191,11 @@ export function TasksTab({ orgId, host, userId }: Props) {
   const [serviceOpen, setServiceOpen] = useState(false)
   const [serviceName, setServiceName] = useState('')
   const [serviceAction, setServiceAction] = useState<'start' | 'stop' | 'restart' | 'status'>('restart')
+  const [svcQueryId, setSvcQueryId] = useState<string | null>(null)
+  const [svcQueryError, setSvcQueryError] = useState<string | null>(null)
+
+  // Selection state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
   const { data: taskRuns = [] } = useQuery({
     queryKey: ['task-runs-host', orgId, host.id],
@@ -187,6 +205,36 @@ export function TasksTab({ orgId, host, userId }: Props) {
       return runs.some((r) => isRunActive(r.status)) ? 5_000 : 30_000
     },
   })
+
+  // Service autocomplete query polling
+  const { data: svcQueryData } = useQuery<AgentQueryPollResponse>({
+    queryKey: ['agent-query', host.id, svcQueryId],
+    queryFn: async () => {
+      const res = await fetch(`/api/hosts/${host.id}/queries/${svcQueryId}`)
+      return res.json()
+    },
+    enabled: svcQueryId !== null,
+    refetchInterval: (q) => {
+      const s = q.state.data?.status
+      return s === 'complete' || s === 'error' ? false : 1_000
+    },
+  })
+
+  async function querySvcServices() {
+    setSvcQueryId(null)
+    setSvcQueryError(null)
+    const res = await fetch(`/api/hosts/${host.id}/queries`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ queryType: 'list_services' }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setSvcQueryError(data.error ?? 'Failed to query services')
+      return
+    }
+    setSvcQueryId(data.id)
+  }
 
   const { mutate: doPatchRun, isPending: isPatching } = useMutation({
     mutationFn: () => triggerPatchRun(orgId, userId, host.id, patchMode),
@@ -211,6 +259,31 @@ export function TasksTab({ orgId, host, userId }: Props) {
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
     },
   })
+
+  const { mutate: doDelete, isPending: isDeleting } = useMutation({
+    mutationFn: () => deleteTaskRuns(orgId, [...selectedIds]),
+    onSuccess: () => {
+      setSelectedIds(new Set())
+      queryClient.invalidateQueries({ queryKey: ['task-runs-host', orgId, host.id] })
+    },
+  })
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (selectedIds.size === taskRuns.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(taskRuns.map((r) => r.id)))
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -242,6 +315,28 @@ export function TasksTab({ orgId, host, userId }: Props) {
         </div>
       </div>
 
+      {/* Selection toolbar */}
+      {selectedIds.size > 0 && (
+        <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2">
+          <span className="text-sm text-muted-foreground">
+            {selectedIds.size} selected
+          </span>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => doDelete()}
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+            ) : (
+              <Trash2 className="size-3.5 mr-1.5" />
+            )}
+            Delete {selectedIds.size}
+          </Button>
+        </div>
+      )}
+
       {/* Task run history */}
       {taskRuns.length === 0 ? (
         <div className="rounded-lg border border-dashed p-10 text-center">
@@ -256,6 +351,13 @@ export function TasksTab({ orgId, host, userId }: Props) {
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={taskRuns.length > 0 && selectedIds.size === taskRuns.length}
+                    onCheckedChange={toggleSelectAll}
+                    aria-label="Select all"
+                  />
+                </TableHead>
                 <TableHead>Task</TableHead>
                 <TableHead>Details</TableHead>
                 <TableHead>Status</TableHead>
@@ -265,7 +367,14 @@ export function TasksTab({ orgId, host, userId }: Props) {
             </TableHeader>
             <TableBody>
               {taskRuns.map((run) => (
-                <TableRow key={run.id}>
+                <TableRow key={run.id} data-state={selectedIds.has(run.id) ? 'selected' : undefined}>
+                  <TableCell>
+                    <Checkbox
+                      checked={selectedIds.has(run.id)}
+                      onCheckedChange={() => toggleSelect(run.id)}
+                      aria-label={`Select run ${run.id}`}
+                    />
+                  </TableCell>
                   <TableCell className="font-medium">
                     {taskTypeLabel(run.taskType)}
                   </TableCell>
@@ -393,7 +502,16 @@ export function TasksTab({ orgId, host, userId }: Props) {
       </Dialog>
 
       {/* Service dialog */}
-      <Dialog open={serviceOpen} onOpenChange={setServiceOpen}>
+      <Dialog
+        open={serviceOpen}
+        onOpenChange={(open) => {
+          setServiceOpen(open)
+          if (!open) {
+            setSvcQueryId(null)
+            setSvcQueryError(null)
+          }
+        }}
+      >
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Service Action</DialogTitle>
@@ -405,11 +523,52 @@ export function TasksTab({ orgId, host, userId }: Props) {
           <div className="space-y-4 py-2">
             <div className="space-y-2">
               <Label className="text-sm font-medium">Service name</Label>
-              <Input
-                placeholder="e.g. nginx, postgresql, ssh"
-                value={serviceName}
-                onChange={(e) => setServiceName(e.target.value)}
-              />
+              <div className="flex gap-2">
+                <Input
+                  placeholder="e.g. nginx, postgresql, ssh"
+                  value={serviceName}
+                  onChange={(e) => setServiceName(e.target.value)}
+                  className="flex-1"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={querySvcServices}
+                  disabled={svcQueryId !== null && svcQueryData?.status !== 'complete' && svcQueryData?.status !== 'error'}
+                  title="Query running services from the host"
+                >
+                  {svcQueryId !== null && svcQueryData?.status !== 'complete' && svcQueryData?.status !== 'error' ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Search className="size-4" />
+                  )}
+                </Button>
+              </div>
+              {svcQueryError && (
+                <p className="text-xs text-destructive">{svcQueryError}</p>
+              )}
+              {svcQueryData?.status === 'complete' && svcQueryData.result?.services && svcQueryData.result.services.length > 0 && (
+                <div className="rounded-md border bg-muted/50 max-h-48 overflow-y-auto divide-y">
+                  {svcQueryData.result.services.map((s) => (
+                    <button
+                      key={s.name}
+                      className="w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors"
+                      onClick={() => {
+                        setServiceName(s.name.replace(/\.service$/, ''))
+                        setSvcQueryId(null)
+                      }}
+                    >
+                      <span className="font-mono text-foreground">{s.name.replace(/\.service$/, '')}</span>
+                      <span className="ml-2 text-xs text-muted-foreground">{s.active_sub}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {svcQueryData?.status === 'error' && (
+                <p className="text-xs text-destructive">
+                  {svcQueryData.error ?? 'Failed to query services'}
+                </p>
+              )}
             </div>
             <div className="space-y-2">
               <Label className="text-sm font-medium">Action</Label>

--- a/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { Loader2, X, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { triggerCustomScriptRun, cancelTaskRun, getTaskRun } from '@/lib/actions/task-runs'
@@ -22,18 +21,17 @@ interface TerminalEntry {
   exitCode: number | null
 }
 
-function entryStatus(hostStatus: string): TerminalEntry['status'] {
+function hostStatusToEntry(hostStatus: string): TerminalEntry['status'] {
   switch (hostStatus) {
     case 'success': return 'success'
     case 'failed': return 'failed'
     case 'cancelled': return 'cancelled'
     case 'cancelling': return 'cancelling'
-    case 'running': return 'running'
     default: return 'running'
   }
 }
 
-function isTerminalStatus(status: TerminalEntry['status']): boolean {
+function isTerminal(status: TerminalEntry['status']): boolean {
   return status === 'success' || status === 'failed' || status === 'cancelled'
 }
 
@@ -43,10 +41,11 @@ export function TerminalTab({ orgId, host, userId }: Props) {
   const [interpreter, setInterpreter] = useState<'sh' | 'bash' | 'python3'>('bash')
   const [activeTaskRunId, setActiveTaskRunId] = useState<string | null>(null)
   const [cmdHistory, setCmdHistory] = useState<string[]>([])
-  const [cmdHistoryIdx, setCmdHistoryIdx] = useState<number>(-1)
+  const [cmdHistoryIdx, setCmdHistoryIdx] = useState(-1)
 
   const outputRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const isRunning = activeTaskRunId !== null
 
@@ -57,41 +56,52 @@ export function TerminalTab({ orgId, host, userId }: Props) {
     }
   }, [history])
 
-  // Focus input on mount and when run completes
+  // Focus input when run completes
   useEffect(() => {
-    if (!isRunning) {
-      inputRef.current?.focus()
-    }
+    if (!isRunning) inputRef.current?.focus()
   }, [isRunning])
 
-  // Poll the running task
-  const { data: currentRun } = useQuery({
-    queryKey: ['terminal-run', activeTaskRunId],
-    queryFn: () => getTaskRun(orgId, activeTaskRunId!),
-    enabled: activeTaskRunId !== null,
-    refetchInterval: activeTaskRunId ? 1_500 : false,
-  })
-
+  // Cleanup polling on unmount
   useEffect(() => {
-    if (!currentRun || !activeTaskRunId) return
-    const hostRow = currentRun.hosts[0]
-    if (!hostRow) return
-
-    const newStatus = entryStatus(hostRow.status)
-    const exitCode = hostRow.exitCode ?? null
-
-    setHistory((prev) =>
-      prev.map((entry) =>
-        entry.taskRunId === activeTaskRunId
-          ? { ...entry, output: hostRow.rawOutput, status: newStatus, exitCode }
-          : entry,
-      ),
-    )
-
-    if (isTerminalStatus(newStatus)) {
-      setActiveTaskRunId(null)
+    return () => {
+      if (pollingRef.current) clearInterval(pollingRef.current)
     }
-  }, [currentRun, activeTaskRunId])
+  }, [])
+
+  /**
+   * Start polling a task run. setState is called from the interval callback,
+   * not synchronously inside an effect — satisfies react-hooks/set-state-in-effect.
+   */
+  function startPolling(taskRunId: string) {
+    if (pollingRef.current) clearInterval(pollingRef.current)
+
+    pollingRef.current = setInterval(async () => {
+      const run = await getTaskRun(orgId, taskRunId)
+      if (!run) return
+
+      const hostRow = run.hosts[0]
+      if (!hostRow) return
+
+      const newStatus = hostStatusToEntry(hostRow.status)
+      const exitCode = hostRow.exitCode ?? null
+      const output = hostRow.rawOutput
+
+      // setState called in interval callback — this is the allowed pattern
+      setHistory((prev) =>
+        prev.map((entry) =>
+          entry.taskRunId === taskRunId
+            ? { ...entry, output, status: newStatus, exitCode }
+            : entry,
+        ),
+      )
+
+      if (isTerminal(newStatus)) {
+        clearInterval(pollingRef.current!)
+        pollingRef.current = null
+        setActiveTaskRunId(null)
+      }
+    }, 1_500)
+  }
 
   const runCommand = useCallback(async () => {
     const cmd = input.trim()
@@ -133,6 +143,8 @@ export function TerminalTab({ orgId, host, userId }: Props) {
       ),
     )
     setActiveTaskRunId(result.taskRunId)
+    startPolling(result.taskRunId)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [input, isRunning, orgId, userId, host.id, interpreter])
 
   async function handleCancel() {
@@ -165,11 +177,9 @@ export function TerminalTab({ orgId, host, userId }: Props) {
       setInput(nextIdx === -1 ? '' : (cmdHistory[nextIdx] ?? ''))
       return
     }
-    if (e.key === 'c' && e.ctrlKey) {
-      if (isRunning) {
-        e.preventDefault()
-        handleCancel()
-      }
+    if (e.key === 'c' && e.ctrlKey && isRunning) {
+      e.preventDefault()
+      handleCancel()
     }
   }
 
@@ -249,8 +259,8 @@ export function TerminalTab({ orgId, host, userId }: Props) {
               </pre>
             )}
 
-            {/* Exit code */}
-            {isTerminalStatus(entry.status) && entry.exitCode !== null && entry.exitCode !== 0 && (
+            {/* Exit code / cancelled */}
+            {isTerminal(entry.status) && entry.exitCode !== null && entry.exitCode !== 0 && (
               <p className="ml-4 mt-0.5 text-xs text-red-400">[exit: {entry.exitCode}]</p>
             )}
             {entry.status === 'cancelled' && (

--- a/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, X, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { triggerCustomScriptRun, cancelTaskRun, getTaskRun } from '@/lib/actions/task-runs'
+import type { HostWithAgent } from '@/lib/actions/agents'
+
+interface Props {
+  orgId: string
+  host: HostWithAgent
+  userId: string
+}
+
+interface TerminalEntry {
+  id: string
+  command: string
+  taskRunId: string | null
+  output: string
+  status: 'creating' | 'running' | 'success' | 'failed' | 'cancelled' | 'cancelling'
+  exitCode: number | null
+}
+
+function entryStatus(hostStatus: string): TerminalEntry['status'] {
+  switch (hostStatus) {
+    case 'success': return 'success'
+    case 'failed': return 'failed'
+    case 'cancelled': return 'cancelled'
+    case 'cancelling': return 'cancelling'
+    case 'running': return 'running'
+    default: return 'running'
+  }
+}
+
+function isTerminalStatus(status: TerminalEntry['status']): boolean {
+  return status === 'success' || status === 'failed' || status === 'cancelled'
+}
+
+export function TerminalTab({ orgId, host, userId }: Props) {
+  const [history, setHistory] = useState<TerminalEntry[]>([])
+  const [input, setInput] = useState('')
+  const [interpreter, setInterpreter] = useState<'sh' | 'bash' | 'python3'>('bash')
+  const [activeTaskRunId, setActiveTaskRunId] = useState<string | null>(null)
+  const [cmdHistory, setCmdHistory] = useState<string[]>([])
+  const [cmdHistoryIdx, setCmdHistoryIdx] = useState<number>(-1)
+
+  const outputRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const isRunning = activeTaskRunId !== null
+
+  // Auto-scroll to bottom when history changes
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [history])
+
+  // Focus input on mount and when run completes
+  useEffect(() => {
+    if (!isRunning) {
+      inputRef.current?.focus()
+    }
+  }, [isRunning])
+
+  // Poll the running task
+  const { data: currentRun } = useQuery({
+    queryKey: ['terminal-run', activeTaskRunId],
+    queryFn: () => getTaskRun(orgId, activeTaskRunId!),
+    enabled: activeTaskRunId !== null,
+    refetchInterval: activeTaskRunId ? 1_500 : false,
+  })
+
+  useEffect(() => {
+    if (!currentRun || !activeTaskRunId) return
+    const hostRow = currentRun.hosts[0]
+    if (!hostRow) return
+
+    const newStatus = entryStatus(hostRow.status)
+    const exitCode = hostRow.exitCode ?? null
+
+    setHistory((prev) =>
+      prev.map((entry) =>
+        entry.taskRunId === activeTaskRunId
+          ? { ...entry, output: hostRow.rawOutput, status: newStatus, exitCode }
+          : entry,
+      ),
+    )
+
+    if (isTerminalStatus(newStatus)) {
+      setActiveTaskRunId(null)
+    }
+  }, [currentRun, activeTaskRunId])
+
+  const runCommand = useCallback(async () => {
+    const cmd = input.trim()
+    if (!cmd || isRunning) return
+
+    const entryId = crypto.randomUUID()
+    const newEntry: TerminalEntry = {
+      id: entryId,
+      command: cmd,
+      taskRunId: null,
+      output: '',
+      status: 'creating',
+      exitCode: null,
+    }
+
+    setHistory((prev) => [...prev, newEntry])
+    setCmdHistory((prev) => [cmd, ...prev.filter((c) => c !== cmd)])
+    setCmdHistoryIdx(-1)
+    setInput('')
+
+    const result = await triggerCustomScriptRun(orgId, userId, host.id, cmd, interpreter)
+
+    if ('error' in result) {
+      setHistory((prev) =>
+        prev.map((e) =>
+          e.id === entryId
+            ? { ...e, status: 'failed', output: `error: ${result.error}` }
+            : e,
+        ),
+      )
+      return
+    }
+
+    setHistory((prev) =>
+      prev.map((e) =>
+        e.id === entryId
+          ? { ...e, taskRunId: result.taskRunId, status: 'running' }
+          : e,
+      ),
+    )
+    setActiveTaskRunId(result.taskRunId)
+  }, [input, isRunning, orgId, userId, host.id, interpreter])
+
+  async function handleCancel() {
+    if (!activeTaskRunId) return
+    await cancelTaskRun(orgId, activeTaskRunId)
+    setHistory((prev) =>
+      prev.map((e) =>
+        e.taskRunId === activeTaskRunId ? { ...e, status: 'cancelling' } : e,
+      ),
+    )
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      runCommand()
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      const nextIdx = Math.min(cmdHistoryIdx + 1, cmdHistory.length - 1)
+      setCmdHistoryIdx(nextIdx)
+      setInput(cmdHistory[nextIdx] ?? '')
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      const nextIdx = Math.max(cmdHistoryIdx - 1, -1)
+      setCmdHistoryIdx(nextIdx)
+      setInput(nextIdx === -1 ? '' : (cmdHistory[nextIdx] ?? ''))
+      return
+    }
+    if (e.key === 'c' && e.ctrlKey) {
+      if (isRunning) {
+        e.preventDefault()
+        handleCancel()
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">Terminal</h3>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Run commands on this host sequentially.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Interpreter selector */}
+          <div className="flex gap-1">
+            {(['sh', 'bash', 'python3'] as const).map((i) => (
+              <button
+                key={i}
+                onClick={() => setInterpreter(i)}
+                disabled={isRunning}
+                className={`rounded-md border px-2.5 py-1 text-xs font-mono transition-colors ${
+                  interpreter === i
+                    ? 'border-primary bg-primary/5 text-foreground font-semibold'
+                    : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+                }`}
+              >
+                {i}
+              </button>
+            ))}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setHistory([])}
+            disabled={history.length === 0}
+          >
+            <Trash2 className="size-3.5 mr-1.5" />
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      {/* Terminal output */}
+      <div
+        ref={outputRef}
+        className="rounded-lg bg-zinc-950 text-zinc-100 font-mono text-sm p-4 min-h-96 max-h-[600px] overflow-y-auto space-y-3 cursor-text"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {history.length === 0 && (
+          <p className="text-zinc-500 text-xs">
+            Type a command and press Enter to run it on {host.displayName ?? host.hostname}.
+          </p>
+        )}
+
+        {history.map((entry) => (
+          <div key={entry.id}>
+            {/* Command line */}
+            <div className="flex items-center gap-2">
+              <span className="text-green-400 select-none">$</span>
+              <span className="text-zinc-100">{entry.command}</span>
+              {entry.status === 'creating' && (
+                <Loader2 className="size-3 animate-spin text-zinc-400 ml-1" />
+              )}
+              {entry.status === 'running' && (
+                <Loader2 className="size-3 animate-spin text-blue-400 ml-1" />
+              )}
+              {entry.status === 'cancelling' && (
+                <span className="text-xs text-amber-400 ml-1">cancelling…</span>
+              )}
+            </div>
+
+            {/* Output */}
+            {entry.output && (
+              <pre className="mt-1 ml-4 text-zinc-300 text-xs whitespace-pre-wrap break-words leading-relaxed">
+                {entry.output}
+              </pre>
+            )}
+
+            {/* Exit code */}
+            {isTerminalStatus(entry.status) && entry.exitCode !== null && entry.exitCode !== 0 && (
+              <p className="ml-4 mt-0.5 text-xs text-red-400">[exit: {entry.exitCode}]</p>
+            )}
+            {entry.status === 'cancelled' && (
+              <p className="ml-4 mt-0.5 text-xs text-amber-400">[cancelled]</p>
+            )}
+          </div>
+        ))}
+
+        {/* Input line */}
+        <div className="flex items-center gap-2">
+          <span className="text-green-400 select-none">$</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={isRunning}
+            placeholder={isRunning ? 'Running… (Ctrl+C to cancel)' : ''}
+            className="flex-1 bg-transparent outline-none text-zinc-100 placeholder:text-zinc-600 caret-green-400 disabled:opacity-50"
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+          {isRunning && (
+            <button
+              onClick={handleCancel}
+              className="text-zinc-500 hover:text-zinc-300 transition-colors"
+              title="Cancel (Ctrl+C)"
+            >
+              <X className="size-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Up/Down arrows recall command history · Ctrl+C cancels the running command · Each command creates a task run visible in the Tasks tab
+      </p>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -23,6 +23,7 @@ import {
   Terminal,
   Power,
 } from 'lucide-react'
+import { Checkbox } from '@/components/ui/checkbox'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
@@ -67,6 +68,7 @@ import {
   triggerGroupCustomScriptRun,
   triggerGroupServiceAction,
   listTaskRunsForGroup,
+  deleteTaskRuns,
 } from '@/lib/actions/task-runs'
 import type { HostGroupWithMembers } from '@/lib/actions/host-groups'
 import type { HostWithAgent } from '@/lib/actions/agents'
@@ -190,6 +192,9 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
   const [serviceAction, setServiceAction] = useState<'start' | 'stop' | 'restart' | 'status'>('restart')
   const [serviceMaxParallel, setServiceMaxParallel] = useState(1)
 
+  // Selection state for task history
+  const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
+
   const { data: group } = useQuery({
     queryKey: ['host-group', orgId, initialGroup.id],
     queryFn: () => getGroup(orgId, initialGroup.id),
@@ -254,6 +259,14 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
     onSuccess: (result) => {
       setServiceOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
+    },
+  })
+
+  const { mutate: doDeleteRuns, isPending: isDeletingRuns } = useMutation({
+    mutationFn: () => deleteTaskRuns(orgId, [...selectedRunIds]),
+    onSuccess: () => {
+      setSelectedRunIds(new Set())
+      queryClient.invalidateQueries({ queryKey: ['task-runs-group', orgId, initialGroup.id] })
     },
   })
 
@@ -383,6 +396,29 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
       {/* Task History */}
       <div className="space-y-3">
         <h2 className="text-base font-semibold text-foreground">Task History</h2>
+
+        {/* Selection toolbar */}
+        {selectedRunIds.size > 0 && (
+          <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2">
+            <span className="text-sm text-muted-foreground">
+              {selectedRunIds.size} selected
+            </span>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => doDeleteRuns()}
+              disabled={isDeletingRuns}
+            >
+              {isDeletingRuns ? (
+                <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <Trash2 className="size-3.5 mr-1.5" />
+              )}
+              Delete {selectedRunIds.size}
+            </Button>
+          </div>
+        )}
+
         {taskRuns.length === 0 ? (
           <div className="rounded-lg border border-dashed p-8 text-center">
             <Terminal className="size-7 mx-auto text-muted-foreground mb-3" />
@@ -396,6 +432,19 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-10">
+                    <Checkbox
+                      checked={taskRuns.length > 0 && selectedRunIds.size === taskRuns.length}
+                      onCheckedChange={() => {
+                        if (selectedRunIds.size === taskRuns.length) {
+                          setSelectedRunIds(new Set())
+                        } else {
+                          setSelectedRunIds(new Set(taskRuns.map((r) => r.id)))
+                        }
+                      }}
+                      aria-label="Select all"
+                    />
+                  </TableHead>
                   <TableHead>Task</TableHead>
                   <TableHead>Details</TableHead>
                   <TableHead>Status</TableHead>
@@ -413,7 +462,21 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
                   const pendingCount = run.hosts.filter((h) => h.status === 'pending').length
 
                   return (
-                    <TableRow key={run.id}>
+                    <TableRow key={run.id} data-state={selectedRunIds.has(run.id) ? 'selected' : undefined}>
+                      <TableCell>
+                        <Checkbox
+                          checked={selectedRunIds.has(run.id)}
+                          onCheckedChange={() => {
+                            setSelectedRunIds((prev) => {
+                              const next = new Set(prev)
+                              if (next.has(run.id)) next.delete(run.id)
+                              else next.add(run.id)
+                              return next
+                            })
+                          }}
+                          aria-label={`Select run ${run.id}`}
+                        />
+                      </TableCell>
                       <TableCell className="font-medium">
                         {run.taskType === 'patch' ? 'Patch'
                           : run.taskType === 'custom_script' ? 'Script'

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CheckIcon } from "lucide-react"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -416,6 +416,49 @@ export async function triggerGroupServiceAction(
   }
 }
 
+// ── Deletion ──────────────────────────────────────────────────────────────────
+
+/**
+ * Soft-deletes one or more task runs (and their host rows).
+ * Both tables filter by isNull(deletedAt) in all queries, so the rows
+ * disappear automatically after this call.
+ */
+export async function deleteTaskRuns(
+  orgId: string,
+  taskRunIds: string[],
+): Promise<{ success: true } | { error: string }> {
+  if (taskRunIds.length === 0) return { success: true }
+  try {
+    const now = new Date()
+    await db.transaction(async (tx) => {
+      await tx
+        .update(taskRunHosts)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            inArray(taskRunHosts.taskRunId, taskRunIds),
+            eq(taskRunHosts.organisationId, orgId),
+            isNull(taskRunHosts.deletedAt),
+          ),
+        )
+      await tx
+        .update(taskRuns)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            inArray(taskRuns.id, taskRunIds),
+            eq(taskRuns.organisationId, orgId),
+            isNull(taskRuns.deletedAt),
+          ),
+        )
+    })
+    return { success: true }
+  } catch (err) {
+    console.error('Failed to delete task runs:', err)
+    return { error: 'Failed to delete task runs' }
+  }
+}
+
 // ── Patch-specific actions ────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- **Service autocomplete**: The Service Action dialog now has a search button that queries the host for running services and shows a clickable dropdown — same pattern as the existing Add Check process query
- **Interactive terminal**: New Terminal tab on host detail provides an SSH-like experience where commands run sequentially, output streams in as the task executes, up/down arrows recall history, Ctrl+C cancels, and a Clear button wipes the session
- **Task history management**: Both host and group task history tables now have checkboxes (including select-all), and a Delete toolbar that soft-deletes selected task runs

## Test plan

- [ ] Host detail → Tasks → Service dialog → click search button → wait for services → click a service to fill the name field
- [ ] Host detail → Terminal tab → type `echo hello` → Enter → see output stream in → type second command → appended below
- [ ] Terminal: up/down arrow recalls previous commands; Ctrl+C cancels a running command; Clear empties the session
- [ ] Host detail → Tasks → check one or more rows → Delete button appears with count → click → rows disappear
- [ ] Group detail → Task History → same checkbox/delete behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)