### PR TITLE
fix(terminal): pin terminal panel to bottom of viewport

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,23 @@
 **Phase 5 — Tooling (in progress)**
 
 ## Current Status
-🟢 Phase 5 progressing — Notifications significantly enhanced: bulk actions (select-all, bulk mark read/unread, bulk delete), severity pie chart and notification trend line chart on the /notifications page, soft-delete to preserve trend history, time-range dropdown on the trend chart (1h → 3 months), and both charts replicated on the host detail Metrics tab filtered per-host.
+🟢 Phase 5 progressing — Terminal panel pinned to viewport bottom; dashboard layout bounded to `h-svh` so the persistent terminal never scrolls off-screen on long pages.
 
 ---
 
 ## What Has Been Built
+
+### Session 36 — Terminal panel viewport fix
+
+**Dashboard layout** (`apps/web/app/(dashboard)/layout.tsx`)
+- `SidebarProvider` container changed from `min-h-svh` to `h-svh overflow-hidden` — bounds the entire dashboard to the viewport height
+- The main content area already uses `overflow-auto` so page content still scrolls internally; the terminal panel stays pinned at the bottom on all pages regardless of content length
+- PR: simonjcarr/infrawatch#165 (`feature/terminal-fixed-bottom`)
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
 
 ### Session 35 — Notification enhancements: bulk actions, charts, soft-delete, and host metrics integration
 


### PR DESCRIPTION
## Summary

- Constrain the `SidebarProvider` container to `h-svh overflow-hidden` in the dashboard layout so the entire dashboard is bounded to the viewport height
- Previously `min-h-svh` allowed the container to grow taller than the viewport on long pages, pushing the terminal panel off-screen
- The main content area already uses `overflow-auto` so all page content still scrolls internally — this is a layout-only fix with no functional regressions

## Test plan

- [ ] Open a page with long content (e.g. Hosts list with many entries)
- [ ] Verify the terminal panel remains pinned at the bottom of the viewport and does not scroll off-screen
- [ ] Verify page content still scrolls normally within the main content area
- [ ] Check Notifications, Alerts, and other long pages behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)