### PR TITLE
feat(notifications): Slack, Telegram, and in-app notification channels

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,66 @@
 **Phase 5 — Tooling (in progress)**
 
 ## Current Status
-🟢 Phase 5 progressing — Task framework expanded with custom script runner, service management (start/stop/restart/status), and service autocomplete from live host queries. Metrics charts upgraded with click-drag zoom and adaptive bucketing. WebSocket-based interactive terminal fully implemented: persistent bottom panel with tabs, per-user host authentication, cross-distro su/login support, username memory, session persistence across browser refresh, and reconnect-on-exit. Terminal is now a VS Code-style panel visible on all pages.
+🟢 Phase 5 progressing — Notification channels expanded: Slack (Incoming Webhooks) and Telegram (Bot API) added alongside webhook and SMTP. In-app notifications implemented end-to-end: Go ingest fan-out → `notifications` table → bell icon in topbar with red unread badge, dropdown, and full `/notifications` page. Org-level notification settings (roles, opt-out) in Settings; per-user opt-out toggle in Profile.
 
 ---
 
 ## What Has Been Built
+
+### Session 34 — Slack, Telegram, and in-app notification channels
+
+**Database** (`apps/web/lib/db/schema/alerts.ts`, `auth.ts`, `organisations.ts`, migration `0026_youthful_anthem`)
+- `notifications` table: per-user rows with subject, body, severity, resourceType, resourceId, read flag, alertInstanceId FK
+- `notificationsEnabled` column added to `user` table (default true)
+- `OrgNotificationSettings` added to `OrgMetadata` JSONB: `inAppEnabled`, `inAppRoles`, `allowUserOptOut`
+- `NotificationChannelType` expanded to `'webhook' | 'smtp' | 'slack' | 'telegram'`
+- `SlackChannelConfig { webhookUrl }` and `TelegramChannelConfig { botToken; chatId }` interfaces added
+
+**Go ingest service** (`apps/ingest/internal/`)
+- `alerts.sql.go`: `GetEnabledSlackChannels`, `GetEnabledTelegramChannels`, `GetOrgNotificationSettings`, `GetAlertTargetUsers` (role + opt-out filter), `InsertNotificationBatch` (pgx.Batch)
+- `notify.go`: `postSlack` (Block Kit JSON), `dispatchSlack`, `postTelegram` (Bot API HTML mode), `dispatchTelegram`, `dispatchInApp` (org settings → user targeting → batch insert)
+- `alerts.go`: `notifChannels` struct expanded; all evaluators (`check_status`, `metric_threshold`, `cert_expiry`) call Slack + Telegram + in-app dispatch on fire and resolve
+
+**TypeScript actions** (`apps/web/lib/actions/`)
+- `alerts.ts`: Zod discriminated union extended for Slack/Telegram; `NotificationChannelSafe` union updated (Telegram masks botToken as `hasBotToken`); `updateNotificationChannel` and `sendTestNotification` handle all four types
+- `notifications.ts`: `getNotifications`, `getUnreadCount`, `markAsRead`, `markAllAsRead`, `deleteNotification`
+- `notification-settings.ts`: `getOrgNotificationSettings` (with defaults), `updateOrgNotificationSettings` (admin-only, Zod-validated)
+- `profile.ts`: `updateNotificationPreference` (respects org `allowUserOptOut`)
+
+**UI — Alerts page** (`apps/web/app/(dashboard)/alerts/alerts-client.tsx`)
+- `AddSlackDialog`, `EditSlackDialog`, `AddTelegramDialog`, `EditTelegramDialog` components following existing dialog pattern
+- "Add Slack" and "Add Telegram" buttons in channels card header
+- Type badges (MessageSquare for Slack, Send for Telegram); details column shows webhookUrl/chatId
+
+**UI — Notification bell** (`apps/web/components/shared/notification-bell.tsx`, `topbar.tsx`)
+- Topbar Bell icon with absolute-positioned red badge showing unread count (capped at 99+)
+- Dropdown: 10 most recent notifications with severity dot, bold subject (unread), relative timestamp, blue dot indicator
+- Click: `markAsRead` + navigate to resource (`/hosts/{id}` or `/certificates/{id}`)
+- Footer: "View all notifications" → `/notifications`
+- Polls every 20 s via TanStack Query `refetchInterval`
+
+**UI — Notifications page** (`apps/web/app/(dashboard)/notifications/`)
+- Server component fetches initial 25 notifications + unread count for SSR
+- Filter tabs: All / Unread (with badge)
+- Cards: severity dot, subject, severity badge, relative + absolute timestamps; click to expand body + resource link + mark-read + delete
+- "Mark all read" header button; Previous/Next pagination (PAGE_SIZE=25)
+- Polls every 30 s
+
+**UI — Settings** (`apps/web/app/(dashboard)/settings/settings-client.tsx`)
+- "Notification Settings" card: Enable in-app toggle, role checkboxes (super_admin/org_admin/engineer/read_only), Allow user opt-out toggle; admin-only
+
+**UI — Profile** (`apps/web/app/(dashboard)/profile/profile-client.tsx`)
+- "Notifications" card: toggle visible when org `inAppEnabled`; disabled with explanatory text when org disallows opt-out
+
+**Sidebar** (`apps/web/components/shared/sidebar.tsx`)
+- "Notifications" entry added to Monitoring group (BellPlus icon, `/notifications`)
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+- `go build ./...` — zero errors ✅
+- PR: simonjcarr/infrawatch#155
+
+---
 
 ### Session 33 — Terminal UX polish: saved username and reconnect on exit
 
@@ -1126,7 +1181,9 @@ Phase 3 is complete and all known technical debt is resolved. Phase 4 starts her
 - [x] Metric graphs (Recharts)
 - [x] Alert rule builder (check_status + metric_threshold, per-host + org-wide)
 - [x] Alert state machine (fire/resolve in ingest; acknowledge in web)
-- [x] Notification channels (webhook with HMAC-SHA256 signing)
+- [x] Notification channels (webhook HMAC-SHA256, SMTP, Slack, Telegram, in-app)
+- [x] In-app notification bell, dropdown, and /notifications page
+- [x] Org notification settings (roles, opt-out) + per-user opt-out
 - [x] Alert silencing
 - [x] Alert acknowledgement
 - [x] Alert history pagination + date/severity filter

--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -225,3 +225,184 @@ func GetEnabledWebhookChannels(ctx context.Context, pool *pgxpool.Pool, orgID st
 	}
 	return result, rows.Err()
 }
+
+// SlackChannelRow is a row from notification_channels where type = 'slack'.
+type SlackChannelRow struct {
+	ID         string
+	ConfigJSON string // raw JSONB as text, shape: { webhookUrl }
+}
+
+// GetEnabledSlackChannels returns all enabled, non-deleted Slack notification
+// channels for the given organisation.
+func GetEnabledSlackChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]SlackChannelRow, error) {
+	const q = `
+		SELECT id, config::text
+		FROM notification_channels
+		WHERE organisation_id = $1
+		  AND type = 'slack'
+		  AND enabled = true
+		  AND deleted_at IS NULL
+	`
+	rows, err := pool.Query(ctx, q, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []SlackChannelRow
+	for rows.Next() {
+		var r SlackChannelRow
+		if err := rows.Scan(&r.ID, &r.ConfigJSON); err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
+// TelegramChannelRow is a row from notification_channels where type = 'telegram'.
+type TelegramChannelRow struct {
+	ID         string
+	ConfigJSON string // raw JSONB as text, shape: { botToken, chatId }
+}
+
+// GetEnabledTelegramChannels returns all enabled, non-deleted Telegram notification
+// channels for the given organisation.
+func GetEnabledTelegramChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]TelegramChannelRow, error) {
+	const q = `
+		SELECT id, config::text
+		FROM notification_channels
+		WHERE organisation_id = $1
+		  AND type = 'telegram'
+		  AND enabled = true
+		  AND deleted_at IS NULL
+	`
+	rows, err := pool.Query(ctx, q, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []TelegramChannelRow
+	for rows.Next() {
+		var r TelegramChannelRow
+		if err := rows.Scan(&r.ID, &r.ConfigJSON); err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
+// OrgNotificationSettingsRow holds the notification settings from org metadata.
+type OrgNotificationSettingsRow struct {
+	InAppEnabled   bool
+	InAppRoles     []string
+	AllowUserOptOut bool
+}
+
+// GetOrgNotificationSettings fetches the in-app notification settings for an org.
+// Returns sensible defaults if metadata is not set.
+func GetOrgNotificationSettings(ctx context.Context, pool *pgxpool.Pool, orgID string) (OrgNotificationSettingsRow, error) {
+	const q = `
+		SELECT
+			COALESCE((metadata->'notificationSettings'->>'inAppEnabled')::boolean, true),
+			COALESCE(
+				ARRAY(SELECT jsonb_array_elements_text(metadata->'notificationSettings'->'inAppRoles')),
+				ARRAY['super_admin','org_admin','engineer']
+			),
+			COALESCE((metadata->'notificationSettings'->>'allowUserOptOut')::boolean, true)
+		FROM organisations
+		WHERE id = $1
+	`
+	var row OrgNotificationSettingsRow
+	err := pool.QueryRow(ctx, q, orgID).Scan(&row.InAppEnabled, &row.InAppRoles, &row.AllowUserOptOut)
+	if err != nil {
+		// Return defaults on error
+		return OrgNotificationSettingsRow{
+			InAppEnabled:    true,
+			InAppRoles:      []string{"super_admin", "org_admin", "engineer"},
+			AllowUserOptOut: true,
+		}, err
+	}
+	return row, nil
+}
+
+// GetAlertTargetUsers returns user IDs in the org that should receive in-app notifications.
+// roles: the roles that are eligible; allowOptOut: if true, exclude users who have opted out.
+func GetAlertTargetUsers(ctx context.Context, pool *pgxpool.Pool, orgID string, roles []string, allowOptOut bool) ([]string, error) {
+	var q string
+	if allowOptOut {
+		q = `
+			SELECT id FROM "user"
+			WHERE organisation_id = $1
+			  AND is_active = true
+			  AND role = ANY($2)
+			  AND notifications_enabled = true
+			  AND deleted_at IS NULL
+		`
+	} else {
+		q = `
+			SELECT id FROM "user"
+			WHERE organisation_id = $1
+			  AND is_active = true
+			  AND role = ANY($2)
+			  AND deleted_at IS NULL
+		`
+	}
+	rows, err := pool.Query(ctx, q, orgID, roles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// NotificationInsert holds the data for a single notifications row insert.
+type NotificationInsert struct {
+	OrgID           string
+	UserID          string
+	AlertInstanceID string // may be empty
+	Subject         string
+	Body            string
+	Severity        string
+	ResourceType    string
+	ResourceID      string
+}
+
+// InsertNotificationBatch bulk-inserts one notification row per user in a single statement.
+func InsertNotificationBatch(ctx context.Context, pool *pgxpool.Pool, rows []NotificationInsert) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// Build VALUES list using pgx named args approach via batch
+	batch := &pgx.Batch{}
+	const q = `
+		INSERT INTO notifications
+		  (organisation_id, user_id, alert_instance_id, subject, body, severity, resource_type, resource_id)
+		VALUES ($1, $2, NULLIF($3,''), $4, $5, $6, $7, $8)
+	`
+	for _, r := range rows {
+		batch.Queue(q, r.OrgID, r.UserID, r.AlertInstanceID, r.Subject, r.Body, r.Severity, r.ResourceType, r.ResourceID)
+	}
+
+	br := pool.SendBatch(ctx, batch)
+	defer br.Close()
+
+	for range rows {
+		if _, err := br.Exec(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/apps/ingest/internal/handlers/alerts.go
+++ b/apps/ingest/internal/handlers/alerts.go
@@ -42,6 +42,8 @@ type webhookChannelConfig struct {
 type notifChannels struct {
 	webhooks []queries.WebhookChannelRow
 	smtp     []queries.SmtpChannelRow
+	slack    []queries.SlackChannelRow
+	telegram []queries.TelegramChannelRow
 }
 
 // evaluateAlerts is called after check results are persisted for a heartbeat.
@@ -85,6 +87,20 @@ func evaluateAlerts(
 		slog.Warn("evaluateAlerts: fetching smtp channels", "org_id", orgID, "err", err)
 	} else {
 		channels.smtp = smtpChs
+	}
+
+	slackChs, err := queries.GetEnabledSlackChannels(ctx, pool, orgID)
+	if err != nil {
+		slog.Warn("evaluateAlerts: fetching slack channels", "org_id", orgID, "err", err)
+	} else {
+		channels.slack = slackChs
+	}
+
+	telegramChs, err := queries.GetEnabledTelegramChannels(ctx, pool, orgID)
+	if err != nil {
+		slog.Warn("evaluateAlerts: fetching telegram channels", "org_id", orgID, "err", err)
+	} else {
+		channels.telegram = telegramChs
 	}
 
 	for _, rule := range rules {
@@ -160,6 +176,9 @@ func evaluateCheckStatusRule(
 		}
 		dispatchWebhooks(ctx, channels.webhooks, ev)
 		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, rule.OrgID, id, "host", hostID, ev)
 		return
 	}
 
@@ -180,6 +199,9 @@ func evaluateCheckStatusRule(
 		}
 		dispatchWebhooks(ctx, channels.webhooks, ev)
 		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, rule.OrgID, existing.ID, "host", hostID, ev)
 	}
 }
 
@@ -241,6 +263,9 @@ func evaluateMetricThresholdRule(
 		}
 		dispatchWebhooks(ctx, channels.webhooks, ev)
 		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, rule.OrgID, id, "host", hostID, ev)
 		return
 	}
 
@@ -260,6 +285,9 @@ func evaluateMetricThresholdRule(
 		}
 		dispatchWebhooks(ctx, channels.webhooks, ev)
 		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, rule.OrgID, existing.ID, "host", hostID, ev)
 	}
 }
 
@@ -290,7 +318,9 @@ func evaluateCertExpiryForCert(
 
 	webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
 	smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, orgID)
-	channels := notifChannels{webhooks: webhooks, smtp: smtpChs}
+	slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, orgID)
+	telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, orgID)
+	channels := notifChannels{webhooks: webhooks, smtp: smtpChs, slack: slackChs, telegram: telegramChs}
 
 	cert := queries.CertSummary{
 		ID:         certID,
@@ -374,6 +404,9 @@ func evaluateCertExpiryRule(
 		}
 		dispatchWebhooks(ctx, channels.webhooks, ev)
 		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, orgID, id, "certificate", cert.ID, ev)
 		return
 	}
 
@@ -394,6 +427,9 @@ func evaluateCertExpiryRule(
 		}
 		dispatchWebhooks(ctx, channels.webhooks, ev)
 		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, orgID, existing.ID, "certificate", cert.ID, ev)
 	}
 }
 
@@ -434,7 +470,9 @@ func runCertExpirySweep(ctx context.Context, pool *pgxpool.Pool) {
 
 		webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
 		smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, orgID)
-		channels := notifChannels{webhooks: webhooks, smtp: smtpChs}
+		slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, orgID)
+		telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, orgID)
+		channels := notifChannels{webhooks: webhooks, smtp: smtpChs, slack: slackChs, telegram: telegramChs}
 
 		for _, rule := range rules {
 			var cfg certExpiryConfig

--- a/apps/ingest/internal/handlers/notify.go
+++ b/apps/ingest/internal/handlers/notify.go
@@ -12,8 +12,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/smtp"
+	"net/url"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/infrawatch/ingest/internal/db/queries"
 )
@@ -197,5 +200,222 @@ func dispatchSmtp(smtpChannels []queries.SmtpChannelRow, event AlertEvent) {
 				slog.Warn("smtp: delivery failed", "host", c.Host, "err", err)
 			}
 		}(cfg)
+	}
+}
+
+// ─── Slack ────────────────────────────────────────────────────────────────────
+
+type slackChannelConfig struct {
+	WebhookURL string `json:"webhookUrl"`
+}
+
+// severityEmoji maps alert severity to a Slack emoji prefix.
+func severityEmoji(severity string) string {
+	switch severity {
+	case "critical":
+		return ":red_circle:"
+	case "warning":
+		return ":large_yellow_circle:"
+	default:
+		return ":large_blue_circle:"
+	}
+}
+
+// postSlack POSTs an AlertEvent to a Slack incoming webhook URL.
+// Failures are logged and discarded — delivery is best-effort.
+func postSlack(ctx context.Context, webhookURL string, event AlertEvent) {
+	emoji := severityEmoji(event.Severity)
+	eventLabel := map[string]string{
+		"alert.fired":    "FIRING",
+		"alert.resolved": "RESOLVED",
+		"alert.test":     "TEST",
+	}[event.Event]
+	if eventLabel == "" {
+		eventLabel = strings.ToUpper(event.Event)
+	}
+
+	payload := map[string]interface{}{
+		"blocks": []map[string]interface{}{
+			{
+				"type": "header",
+				"text": map[string]string{
+					"type": "plain_text",
+					"text": fmt.Sprintf("%s [%s] %s on %s", emoji, eventLabel, event.Rule, event.Host),
+				},
+			},
+			{
+				"type": "section",
+				"fields": []map[string]string{
+					{"type": "mrkdwn", "text": fmt.Sprintf("*Severity:*\n%s", event.Severity)},
+					{"type": "mrkdwn", "text": fmt.Sprintf("*Host:*\n%s", event.Host)},
+					{"type": "mrkdwn", "text": fmt.Sprintf("*Rule:*\n%s", event.Rule)},
+					{"type": "mrkdwn", "text": fmt.Sprintf("*Time:*\n%s", event.Timestamp)},
+				},
+			},
+			{
+				"type": "section",
+				"text": map[string]string{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Message:*\n%s", event.Message),
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		slog.Warn("slack: marshalling payload", "err", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		slog.Warn("slack: building request", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Warn("slack: delivery failed", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		slog.Warn("slack: non-2xx response", "status", resp.StatusCode)
+	}
+}
+
+// dispatchSlack fans out an AlertEvent to all configured Slack channels.
+func dispatchSlack(ctx context.Context, channels []queries.SlackChannelRow, event AlertEvent) {
+	for _, ch := range channels {
+		var cfg slackChannelConfig
+		if err := json.Unmarshal([]byte(ch.ConfigJSON), &cfg); err != nil {
+			slog.Warn("dispatchSlack: unmarshal channel config", "channel_id", ch.ID, "err", err)
+			continue
+		}
+		go postSlack(ctx, cfg.WebhookURL, event)
+	}
+}
+
+// ─── Telegram ─────────────────────────────────────────────────────────────────
+
+type telegramChannelConfig struct {
+	BotToken string `json:"botToken"`
+	ChatID   string `json:"chatId"`
+}
+
+// postTelegram sends an AlertEvent via the Telegram Bot API.
+// Failures are logged and discarded — delivery is best-effort.
+func postTelegram(ctx context.Context, botToken, chatID string, event AlertEvent) {
+	eventLabel := map[string]string{
+		"alert.fired":    "🔴 FIRING",
+		"alert.resolved": "✅ RESOLVED",
+		"alert.test":     "🔵 TEST",
+	}[event.Event]
+	if eventLabel == "" {
+		eventLabel = strings.ToUpper(event.Event)
+	}
+
+	text := fmt.Sprintf(
+		"<b>%s</b>\n\n<b>Rule:</b> %s\n<b>Host:</b> %s\n<b>Severity:</b> %s\n<b>Message:</b> %s\n<b>Time:</b> %s",
+		eventLabel, event.Rule, event.Host, event.Severity, event.Message, event.Timestamp,
+	)
+
+	apiURL := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", url.PathEscape(botToken))
+	payload := map[string]string{
+		"chat_id":    chatID,
+		"text":       text,
+		"parse_mode": "HTML",
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		slog.Warn("telegram: marshalling payload", "err", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	if err != nil {
+		slog.Warn("telegram: building request", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Warn("telegram: delivery failed", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		slog.Warn("telegram: non-2xx response", "status", resp.StatusCode)
+	}
+}
+
+// dispatchTelegram fans out an AlertEvent to all configured Telegram channels.
+func dispatchTelegram(ctx context.Context, channels []queries.TelegramChannelRow, event AlertEvent) {
+	for _, ch := range channels {
+		var cfg telegramChannelConfig
+		if err := json.Unmarshal([]byte(ch.ConfigJSON), &cfg); err != nil {
+			slog.Warn("dispatchTelegram: unmarshal channel config", "channel_id", ch.ID, "err", err)
+			continue
+		}
+		go postTelegram(ctx, cfg.BotToken, cfg.ChatID, event)
+	}
+}
+
+// ─── In-app notifications ─────────────────────────────────────────────────────
+
+// dispatchInApp creates an in-app notification row for each eligible user in the org.
+// alertInstanceID may be empty (cert alerts use a different instance query).
+func dispatchInApp(ctx context.Context, pool *pgxpool.Pool, orgID, alertInstanceID, resourceType, resourceID string, event AlertEvent) {
+	settings, err := queries.GetOrgNotificationSettings(ctx, pool, orgID)
+	if err != nil {
+		slog.Warn("dispatchInApp: fetching org notification settings", "org_id", orgID, "err", err)
+		// Proceed with defaults (already set by the query function on error)
+	}
+
+	if !settings.InAppEnabled {
+		return
+	}
+
+	userIDs, err := queries.GetAlertTargetUsers(ctx, pool, orgID, settings.InAppRoles, settings.AllowUserOptOut)
+	if err != nil {
+		slog.Warn("dispatchInApp: fetching target users", "org_id", orgID, "err", err)
+		return
+	}
+	if len(userIDs) == 0 {
+		return
+	}
+
+	eventLabel := map[string]string{
+		"alert.fired":    "FIRING",
+		"alert.resolved": "RESOLVED",
+	}[event.Event]
+	if eventLabel == "" {
+		eventLabel = strings.ToUpper(event.Event)
+	}
+
+	subject := fmt.Sprintf("[%s] %s on %s", eventLabel, event.Rule, event.Host)
+
+	rows := make([]queries.NotificationInsert, 0, len(userIDs))
+	for _, uid := range userIDs {
+		rows = append(rows, queries.NotificationInsert{
+			OrgID:           orgID,
+			UserID:          uid,
+			AlertInstanceID: alertInstanceID,
+			Subject:         subject,
+			Body:            event.Message,
+			Severity:        event.Severity,
+			ResourceType:    resourceType,
+			ResourceID:      resourceID,
+		})
+	}
+
+	if err := queries.InsertNotificationBatch(ctx, pool, rows); err != nil {
+		slog.Warn("dispatchInApp: inserting notifications", "org_id", orgID, "err", err)
 	}
 }

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -10,8 +10,10 @@ import {
   FlaskConical,
   Loader2,
   Mail,
+  MessageSquare,
   Pencil,
   Plus,
+  Send,
   Trash2,
   VolumeX,
   Webhook,
@@ -407,7 +409,7 @@ function AddSmtpDialog({
 
 interface TestLogEntry {
   channelName: string
-  channelType: 'webhook' | 'smtp'
+  channelType: 'webhook' | 'smtp' | 'slack' | 'telegram'
   ok: boolean
   message: string
   at: Date
@@ -719,6 +721,328 @@ function EditSmtpDialog({
   )
 }
 
+// ─── Slack Dialogs ────────────────────────────────────────────────────────────
+
+const slackFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  webhookUrl: z.string().url('Must be a valid URL'),
+})
+
+type SlackFormValues = z.infer<typeof slackFormSchema>
+
+function AddSlackDialog({
+  orgId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<SlackFormValues>({ resolver: zodResolver(slackFormSchema) })
+
+  async function onSubmit(values: SlackFormValues) {
+    const result = await createNotificationChannel(orgId, {
+      name: values.name,
+      type: 'slack',
+      config: { webhookUrl: values.webhookUrl },
+    })
+    if ('error' in result) return
+    reset()
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Slack Channel</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="slack-name">Name</Label>
+            <Input id="slack-name" placeholder="e.g. #alerts-channel" {...register('name')} />
+            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="slack-url">Incoming Webhook URL</Label>
+            <Input
+              id="slack-url"
+              placeholder="https://hooks.slack.com/services/..."
+              type="url"
+              {...register('webhookUrl')}
+            />
+            <p className="text-xs text-muted-foreground">
+              Create an incoming webhook in your Slack workspace settings
+            </p>
+            {errors.webhookUrl && <p className="text-sm text-red-600">{errors.webhookUrl.message}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Add Channel
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function EditSlackDialog({
+  orgId,
+  channel,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  channel: NotificationChannelSafe & { type: 'slack' }
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<SlackFormValues>({ resolver: zodResolver(slackFormSchema) })
+
+  useEffect(() => {
+    if (open) reset({ name: channel.name, webhookUrl: channel.config.webhookUrl })
+  }, [open, channel, reset])
+
+  async function onSubmit(values: SlackFormValues) {
+    const result = await updateNotificationChannel(orgId, channel.id, {
+      name: values.name,
+      webhookUrl: values.webhookUrl,
+    })
+    if ('error' in result) return
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Slack Channel</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-slack-name">Name</Label>
+            <Input id="edit-slack-name" {...register('name')} />
+            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-slack-url">Incoming Webhook URL</Label>
+            <Input id="edit-slack-url" type="url" {...register('webhookUrl')} />
+            {errors.webhookUrl && <p className="text-sm text-red-600">{errors.webhookUrl.message}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ─── Telegram Dialogs ─────────────────────────────────────────────────────────
+
+const telegramFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  botToken: z.string().min(1, 'Bot token is required'),
+  chatId: z.string().min(1, 'Chat ID is required'),
+})
+
+type TelegramFormValues = z.infer<typeof telegramFormSchema>
+
+function AddTelegramDialog({
+  orgId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<TelegramFormValues>({ resolver: zodResolver(telegramFormSchema) })
+
+  async function onSubmit(values: TelegramFormValues) {
+    const result = await createNotificationChannel(orgId, {
+      name: values.name,
+      type: 'telegram',
+      config: { botToken: values.botToken, chatId: values.chatId },
+    })
+    if ('error' in result) return
+    reset()
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Telegram Channel</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="tg-name">Name</Label>
+            <Input id="tg-name" placeholder="e.g. Ops Team Telegram" {...register('name')} />
+            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="tg-token">Bot Token</Label>
+            <Input
+              id="tg-token"
+              placeholder="123456789:ABCdef..."
+              type="password"
+              {...register('botToken')}
+            />
+            <p className="text-xs text-muted-foreground">
+              Create a bot via @BotFather on Telegram and paste the token here
+            </p>
+            {errors.botToken && <p className="text-sm text-red-600">{errors.botToken.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="tg-chat">Chat ID</Label>
+            <Input
+              id="tg-chat"
+              placeholder="-1001234567890"
+              {...register('chatId')}
+            />
+            <p className="text-xs text-muted-foreground">
+              The numeric ID of the chat, group, or channel to send messages to
+            </p>
+            {errors.chatId && <p className="text-sm text-red-600">{errors.chatId.message}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Add Channel
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const editTelegramFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  botToken: z.string().optional(),
+  chatId: z.string().min(1, 'Chat ID is required'),
+})
+
+type EditTelegramFormValues = z.infer<typeof editTelegramFormSchema>
+
+function EditTelegramDialog({
+  orgId,
+  channel,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  orgId: string
+  channel: NotificationChannelSafe & { type: 'telegram' }
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onSuccess: () => void
+}) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<EditTelegramFormValues>({ resolver: zodResolver(editTelegramFormSchema) })
+
+  useEffect(() => {
+    if (open) reset({ name: channel.name, botToken: '', chatId: channel.config.chatId })
+  }, [open, channel, reset])
+
+  async function onSubmit(values: EditTelegramFormValues) {
+    const result = await updateNotificationChannel(orgId, channel.id, {
+      name: values.name,
+      botToken: values.botToken || undefined,
+      chatId: values.chatId,
+    })
+    if ('error' in result) return
+    onSuccess()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Telegram Channel</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-tg-name">Name</Label>
+            <Input id="edit-tg-name" {...register('name')} />
+            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-tg-token">
+              Bot Token{' '}
+              {channel.config.hasBotToken && (
+                <span className="text-muted-foreground font-normal">(leave blank to keep existing)</span>
+              )}
+            </Label>
+            <Input
+              id="edit-tg-token"
+              type="password"
+              placeholder={channel.config.hasBotToken ? '••••••••' : '123456789:ABCdef...'}
+              {...register('botToken')}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="edit-tg-chat">Chat ID</Label>
+            <Input id="edit-tg-chat" {...register('chatId')} />
+            {errors.chatId && <p className="text-sm text-red-600">{errors.chatId.message}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 // ─── Add Silence Dialog ────────────────────────────────────────────────────────
 
 function toLocalDatetimeValue(d: Date): string {
@@ -867,6 +1191,8 @@ export function AlertsClient({
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all')
   const [addWebhookOpen, setAddWebhookOpen] = useState(false)
   const [addSmtpOpen, setAddSmtpOpen] = useState(false)
+  const [addSlackOpen, setAddSlackOpen] = useState(false)
+  const [addTelegramOpen, setAddTelegramOpen] = useState(false)
   const [addSilenceOpen, setAddSilenceOpen] = useState(false)
   const [editingChannel, setEditingChannel] = useState<NotificationChannelSafe | null>(null)
   const [testingChannelId, setTestingChannelId] = useState<string | null>(null)
@@ -1311,7 +1637,7 @@ export function AlertsClient({
               Channels that receive alert fired/resolved events
             </CardDescription>
           </div>
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">
             <Button
               size="sm"
               variant="outline"
@@ -1327,6 +1653,22 @@ export function AlertsClient({
             >
               <Plus className="size-3.5 mr-1" />
               Add SMTP
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setAddSlackOpen(true)}
+            >
+              <Plus className="size-3.5 mr-1" />
+              Add Slack
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setAddTelegramOpen(true)}
+            >
+              <Plus className="size-3.5 mr-1" />
+              Add Telegram
             </Button>
           </div>
         </CardHeader>
@@ -1355,6 +1697,16 @@ export function AlertsClient({
                           <Mail className="size-3" />
                           SMTP
                         </Badge>
+                      ) : ch.type === 'slack' ? (
+                        <Badge variant="outline" className="gap-1">
+                          <MessageSquare className="size-3" />
+                          Slack
+                        </Badge>
+                      ) : ch.type === 'telegram' ? (
+                        <Badge variant="outline" className="gap-1">
+                          <Send className="size-3" />
+                          Telegram
+                        </Badge>
                       ) : (
                         <Badge variant="outline" className="gap-1">
                           <Webhook className="size-3" />
@@ -1367,6 +1719,10 @@ export function AlertsClient({
                         <span>
                           {ch.config.host}:{ch.config.port} ({ch.config.encryption.toUpperCase()}) → {ch.config.toAddresses.join(', ')}
                         </span>
+                      ) : ch.type === 'slack' ? (
+                        <span className="font-mono truncate block max-w-xs">{ch.config.webhookUrl}</span>
+                      ) : ch.type === 'telegram' ? (
+                        <span>Chat ID: {ch.config.chatId}</span>
                       ) : (
                         <span className="font-mono truncate block max-w-xs">{ch.config.url}</span>
                       )}
@@ -1436,6 +1792,18 @@ export function AlertsClient({
         onOpenChange={setAddSmtpOpen}
         onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
       />
+      <AddSlackDialog
+        orgId={orgId}
+        open={addSlackOpen}
+        onOpenChange={setAddSlackOpen}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
+      />
+      <AddTelegramDialog
+        orgId={orgId}
+        open={addTelegramOpen}
+        onOpenChange={setAddTelegramOpen}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
+      />
       {testLog && (
         <TestLogDialog entry={testLog} onClose={() => setTestLog(null)} />
       )}
@@ -1453,6 +1821,30 @@ export function AlertsClient({
       )}
       {editingChannel?.type === 'smtp' && (
         <EditSmtpDialog
+          orgId={orgId}
+          channel={editingChannel}
+          open={true}
+          onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
+          onSuccess={() => {
+            setEditingChannel(null)
+            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+          }}
+        />
+      )}
+      {editingChannel?.type === 'slack' && (
+        <EditSlackDialog
+          orgId={orgId}
+          channel={editingChannel}
+          open={true}
+          onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
+          onSuccess={() => {
+            setEditingChannel(null)
+            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+          }}
+        />
+      )}
+      {editingChannel?.type === 'telegram' && (
+        <EditTelegramDialog
           orgId={orgId}
           channel={editingChannel}
           open={true}

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -27,7 +27,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
       <SidebarProvider>
         <AppSidebar orgId={orgId} />
         <TerminalContentWrapper orgId={orgId}>
-          <Topbar />
+          <Topbar orgId={orgId} />
           <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>
         </TerminalContentWrapper>
       </SidebarProvider>

--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { formatDistanceToNow, format } from 'date-fns'
+import { Bell, CheckCircle2, ExternalLink, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { getNotifications, getUnreadCount, markAsRead, markAllAsRead, deleteNotification } from '@/lib/actions/notifications'
+import type { Notification } from '@/lib/db/schema'
+
+const PAGE_SIZE = 25
+
+interface NotificationsClientProps {
+  orgId: string
+  userId: string
+  initialNotifications: Notification[]
+  initialUnread: number
+}
+
+function getResourceUrl(resourceType: string, resourceId: string): string {
+  switch (resourceType) {
+    case 'host': return `/hosts/${resourceId}`
+    case 'certificate': return `/certificates/${resourceId}`
+    default: return '/alerts'
+  }
+}
+
+function severityBadgeVariant(severity: string): 'destructive' | 'default' | 'secondary' | 'outline' {
+  if (severity === 'critical') return 'destructive'
+  if (severity === 'warning') return 'default'
+  return 'secondary'
+}
+
+function SeverityDot({ severity }: { severity: string }) {
+  const cls = severity === 'critical'
+    ? 'bg-red-500'
+    : severity === 'warning'
+    ? 'bg-amber-500'
+    : 'bg-blue-500'
+  return <span className={`inline-block size-2.5 rounded-full shrink-0 mt-1 ${cls}`} />
+}
+
+export function NotificationsClient({
+  orgId,
+  userId,
+  initialNotifications,
+  initialUnread,
+}: NotificationsClientProps) {
+  const router = useRouter()
+  const qc = useQueryClient()
+  const [offset, setOffset] = useState(0)
+  const [filter, setFilter] = useState<'all' | 'unread'>('all')
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  const { data: unread = initialUnread } = useQuery({
+    queryKey: ['notifications-unread', orgId, userId],
+    queryFn: () => getUnreadCount(orgId, userId),
+    initialData: initialUnread,
+    refetchInterval: 20_000,
+  })
+
+  const { data: notifications = initialNotifications } = useQuery({
+    queryKey: ['notifications', orgId, userId, offset],
+    queryFn: () => getNotifications(orgId, userId, PAGE_SIZE, offset),
+    initialData: offset === 0 ? initialNotifications : undefined,
+    refetchInterval: 30_000,
+  })
+
+  const markReadMutation = useMutation({
+    mutationFn: (id: string) => markAsRead(orgId, userId, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+    },
+  })
+
+  const markAllMutation = useMutation({
+    mutationFn: () => markAllAsRead(orgId, userId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteNotification(orgId, userId, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
+    },
+  })
+
+  function handleNotificationClick(n: Notification) {
+    if (!n.read) markReadMutation.mutate(n.id)
+    setExpandedId(expandedId === n.id ? null : n.id)
+  }
+
+  const displayed = filter === 'unread' ? notifications.filter((n) => !n.read) : notifications
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground flex items-center gap-2">
+            <Bell className="size-6" />
+            Notifications
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Alert events and system messages
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {unread > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => markAllMutation.mutate()}
+              disabled={markAllMutation.isPending}
+            >
+              <CheckCircle2 className="size-3.5 mr-1" />
+              Mark all read
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex items-center gap-1 border-b">
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            filter === 'all'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setFilter('all')}
+        >
+          All
+        </button>
+        <button
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors flex items-center gap-1.5 ${
+            filter === 'unread'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setFilter('unread')}
+        >
+          Unread
+          {unread > 0 && (
+            <Badge variant="secondary" className="text-xs px-1.5 py-0 h-4">
+              {unread}
+            </Badge>
+          )}
+        </button>
+      </div>
+
+      {displayed.length === 0 ? (
+        <Card>
+          <CardContent className="py-16 text-center">
+            <Bell className="size-8 mx-auto text-muted-foreground mb-3" />
+            <p className="text-sm text-muted-foreground">
+              {filter === 'unread' ? 'No unread notifications' : 'No notifications yet'}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {displayed.map((n) => (
+            <Card
+              key={n.id}
+              className={`transition-colors ${!n.read ? 'border-blue-200 bg-blue-50/30' : ''}`}
+            >
+              <CardHeader
+                className="py-3 px-4 cursor-pointer"
+                onClick={() => handleNotificationClick(n)}
+              >
+                <div className="flex items-start gap-3">
+                  <SeverityDot severity={n.severity} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                      <CardTitle className={`text-sm leading-snug ${n.read ? 'font-normal text-muted-foreground' : 'font-medium text-foreground'}`}>
+                        {n.subject}
+                      </CardTitle>
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        <Badge variant={severityBadgeVariant(n.severity)} className="text-xs">
+                          {n.severity}
+                        </Badge>
+                        {!n.read && (
+                          <span className="size-1.5 rounded-full bg-blue-500" />
+                        )}
+                      </div>
+                    </div>
+                    <CardDescription className="text-xs mt-0.5">
+                      {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                      {' · '}
+                      {format(new Date(n.createdAt), 'MMM d, yyyy HH:mm')}
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+
+              {expandedId === n.id && (
+                <CardContent className="pt-0 pb-3 px-4 border-t">
+                  <div className="pt-3 space-y-3">
+                    <p className="text-sm text-foreground">{n.body}</p>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => router.push(getResourceUrl(n.resourceType, n.resourceId))}
+                      >
+                        <ExternalLink className="size-3.5 mr-1.5" />
+                        View {n.resourceType}
+                      </Button>
+                      {!n.read && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => markReadMutation.mutate(n.id)}
+                          disabled={markReadMutation.isPending}
+                        >
+                          <CheckCircle2 className="size-3.5 mr-1.5" />
+                          Mark as read
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-destructive ml-auto"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          deleteMutation.mutate(n.id)
+                        }}
+                        disabled={deleteMutation.isPending}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              )}
+            </Card>
+          ))}
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Showing {offset + 1}–{offset + displayed.length}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={notifications.length < PAGE_SIZE}
+              onClick={() => setOffset(offset + PAGE_SIZE)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/notifications/page.tsx
+++ b/apps/web/app/(dashboard)/notifications/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import { getRequiredSession } from '@/lib/auth/session'
+import { getNotifications, getUnreadCount } from '@/lib/actions/notifications'
+import { NotificationsClient } from './notifications-client'
+
+export const metadata: Metadata = {
+  title: 'Notifications',
+}
+
+export default async function NotificationsPage() {
+  const session = await getRequiredSession()
+  const orgId = session.user.organisationId ?? ''
+  const userId = session.user.id
+
+  const [initialNotifications, initialUnread] = await Promise.all([
+    getNotifications(orgId, userId, 25),
+    getUnreadCount(orgId, userId),
+  ])
+
+  return (
+    <NotificationsClient
+      orgId={orgId}
+      userId={userId}
+      initialNotifications={initialNotifications}
+      initialUnread={initialUnread}
+    />
+  )
+}

--- a/apps/web/app/(dashboard)/profile/page.tsx
+++ b/apps/web/app/(dashboard)/profile/page.tsx
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 
 export default async function ProfilePage() {
   const session = await getRequiredSession()
-  return <ProfileClient user={session.user} />
+  return <ProfileClient user={session.user} orgId={session.user.organisationId ?? ''} />
 }

--- a/apps/web/app/(dashboard)/profile/profile-client.tsx
+++ b/apps/web/app/(dashboard)/profile/profile-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -10,8 +10,10 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { CheckCircle2, ShieldCheck, Sun, Moon, Monitor } from 'lucide-react'
-import { updateName, updatePassword, updateTheme } from '@/lib/actions/profile'
+import { Switch } from '@/components/ui/switch'
+import { CheckCircle2, ShieldCheck, Sun, Moon, Monitor, Bell } from 'lucide-react'
+import { updateName, updatePassword, updateTheme, updateNotificationPreference } from '@/lib/actions/profile'
+import { getOrgNotificationSettings } from '@/lib/actions/notification-settings'
 import type { SessionUser } from '@/lib/auth/session'
 
 type Theme = 'light' | 'dark' | 'system'
@@ -56,14 +58,38 @@ type PasswordValues = z.infer<typeof passwordSchema>
 
 interface ProfileClientProps {
   user: SessionUser
+  orgId: string
 }
 
-export function ProfileClient({ user }: ProfileClientProps) {
+export function ProfileClient({ user, orgId }: ProfileClientProps) {
   const [nameSaveSuccess, setNameSaveSuccess] = useState(false)
   const [passwordSuccess, setPasswordSuccess] = useState(false)
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [currentTheme, setCurrentTheme] = useState<Theme>((user.theme as Theme) ?? 'system')
   const [themeSaving, setThemeSaving] = useState(false)
+  const [notificationsEnabled, setNotificationsEnabled] = useState(user.notificationsEnabled)
+  const [notifSaveSuccess, setNotifSaveSuccess] = useState(false)
+  const [notifError, setNotifError] = useState<string | null>(null)
+
+  const { data: orgNotifSettings } = useQuery({
+    queryKey: ['org-notification-settings', orgId],
+    queryFn: () => getOrgNotificationSettings(orgId),
+    enabled: !!orgId,
+  })
+
+  const notifMutation = useMutation({
+    mutationFn: (enabled: boolean) => updateNotificationPreference(user.id, orgId, enabled),
+    onSuccess: (result) => {
+      if ('error' in result) {
+        setNotifError(result.error)
+        setNotificationsEnabled(user.notificationsEnabled) // revert
+        return
+      }
+      setNotifSaveSuccess(true)
+      setNotifError(null)
+      setTimeout(() => setNotifSaveSuccess(false), 3000)
+    },
+  })
 
   const nameForm = useForm<NameValues>({
     resolver: zodResolver(nameSchema),
@@ -289,6 +315,50 @@ export function ProfileClient({ user }: ProfileClientProps) {
           </div>
         </CardContent>
       </Card>
+
+      {/* Notifications */}
+      {orgNotifSettings?.inAppEnabled && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Bell className="size-4 text-muted-foreground" />
+              Notifications
+            </CardTitle>
+            <CardDescription>
+              {orgNotifSettings.allowUserOptOut
+                ? 'Control whether you receive in-app notifications for alert events'
+                : 'Your organisation requires in-app notifications for your role'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-sm">In-app notifications</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Receive a notification when alerts fire or resolve
+                </p>
+              </div>
+              <Switch
+                checked={notificationsEnabled}
+                disabled={!orgNotifSettings.allowUserOptOut || notifMutation.isPending}
+                onCheckedChange={(checked) => {
+                  setNotificationsEnabled(checked)
+                  notifMutation.mutate(checked)
+                }}
+              />
+            </div>
+            {notifError && (
+              <p className="text-xs text-destructive">{notifError}</p>
+            )}
+            {notifSaveSuccess && (
+              <span className="flex items-center gap-1 text-sm text-green-700">
+                <CheckCircle2 className="size-4" />
+                Saved
+              </span>
+            )}
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -10,15 +10,25 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Users, TerminalSquare, ScrollText, ShieldAlert } from 'lucide-react'
+import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Users, TerminalSquare, ScrollText, ShieldAlert, Bell } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
 import { updateOrgName, saveLicenceKey, updateMetricRetention } from '@/lib/actions/settings'
 import { getOrgDefaultCollectionSettings, updateOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
 import { getOrgTerminalSettings, updateOrgTerminalSettings } from '@/lib/actions/terminal'
+import { getOrgNotificationSettings, updateOrgNotificationSettings } from '@/lib/actions/notification-settings'
 import type { OrgTerminalSettings } from '@/lib/actions/terminal'
+import type { OrgNotificationSettingsFull } from '@/lib/actions/notification-settings'
 import type { Organisation, HostCollectionSettings } from '@/lib/db/schema'
 import { DEFAULT_COLLECTION_SETTINGS } from '@/lib/db/schema'
+
+const ALL_ROLES = [
+  { value: 'super_admin', label: 'Super Admin' },
+  { value: 'org_admin', label: 'Org Admin' },
+  { value: 'engineer', label: 'Engineer' },
+  { value: 'read_only', label: 'Read Only' },
+]
 
 const orgNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -153,6 +163,31 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
       setTerminalSaveSuccess(true)
       queryClient.invalidateQueries({ queryKey: ['org-terminal-settings', org.id] })
       setTimeout(() => setTerminalSaveSuccess(false), 3000)
+    },
+  })
+
+  // Notification settings
+  const [notificationSaveSuccess, setNotificationSaveSuccess] = useState(false)
+  const { data: notificationDefaults } = useQuery({
+    queryKey: ['org-notification-settings', org.id],
+    queryFn: () => getOrgNotificationSettings(org.id),
+  })
+  const [localNotificationSettings, setLocalNotificationSettings] = useState<OrgNotificationSettingsFull | null>(null)
+  const currentNotificationSettings = localNotificationSettings ?? notificationDefaults ?? {
+    inAppEnabled: true,
+    inAppRoles: ['super_admin', 'org_admin', 'engineer'],
+    allowUserOptOut: true,
+  }
+  const notificationDirty = localNotificationSettings !== null
+
+  const notificationMutation = useMutation({
+    mutationFn: (settings: OrgNotificationSettingsFull) => updateOrgNotificationSettings(org.id, settings),
+    onSuccess: (result) => {
+      if ('error' in result) return
+      setLocalNotificationSettings(null)
+      setNotificationSaveSuccess(true)
+      queryClient.invalidateQueries({ queryKey: ['org-notification-settings', org.id] })
+      setTimeout(() => setNotificationSaveSuccess(false), 3000)
     },
   })
 
@@ -467,6 +502,116 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                 <>
                   <p>Session Logging: {currentTerminalSettings.terminalLoggingEnabled ? 'Enabled' : 'Disabled'}</p>
                   <p>Direct Access (Legacy): {currentTerminalSettings.terminalDirectAccess ? 'Enabled' : 'Disabled'}</p>
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Notification Settings section */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Bell className="size-4 text-muted-foreground" />
+            Notification Settings
+          </CardTitle>
+          <CardDescription>
+            Control in-app notifications and which roles receive them.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {isAdmin ? (
+            <>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="text-sm">Enable In-App Notifications</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    When enabled, alert events appear in the notification bell for eligible users
+                  </p>
+                </div>
+                <Switch
+                  checked={currentNotificationSettings.inAppEnabled}
+                  onCheckedChange={(checked) =>
+                    setLocalNotificationSettings({
+                      ...currentNotificationSettings,
+                      inAppEnabled: checked,
+                    })
+                  }
+                />
+              </div>
+              {currentNotificationSettings.inAppEnabled && (
+                <>
+                  <div className="space-y-2">
+                    <Label className="text-sm">Roles that receive notifications</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Select which roles get in-app notifications when alerts fire or resolve
+                    </p>
+                    <div className="space-y-2 pt-1">
+                      {ALL_ROLES.map((role) => (
+                        <div key={role.value} className="flex items-center gap-2">
+                          <Checkbox
+                            id={`role-${role.value}`}
+                            checked={currentNotificationSettings.inAppRoles.includes(role.value)}
+                            onCheckedChange={(checked) => {
+                              const roles = checked
+                                ? [...currentNotificationSettings.inAppRoles, role.value]
+                                : currentNotificationSettings.inAppRoles.filter((r) => r !== role.value)
+                              setLocalNotificationSettings({
+                                ...currentNotificationSettings,
+                                inAppRoles: roles,
+                              })
+                            }}
+                          />
+                          <Label htmlFor={`role-${role.value}`} className="text-sm font-normal cursor-pointer">
+                            {role.label}
+                          </Label>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label className="text-sm">Allow users to opt out</Label>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        When enabled, users can turn off their own in-app notifications in their profile
+                      </p>
+                    </div>
+                    <Switch
+                      checked={currentNotificationSettings.allowUserOptOut}
+                      onCheckedChange={(checked) =>
+                        setLocalNotificationSettings({
+                          ...currentNotificationSettings,
+                          allowUserOptOut: checked,
+                        })
+                      }
+                    />
+                  </div>
+                </>
+              )}
+              <div className="flex items-center gap-3 pt-2 border-t">
+                <Button
+                  size="sm"
+                  disabled={!notificationDirty || notificationMutation.isPending}
+                  onClick={() => notificationMutation.mutate(currentNotificationSettings)}
+                >
+                  {notificationMutation.isPending ? 'Saving...' : 'Save'}
+                </Button>
+                {notificationSaveSuccess && (
+                  <span className="flex items-center gap-1 text-sm text-green-700">
+                    <CheckCircle2 className="size-4" />
+                    Saved
+                  </span>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="space-y-2 text-sm">
+              <p>In-App Notifications: {currentNotificationSettings.inAppEnabled ? 'Enabled' : 'Disabled'}</p>
+              {currentNotificationSettings.inAppEnabled && (
+                <>
+                  <p>Receiving roles: {currentNotificationSettings.inAppRoles.join(', ')}</p>
+                  <p>User opt-out: {currentNotificationSettings.allowUserOptOut ? 'Allowed' : 'Not allowed'}</p>
                 </>
               )}
             </div>

--- a/apps/web/components/shared/notification-bell.tsx
+++ b/apps/web/components/shared/notification-bell.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { Bell } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { getNotifications, getUnreadCount, markAsRead, markAllAsRead } from '@/lib/actions/notifications'
+import type { Notification } from '@/lib/db/schema'
+
+interface NotificationBellProps {
+  orgId: string
+  userId: string
+}
+
+function getResourceUrl(resourceType: string, resourceId: string): string {
+  switch (resourceType) {
+    case 'host': return `/hosts/${resourceId}`
+    case 'certificate': return `/certificates/${resourceId}`
+    default: return '/alerts'
+  }
+}
+
+function severityDot(severity: string) {
+  const cls = severity === 'critical'
+    ? 'bg-red-500'
+    : severity === 'warning'
+    ? 'bg-amber-500'
+    : 'bg-blue-500'
+  return <span className={`inline-block size-2 rounded-full shrink-0 mt-1.5 ${cls}`} />
+}
+
+export function NotificationBell({ orgId, userId }: NotificationBellProps) {
+  const router = useRouter()
+  const qc = useQueryClient()
+
+  const { data: unreadCount = 0 } = useQuery({
+    queryKey: ['notifications-unread', orgId, userId],
+    queryFn: () => getUnreadCount(orgId, userId),
+    refetchInterval: 20_000,
+    staleTime: 10_000,
+  })
+
+  const { data: notifications = [] } = useQuery({
+    queryKey: ['notifications-recent', orgId, userId],
+    queryFn: () => getNotifications(orgId, userId, 10),
+    refetchInterval: 20_000,
+    staleTime: 10_000,
+  })
+
+  const markReadMutation = useMutation({
+    mutationFn: (id: string) => markAsRead(orgId, userId, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+    },
+  })
+
+  const markAllMutation = useMutation({
+    mutationFn: () => markAllAsRead(orgId, userId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+    },
+  })
+
+  function handleNotificationClick(n: Notification) {
+    markReadMutation.mutate(n.id)
+    router.push(getResourceUrl(n.resourceType, n.resourceId))
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative">
+          <Bell className="size-4" />
+          {unreadCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white leading-none">
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          )}
+          <span className="sr-only">Notifications</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-96">
+        <DropdownMenuLabel className="flex items-center justify-between py-2">
+          <span className="font-semibold">Notifications</span>
+          {unreadCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
+              onClick={(e) => {
+                e.preventDefault()
+                markAllMutation.mutate()
+              }}
+            >
+              Mark all read
+            </Button>
+          )}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {notifications.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No notifications yet
+          </div>
+        ) : (
+          <div className="max-h-96 overflow-y-auto">
+            {notifications.map((n) => (
+              <DropdownMenuItem
+                key={n.id}
+                className="flex items-start gap-2.5 p-3 cursor-pointer"
+                onClick={() => handleNotificationClick(n)}
+              >
+                {severityDot(n.severity)}
+                <div className="flex-1 min-w-0">
+                  <p className={`text-sm leading-snug truncate ${n.read ? 'text-muted-foreground' : 'font-medium text-foreground'}`}>
+                    {n.subject}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                  </p>
+                </div>
+                {!n.read && (
+                  <span className="size-1.5 rounded-full bg-blue-500 shrink-0 mt-1.5" />
+                )}
+              </DropdownMenuItem>
+            ))}
+          </div>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="justify-center text-sm text-muted-foreground hover:text-foreground cursor-pointer py-2"
+          onClick={() => router.push('/notifications')}
+        >
+          View all notifications
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -68,6 +68,7 @@ const primaryNav: NavItem[] = [
     ],
   },
   { title: 'Checks & Alerts', href: '/alerts', icon: Bell },
+  { title: 'Notifications', href: '/notifications', icon: BellPlus },
   { title: 'Certificates', href: '/certificates', icon: ShieldCheck },
   { title: 'Service Accounts', href: '/service-accounts', icon: Key },
 ]

--- a/apps/web/components/shared/topbar.tsx
+++ b/apps/web/components/shared/topbar.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { LogOut, User } from 'lucide-react'
+import { NotificationBell } from './notification-bell'
 
 function getInitials(name: string): string {
   return name
@@ -24,7 +25,11 @@ function getInitials(name: string): string {
     .slice(0, 2)
 }
 
-export function Topbar() {
+interface TopbarProps {
+  orgId: string
+}
+
+export function Topbar({ orgId }: TopbarProps) {
   const { data: session } = useSession()
   const router = useRouter()
 
@@ -34,11 +39,15 @@ export function Topbar() {
 
   const userName = session?.user?.name ?? 'User'
   const userEmail = session?.user?.email ?? ''
+  const userId = session?.user?.id
 
   return (
     <header className="flex h-14 items-center gap-3 border-b bg-background px-4">
       <SidebarTrigger />
       <div className="flex-1" />
+      {userId && orgId && (
+        <NotificationBell orgId={orgId} userId={userId} />
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon" className="rounded-full">

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -16,6 +16,8 @@ import type {
   WebhookChannelConfig,
   SmtpChannelConfig,
   SmtpEncryption,
+  SlackChannelConfig,
+  TelegramChannelConfig,
   AlertSilence,
 } from '@/lib/db/schema'
 
@@ -84,6 +86,21 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
       fromAddress: z.string().email(),
       fromName: z.string().optional(),
       toAddresses: z.array(z.string().email()).min(1),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(100),
+    type: z.literal('slack'),
+    config: z.object({
+      webhookUrl: z.string().url(),
+    }),
+  }),
+  z.object({
+    name: z.string().min(1).max(100),
+    type: z.literal('telegram'),
+    config: z.object({
+      botToken: z.string().min(1, 'Bot token is required'),
+      chatId: z.string().min(1, 'Chat ID is required'),
     }),
   }),
 ])
@@ -428,6 +445,8 @@ export type NotificationChannelSafe = Omit<NotificationChannel, 'config' | 'type
         hasPassword: boolean
       }
     }
+  | { type: 'slack'; config: { webhookUrl: string } }
+  | { type: 'telegram'; config: { chatId: string; hasBotToken: boolean } }
 )
 
 /** Normalise SMTP config rows written before the encryption field was introduced. */
@@ -465,6 +484,22 @@ export async function getNotificationChannels(orgId: string): Promise<Notificati
           toAddresses: cfg.toAddresses,
           hasPassword: !!(cfg.password),
         },
+      }
+    }
+    if (ch.type === 'slack') {
+      const cfg = ch.config as SlackChannelConfig
+      return {
+        ...ch,
+        type: 'slack' as const,
+        config: { webhookUrl: cfg.webhookUrl },
+      }
+    }
+    if (ch.type === 'telegram') {
+      const cfg = ch.config as TelegramChannelConfig
+      return {
+        ...ch,
+        type: 'telegram' as const,
+        config: { chatId: cfg.chatId, hasBotToken: !!(cfg.botToken) },
       }
     }
     const cfg = ch.config as WebhookChannelConfig
@@ -548,6 +583,17 @@ const updateSmtpChannelSchema = z.object({
   toAddresses: z.array(z.string().email()).min(1),
 })
 
+const updateSlackChannelSchema = z.object({
+  name: z.string().min(1).max(100),
+  webhookUrl: z.string().url(),
+})
+
+const updateTelegramChannelSchema = z.object({
+  name: z.string().min(1).max(100),
+  botToken: z.string().optional(),
+  chatId: z.string().min(1),
+})
+
 export async function updateNotificationChannel(
   orgId: string,
   channelId: string,
@@ -570,14 +616,13 @@ export async function updateNotificationChannel(
       const existingConfig = existing.config as WebhookChannelConfig
       const newConfig: WebhookChannelConfig = {
         url,
-        // Non-empty string replaces; empty/absent keeps existing
         secret: secret || existingConfig.secret,
       }
       await db
         .update(notificationChannels)
         .set({ name, config: newConfig, updatedAt: new Date() })
         .where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organisationId, orgId)))
-    } else {
+    } else if (existing.type === 'smtp') {
       const parsed = updateSmtpChannelSchema.safeParse(input)
       if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
       const { name, host, port, encryption, username, password, fromAddress, fromName, toAddresses } = parsed.data
@@ -587,11 +632,32 @@ export async function updateNotificationChannel(
         port,
         encryption,
         username: username || undefined,
-        // Non-empty string replaces; empty/absent keeps existing
         password: password || existingConfig.password,
         fromAddress,
         fromName: fromName || undefined,
         toAddresses,
+      }
+      await db
+        .update(notificationChannels)
+        .set({ name, config: newConfig, updatedAt: new Date() })
+        .where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organisationId, orgId)))
+    } else if (existing.type === 'slack') {
+      const parsed = updateSlackChannelSchema.safeParse(input)
+      if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+      const { name, webhookUrl } = parsed.data
+      const newConfig: SlackChannelConfig = { webhookUrl }
+      await db
+        .update(notificationChannels)
+        .set({ name, config: newConfig, updatedAt: new Date() })
+        .where(and(eq(notificationChannels.id, channelId), eq(notificationChannels.organisationId, orgId)))
+    } else if (existing.type === 'telegram') {
+      const parsed = updateTelegramChannelSchema.safeParse(input)
+      if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+      const { name, botToken, chatId } = parsed.data
+      const existingConfig = existing.config as TelegramChannelConfig
+      const newConfig: TelegramChannelConfig = {
+        botToken: botToken || existingConfig.botToken,
+        chatId,
       }
       await db
         .update(notificationChannels)
@@ -652,7 +718,7 @@ export async function sendTestNotification(
     } catch (err) {
       return { error: err instanceof Error ? err.message : 'Request failed' }
     }
-  } else {
+  } else if (existing.type === 'smtp') {
     const cfg = normaliseSmtpConfig(existing.config)
     const transporter = nodemailer.createTransport({
       host: cfg.host,
@@ -674,6 +740,56 @@ export async function sendTestNotification(
     } catch (err) {
       return { error: err instanceof Error ? err.message : 'Failed to send email' }
     }
+  } else if (existing.type === 'slack') {
+    const cfg = existing.config as SlackChannelConfig
+    const payload = JSON.stringify({
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: ':large_blue_circle: [TEST] Infrawatch Test Notification' },
+        },
+        {
+          type: 'section',
+          text: { type: 'mrkdwn', text: 'Your Slack notification channel is configured correctly.' },
+        },
+      ],
+    })
+    try {
+      const res = await fetch(cfg.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!res.ok) return { error: `Slack returned ${res.status} ${res.statusText}` }
+      return { success: true }
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'Request failed' }
+    }
+  } else if (existing.type === 'telegram') {
+    const cfg = existing.config as TelegramChannelConfig
+    const apiUrl = `https://api.telegram.org/bot${encodeURIComponent(cfg.botToken)}/sendMessage`
+    try {
+      const res = await fetch(apiUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: cfg.chatId,
+          text: '<b>🔵 TEST</b>\n\nYour Telegram notification channel is configured correctly.',
+          parse_mode: 'HTML',
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        return { error: `Telegram returned ${res.status}: ${body}` }
+      }
+      return { success: true }
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'Request failed' }
+    }
+  } else {
+    return { error: 'Unsupported channel type' }
   }
 }
 

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -1,0 +1,90 @@
+'use server'
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { organisations } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import type { OrgMetadata, OrgNotificationSettings } from '@/lib/db/schema/organisations'
+import { getRequiredSession } from '@/lib/auth/session'
+
+const ADMIN_ROLES = ['org_admin', 'super_admin'] as const
+
+const DEFAULT_ROLES = ['super_admin', 'org_admin', 'engineer']
+
+const updateOrgNotificationSettingsSchema = z.object({
+  inAppEnabled: z.boolean(),
+  inAppRoles: z.array(z.string()).min(1, 'At least one role must be selected'),
+  allowUserOptOut: z.boolean(),
+})
+
+export type OrgNotificationSettingsInput = z.infer<typeof updateOrgNotificationSettingsSchema>
+
+export interface OrgNotificationSettingsFull {
+  inAppEnabled: boolean
+  inAppRoles: string[]
+  allowUserOptOut: boolean
+}
+
+export async function getOrgNotificationSettings(
+  orgId: string,
+): Promise<OrgNotificationSettingsFull> {
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+    columns: { metadata: true },
+  })
+  const meta = (org?.metadata ?? {}) as OrgMetadata
+  const ns = meta.notificationSettings ?? {}
+  return {
+    inAppEnabled: ns.inAppEnabled !== false,
+    inAppRoles: ns.inAppRoles ?? DEFAULT_ROLES,
+    allowUserOptOut: ns.allowUserOptOut !== false,
+  }
+}
+
+export async function updateOrgNotificationSettings(
+  orgId: string,
+  input: unknown,
+): Promise<{ success: true } | { error: string }> {
+  const session = await getRequiredSession()
+
+  if (!ADMIN_ROLES.includes(session.user.role as (typeof ADMIN_ROLES)[number])) {
+    return { error: 'You do not have permission to update notification settings' }
+  }
+
+  if (session.user.organisationId !== orgId) {
+    return { error: 'Organisation mismatch' }
+  }
+
+  const parsed = updateOrgNotificationSettingsSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
+
+  const { inAppEnabled, inAppRoles, allowUserOptOut } = parsed.data
+
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+    columns: { metadata: true },
+  })
+  if (!org) return { error: 'Organisation not found' }
+
+  const currentMetadata = (org.metadata ?? {}) as OrgMetadata
+  const updatedMetadata: OrgMetadata = {
+    ...currentMetadata,
+    notificationSettings: {
+      inAppEnabled,
+      inAppRoles,
+      allowUserOptOut,
+    } satisfies OrgNotificationSettings,
+  }
+
+  try {
+    await db
+      .update(organisations)
+      .set({ metadata: updatedMetadata, updatedAt: new Date() })
+      .where(eq(organisations.id, orgId))
+    return { success: true }
+  } catch {
+    return { error: 'Failed to update notification settings' }
+  }
+}

--- a/apps/web/lib/actions/notifications.ts
+++ b/apps/web/lib/actions/notifications.ts
@@ -1,0 +1,101 @@
+'use server'
+
+import { db } from '@/lib/db'
+import { notifications } from '@/lib/db/schema'
+import { eq, and, desc, count } from 'drizzle-orm'
+import type { Notification } from '@/lib/db/schema'
+
+export async function getNotifications(
+  orgId: string,
+  userId: string,
+  limit = 20,
+  offset = 0,
+): Promise<Notification[]> {
+  return db.query.notifications.findMany({
+    where: and(
+      eq(notifications.organisationId, orgId),
+      eq(notifications.userId, userId),
+    ),
+    orderBy: desc(notifications.createdAt),
+    limit,
+    offset,
+  })
+}
+
+export async function getUnreadCount(orgId: string, userId: string): Promise<number> {
+  const [result] = await db
+    .select({ value: count() })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.organisationId, orgId),
+        eq(notifications.userId, userId),
+        eq(notifications.read, false),
+      ),
+    )
+  return result?.value ?? 0
+}
+
+export async function markAsRead(
+  orgId: string,
+  userId: string,
+  notificationId: string,
+): Promise<{ success: true } | { error: string }> {
+  try {
+    await db
+      .update(notifications)
+      .set({ read: true })
+      .where(
+        and(
+          eq(notifications.id, notificationId),
+          eq(notifications.organisationId, orgId),
+          eq(notifications.userId, userId),
+        ),
+      )
+    return { success: true }
+  } catch {
+    return { error: 'Failed to mark notification as read' }
+  }
+}
+
+export async function markAllAsRead(
+  orgId: string,
+  userId: string,
+): Promise<{ success: true } | { error: string }> {
+  try {
+    await db
+      .update(notifications)
+      .set({ read: true })
+      .where(
+        and(
+          eq(notifications.organisationId, orgId),
+          eq(notifications.userId, userId),
+          eq(notifications.read, false),
+        ),
+      )
+    return { success: true }
+  } catch {
+    return { error: 'Failed to mark all notifications as read' }
+  }
+}
+
+export async function deleteNotification(
+  orgId: string,
+  userId: string,
+  notificationId: string,
+): Promise<{ success: true } | { error: string }> {
+  try {
+    await db
+      .delete(notifications)
+      .where(
+        and(
+          eq(notifications.id, notificationId),
+          eq(notifications.organisationId, orgId),
+          eq(notifications.userId, userId),
+        ),
+      )
+    return { success: true }
+  } catch {
+    return { error: 'Failed to delete notification' }
+  }
+}

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -2,9 +2,10 @@
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
+import { users, organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { headers, cookies } from 'next/headers'
+import type { OrgMetadata } from '@/lib/db/schema/organisations'
 
 const updateNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -97,6 +98,34 @@ export async function updateTheme(
   } catch (err) {
     console.error('Failed to update theme:', err)
     return { error: 'An unexpected error occurred' }
+  }
+}
+
+export async function updateNotificationPreference(
+  userId: string,
+  orgId: string,
+  enabled: boolean,
+): Promise<{ success: true } | { error: string }> {
+  // Check whether the org allows users to opt out
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+    columns: { metadata: true },
+  })
+  const meta = (org?.metadata ?? {}) as OrgMetadata
+  const allowOptOut = meta.notificationSettings?.allowUserOptOut !== false
+
+  if (!allowOptOut && !enabled) {
+    return { error: 'Your organisation does not allow opting out of notifications' }
+  }
+
+  try {
+    await db
+      .update(users)
+      .set({ notificationsEnabled: enabled, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+    return { success: true }
+  } catch {
+    return { error: 'Failed to update notification preference' }
   }
 }
 

--- a/apps/web/lib/db/migrations/0026_youthful_anthem.sql
+++ b/apps/web/lib/db/migrations/0026_youthful_anthem.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "notifications" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organisation_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"alert_instance_id" text,
+	"subject" text NOT NULL,
+	"body" text NOT NULL,
+	"severity" text NOT NULL,
+	"resource_type" text NOT NULL,
+	"resource_id" text NOT NULL,
+	"read" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "notifications_enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_organisation_id_organisations_id_fk" FOREIGN KEY ("organisation_id") REFERENCES "public"."organisations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_alert_instance_id_alert_instances_id_fk" FOREIGN KEY ("alert_instance_id") REFERENCES "public"."alert_instances"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "notifications_user_read_idx" ON "notifications" USING btree ("user_id","read");--> statement-breakpoint
+CREATE INDEX "notifications_org_user_idx" ON "notifications" USING btree ("organisation_id","user_id");--> statement-breakpoint
+CREATE INDEX "notifications_user_created_idx" ON "notifications" USING btree ("user_id","created_at");

--- a/apps/web/lib/db/migrations/meta/0026_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,5096 @@
+{
+  "id": "57fe5abe-4f26-43f6-8747-1c3d7296d9c5",
+  "prevId": "529ef1d1-cdf8-4833-b987-b870472ad5cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organisations": {
+      "name": "organisations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licence_tier": {
+          "name": "licence_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "licence_key": {
+          "name": "licence_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_retention_days": {
+          "name": "metric_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organisations_slug_unique": {
+          "name": "organisations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totp_credential": {
+      "name": "totp_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "totp_credential_user_id_user_id_fk": {
+          "name": "totp_credential_user_id_user_id_fk",
+          "tableFrom": "totp_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organisation_id_organisations_id_fk": {
+          "name": "user_organisation_id_organisations_id_fk",
+          "tableFrom": "user",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organisation_id_organisations_id_fk": {
+          "name": "invitations_organisation_id_organisations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_id_user_id_fk": {
+          "name": "invitations_invited_by_id_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_enrolment_tokens": {
+      "name": "agent_enrolment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_approve": {
+          "name": "auto_approve",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skip_verify": {
+          "name": "skip_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_enrolment_tokens_organisation_id_organisations_id_fk": {
+          "name": "agent_enrolment_tokens_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_enrolment_tokens",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_enrolment_tokens_created_by_id_user_id_fk": {
+          "name": "agent_enrolment_tokens_created_by_id_user_id_fk",
+          "tableFrom": "agent_enrolment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_enrolment_tokens_token_unique": {
+          "name": "agent_enrolment_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_status_history": {
+      "name": "agent_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_status_history_agent_id_agents_id_fk": {
+          "name": "agent_status_history_agent_id_agents_id_fk",
+          "tableFrom": "agent_status_history",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_status_history_organisation_id_organisations_id_fk": {
+          "name": "agent_status_history_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_status_history",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_id": {
+          "name": "approved_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolment_token_id": {
+          "name": "enrolment_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_organisation_id_organisations_id_fk": {
+          "name": "agents_organisation_id_organisations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_approved_by_id_user_id_fk": {
+          "name": "agents_approved_by_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_enrolment_token_id_agent_enrolment_tokens_id_fk": {
+          "name": "agents_enrolment_token_id_agent_enrolment_tokens_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "agent_enrolment_tokens",
+          "columnsFrom": [
+            "enrolment_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_public_key_unique": {
+          "name": "agents_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosts": {
+      "name": "hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_addresses": {
+          "name": "ip_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_percent": {
+          "name": "disk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosts_organisation_id_organisations_id_fk": {
+          "name": "hosts_organisation_id_organisations_id_fk",
+          "tableFrom": "hosts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hosts_agent_id_agents_id_fk": {
+          "name": "hosts_agent_id_agents_id_fk",
+          "tableFrom": "hosts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_tags": {
+      "name": "resource_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_tags_resource_idx": {
+          "name": "resource_tags_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_tags_org_kv_idx": {
+          "name": "resource_tags_org_kv_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_tags_organisation_id_organisations_id_fk": {
+          "name": "resource_tags_organisation_id_organisations_id_fk",
+          "tableFrom": "resource_tags",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_metrics": {
+      "name": "host_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_percent": {
+          "name": "disk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_metrics_organisation_id_organisations_id_fk": {
+          "name": "host_metrics_organisation_id_organisations_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_metrics_host_id_hosts_id_fk": {
+          "name": "host_metrics_host_id_hosts_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "host_metrics_id_recorded_at_pk": {
+          "name": "host_metrics_id_recorded_at_pk",
+          "columns": [
+            "id",
+            "recorded_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_results": {
+      "name": "check_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "check_results_check_idx": {
+          "name": "check_results_check_idx",
+          "columns": [
+            {
+              "expression": "check_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "check_results_org_idx": {
+          "name": "check_results_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "check_results_check_id_checks_id_fk": {
+          "name": "check_results_check_id_checks_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "checks",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "check_results_host_id_hosts_id_fk": {
+          "name": "check_results_host_id_hosts_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "check_results_organisation_id_organisations_id_fk": {
+          "name": "check_results_organisation_id_organisations_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checks": {
+      "name": "checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "checks_org_host_idx": {
+          "name": "checks_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checks_organisation_id_organisations_id_fk": {
+          "name": "checks_organisation_id_organisations_id_fk",
+          "tableFrom": "checks",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "checks_host_id_hosts_id_fk": {
+          "name": "checks_host_id_hosts_id_fk",
+          "tableFrom": "checks",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_queries": {
+      "name": "agent_queries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_queries_host_status_idx": {
+          "name": "agent_queries_host_status_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_queries_org_idx": {
+          "name": "agent_queries_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_queries_organisation_id_organisations_id_fk": {
+          "name": "agent_queries_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_queries",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_queries_host_id_hosts_id_fk": {
+          "name": "agent_queries_host_id_hosts_id_fk",
+          "tableFrom": "agent_queries",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_instances": {
+      "name": "alert_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_instances_org_status_idx": {
+          "name": "alert_instances_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_instances_rule_host_status_idx": {
+          "name": "alert_instances_rule_host_status_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_instances_rule_id_alert_rules_id_fk": {
+          "name": "alert_instances_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_instances_host_id_hosts_id_fk": {
+          "name": "alert_instances_host_id_hosts_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_instances_organisation_id_organisations_id_fk": {
+          "name": "alert_instances_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rules": {
+      "name": "alert_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warning'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_global_default": {
+          "name": "is_global_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_rules_org_host_idx": {
+          "name": "alert_rules_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_enabled_idx": {
+          "name": "alert_rules_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_global_idx": {
+          "name": "alert_rules_org_global_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_global_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_organisation_id_organisations_id_fk": {
+          "name": "alert_rules_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_rules_host_id_hosts_id_fk": {
+          "name": "alert_rules_host_id_hosts_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_silences": {
+      "name": "alert_silences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_silences_org_host_idx": {
+          "name": "alert_silences_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_silences_org_active_idx": {
+          "name": "alert_silences_org_active_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_silences_organisation_id_organisations_id_fk": {
+          "name": "alert_silences_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_host_id_hosts_id_fk": {
+          "name": "alert_silences_host_id_hosts_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_rule_id_alert_rules_id_fk": {
+          "name": "alert_silences_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_created_by_user_id_fk": {
+          "name": "alert_silences_created_by_user_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_channels_org_enabled_idx": {
+          "name": "notification_channels_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_organisation_id_organisations_id_fk": {
+          "name": "notification_channels_organisation_id_organisations_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_instance_id": {
+          "name": "alert_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_user_idx": {
+          "name": "notifications_org_user_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organisation_id_organisations_id_fk": {
+          "name": "notifications_organisation_id_organisations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_alert_instance_id_alert_instances_id_fk": {
+          "name": "notifications_alert_instance_id_alert_instances_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "alert_instances",
+          "columnsFrom": [
+            "alert_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate_events": {
+      "name": "certificate_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cert_events_cert_time_idx": {
+          "name": "cert_events_cert_time_idx",
+          "columns": [
+            {
+              "expression": "certificate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cert_events_org_time_idx": {
+          "name": "cert_events_org_time_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificate_events_organisation_id_organisations_id_fk": {
+          "name": "certificate_events_organisation_id_organisations_id_fk",
+          "tableFrom": "certificate_events",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_events_certificate_id_certificates_id_fk": {
+          "name": "certificate_events_certificate_id_certificates_id_fk",
+          "tableFrom": "certificate_events",
+          "tableTo": "certificates",
+          "columnsFrom": [
+            "certificate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_by_host_id": {
+          "name": "discovered_by_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discovered'"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sans": {
+          "name": "sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "not_before": {
+          "name": "not_before",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_after": {
+          "name": "not_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_sha256": {
+          "name": "fingerprint_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "certificates_identity_idx": {
+          "name": "certificates_identity_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_org_expiry_idx": {
+          "name": "certificates_org_expiry_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "not_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_org_status_idx": {
+          "name": "certificates_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_org_host_idx": {
+          "name": "certificates_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discovered_by_host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificates_organisation_id_organisations_id_fk": {
+          "name": "certificates_organisation_id_organisations_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_discovered_by_host_id_hosts_id_fk": {
+          "name": "certificates_discovered_by_host_id_hosts_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "discovered_by_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_check_id_checks_id_fk": {
+          "name": "certificates_check_id_checks_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "checks",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_events": {
+      "name": "identity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_key_id": {
+          "name": "ssh_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "identity_events_org_time_idx": {
+          "name": "identity_events_org_time_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_events_account_time_idx": {
+          "name": "identity_events_account_time_idx",
+          "columns": [
+            {
+              "expression": "service_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_events_key_time_idx": {
+          "name": "identity_events_key_time_idx",
+          "columns": [
+            {
+              "expression": "ssh_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_events_host_time_idx": {
+          "name": "identity_events_host_time_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_events_organisation_id_organisations_id_fk": {
+          "name": "identity_events_organisation_id_organisations_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "identity_events_service_account_id_service_accounts_id_fk": {
+          "name": "identity_events_service_account_id_service_accounts_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "service_accounts",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "identity_events_ssh_key_id_ssh_keys_id_fk": {
+          "name": "identity_events_ssh_key_id_ssh_keys_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "ssh_keys",
+          "columnsFrom": [
+            "ssh_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "identity_events_host_id_hosts_id_fk": {
+          "name": "identity_events_host_id_hosts_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_accounts": {
+      "name": "service_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gid": {
+          "name": "gid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_directory": {
+          "name": "home_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shell": {
+          "name": "shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service'"
+        },
+        "has_login_capability": {
+          "name": "has_login_capability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_running_processes": {
+          "name": "has_running_processes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_locked": {
+          "name": "account_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_expires_at": {
+          "name": "password_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_last_changed_at": {
+          "name": "password_last_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_accounts_identity_idx": {
+          "name": "service_accounts_identity_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_accounts_org_type_idx": {
+          "name": "service_accounts_org_type_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_accounts_org_status_idx": {
+          "name": "service_accounts_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_accounts_org_host_idx": {
+          "name": "service_accounts_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_accounts_organisation_id_organisations_id_fk": {
+          "name": "service_accounts_organisation_id_organisations_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_accounts_host_id_hosts_id_fk": {
+          "name": "service_accounts_host_id_hosts_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_keys": {
+      "name": "ssh_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_type": {
+          "name": "key_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "bit_length": {
+          "name": "bit_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint_sha256": {
+          "name": "fingerprint_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authorized_keys'"
+        },
+        "associated_username": {
+          "name": "associated_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "key_age_seconds": {
+          "name": "key_age_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ssh_keys_identity_idx": {
+          "name": "ssh_keys_identity_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_fingerprint_idx": {
+          "name": "ssh_keys_org_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_type_idx": {
+          "name": "ssh_keys_org_type_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_status_idx": {
+          "name": "ssh_keys_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_host_idx": {
+          "name": "ssh_keys_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_account_idx": {
+          "name": "ssh_keys_account_idx",
+          "columns": [
+            {
+              "expression": "service_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssh_keys_organisation_id_organisations_id_fk": {
+          "name": "ssh_keys_organisation_id_organisations_id_fk",
+          "tableFrom": "ssh_keys",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ssh_keys_host_id_hosts_id_fk": {
+          "name": "ssh_keys_host_id_hosts_id_fk",
+          "tableFrom": "ssh_keys",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ssh_keys_service_account_id_service_accounts_id_fk": {
+          "name": "ssh_keys_service_account_id_service_accounts_id_fk",
+          "tableFrom": "ssh_keys",
+          "tableTo": "service_accounts",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_accounts": {
+      "name": "domain_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "ldap_configuration_id": {
+          "name": "ldap_configuration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinguished_name": {
+          "name": "distinguished_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sam_account_name": {
+          "name": "sam_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_principal_name": {
+          "name": "user_principal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groups": {
+          "name": "groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "account_locked": {
+          "name": "account_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_expires_at": {
+          "name": "password_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_last_changed_at": {
+          "name": "password_last_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "domain_accounts_org_source_username_idx": {
+          "name": "domain_accounts_org_source_username_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_accounts_org_status_idx": {
+          "name": "domain_accounts_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_accounts_org_source_idx": {
+          "name": "domain_accounts_org_source_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_accounts_organisation_id_organisations_id_fk": {
+          "name": "domain_accounts_organisation_id_organisations_id_fk",
+          "tableFrom": "domain_accounts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "domain_accounts_ldap_configuration_id_ldap_configurations_id_fk": {
+          "name": "domain_accounts_ldap_configuration_id_ldap_configurations_id_fk",
+          "tableFrom": "domain_accounts",
+          "tableTo": "ldap_configurations",
+          "columnsFrom": [
+            "ldap_configuration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_configurations": {
+      "name": "ldap_configurations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 389
+        },
+        "use_tls": {
+          "name": "use_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_start_tls": {
+          "name": "use_start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_certificate": {
+          "name": "tls_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'(uid={{username}})'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uid'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "display_name_attribute": {
+          "name": "display_name_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cn'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allow_login": {
+          "name": "allow_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_interval_minutes": {
+          "name": "sync_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ldap_configurations_organisation_id_organisations_id_fk": {
+          "name": "ldap_configurations_organisation_id_organisations_id_fk",
+          "tableFrom": "ldap_configurations",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_group_members": {
+      "name": "host_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_group_members_organisation_id_organisations_id_fk": {
+          "name": "host_group_members_organisation_id_organisations_id_fk",
+          "tableFrom": "host_group_members",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_group_members_group_id_host_groups_id_fk": {
+          "name": "host_group_members_group_id_host_groups_id_fk",
+          "tableFrom": "host_group_members",
+          "tableTo": "host_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_group_members_host_id_hosts_id_fk": {
+          "name": "host_group_members_host_id_hosts_id_fk",
+          "tableFrom": "host_group_members",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_groups": {
+      "name": "host_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_groups_organisation_id_organisations_id_fk": {
+          "name": "host_groups_organisation_id_organisations_id_fk",
+          "tableFrom": "host_groups",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_run_hosts": {
+      "name": "task_run_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_run_id": {
+          "name": "task_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_output": {
+          "name": "raw_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_run_hosts_run_idx": {
+          "name": "task_run_hosts_run_idx",
+          "columns": [
+            {
+              "expression": "task_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_hosts_host_status_idx": {
+          "name": "task_run_hosts_host_status_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_run_hosts_organisation_id_organisations_id_fk": {
+          "name": "task_run_hosts_organisation_id_organisations_id_fk",
+          "tableFrom": "task_run_hosts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_run_hosts_task_run_id_task_runs_id_fk": {
+          "name": "task_run_hosts_task_run_id_task_runs_id_fk",
+          "tableFrom": "task_run_hosts",
+          "tableTo": "task_runs",
+          "columnsFrom": [
+            "task_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_run_hosts_host_id_hosts_id_fk": {
+          "name": "task_run_hosts_host_id_hosts_id_fk",
+          "tableFrom": "task_run_hosts",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_runs": {
+      "name": "task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_parallel": {
+          "name": "max_parallel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_runs_org_idx": {
+          "name": "task_runs_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_target_idx": {
+          "name": "task_runs_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_runs_organisation_id_organisations_id_fk": {
+          "name": "task_runs_organisation_id_organisations_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_runs_triggered_by_user_id_fk": {
+          "name": "task_runs_triggered_by_user_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terminal_sessions": {
+      "name": "terminal_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording": {
+          "name": "recording",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "terminal_sessions_org_host_idx": {
+          "name": "terminal_sessions_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_sessions_session_id_idx": {
+          "name": "terminal_sessions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_organisation_id_organisations_id_fk": {
+          "name": "terminal_sessions_organisation_id_organisations_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_user_id_user_id_fk": {
+          "name": "terminal_sessions_user_id_user_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "terminal_sessions_session_id_unique": {
+          "name": "terminal_sessions_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1776060859671,
       "tag": "0025_luxuriant_smasher",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1776086940630,
+      "tag": "0026_youthful_anthem",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/alerts.ts
+++ b/apps/web/lib/db/schema/alerts.ts
@@ -4,6 +4,8 @@ import { organisations } from './organisations'
 import { hosts } from './hosts'
 import { users } from './auth'
 
+export type NotificationResourceType = 'host' | 'certificate'
+
 export interface CheckStatusConfig {
   checkId: string
   failureThreshold: number
@@ -45,7 +47,16 @@ export interface SmtpChannelConfig {
   toAddresses: string[]
 }
 
-export type NotificationChannelType = 'webhook' | 'smtp'
+export interface SlackChannelConfig {
+  webhookUrl: string
+}
+
+export interface TelegramChannelConfig {
+  botToken: string
+  chatId: string
+}
+
+export type NotificationChannelType = 'webhook' | 'smtp' | 'slack' | 'telegram'
 
 export const alertRules = pgTable('alert_rules', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
@@ -89,7 +100,7 @@ export const notificationChannels = pgTable('notification_channels', {
   organisationId: text('organisation_id').notNull().references(() => organisations.id),
   name: text('name').notNull(),
   type: text('type').notNull().$type<NotificationChannelType>(),
-  config: jsonb('config').notNull().$type<WebhookChannelConfig | SmtpChannelConfig>(),
+  config: jsonb('config').notNull().$type<WebhookChannelConfig | SmtpChannelConfig | SlackChannelConfig | TelegramChannelConfig>(),
   enabled: boolean('enabled').notNull().default(true),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
@@ -97,6 +108,24 @@ export const notificationChannels = pgTable('notification_channels', {
   metadata: jsonb('metadata'),
 }, (table) => [
   index('notification_channels_org_enabled_idx').on(table.organisationId, table.enabled),
+])
+
+export const notifications = pgTable('notifications', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  organisationId: text('organisation_id').notNull().references(() => organisations.id),
+  userId: text('user_id').notNull().references(() => users.id),
+  alertInstanceId: text('alert_instance_id').references(() => alertInstances.id),
+  subject: text('subject').notNull(),
+  body: text('body').notNull(),
+  severity: text('severity').notNull().$type<'info' | 'warning' | 'critical'>(),
+  resourceType: text('resource_type').notNull().$type<NotificationResourceType>(),
+  resourceId: text('resource_id').notNull(),
+  read: boolean('read').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => [
+  index('notifications_user_read_idx').on(table.userId, table.read),
+  index('notifications_org_user_idx').on(table.organisationId, table.userId),
+  index('notifications_user_created_idx').on(table.userId, table.createdAt),
 ])
 
 export const alertSilences = pgTable('alert_silences', {
@@ -125,3 +154,5 @@ export type NotificationChannel = typeof notificationChannels.$inferSelect
 export type NewNotificationChannel = typeof notificationChannels.$inferInsert
 export type AlertSilence = typeof alertSilences.$inferSelect
 export type NewAlertSilence = typeof alertSilences.$inferInsert
+export type Notification = typeof notifications.$inferSelect
+export type NewNotification = typeof notifications.$inferInsert

--- a/apps/web/lib/db/schema/auth.ts
+++ b/apps/web/lib/db/schema/auth.ts
@@ -18,6 +18,7 @@ export const users = pgTable('user', {
   twoFactorEnabled: boolean('two_factor_enabled').notNull().default(false),
   deletedAt: timestamp('deleted_at', { withTimezone: true }),
   theme: text('theme').notNull().default('system'),
+  notificationsEnabled: boolean('notifications_enabled').notNull().default(true),
 })
 
 export const sessions = pgTable('session', {

--- a/apps/web/lib/db/schema/organisations.ts
+++ b/apps/web/lib/db/schema/organisations.ts
@@ -2,11 +2,18 @@ import { pgTable, text, timestamp, jsonb, integer } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
 import type { HostCollectionSettings } from './hosts'
 
+export interface OrgNotificationSettings {
+  inAppEnabled?: boolean      // default true — master switch for in-app notifications
+  inAppRoles?: string[]       // default ['super_admin','org_admin','engineer']
+  allowUserOptOut?: boolean   // default true — whether users can individually opt out
+}
+
 export interface OrgMetadata {
   defaultCollectionSettings?: HostCollectionSettings
   terminalEnabled?: boolean
   terminalLoggingEnabled?: boolean
   terminalDirectAccess?: boolean
+  notificationSettings?: OrgNotificationSettings
 }
 
 export const organisations = pgTable('organisations', {


### PR DESCRIPTION
## Summary

- **Slack & Telegram channels** — new notification channel types with UI dialogs in the Alerts page, Go dispatch via Slack Incoming Webhooks (Block Kit) and Telegram Bot API (HTML parse_mode), TypeScript CRUD actions including masked bot token and send-test support
- **In-app notifications** — new `notifications` table, Go ingest fan-out on every alert fire/resolve (reads org settings to determine eligible users by role/opt-out), server actions for fetch/mark-read/delete
- **Notification bell** — topbar Bell icon with red unread badge, dropdown of 10 recent notifications (severity dot, subject, relative timestamp), click navigates to resource, footer links to full page
- **Notifications page** (`/notifications`) — filterable All/Unread tabs, expandable cards with body text and resource link, mark-as-read/delete per item, mark-all-read, paginated (25/page)
- **Org notification settings** — new card in Settings for admins: enable/disable in-app, role selection, allow-user-opt-out toggle
- **User opt-out** — Notifications card on Profile page, respects org-level allow-opt-out flag
- **Sidebar link** — Notifications entry (BellPlus icon) added to Monitoring group
- **DB migration** — `0026_youthful_anthem.sql` adds `notifications` table, `notifications_enabled` column on `user`, and notification settings to org metadata

## Test plan

- [ ] `pnpm run db:generate && pnpm run db:migrate` — migration applies cleanly (already done)
- [ ] `pnpm run build` — zero TypeScript errors (already verified)
- [ ] `go build ./...` — Go compiles cleanly (already verified)
- [ ] Create a Slack channel in Alerts → send test → verify Slack message received
- [ ] Create a Telegram channel in Alerts → send test → verify Telegram message received
- [ ] Settings → Notification Settings card appears for admins, saves correctly
- [ ] Profile → Notifications opt-out toggle visible; disabled when org disallows opt-out
- [ ] Trigger an alert — verify notification bell badge increments and notification appears in dropdown
- [ ] Click a notification → navigates to host/certificate resource page
- [ ] Click "View all notifications" → `/notifications` page renders with full list
- [ ] Mark as read / mark all → unread badge updates correctly
- [ ] Delete a notification → removed from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)