### PR TITLE
fix(terminal): fix heartbeat poll structure and INGEST_WS_URL default

### DIFF
--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -201,9 +201,7 @@ loop:
 			pending, err := queries.GetPendingQueriesForHost(ctx, h.pool, hostID)
 			if err != nil {
 				slog.Warn("fetching pending queries", "host_id", hostID, "err", err)
-				continue
-			}
-			if len(pending) > 0 {
+			} else if len(pending) > 0 {
 				pqs := make([]*agentv1.AgentQuery, 0, len(pending))
 				for _, p := range pending {
 					pqs = append(pqs, &agentv1.AgentQuery{QueryId: p.ID, QueryType: p.QueryType})
@@ -216,18 +214,14 @@ loop:
 			}
 
 			// Dispatch the next eligible task (parallelism enforced in SQL).
-			pendingTasks, err := queries.GetPendingTasksForHost(ctx, h.pool, hostID)
-			if err != nil {
-				slog.Warn("fetching pending tasks", "host_id", hostID, "err", err)
-				continue
-			}
-			if len(pendingTasks) > 0 {
+			pendingTasks, taskErr := queries.GetPendingTasksForHost(ctx, h.pool, hostID)
+			if taskErr != nil {
+				slog.Warn("fetching pending tasks", "host_id", hostID, "err", taskErr)
+			} else if len(pendingTasks) > 0 {
 				t := pendingTasks[0]
 				if err := queries.MarkTaskRunHostRunning(ctx, h.pool, t.ID); err != nil {
 					slog.Warn("marking task run host running", "task_run_host_id", t.ID, "err", err)
-					continue
-				}
-				if err := stream.Send(&agentv1.HeartbeatResponse{
+				} else if err := stream.Send(&agentv1.HeartbeatResponse{
 					Ok: true,
 					PendingTask: &agentv1.AgentTask{
 						TaskId:     t.ID,
@@ -237,15 +231,15 @@ loop:
 				}); err != nil {
 					slog.Warn("pushing pending task to agent", "task_run_host_id", t.ID, "err", err)
 					return err
+				} else {
+					slog.Info("dispatched task to agent", "host_id", hostID, "task_run_host_id", t.ID, "task_type", t.TaskType)
 				}
-				slog.Info("dispatched task to agent", "host_id", hostID, "task_run_host_id", t.ID, "task_type", t.TaskType)
 			}
-		}
 
 			// Send cancellation signals for any tasks the user has stopped.
-			cancelIDs, err := queries.GetCancellingTasksForHost(ctx, h.pool, hostID)
-			if err != nil {
-				slog.Warn("fetching cancelling tasks", "host_id", hostID, "err", err)
+			cancelIDs, cancelErr := queries.GetCancellingTasksForHost(ctx, h.pool, hostID)
+			if cancelErr != nil {
+				slog.Warn("fetching cancelling tasks", "host_id", hostID, "err", cancelErr)
 			} else if len(cancelIDs) > 0 {
 				if err := stream.Send(&agentv1.HeartbeatResponse{
 					Ok:            true,
@@ -273,6 +267,7 @@ loop:
 					slog.Info("pushed pending terminal sessions to agent", "host_id", hostID, "count", len(pendingSessions))
 				}
 			}
+		}
 	}
 
 	// Mark agent and host offline on stream close

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -34,7 +34,7 @@ services:
       BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:3000}
       NODE_ENV: production
       AGENT_DIST_DIR: /var/lib/infrawatch/agent-dist
-      INGEST_WS_URL: ${INGEST_WS_URL:-ws://ingest:8080}
+      INGEST_WS_URL: ${INGEST_WS_URL:-ws://localhost:8080}
     volumes:
       - agent_dist:/var/lib/infrawatch/agent-dist
 


### PR DESCRIPTION
## Summary
- **Heartbeat poll structure bug**: The cancel-task and terminal-session push logic was outside the `select` block but inside the `for` loop, causing it to run after every select case (heartbeat messages, timer ticks) rather than only on the 2s poll ticker. Additionally, `continue` statements in the poll ticker case skipped this logic entirely, meaning terminal sessions were never pushed to agents. Moved all poll-related logic into the `queryPollTicker.C` case and replaced `continue` with `else-if` chains.
- **INGEST_WS_URL default**: Changed docker-compose.single.yml default from `ws://ingest:8080` (Docker-internal hostname, unreachable from browser) to `ws://localhost:8080` (browser-reachable for local deployments). This URL is returned to the browser by the server action for WebSocket connections, so it must be browser-reachable.

## Test plan
- [ ] Deploy updated ingest image and verify terminal WebSocket connects successfully
- [ ] Open terminal tab on a host, click Connect, verify shell session starts
- [ ] Verify task cancellation still works (was also affected by the poll structure bug)
- [ ] Test with docker-compose.single.yml — browser should connect to `ws://localhost:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)