### PR TITLE
fix(terminal): enhanced diagnostics with poll query and store checks

### DIFF
--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -116,9 +117,14 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					slog.Warn("terminal ws: diag status query failed", "session_id", sessionID, "err", err)
 					continue
 				}
+				// Run the same query the heartbeat uses to find pending sessions
+				pendingSessions, _ := queries.GetPendingTerminalSessionsForHost(ctx, h.pool, info.HostID)
+				// Check if the store has this session registered
+				_, inStore := h.store.Get(sessionID)
 				diagMsg, _ := json.Marshal(wsMessage{
 					Type: "diagnostic",
-					Msg:  "session_status=" + dbStatus + " host_id=" + info.HostID,
+					Msg: fmt.Sprintf("status=%s host_id=%s poll_would_find=%d in_store=%v",
+						dbStatus, info.HostID, len(pendingSessions), inStore),
 				})
 				if err := conn.Write(ctx, websocket.MessageText, diagMsg); err != nil {
 					return


### PR DESCRIPTION
## Summary
- Diagnostic now runs the exact same `GetPendingTerminalSessionsForHost` query the heartbeat uses
- Reports `poll_would_find=N` (how many sessions the heartbeat poll query would return)
- Reports `in_store=true/false` (whether the session is in the in-memory TerminalStore)

## Context
Previous diagnostics confirmed session stays `active` with correct `host_id`. This additional data will show:
- If `poll_would_find=0`: the heartbeat query can't find the session despite it being active — likely a timing or query issue
- If `poll_would_find=1` + `in_store=true`: the heartbeat should push it — issue is on the agent side
- If `in_store=false`: the session wasn't properly registered in the TerminalStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)