### PR TITLE
feat(notifications): time-range selector on notification trend chart

### DIFF
--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
-import { formatDistanceToNow, format, parseISO } from 'date-fns'
+import { formatDistanceToNow, format } from 'date-fns'
 import { Bell, CheckCircle2, ExternalLink, Trash2, X } from 'lucide-react'
 import {
   PieChart,
@@ -23,6 +23,13 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   getNotifications,
   getUnreadCount,
   markAsRead,
@@ -33,7 +40,29 @@ import {
   getNotificationStats,
   getNotificationsOverTime,
 } from '@/lib/actions/notifications'
+import type { TrendRange } from '@/lib/actions/notifications'
 import type { Notification } from '@/lib/db/schema'
+
+const TREND_RANGE_OPTIONS: { value: TrendRange; label: string }[] = [
+  { value: '1h',  label: 'Last 1 hour'  },
+  { value: '6h',  label: 'Last 6 hours' },
+  { value: '12h', label: 'Last 12 hours' },
+  { value: '24h', label: 'Last 24 hours' },
+  { value: '7d',  label: 'Last 7 days'  },
+  { value: '30d', label: 'Last 30 days' },
+  { value: '90d', label: 'Last 3 months' },
+]
+
+function formatTrendDate(raw: string, range: TrendRange): string {
+  // Hourly ranges: raw is a Postgres timestamp text like "2026-04-13 20:00:00"
+  // Daily ranges: raw is a date string like "2026-04-13"
+  const d = new Date(raw)
+  if (range === '1h' || range === '6h' || range === '12h' || range === '24h') {
+    return format(d, 'HH:mm')
+  }
+  if (range === '7d') return format(d, 'MMM d')
+  return format(d, 'MMM d')
+}
 
 const PAGE_SIZE = 25
 
@@ -74,6 +103,8 @@ function SeverityDot({ severity }: { severity: string }) {
 }
 
 function NotificationCharts({ orgId, userId }: { orgId: string; userId: string }) {
+  const [trendRange, setTrendRange] = useState<TrendRange>('30d')
+
   const { data: stats } = useQuery({
     queryKey: ['notifications-stats', orgId, userId],
     queryFn: () => getNotificationStats(orgId, userId),
@@ -81,8 +112,8 @@ function NotificationCharts({ orgId, userId }: { orgId: string; userId: string }
   })
 
   const { data: timeSeries } = useQuery({
-    queryKey: ['notifications-time-series', orgId, userId],
-    queryFn: () => getNotificationsOverTime(orgId, userId, 30),
+    queryKey: ['notifications-time-series', orgId, userId, trendRange],
+    queryFn: () => getNotificationsOverTime(orgId, userId, trendRange),
     refetchInterval: 60_000,
   })
 
@@ -96,7 +127,7 @@ function NotificationCharts({ orgId, userId }: { orgId: string; userId: string }
 
   const lineData = (timeSeries ?? []).map((point) => ({
     ...point,
-    date: format(parseISO(point.date), 'MMM d'),
+    date: formatTrendDate(point.date, trendRange),
   }))
 
   return (
@@ -145,9 +176,24 @@ function NotificationCharts({ orgId, userId }: { orgId: string; userId: string }
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium">Notification Trend</CardTitle>
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="text-sm font-medium">Notification Trend</CardTitle>
+            <Select value={trendRange} onValueChange={(v) => setTrendRange(v as TrendRange)}>
+              <SelectTrigger className="h-7 w-36 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TREND_RANGE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <CardDescription className="text-xs">
-            Critical &amp; warning notifications over the last 30 days
+            Critical &amp; warning notifications —{' '}
+            {TREND_RANGE_OPTIONS.find((o) => o.value === trendRange)?.label.toLowerCase()}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web/lib/actions/notifications.ts
+++ b/apps/web/lib/actions/notifications.ts
@@ -181,8 +181,20 @@ export async function getNotificationStats(
   return results.map((r) => ({ severity: r.severity, total: Number(r.total) }))
 }
 
+export type TrendRange = '1h' | '6h' | '12h' | '24h' | '7d' | '30d' | '90d'
+
+const TREND_RANGE_CONFIG: Record<TrendRange, { cutoffMs: number; trunc: 'hour' | 'day' }> = {
+  '1h':  { cutoffMs: 1  * 60 * 60 * 1000,          trunc: 'hour' },
+  '6h':  { cutoffMs: 6  * 60 * 60 * 1000,          trunc: 'hour' },
+  '12h': { cutoffMs: 12 * 60 * 60 * 1000,          trunc: 'hour' },
+  '24h': { cutoffMs: 24 * 60 * 60 * 1000,          trunc: 'hour' },
+  '7d':  { cutoffMs: 7  * 24 * 60 * 60 * 1000,     trunc: 'day'  },
+  '30d': { cutoffMs: 30 * 24 * 60 * 60 * 1000,     trunc: 'day'  },
+  '90d': { cutoffMs: 90 * 24 * 60 * 60 * 1000,     trunc: 'day'  },
+}
+
 export type NotificationTimeSeriesPoint = {
-  date: string
+  date: string  // ISO timestamp (hourly) or ISO date string (daily)
   critical: number
   warning: number
   info: number
@@ -191,15 +203,24 @@ export type NotificationTimeSeriesPoint = {
 export async function getNotificationsOverTime(
   orgId: string,
   userId: string,
-  days = 30,
+  range: TrendRange = '30d',
 ): Promise<NotificationTimeSeriesPoint[]> {
   // Intentionally does NOT filter on deletedAt so that deleting notifications
-  // from the inbox does not affect the historical trend. Retains up to 90 days.
-  const cutoff = new Date(Date.now() - Math.min(days, 90) * 24 * 60 * 60 * 1000)
+  // from the inbox does not affect the historical trend.
+  const config = TREND_RANGE_CONFIG[range]
+  const cutoff = new Date(Date.now() - config.cutoffMs)
+
+  const truncExpr = config.trunc === 'hour'
+    ? sql<string>`date_trunc('hour', ${notifications.createdAt})::text`
+    : sql<string>`date_trunc('day', ${notifications.createdAt})::date::text`
+
+  const truncGroup = config.trunc === 'hour'
+    ? sql`date_trunc('hour', ${notifications.createdAt})`
+    : sql`date_trunc('day', ${notifications.createdAt})::date`
 
   const rows = await db
     .select({
-      date: sql<string>`date_trunc('day', ${notifications.createdAt})::date::text`,
+      date: truncExpr,
       severity: notifications.severity,
       total: count(),
     })
@@ -211,11 +232,8 @@ export async function getNotificationsOverTime(
         gte(notifications.createdAt, cutoff),
       ),
     )
-    .groupBy(
-      sql`date_trunc('day', ${notifications.createdAt})::date`,
-      notifications.severity,
-    )
-    .orderBy(sql`date_trunc('day', ${notifications.createdAt})::date`)
+    .groupBy(truncGroup, notifications.severity)
+    .orderBy(truncGroup)
 
   const map = new Map<string, NotificationTimeSeriesPoint>()
   for (const row of rows) {


### PR DESCRIPTION
## Summary

Adds a dropdown to the Notification Trend card header so users can choose how far back the chart looks:

| Option | Granularity | X-axis label |
|---|---|---|
| Last 1 hour | Per hour | HH:mm |
| Last 6 hours | Per hour | HH:mm |
| Last 12 hours | Per hour | HH:mm |
| Last 24 hours | Per hour | HH:mm |
| Last 7 days | Per day | MMM d |
| Last 30 days | Per day | MMM d |
| Last 3 months | Per day | MMM d |

- Default remains **Last 30 days**
- Card description updates dynamically to reflect the selected period
- TanStack Query key includes the range so switching triggers a fresh fetch
- `getNotificationsOverTime` now accepts a `TrendRange` parameter and switches between `date_trunc('hour', …)` and `date_trunc('day', …)` aggregation accordingly
- Historical trend data is still preserved even when notifications are deleted from the inbox (soft-delete approach from PR #161)

## Test plan

- [ ] Dropdown renders in the Notification Trend card header
- [ ] Selecting each option fetches and renders the correct data
- [ ] Sub-24h ranges show hourly HH:mm X-axis labels
- [ ] 7d / 30d / 90d ranges show daily MMM d labels
- [ ] Card subtitle updates to match selection
- [ ] Switching ranges does not cause stale data to persist
- [ ] `pnpm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)