### PR TITLE
feat(terminal): persist tabs across browser refresh

### DIFF
--- a/apps/web/components/terminal/terminal-panel-context.tsx
+++ b/apps/web/components/terminal/terminal-panel-context.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState, useCallback } from 'react'
+import { createContext, useContext, useState, useCallback, useEffect } from 'react'
 import { createId } from '@paralleldrive/cuid2'
 
 export interface TerminalTabInfo {
@@ -43,13 +43,112 @@ const DEFAULT_PANEL_HEIGHT = 350
 const MIN_PANEL_HEIGHT = 150
 const MAX_PANEL_HEIGHT_RATIO = 0.7
 
-export function TerminalPanelProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<TerminalPanelState>({
-    isOpen: false,
-    panelHeight: DEFAULT_PANEL_HEIGHT,
-    tabs: [],
-    activeTabId: null,
+// --- sessionStorage persistence ---
+
+const STORAGE_KEY = 'terminal-panel-state'
+
+interface PersistedTerminalState {
+  tabs: Omit<TerminalTabInfo, 'id'>[]
+  activeTabIndex: number | null
+  isOpen: boolean
+  panelHeight: number
+}
+
+function isValidPersistedState(value: unknown): value is PersistedTerminalState {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+
+  if (typeof obj.isOpen !== 'boolean') return false
+  if (typeof obj.panelHeight !== 'number' || !Number.isFinite(obj.panelHeight)) return false
+  if (obj.activeTabIndex !== null && typeof obj.activeTabIndex !== 'number') return false
+  if (!Array.isArray(obj.tabs)) return false
+
+  return obj.tabs.every((tab: unknown) => {
+    if (typeof tab !== 'object' || tab === null) return false
+    const t = tab as Record<string, unknown>
+    return (
+      typeof t.hostId === 'string' &&
+      typeof t.hostname === 'string' &&
+      (t.username === null || typeof t.username === 'string') &&
+      typeof t.orgId === 'string' &&
+      typeof t.directAccess === 'boolean'
+    )
   })
+}
+
+function loadPersistedState(): TerminalPanelState | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+
+    const parsed: unknown = JSON.parse(raw)
+    if (!isValidPersistedState(parsed)) return null
+    if (parsed.tabs.length === 0) return null
+
+    const tabs: TerminalTabInfo[] = parsed.tabs.map((t) => ({
+      id: createId(),
+      ...t,
+    }))
+
+    const restoredTab =
+      parsed.activeTabIndex !== null ? tabs[parsed.activeTabIndex] : undefined
+    const activeTabId = restoredTab?.id ?? tabs[0]?.id ?? null
+
+    return {
+      tabs,
+      activeTabId,
+      isOpen: parsed.isOpen,
+      panelHeight: Math.max(MIN_PANEL_HEIGHT, Math.min(parsed.panelHeight, 1200)),
+    }
+  } catch {
+    return null
+  }
+}
+
+function persistState(state: TerminalPanelState): void {
+  try {
+    if (state.tabs.length === 0) {
+      sessionStorage.removeItem(STORAGE_KEY)
+      return
+    }
+    const toPersist: PersistedTerminalState = {
+      tabs: state.tabs.map((t) => ({
+        hostId: t.hostId,
+        hostname: t.hostname,
+        username: t.username,
+        orgId: t.orgId,
+        directAccess: t.directAccess,
+      })),
+      activeTabIndex: state.activeTabId
+        ? state.tabs.findIndex((t) => t.id === state.activeTabId)
+        : null,
+      isOpen: state.isOpen,
+      panelHeight: state.panelHeight,
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(toPersist))
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+const DEFAULT_STATE: TerminalPanelState = {
+  isOpen: false,
+  panelHeight: DEFAULT_PANEL_HEIGHT,
+  tabs: [],
+  activeTabId: null,
+}
+
+// --- Provider ---
+
+export function TerminalPanelProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<TerminalPanelState>(
+    () => loadPersistedState() ?? DEFAULT_STATE,
+  )
+
+  useEffect(() => {
+    persistState(state)
+  }, [state])
 
   const openTerminal = useCallback(
     (params: {


### PR DESCRIPTION
## Summary
- Persist terminal tab state (hosts, usernames, panel height, active tab) to `sessionStorage`
- On browser refresh, tabs are restored and automatically reconnect with fresh shell sessions
- Uses lazy `useState` initializer to avoid flash of empty state before restore
- Tabs do not survive closing the browser tab (correct — PTY sessions are dead anyway)
- Single file change: `terminal-panel-context.tsx`

## Test plan
- [ ] Open 2-3 terminals to different hosts
- [ ] Refresh the browser — all tabs should reappear and auto-reconnect
- [ ] Verify panel height and open/closed state is preserved
- [ ] Close all tabs, refresh — should start with no terminals
- [ ] Open a terminal, close the browser tab entirely, re-open the page — should start clean (sessionStorage is per-tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)