### PR TITLE
fix(terminal): include pending terminal sessions in every heartbeat response

### DIFF
--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -476,6 +476,19 @@ func (h *HeartbeatHandler) processHeartbeat(
 			}
 			resp.Checks = defs
 		}
+
+		// Also include pending terminal sessions in every heartbeat response.
+		// This is redundant with the queryPollTicker push but ensures the agent
+		// sees terminal sessions even if the poll ticker is delayed.
+		if h.terminalStore != nil {
+			pendingSessions, tsErr := queries.GetPendingTerminalSessionsForHost(ctx, h.pool, hostID)
+			if tsErr != nil {
+				slog.Warn("fetching terminal sessions in heartbeat response", "host_id", hostID, "err", tsErr)
+			} else if len(pendingSessions) > 0 {
+				resp.PendingTerminalSessions = pendingSessions
+				slog.Info("including terminal sessions in heartbeat response", "host_id", hostID, "count", len(pendingSessions))
+			}
+		}
 	}
 
 	return stream.Send(resp)


### PR DESCRIPTION
## Summary
- Terminal sessions were only pushed via the 2s poll ticker in the queryPollTicker case
- If any preceding DB work (queries, tasks, alert evaluation) delayed the ticker, the agent could miss the 30-second pickup window
- Now every heartbeat response also includes pending terminal sessions, ensuring the agent sees them immediately

## Test plan
- [ ] Connect terminal, verify agent picks up session within one heartbeat cycle
- [ ] Verify diagnostic output shows `poll_would_find=1` and `in_store=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)