### PR TITLE
fix(notifications): apply default inAppRoles when org metadata is absent

### DIFF
--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -325,6 +325,11 @@ func GetOrgNotificationSettings(ctx context.Context, pool *pgxpool.Pool, orgID s
 			AllowUserOptOut: true,
 		}, err
 	}
+	// ARRAY(SELECT ...) returns '{}' (not NULL) when the JSON key is absent, so
+	// COALESCE in SQL never fires. Apply the default here instead.
+	if len(row.InAppRoles) == 0 {
+		row.InAppRoles = []string{"super_admin", "org_admin", "engineer"}
+	}
 	return row, nil
 }
 


### PR DESCRIPTION
## Summary

- `ARRAY(SELECT jsonb_array_elements_text(...))` returns `{}` (empty array, **not** NULL) when the JSON key is absent from org metadata
- SQL `COALESCE` never fires for an empty array — only for NULL — so the default roles were silently dropped
- `GetAlertTargetUsers` was called with an empty slice, generating `WHERE role = ANY('{}')` which matches no users
- `dispatchInApp` would find zero target users and return early, so no in-app notifications were ever written regardless of the INSERT fix in #157

## Fix

After scanning the row from PostgreSQL, check `len(row.InAppRoles) == 0` and apply the default `['super_admin', 'org_admin', 'engineer']` in Go where the type system makes the intent clear.

## Test plan

- [ ] Trigger an alert on an org with no `notificationSettings` in `organisations.metadata`
- [ ] Verify in-app notifications appear in the web UI for `super_admin`, `org_admin`, and `engineer` users
- [ ] Verify orgs with explicit `inAppRoles` in metadata still use their configured roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)