### PR TITLE
fix(terminal): show xterm container during connecting to fix 0x0 PTY

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
@@ -82,9 +82,15 @@ export function TerminalTab({ orgId, host }: Props) {
     term.loadAddon(fitAddon)
     term.loadAddon(webLinksAddon)
     term.open(containerRef.current)
-    fitAddon.fit()
     termRef.current = term
     fitRef.current = fitAddon
+
+    // Defer fit to next frame so the container is visible (display: block)
+    // after React processes the 'connecting' status. Without this, fit()
+    // calculates 0 cols/rows because the container is still display: none.
+    requestAnimationFrame(() => {
+      fitAddon.fit()
+    })
 
     term.writeln('\x1b[90mConnecting to ' + (host.displayName ?? host.hostname) + '...\x1b[0m')
 
@@ -95,7 +101,8 @@ export function TerminalTab({ orgId, host }: Props) {
     ws.onopen = () => {
       setStatus('connected')
       term.writeln('\x1b[32mConnected.\x1b[0m\r\n')
-      // Send initial size
+      // Send initial size — fit has already run by now so cols/rows are correct
+      fitAddon.fit()
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
       }
@@ -181,7 +188,7 @@ export function TerminalTab({ orgId, host }: Props) {
     setStatus('closed')
   }, [])
 
-  const showTerminal = status === 'connected' || status === 'closed'
+  const showTerminal = status === 'connecting' || status === 'connected' || status === 'closed'
 
   return (
     <div className="space-y-3">
@@ -234,18 +241,10 @@ export function TerminalTab({ orgId, host }: Props) {
         }}
       />
 
-      {/* Placeholder states */}
+      {/* Placeholder state — shown only when idle (terminal container is hidden) */}
       {!showTerminal && !errorMsg && (
         <div className="rounded-lg bg-zinc-950 border border-border flex items-center justify-center" style={{ height: '500px' }}>
-          {status === 'idle' && (
-            <p className="text-zinc-500 text-sm">Click Connect to start a terminal session</p>
-          )}
-          {status === 'connecting' && (
-            <div className="flex items-center gap-2 text-zinc-400">
-              <Loader2 className="size-5 animate-spin" />
-              <span className="text-sm">Establishing connection...</span>
-            </div>
-          )}
+          <p className="text-zinc-500 text-sm">Click Connect to start a terminal session</p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Show the xterm.js container during the `connecting` phase so `fitAddon.fit()` calculates correct dimensions instead of 0x0
- Defer initial `fit()` to `requestAnimationFrame` so the container is rendered before measurement
- Re-fit and send correct `cols`/`rows` on WebSocket open before the resize message reaches the agent PTY
- Remove dead connecting-spinner placeholder code that TypeScript correctly flagged as unreachable

## Context
After PR #126 fixed the heartbeat poll structure and WebSocket URL, the terminal successfully connected but keystrokes produced no output. Root cause: xterm.js was mounted into a `display: none` container (only shown for `connected` | `closed` states), so `fit()` computed 0 columns and 0 rows, and the agent PTY was resized to 0x0.

## Test plan
- [ ] Connect to a host terminal — verify the cursor blinks and keystrokes produce output
- [ ] Resize the browser window — verify the terminal reflows correctly
- [ ] Disconnect and reconnect — verify the terminal works again
- [ ] Verify the idle placeholder still shows "Click Connect to start a terminal session"

🤖 Generated with [Claude Code](https://claude.com/claude-code)