### PR TITLE
fix(notifications): include id column in in-app notification INSERT

### DIFF
--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -389,11 +389,11 @@ func InsertNotificationBatch(ctx context.Context, pool *pgxpool.Pool, rows []Not
 	batch := &pgx.Batch{}
 	const q = `
 		INSERT INTO notifications
-		  (organisation_id, user_id, alert_instance_id, subject, body, severity, resource_type, resource_id)
-		VALUES ($1, $2, NULLIF($3,''), $4, $5, $6, $7, $8)
+		  (id, organisation_id, user_id, alert_instance_id, subject, body, severity, resource_type, resource_id)
+		VALUES ($1, $2, $3, NULLIF($4,''), $5, $6, $7, $8, $9)
 	`
 	for _, r := range rows {
-		batch.Queue(q, r.OrgID, r.UserID, r.AlertInstanceID, r.Subject, r.Body, r.Severity, r.ResourceType, r.ResourceID)
+		batch.Queue(q, newCUID(), r.OrgID, r.UserID, r.AlertInstanceID, r.Subject, r.Body, r.Severity, r.ResourceType, r.ResourceID)
 	}
 
 	br := pool.SendBatch(ctx, batch)


### PR DESCRIPTION
## Summary

- The `notifications` table has `id text PRIMARY KEY NOT NULL` with no database-level default
- `InsertNotificationBatch` in the Go ingest service was omitting `id` from the INSERT statement
- Every in-app notification was silently failing with a NOT NULL violation — the error was caught and logged as a warning but discarded
- Email, Slack, and Telegram channels were unaffected as they make HTTP requests and don't write to the database

## Fix

Added `id` as the first column in the INSERT and pass `newCUID()` (already present in the same `queries` package) as the generated value. No struct changes required — ID generation is internal to the batch function.

## Test plan

- [ ] Trigger an alert with an in-app notification channel configured
- [ ] Verify notification appears in the web UI notification panel
- [ ] Verify email/Slack/Telegram channels still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)