### PR TITLE
fix(terminal): move provider above sidebar for context access

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -3,7 +3,7 @@ import { SidebarProvider } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/shared/sidebar'
 import { Topbar } from '@/components/shared/topbar'
 import { getRequiredSession } from '@/lib/auth/session'
-import { TerminalLayoutWrapper } from '@/components/terminal/terminal-layout-wrapper'
+import { TerminalProviderWrapper, TerminalContentWrapper } from '@/components/terminal/terminal-layout-wrapper'
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const session = await getRequiredSession()
@@ -23,12 +23,14 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const orgId = session.user.organisationId
 
   return (
-    <SidebarProvider>
-      <AppSidebar orgId={orgId} />
-      <TerminalLayoutWrapper orgId={orgId}>
-        <Topbar />
-        <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>
-      </TerminalLayoutWrapper>
-    </SidebarProvider>
+    <TerminalProviderWrapper>
+      <SidebarProvider>
+        <AppSidebar orgId={orgId} />
+        <TerminalContentWrapper orgId={orgId}>
+          <Topbar />
+          <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>
+        </TerminalContentWrapper>
+      </SidebarProvider>
+    </TerminalProviderWrapper>
   )
 }

--- a/apps/web/components/terminal/index.ts
+++ b/apps/web/components/terminal/index.ts
@@ -1,5 +1,5 @@
 export { TerminalPanelProvider, useTerminalPanel } from './terminal-panel-context'
 export type { TerminalTabInfo } from './terminal-panel-context'
 export { TerminalPanel, TerminalPanelTrigger } from './terminal-panel'
-export { TerminalLayoutWrapper } from './terminal-layout-wrapper'
+export { TerminalProviderWrapper, TerminalContentWrapper } from './terminal-layout-wrapper'
 export { HostSelectorDialog } from './host-selector-dialog'

--- a/apps/web/components/terminal/terminal-layout-wrapper.tsx
+++ b/apps/web/components/terminal/terminal-layout-wrapper.tsx
@@ -3,18 +3,23 @@
 import { TerminalPanelProvider } from './terminal-panel-context'
 import { TerminalPanel } from './terminal-panel'
 
-interface Props {
-  orgId: string
-  children: React.ReactNode
+/**
+ * Wraps the entire dashboard (sidebar + content) so that both the sidebar's
+ * TerminalPanelTrigger and the main content can access the terminal context.
+ */
+export function TerminalProviderWrapper({ children }: { children: React.ReactNode }) {
+  return <TerminalPanelProvider>{children}</TerminalPanelProvider>
 }
 
-export function TerminalLayoutWrapper({ orgId, children }: Props) {
+/**
+ * Inner wrapper for the main content column. Renders the TerminalPanel at the
+ * bottom and lets the page content shrink to fit.
+ */
+export function TerminalContentWrapper({ orgId, children }: { orgId: string; children: React.ReactNode }) {
   return (
-    <TerminalPanelProvider>
-      <div className="flex flex-col flex-1 min-h-0">
-        {children}
-        <TerminalPanel orgId={orgId} />
-      </div>
-    </TerminalPanelProvider>
+    <div className="flex flex-col flex-1 min-w-0 min-h-0">
+      {children}
+      <TerminalPanel orgId={orgId} />
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Fix `useTerminalPanel must be used within a TerminalPanelProvider` error
- Split `TerminalLayoutWrapper` into `TerminalProviderWrapper` (wraps entire tree including sidebar) and `TerminalContentWrapper` (wraps main content + terminal panel)
- The sidebar's `TerminalPanelTrigger` now has access to the terminal context

## Test plan
- [ ] Navigate to dashboard — no error in console
- [ ] Click Terminal in sidebar Tooling section — host selector opens
- [ ] Open terminal from host detail page — opens in bottom panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)