### PR TITLE
fix(terminal): use login instead of su for per-user auth

### DIFF
--- a/agent/internal/terminal/session.go
+++ b/agent/internal/terminal/session.go
@@ -77,17 +77,19 @@ func OpenSession(dialFunc func() (*grpc.ClientConn, error), jwtToken string, req
 		cmd.Env = env
 		slog.Info("terminal: direct access mode", "session_id", sessionID, "shell", shell)
 	} else if req.Username != "" {
-		// Per-user mode: validate username and use su to authenticate
+		// Per-user mode: validate username and use login to authenticate.
+		// login always authenticates via PAM (unlike su, which skips auth from root).
+		// The user will see a "Password:" prompt in the terminal.
 		if len(req.Username) > 256 || !validUsernameRE.MatchString(req.Username) {
 			sendClosedMsg(stream, sessionID, -1)
 			return fmt.Errorf("terminal: invalid username %q", req.Username)
 		}
-		cmd = exec.Command("su", "-", req.Username)
+		cmd = exec.Command("login", "-p", req.Username)
 		cmd.Dir = "/"
 		env := os.Environ()
 		env = setEnv(env, "TERM", "xterm-256color")
 		cmd.Env = env
-		slog.Info("terminal: per-user mode", "session_id", sessionID, "username", req.Username)
+		slog.Info("terminal: per-user mode (login)", "session_id", sessionID, "username", req.Username)
 	} else {
 		// No username and not direct access — refuse session
 		sendClosedMsg(stream, sessionID, -1)


### PR DESCRIPTION
## Summary
- `su` from root does not prompt for a password — root can switch to any user without authentication, completely bypassing the security requirement added in #140
- Replaced `su - <username>` with `login -p <username>`, which always authenticates via PAM regardless of the calling user
- Users will now see a "Password:" prompt and must enter their host credentials before getting a shell

## Test plan
- [ ] Enter username → Connect → see "Password:" prompt in terminal
- [ ] Type correct password → authenticated, get shell as that user
- [ ] Type wrong password → authentication failure, session ends
- [ ] Direct access mode still works unchanged (no password prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)