### PR TITLE
fix(terminal): add agent connection signaling and diagnostics

### DIFF
--- a/apps/ingest/internal/handlers/terminal_grpc.go
+++ b/apps/ingest/internal/handlers/terminal_grpc.go
@@ -84,6 +84,9 @@ func (h *TerminalHandler) Terminal(stream agentv1.IngestService_TerminalServer) 
 		return status.Error(codes.NotFound, "terminal session not found in store")
 	}
 
+	// Signal the WS handler that the agent has connected and the bridge is up.
+	close(sess.agentConnected)
+
 	// Goroutine: read from fromBrowser channel → parse → send to agent via stream
 	agentDone := make(chan struct{})
 	go func() {

--- a/apps/ingest/internal/handlers/terminal_store.go
+++ b/apps/ingest/internal/handlers/terminal_store.go
@@ -20,6 +20,11 @@ type terminalSession struct {
 	// (received from the agent) to the WebSocket handler which sends them to the browser.
 	toBrowser chan []byte
 
+	// agentConnected is closed by the gRPC Terminal handler when the agent
+	// successfully bridges this session. The WS handler watches this to
+	// notify the browser that the full pipeline is up.
+	agentConnected chan struct{}
+
 	cancel    context.CancelFunc
 	startedAt time.Time
 
@@ -85,6 +90,7 @@ func (s *TerminalStore) Register(sessionID string, loggingEnabled bool) (*termin
 	sess := &terminalSession{
 		fromBrowser:    make(chan []byte, 64),
 		toBrowser:      make(chan []byte, 64),
+		agentConnected: make(chan struct{}),
 		cancel:         cancel,
 		startedAt:      time.Now(),
 		recording:      rec,

--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -89,10 +89,24 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		slog.Info("terminal ws: session ended", "session_id", sessionID, "duration_seconds", duration)
 	}()
 
-	// Goroutine: read from toBrowser channel → send to WebSocket
+	// Goroutine: notify browser when agent connects, then relay PTY output
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+
+		// Wait for the agent to connect via gRPC and bridge this session.
+		select {
+		case <-sess.agentConnected:
+			slog.Info("terminal ws: agent connected, bridge is up", "session_id", sessionID)
+			agentMsg, _ := json.Marshal(wsMessage{Type: "agent_connected"})
+			if err := conn.Write(ctx, websocket.MessageText, agentMsg); err != nil {
+				return
+			}
+		case <-sessCtx.Done():
+			return
+		}
+
+		// Relay PTY output from the gRPC handler to the browser.
 		for {
 			select {
 			case <-sessCtx.Done():

--- a/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
@@ -98,9 +98,17 @@ export function TerminalTab({ orgId, host }: Props) {
     const ws = new WebSocket(result.ingestWsUrl)
     wsRef.current = ws
 
+    // Track whether the agent has connected so we can show diagnostics
+    let agentDidConnect = false
+    const waitingTimer = setTimeout(() => {
+      if (!agentDidConnect) {
+        term.writeln('\x1b[33mWaiting for agent to start shell...\x1b[0m')
+      }
+    }, 5000)
+
     ws.onopen = () => {
       setStatus('connected')
-      term.writeln('\x1b[32mConnected.\x1b[0m\r\n')
+      term.writeln('\x1b[32mConnected to ingest. Waiting for agent...\x1b[0m')
       // Send initial size — fit has already run by now so cols/rows are correct
       fitAddon.fit()
       if (ws.readyState === WebSocket.OPEN) {
@@ -112,12 +120,22 @@ export function TerminalTab({ orgId, host }: Props) {
     ws.onmessage = (e) => {
       try {
         const msg = JSON.parse(e.data)
-        if (msg.type === 'output' && msg.data) {
+        if (msg.type === 'agent_connected') {
+          agentDidConnect = true
+          clearTimeout(waitingTimer)
+          term.writeln('\x1b[32mAgent connected. Starting shell...\x1b[0m\r\n')
+        } else if (msg.type === 'output' && msg.data) {
+          if (!agentDidConnect) {
+            agentDidConnect = true
+            clearTimeout(waitingTimer)
+          }
           term.write(atob(msg.data))
         } else if (msg.type === 'closed') {
+          clearTimeout(waitingTimer)
           term.writeln('\r\n\x1b[90mSession ended.\x1b[0m')
           setStatus('closed')
         } else if (msg.type === 'error' && msg.message) {
+          clearTimeout(waitingTimer)
           term.writeln('\r\n\x1b[31mError: ' + msg.message + '\x1b[0m')
           setStatus('error')
           setErrorMsg(msg.message)
@@ -168,6 +186,7 @@ export function TerminalTab({ orgId, host }: Props) {
 
     // Cleanup function
     cleanupRef.current = () => {
+      clearTimeout(waitingTimer)
       dataDisposable.dispose()
       resizeDisposable.dispose()
       resizeObserver?.disconnect()


### PR DESCRIPTION
## Summary
- Add `agentConnected` channel to `TerminalStore` session — gRPC handler closes it when the agent bridges successfully
- WS handler watches the channel and sends `{type: "agent_connected"}` to the browser
- Frontend shows step-by-step progress: "Connected to ingest. Waiting for agent..." -> "Agent connected. Starting shell..."
- After 5s with no agent response, shows "Waiting for agent to start shell..." diagnostic

## Context
After PRs #126 and #127 fixed the heartbeat poll structure, WS URL, and xterm container visibility, the terminal connects (WS opens, xterm renders) but shows no shell prompt. There was no feedback about whether the agent had actually received the session via heartbeat and opened the gRPC Terminal stream. This makes it impossible to tell where the pipeline stalls.

With this change, if the terminal shows "Connected to ingest. Waiting for agent..." but never progresses to "Agent connected", we know the agent either:
1. Hasn't auto-updated to v0.20.0 (which includes terminal support)
2. Isn't receiving the heartbeat push
3. Can't open the gRPC Terminal stream

## Test plan
- [ ] Connect to terminal — verify step-by-step messages appear
- [ ] If agent connects, verify "Agent connected. Starting shell..." appears followed by shell prompt
- [ ] If agent doesn't connect within 5s, verify "Waiting for agent to start shell..." warning appears
- [ ] Disconnect and reconnect — verify messages appear correctly again

🤖 Generated with [Claude Code](https://claude.com/claude-code)