### PR TITLE
fix(terminal): add agent status diagnostics and host_id verification

### DIFF
--- a/apps/ingest/internal/db/queries/hosts.sql.go
+++ b/apps/ingest/internal/db/queries/hosts.sql.go
@@ -31,6 +31,19 @@ func GetHostByAgentID(ctx context.Context, pool *pgxpool.Pool, agentID string) (
 	return id, err
 }
 
+// GetHostAgentStatus returns the agent status and agent_id for a given host ID.
+// Used for terminal diagnostics to verify the heartbeat is active.
+func GetHostAgentStatus(ctx context.Context, pool *pgxpool.Pool, hostID string) (agentID, agentStatus string, err error) {
+	const q = `
+		SELECT COALESCE(h.agent_id, ''), COALESCE(a.status, 'none')
+		FROM hosts h
+		LEFT JOIN agents a ON a.id = h.agent_id
+		WHERE h.id = $1 AND h.deleted_at IS NULL
+	`
+	err = pool.QueryRow(ctx, q, hostID).Scan(&agentID, &agentStatus)
+	return
+}
+
 // UpdateHostVitals overwrites the latest vitals on the host row for a given agent.
 func UpdateHostVitals(ctx context.Context, pool *pgxpool.Pool, agentID string, cpu, mem, disk float32, uptime int64, ipAddresses []string, osVersion, agentOS, agentArch, disksJSON, netJSON string) error {
 	const q = `

--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -121,10 +121,17 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				pendingSessions, _ := queries.GetPendingTerminalSessionsForHost(ctx, h.pool, info.HostID)
 				// Check if the store has this session registered
 				_, inStore := h.store.Get(sessionID)
+				// Check agent status and verify host_id reverse-lookup
+				agentID, agentStatus, _ := queries.GetHostAgentStatus(ctx, h.pool, info.HostID)
+				reverseHostID := ""
+				if agentID != "" {
+					reverseHostID, _ = queries.GetHostByAgentID(ctx, h.pool, agentID)
+				}
+				hostMatch := reverseHostID == info.HostID
 				diagMsg, _ := json.Marshal(wsMessage{
 					Type: "diagnostic",
-					Msg: fmt.Sprintf("status=%s host_id=%s poll_would_find=%d in_store=%v",
-						dbStatus, info.HostID, len(pendingSessions), inStore),
+					Msg: fmt.Sprintf("status=%s host_id=%s poll_would_find=%d in_store=%v agent=%s(%s) host_match=%v",
+						dbStatus, info.HostID, len(pendingSessions), inStore, agentStatus, agentID, hostMatch),
 				})
 				if err := conn.Write(ctx, websocket.MessageText, diagMsg); err != nil {
 					return


### PR DESCRIPTION
## Summary
- Adds agent status (active/offline/none) and agent_id to terminal diagnostic output
- Verifies host_id reverse-lookup: checks that `GetHostByAgentID(agent_id)` returns the same host_id as the terminal session
- Helps identify if the heartbeat's host_id doesn't match the terminal session's host_id

## Test plan
- [ ] Connect terminal, check diagnostic lines show `agent=active(<id>) host_match=true`
- [ ] If `host_match=false`, the heartbeat can't find the session — root cause identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)