### PR TITLE
fix(terminal): pin terminal panel to bottom of viewport

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -24,7 +24,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
 
   return (
     <TerminalProviderWrapper>
-      <SidebarProvider>
+      <SidebarProvider className="h-svh overflow-hidden">
         <AppSidebar orgId={orgId} />
         <TerminalContentWrapper orgId={orgId}>
           <Topbar orgId={orgId} />


### PR DESCRIPTION
## Summary

- Constrains the `SidebarProvider` wrapper to `h-svh overflow-hidden` in the dashboard layout
- Previously `SidebarProvider` rendered with `min-h-svh`, allowing the container to grow taller than the viewport on long pages and pushing the terminal panel off screen
- The `main` content area already has `overflow-auto` so it handles scrolling internally; the terminal panel (`shrink-0`) now always remains anchored at the bottom of the viewport

## Test plan

- [ ] Open a page with long content (e.g. a host detail page with many metrics)
- [ ] Open a terminal session via the sidebar trigger
- [ ] Verify the terminal panel is visible and fixed at the bottom — page content scrolls above it
- [ ] Verify resizing the terminal panel still works
- [ ] Verify the sidebar and topbar render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)