### PR TITLE
feat(terminal): remember last username and reconnect on exit

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { Terminal, User, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -17,20 +17,21 @@ interface Props {
 }
 
 export function HostTerminalLauncher({ orgId, host, directAccess, accessDeniedReason }: Props) {
-  const [username, setUsername] = useState('')
   const { openTerminal } = useTerminalPanel()
   const { data: session } = useSession()
 
-  // Pre-fill with last-used username for this host
-  useEffect(() => {
-    if (!session?.user?.id) return
+  // Derive last-used username from localStorage (updates when session loads)
+  const savedUsername = useMemo(() => {
+    if (typeof window === 'undefined' || !session?.user?.id) return ''
     try {
-      const saved = localStorage.getItem(`terminal-username:${session.user.id}:${host.id}`)
-      if (saved) setUsername(saved)
+      return localStorage.getItem(`terminal-username:${session.user.id}:${host.id}`) ?? ''
     } catch {
-      // localStorage may be unavailable
+      return ''
     }
   }, [session?.user?.id, host.id])
+
+  const [typedUsername, setTypedUsername] = useState<string | null>(null)
+  const username = typedUsername ?? savedUsername
 
   if (accessDeniedReason) {
     return (
@@ -91,7 +92,7 @@ export function HostTerminalLauncher({ orgId, host, directAccess, accessDeniedRe
             <Input
               id="host-terminal-username"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => setTypedUsername(e.target.value)}
               placeholder="e.g. jsmith"
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && username.trim()) handleOpen()

--- a/apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Terminal, User, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useTerminalPanel } from '@/components/terminal'
+import { useSession } from '@/lib/auth/client'
 import type { HostWithAgent } from '@/lib/actions/agents'
 
 interface Props {
@@ -18,6 +19,18 @@ interface Props {
 export function HostTerminalLauncher({ orgId, host, directAccess, accessDeniedReason }: Props) {
   const [username, setUsername] = useState('')
   const { openTerminal } = useTerminalPanel()
+  const { data: session } = useSession()
+
+  // Pre-fill with last-used username for this host
+  useEffect(() => {
+    if (!session?.user?.id) return
+    try {
+      const saved = localStorage.getItem(`terminal-username:${session.user.id}:${host.id}`)
+      if (saved) setUsername(saved)
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, [session?.user?.id, host.id])
 
   if (accessDeniedReason) {
     return (
@@ -30,6 +43,13 @@ export function HostTerminalLauncher({ orgId, host, directAccess, accessDeniedRe
   }
 
   const handleOpen = () => {
+    if (!directAccess && username.trim() && session?.user?.id) {
+      try {
+        localStorage.setItem(`terminal-username:${session.user.id}:${host.id}`, username.trim())
+      } catch {
+        // localStorage may be unavailable
+      }
+    }
     openTerminal({
       hostId: host.id,
       hostname: host.displayName ?? host.hostname,

--- a/apps/web/components/terminal/host-selector-dialog.tsx
+++ b/apps/web/components/terminal/host-selector-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Search, Server, Terminal, User, Loader2, WifiOff } from 'lucide-react'
 import {
@@ -29,11 +29,11 @@ interface Props {
 export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
   const [search, setSearch] = useState('')
   const [selectedHostId, setSelectedHostId] = useState<string | null>(null)
-  const [username, setUsername] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
   const { openTerminal } = useTerminalPanel()
   const { data: session } = useSession()
+  const [typedUsername, setTypedUsername] = useState<string | null>(null)
 
   const { data: hosts = [], isLoading } = useQuery({
     queryKey: ['hosts', orgId],
@@ -75,16 +75,17 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
 
   const directAccess = terminalAccess?.allowed === true ? terminalAccess.directAccess : false
 
-  // Pre-fill with last-used username when a host is selected
-  useEffect(() => {
-    if (!selectedHostId || !session?.user?.id) return
+  // Derive last-used username from localStorage (updates when host is selected)
+  const savedUsername = useMemo(() => {
+    if (typeof window === 'undefined' || !session?.user?.id || !selectedHostId) return ''
     try {
-      const saved = localStorage.getItem(`terminal-username:${session.user.id}:${selectedHostId}`)
-      if (saved) setUsername(saved)
+      return localStorage.getItem(`terminal-username:${session.user.id}:${selectedHostId}`) ?? ''
     } catch {
-      // localStorage may be unavailable
+      return ''
     }
-  }, [selectedHostId, session?.user?.id])
+  }, [session?.user?.id, selectedHostId])
+
+  const username = typedUsername ?? savedUsername
 
   const handleConnect = async () => {
     if (!selectedHost) return
@@ -122,7 +123,7 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
     // Reset state and close
     setSearch('')
     setSelectedHostId(null)
-    setUsername('')
+    setTypedUsername(null)
     setError(null)
     setConnecting(false)
     onOpenChange(false)
@@ -130,7 +131,7 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
 
   const handleBack = () => {
     setSelectedHostId(null)
-    setUsername('')
+    setTypedUsername(null)
     setError(null)
   }
 
@@ -138,7 +139,7 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
     if (!nextOpen) {
       setSearch('')
       setSelectedHostId(null)
-      setUsername('')
+      setTypedUsername(null)
       setError(null)
     }
     onOpenChange(nextOpen)
@@ -251,7 +252,7 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
                       id="host-selector-username"
                       value={username}
                       onChange={(e) => {
-                        setUsername(e.target.value)
+                        setTypedUsername(e.target.value)
                         setError(null)
                       }}
                       placeholder="e.g. jsmith"

--- a/apps/web/components/terminal/host-selector-dialog.tsx
+++ b/apps/web/components/terminal/host-selector-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Search, Server, Terminal, User, Loader2, WifiOff } from 'lucide-react'
 import {
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { listHosts } from '@/lib/actions/agents'
 import { checkTerminalAccess } from '@/lib/actions/terminal'
+import { useSession } from '@/lib/auth/client'
 import { useTerminalPanel } from './terminal-panel-context'
 
 interface Props {
@@ -32,6 +33,7 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
   const { openTerminal } = useTerminalPanel()
+  const { data: session } = useSession()
 
   const { data: hosts = [], isLoading } = useQuery({
     queryKey: ['hosts', orgId],
@@ -73,6 +75,17 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
 
   const directAccess = terminalAccess?.allowed === true ? terminalAccess.directAccess : false
 
+  // Pre-fill with last-used username when a host is selected
+  useEffect(() => {
+    if (!selectedHostId || !session?.user?.id) return
+    try {
+      const saved = localStorage.getItem(`terminal-username:${session.user.id}:${selectedHostId}`)
+      if (saved) setUsername(saved)
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, [selectedHostId, session?.user?.id])
+
   const handleConnect = async () => {
     if (!selectedHost) return
 
@@ -88,6 +101,15 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
 
     setConnecting(true)
     setError(null)
+
+    // Save last-used username for this host
+    if (!directAccess && username.trim() && session?.user?.id && selectedHostId) {
+      try {
+        localStorage.setItem(`terminal-username:${session.user.id}:${selectedHostId}`, username.trim())
+      } catch {
+        // localStorage may be unavailable
+      }
+    }
 
     openTerminal({
       hostId: selectedHost.id,

--- a/apps/web/components/terminal/terminal-session.tsx
+++ b/apps/web/components/terminal/terminal-session.tsx
@@ -17,8 +17,9 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
   const termRef = useRef<unknown>(null)
   const fitRef = useRef<unknown>(null)
   const wsRef = useRef<WebSocket | null>(null)
-  const cleanupRef = useRef<(() => void) | null>(null)
-  const hasConnectedRef = useRef(false)
+  const connectionCleanupRef = useRef<(() => void) | null>(null)
+  const resizeObserverRef = useRef<ResizeObserver | null>(null)
+  const hasInitializedRef = useRef(false)
 
   const updateStatus = useCallback(
     (s: Status) => {
@@ -41,26 +42,14 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
     }
   }, [isVisible])
 
-  // Connect on mount
+  // Initialize terminal and start first connection
   useEffect(() => {
-    if (hasConnectedRef.current) return
-    hasConnectedRef.current = true
+    if (hasInitializedRef.current) return
+    hasInitializedRef.current = true
 
     let cancelled = false
 
-    const connect = async () => {
-      const result = await createTerminalSession(
-        tab.orgId,
-        tab.hostId,
-        tab.directAccess ? undefined : (tab.username ?? undefined),
-      )
-      if (cancelled) return
-
-      if ('error' in result) {
-        updateStatus('error')
-        return
-      }
-
+    const init = async () => {
       const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
         import('@xterm/xterm'),
         import('@xterm/addon-fit'),
@@ -95,116 +84,171 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
         fitAddon.fit()
       })
 
-      const connectMsg = tab.directAccess
-        ? `Connecting to ${tab.hostname}...`
-        : `Connecting to ${tab.hostname} as ${tab.username}...`
-      term.writeln(`\x1b[90m${connectMsg}\x1b[0m`)
-
-      const ws = new WebSocket(result.ingestWsUrl)
-      wsRef.current = ws
-
-      let agentDidConnect = false
-      const waitingTimer = setTimeout(() => {
-        if (!agentDidConnect) {
-          term.writeln('\x1b[33mWaiting for agent to start shell...\x1b[0m')
-        }
-      }, 5000)
-
-      ws.onopen = () => {
-        updateStatus('connected')
-        term.writeln('\x1b[32mConnected to ingest. Waiting for agent...\x1b[0m')
-        fitAddon.fit()
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
-        }
-        term.focus()
-      }
-
-      ws.onmessage = (e) => {
-        try {
-          const msg = JSON.parse(e.data)
-          if (msg.type === 'agent_connected') {
-            agentDidConnect = true
-            clearTimeout(waitingTimer)
-            term.writeln('\x1b[32mAgent connected. Starting shell...\x1b[0m\r\n')
-          } else if (msg.type === 'output' && msg.data) {
-            if (!agentDidConnect) {
-              agentDidConnect = true
-              clearTimeout(waitingTimer)
-            }
-            term.write(atob(msg.data))
-          } else if (msg.type === 'closed') {
-            clearTimeout(waitingTimer)
-            term.writeln('\r\n\x1b[90mSession ended.\x1b[0m')
-            updateStatus('closed')
-          } else if (msg.type === 'diagnostic' && msg.message) {
-            term.writeln(`\x1b[90m[diag] ${msg.message}\x1b[0m`)
-          } else if (msg.type === 'error' && msg.message) {
-            clearTimeout(waitingTimer)
-            term.writeln(`\r\n\x1b[31mError: ${msg.message}\x1b[0m`)
-            updateStatus('error')
-          }
-        } catch {
-          // ignore malformed messages
-        }
-      }
-
-      ws.onerror = () => {
-        updateStatus('error')
-      }
-
-      ws.onclose = (e) => {
-        if (e.code !== 1000) {
-          updateStatus('closed')
-        }
-      }
-
-      const dataDisposable = term.onData((data) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'input', data: btoa(data) }))
-        }
-      })
-
-      const resizeDisposable = term.onResize(({ cols, rows }) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'resize', cols, rows }))
-        }
-      })
-
-      let resizeObserver: ResizeObserver | null = null
+      // Resize observer persists across reconnections
       if (containerRef.current) {
-        resizeObserver = new ResizeObserver(() => {
+        const observer = new ResizeObserver(() => {
           try {
             fitAddon.fit()
           } catch {
-            // ignore errors during cleanup
+            // ignore
           }
         })
-        resizeObserver.observe(containerRef.current)
+        observer.observe(containerRef.current)
+        resizeObserverRef.current = observer
       }
 
-      cleanupRef.current = () => {
-        clearTimeout(waitingTimer)
-        dataDisposable.dispose()
-        resizeDisposable.dispose()
-        resizeObserver?.disconnect()
-        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-          ws.send(JSON.stringify({ type: 'close' }))
-          ws.close(1000, 'tab closed')
+      // Reconnectable session — called on initial mount and after exit/error
+      const connectSession = async () => {
+        if (cancelled) return
+
+        // Tear down previous WebSocket connection if any
+        connectionCleanupRef.current?.()
+        connectionCleanupRef.current = null
+
+        updateStatus('connecting')
+        term.clear()
+
+        const connectMsg = tab.directAccess
+          ? `Connecting to ${tab.hostname}...`
+          : `Connecting to ${tab.hostname} as ${tab.username}...`
+        term.writeln(`\x1b[90m${connectMsg}\x1b[0m`)
+
+        const result = await createTerminalSession(
+          tab.orgId,
+          tab.hostId,
+          tab.directAccess ? undefined : (tab.username ?? undefined),
+        )
+
+        if (cancelled) return
+
+        if ('error' in result) {
+          term.writeln(`\r\n\x1b[31mError: ${result.error}\x1b[0m`)
+          term.writeln('\r\n\x1b[90mPress any key to retry...\x1b[0m')
+          updateStatus('error')
+          const retryDisposable = term.onData(() => {
+            retryDisposable.dispose()
+            connectSession()
+          })
+          return
         }
-        term.dispose()
-        termRef.current = null
-        fitRef.current = null
-        wsRef.current = null
+
+        const ws = new WebSocket(result.ingestWsUrl)
+        wsRef.current = ws
+
+        let agentDidConnect = false
+        let sessionEnded = false
+        const waitingTimer = setTimeout(() => {
+          if (!agentDidConnect) {
+            term.writeln('\x1b[33mWaiting for agent to start shell...\x1b[0m')
+          }
+        }, 5000)
+
+        const promptReconnect = () => {
+          if (sessionEnded) return
+          sessionEnded = true
+          term.writeln('\r\n\x1b[90mPress any key to reconnect...\x1b[0m')
+          const reconnectDisposable = term.onData(() => {
+            reconnectDisposable.dispose()
+            connectSession()
+          })
+        }
+
+        ws.onopen = () => {
+          updateStatus('connected')
+          term.writeln('\x1b[32mConnected to ingest. Waiting for agent...\x1b[0m')
+          fitAddon.fit()
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }))
+          }
+          term.focus()
+        }
+
+        ws.onmessage = (e) => {
+          try {
+            const msg = JSON.parse(e.data)
+            if (msg.type === 'agent_connected') {
+              agentDidConnect = true
+              clearTimeout(waitingTimer)
+              term.writeln('\x1b[32mAgent connected. Starting shell...\x1b[0m\r\n')
+            } else if (msg.type === 'output' && msg.data) {
+              if (!agentDidConnect) {
+                agentDidConnect = true
+                clearTimeout(waitingTimer)
+              }
+              term.write(atob(msg.data))
+            } else if (msg.type === 'closed') {
+              clearTimeout(waitingTimer)
+              term.writeln('\r\n\x1b[90mSession ended.\x1b[0m')
+              updateStatus('closed')
+              promptReconnect()
+            } else if (msg.type === 'diagnostic' && msg.message) {
+              term.writeln(`\x1b[90m[diag] ${msg.message}\x1b[0m`)
+            } else if (msg.type === 'error' && msg.message) {
+              clearTimeout(waitingTimer)
+              term.writeln(`\r\n\x1b[31mError: ${msg.message}\x1b[0m`)
+              updateStatus('error')
+              promptReconnect()
+            }
+          } catch {
+            // ignore malformed messages
+          }
+        }
+
+        ws.onerror = () => {
+          updateStatus('error')
+        }
+
+        ws.onclose = (e) => {
+          if (e.code !== 1000) {
+            updateStatus('closed')
+            promptReconnect()
+          }
+        }
+
+        const dataDisposable = term.onData((data: string) => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'input', data: btoa(data) }))
+          }
+        })
+
+        const resizeDisposable = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'resize', cols, rows }))
+          }
+        })
+
+        connectionCleanupRef.current = () => {
+          clearTimeout(waitingTimer)
+          dataDisposable.dispose()
+          resizeDisposable.dispose()
+          if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+            try {
+              ws.send(JSON.stringify({ type: 'close' }))
+            } catch {
+              // ignore send errors on closing socket
+            }
+            ws.close(1000, 'tab closed')
+          }
+          wsRef.current = null
+        }
       }
+
+      connectSession()
     }
 
-    connect()
+    init()
 
     return () => {
       cancelled = true
-      cleanupRef.current?.()
-      cleanupRef.current = null
+      connectionCleanupRef.current?.()
+      connectionCleanupRef.current = null
+      resizeObserverRef.current?.disconnect()
+      resizeObserverRef.current = null
+      const term = termRef.current as { dispose: () => void } | null
+      term?.dispose()
+      termRef.current = null
+      fitRef.current = null
+      wsRef.current = null
     }
   }, [tab, updateStatus])
 


### PR DESCRIPTION
## Summary
- **Remember username**: Saves the last-used terminal username per host per user in localStorage, pre-filling it on the next connection attempt (both host detail page and host selector dialog)
- **Reconnect on exit**: When a terminal session ends (e.g. typing `exit`), shows "Press any key to reconnect..." instead of leaving a dead terminal — pressing any key starts a fresh session to the same host with the same credentials
- **Retry on error**: Connection errors also show "Press any key to retry..." for easy recovery

## Test plan
- [ ] Open terminal to a host, enter a username, connect — close the tab and reopen; the username field should be pre-filled
- [ ] Use the sidebar host selector dialog to connect; verify username is also remembered there
- [ ] Connect to a terminal and type `exit` — verify "Session ended. Press any key to reconnect..." appears
- [ ] Press any key after session ends — verify a new session starts automatically
- [ ] Verify the terminal status indicator returns to green on reconnect
- [ ] Log in as a different user and verify they get their own saved usernames (not the other user's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)