### PR TITLE
fix(terminal): add DB session diagnostics for agent connection debugging

### DIFF
--- a/apps/ingest/internal/db/queries/terminal_sessions.sql.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions.sql.go
@@ -110,6 +110,14 @@ func SetTerminalSessionError(ctx context.Context, pool *pgxpool.Pool, sessionID,
 	return nil
 }
 
+// GetTerminalSessionStatus returns the current status of a terminal session by session_id.
+func GetTerminalSessionStatus(ctx context.Context, pool *pgxpool.Pool, sessionID string) (string, error) {
+	const q = `SELECT status FROM terminal_sessions WHERE session_id = $1`
+	var status string
+	err := pool.QueryRow(ctx, q, sessionID).Scan(&status)
+	return status, err
+}
+
 // CleanupTerminalSessionsForHost marks all pending/active terminal sessions for
 // a host as 'error'. Used when an agent disconnects.
 func CleanupTerminalSessionsForHost(ctx context.Context, pool *pgxpool.Pool, hostID string) error {

--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -73,7 +73,7 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("terminal ws: session activated", "session_id", sessionID, "host_id", info.HostID)
+	slog.Info("terminal ws: session activated", "session_id", sessionID, "host_id", info.HostID, "org_id", info.OrganisationID)
 
 	// Register in terminal store so the gRPC Terminal handler can find us
 	sess, sessCtx := h.store.Register(sessionID, info.LoggingEnabled)
@@ -94,17 +94,39 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer close(done)
 
-		// Wait for the agent to connect via gRPC and bridge this session.
-		select {
-		case <-sess.agentConnected:
-			slog.Info("terminal ws: agent connected, bridge is up", "session_id", sessionID)
-			agentMsg, _ := json.Marshal(wsMessage{Type: "agent_connected"})
-			if err := conn.Write(ctx, websocket.MessageText, agentMsg); err != nil {
+		// Poll DB status every 3s and report to browser while waiting for agent.
+		// This helps diagnose whether the heartbeat finds and pushes the session.
+		diagTicker := time.NewTicker(3 * time.Second)
+		defer diagTicker.Stop()
+
+		for {
+			select {
+			case <-sess.agentConnected:
+				slog.Info("terminal ws: agent connected, bridge is up", "session_id", sessionID)
+				agentMsg, _ := json.Marshal(wsMessage{Type: "agent_connected"})
+				if err := conn.Write(ctx, websocket.MessageText, agentMsg); err != nil {
+					return
+				}
+				goto relayOutput
+			case <-sessCtx.Done():
 				return
+			case <-diagTicker.C:
+				dbStatus, err := queries.GetTerminalSessionStatus(ctx, h.pool, sessionID)
+				if err != nil {
+					slog.Warn("terminal ws: diag status query failed", "session_id", sessionID, "err", err)
+					continue
+				}
+				diagMsg, _ := json.Marshal(wsMessage{
+					Type: "diagnostic",
+					Msg:  "session_status=" + dbStatus + " host_id=" + info.HostID,
+				})
+				if err := conn.Write(ctx, websocket.MessageText, diagMsg); err != nil {
+					return
+				}
 			}
-		case <-sessCtx.Done():
-			return
 		}
+
+	relayOutput:
 
 		// Relay PTY output from the gRPC handler to the browser.
 		for {

--- a/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/terminal-tab.tsx
@@ -134,6 +134,8 @@ export function TerminalTab({ orgId, host }: Props) {
           clearTimeout(waitingTimer)
           term.writeln('\r\n\x1b[90mSession ended.\x1b[0m')
           setStatus('closed')
+        } else if (msg.type === 'diagnostic' && msg.message) {
+          term.writeln('\x1b[90m[diag] ' + msg.message + '\x1b[0m')
         } else if (msg.type === 'error' && msg.message) {
           clearTimeout(waitingTimer)
           term.writeln('\r\n\x1b[31mError: ' + msg.message + '\x1b[0m')


### PR DESCRIPTION
## Summary
- Ingest WS handler polls DB session status every 3s while waiting for agent and sends `diagnostic` messages to browser
- Browser displays diagnostic lines showing `session_status` and `host_id`
- Added `GetTerminalSessionStatus` query helper

## Context
PR #129 confirmed the agent never connects (stalls at "Waiting for agent..."). Agent is confirmed v0.20.0 and online. These diagnostics will reveal:
- Whether the session stays `active` (heartbeat poll should find it)
- The `host_id` stored in the session (to verify it matches the heartbeat's resolved host ID)

## Test plan
- [ ] Connect to terminal — verify [diag] lines appear every 3s showing session status and host_id
- [ ] Use the host_id to cross-reference with the host detail page URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)