### PR TITLE
feat(hosts): remote agent uninstall on host deletion

### DIFF
--- a/agent/internal/tasks/uninstall.go
+++ b/agent/internal/tasks/uninstall.go
@@ -1,0 +1,66 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+func init() {
+	Register("agent_uninstall", RunUninstall)
+}
+
+// uninstallResult is the JSON structure stored in task_run_hosts.result.
+type uninstallResult struct {
+	Status string `json:"status"`         // always "scheduled"
+	Note   string `json:"note,omitempty"` // optional context for the UI
+}
+
+// RunUninstall schedules the agent to uninstall itself from the host.
+//
+// Uninstall is performed by a detached child process that re-executes the
+// current agent binary with the existing -uninstall flag. The child survives
+// after the service manager terminates this process, so the full uninstall
+// sequence (service stop, file removal, daemon reload) always completes.
+//
+// A short delay is inserted between the handler returning and the child
+// launching so that the "scheduled" result is shipped back to the server on
+// the next heartbeat before we are killed. Output is captured to
+// /tmp/infrawatch-uninstall.log on the host for post-mortem inspection.
+func RunUninstall(ctx context.Context, configJSON string, progressFn func(chunk string)) *agentv1.AgentTaskResult {
+	_ = configJSON // reserved for future flags
+
+	binPath, err := os.Executable()
+	if err != nil {
+		return errorResult(fmt.Sprintf("cannot determine agent binary path: %v", err))
+	}
+
+	progressFn("Agent uninstall requested.\n")
+	progressFn(fmt.Sprintf("Binary: %s\n", binPath))
+	progressFn("Spawning detached uninstaller process in 3 seconds.\n")
+	progressFn("The agent service will stop shortly after; uninstaller output is written to /tmp/infrawatch-uninstall.log on the host.\n")
+
+	// Run the launcher in a goroutine so the result below is shipped first.
+	go func() {
+		time.Sleep(3 * time.Second)
+		if err := launchDetachedUninstaller(binPath); err != nil {
+			slog.Error("failed to launch detached uninstaller", "err", err)
+			return
+		}
+		slog.Info("detached uninstaller launched", "bin", binPath)
+	}()
+
+	payload, _ := json.Marshal(uninstallResult{
+		Status: "scheduled",
+		Note:   "uninstaller runs in a detached process; agent will exit within seconds",
+	})
+	return &agentv1.AgentTaskResult{
+		ExitCode:   0,
+		ResultJson: string(payload),
+	}
+}

--- a/agent/internal/tasks/uninstall_unix.go
+++ b/agent/internal/tasks/uninstall_unix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package tasks
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// launchDetachedUninstaller spawns the agent binary with -uninstall in a new
+// session so it survives when systemd / launchd terminates the current process.
+// Stdout and stderr are redirected to /tmp/infrawatch-uninstall.log so an
+// operator can see the uninstall outcome after the agent has gone.
+func launchDetachedUninstaller(binPath string) error {
+	const logPath = "/tmp/infrawatch-uninstall.log"
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		// Logging is best-effort — don't abort the uninstall just because
+		// we can't open a log file (unusual but possible on read-only /tmp).
+		logFile = nil
+	}
+
+	cmd := exec.Command(binPath, "-uninstall")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if logFile != nil {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
+
+	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			_ = logFile.Close()
+		}
+		return fmt.Errorf("starting uninstaller: %w", err)
+	}
+	// Intentionally do not Wait — the child runs independently and this
+	// process is about to be terminated by the service manager.
+	return nil
+}

--- a/agent/internal/tasks/uninstall_windows.go
+++ b/agent/internal/tasks/uninstall_windows.go
@@ -1,0 +1,71 @@
+//go:build windows
+
+package tasks
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// Windows process-creation flags not exposed by the stdlib constants.
+const (
+	detachedProcess     = 0x00000008
+	createNewProcessGrp = 0x00000200
+)
+
+// launchDetachedUninstaller copies the agent binary to %TEMP% and spawns it
+// there with -uninstall. Running from a temp path is required because the
+// uninstall step removes C:\Program Files\infrawatch, which would fail on
+// Windows if the currently-running executable was located inside it.
+// The child is detached so it survives SCM stopping the service.
+func launchDetachedUninstaller(binPath string) error {
+	tmpBin, err := stageWindowsUninstaller(binPath)
+	if err != nil {
+		return fmt.Errorf("staging uninstaller binary: %w", err)
+	}
+
+	cmd := exec.Command(tmpBin, "-uninstall")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: detachedProcess | createNewProcessGrp,
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting uninstaller: %w", err)
+	}
+	return nil
+}
+
+// stageWindowsUninstaller copies binPath into %TEMP% with a fixed name and
+// returns the destination path. Overwrites any prior copy.
+func stageWindowsUninstaller(binPath string) (string, error) {
+	tmpDir := os.TempDir()
+	dst := filepath.Join(tmpDir, "infrawatch-uninstaller.exe")
+
+	srcFile, err := os.Open(binPath)
+	if err != nil {
+		return "", fmt.Errorf("opening source binary: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return "", fmt.Errorf("creating destination: %w", err)
+	}
+	defer dstFile.Close()
+
+	buf := make([]byte, 64*1024)
+	for {
+		n, rerr := srcFile.Read(buf)
+		if n > 0 {
+			if _, werr := dstFile.Write(buf[:n]); werr != nil {
+				return "", fmt.Errorf("writing destination: %w", werr)
+			}
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	return dst, nil
+}

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -34,6 +34,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import {
   Table,
   TableBody,
@@ -42,7 +49,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { getHost, getHostMetrics, getHeartbeatHistory, deleteHost } from '@/lib/actions/agents'
+import { getHost, getHostMetrics, getHeartbeatHistory, deleteHost, uninstallAndDeleteHost } from '@/lib/actions/agents'
 import type { HostWithAgent, MetricsPreset, MetricsQuery, HeartbeatPoint } from '@/lib/actions/agents'
 import { useHostStream } from '@/hooks/use-host-stream'
 import { useChartZoom } from '@/hooks/use-chart-zoom'
@@ -218,6 +225,8 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
   const [activeTab, setActiveTab] = useState<Tab>('overview')
   const [metricsRange, setMetricsRange] = useState<MetricsPreset>('24h')
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [uninstallAgent, setUninstallAgent] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const [addGroupOpen, setAddGroupOpen] = useState(false)
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -249,9 +258,13 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
     : 720
 
   const { mutate: removeHost, isPending: isDeleting } = useMutation({
-    mutationFn: () => deleteHost(orgId, initialHost.id),
+    mutationFn: (opts: { uninstall: boolean }) =>
+      opts.uninstall
+        ? uninstallAndDeleteHost(orgId, currentUserId, initialHost.id)
+        : deleteHost(orgId, initialHost.id),
     onSuccess: (result) => {
       if ('success' in result) {
+        setDeleteError(null)
         // Cancel and remove all queries for this host before navigating away
         // to stop refetchInterval timers from firing against a deleted resource
         queryClient.cancelQueries({ queryKey: ['host', orgId, initialHost.id] })
@@ -271,6 +284,11 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
         // Also invalidate the hosts list so it reflects the deletion
         queryClient.invalidateQueries({ queryKey: ['hosts'] })
         router.push('/hosts')
+      } else {
+        // Error case — keep dialog open so user can retry or fall back to
+        // host-only delete (especially important when the uninstall task
+        // failed or timed out).
+        setDeleteError(result.error)
       }
     },
   })
@@ -417,7 +435,11 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
           <Button
             variant="destructive"
             size="sm"
-            onClick={() => setDeleteOpen(true)}
+            onClick={() => {
+              setDeleteError(null)
+              setUninstallAgent(false)
+              setDeleteOpen(true)
+            }}
             disabled={isDeleting}
           >
             {isDeleting ? (
@@ -974,7 +996,17 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
         />
       )}
 
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+      <AlertDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          if (isDeleting) return
+          setDeleteOpen(open)
+          if (!open) {
+            setDeleteError(null)
+            setUninstallAgent(false)
+          }
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete host</AlertDialogTitle>
@@ -985,18 +1017,89 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
               certificates, users, and SSH keys. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+
+          {/* Remote uninstall option */}
+          <div className="rounded-md border border-border bg-muted/30 p-3">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <label
+                    className={`flex items-start gap-3 ${
+                      host.agent?.status === 'active'
+                        ? 'cursor-pointer'
+                        : 'cursor-not-allowed opacity-60'
+                    }`}
+                  >
+                    <Checkbox
+                      checked={uninstallAgent}
+                      onCheckedChange={(v) => setUninstallAgent(v === true)}
+                      disabled={isDeleting || host.agent?.status !== 'active'}
+                      className="mt-0.5"
+                    />
+                    <div className="flex-1 text-sm">
+                      <div className="font-medium text-foreground">
+                        Also uninstall agent from the remote host
+                      </div>
+                      <div className="mt-1 text-muted-foreground">
+                        Sends an uninstall command to the agent. The agent will
+                        stop its service, remove the binary, configuration, and
+                        data before the host record is deleted.
+                      </div>
+                      {host.agent?.status !== 'active' && (
+                        <div className="mt-1 text-amber-600 dark:text-amber-400">
+                          Unavailable — the agent must be connected to receive
+                          the uninstall command.
+                        </div>
+                      )}
+                    </div>
+                  </label>
+                </TooltipTrigger>
+                {host.agent?.status !== 'active' && (
+                  <TooltipContent side="top" className="max-w-xs">
+                    The agent is{' '}
+                    {host.agent?.status ?? 'not registered'}. Remote uninstall
+                    requires an active connection.
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+
+          {deleteError && (
+            <div
+              role="alert"
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              {deleteError}
+              {uninstallAgent && (
+                <div className="mt-2 text-xs text-foreground">
+                  You can uncheck the option above and try again to delete the
+                  host record without uninstalling the agent.
+                </div>
+              )}
+            </div>
+          )}
+
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="bg-red-600 hover:bg-red-700 text-white"
               disabled={isDeleting}
-              onClick={() => removeHost()}
+              onClick={(e) => {
+                // Prevent the dialog from closing automatically on click so we
+                // can keep it open to show the error on failure.
+                e.preventDefault()
+                setDeleteError(null)
+                removeHost({ uninstall: uninstallAgent })
+              }}
             >
               {isDeleting ? (
                 <>
                   <Loader2 className="size-4 mr-1 animate-spin" />
-                  Deleting…
+                  {uninstallAgent ? 'Uninstalling & deleting…' : 'Deleting…'}
                 </>
+              ) : uninstallAgent ? (
+                'Uninstall agent & delete'
               ) : (
                 'Delete permanently'
               )}

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -20,11 +20,14 @@ import {
   identityEvents,
   agentQueries,
   resourceTags,
+  taskRuns,
+  taskRunHosts,
 } from '@/lib/db/schema'
 import { eq, and, isNull, gt, gte, lte, asc, sql, inArray } from 'drizzle-orm'
 import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
 import { applyGlobalDefaultsToHost } from '@/lib/actions/alerts'
 import { getOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
+import { triggerAgentUninstall, getTaskRun } from '@/lib/actions/task-runs'
 import type { HostMetadata } from '@/lib/db/schema'
 
 export type OfflinePeriod = { start: number; end: number | null }
@@ -680,6 +683,24 @@ export async function deleteHost(
           eq(resourceTags.organisationId, orgId),
         ))
 
+      // 13a. Task run host rows (FK to hosts; must be removed before the host
+      //      is deleted or the transaction fails). Group-targeted task_runs
+      //      keep their rows for other hosts; host-targeted task_runs are
+      //      then removed as orphans below since they have no remaining rows.
+      await tx
+        .delete(taskRunHosts)
+        .where(and(
+          eq(taskRunHosts.hostId, hostId),
+          eq(taskRunHosts.organisationId, orgId),
+        ))
+      await tx
+        .delete(taskRuns)
+        .where(and(
+          eq(taskRuns.organisationId, orgId),
+          eq(taskRuns.targetType, 'host'),
+          eq(taskRuns.targetId, hostId),
+        ))
+
       // 14. Host itself
       await tx
         .delete(hosts)
@@ -702,5 +723,85 @@ export async function deleteHost(
   } catch (err) {
     console.error('Failed to delete host:', err)
     return { error: 'An unexpected error occurred while deleting the host' }
+  }
+}
+
+/**
+ * Dispatches a remote agent uninstall task and, on success, removes the host
+ * record using the existing deleteHost cascade.
+ *
+ * Flow:
+ *  1. Verify the host exists and its agent is currently active — remote
+ *     uninstall requires the agent to be connected so it can receive the task.
+ *  2. Create a task_run of type 'agent_uninstall' targeting the host.
+ *  3. Poll task_run_hosts.status until 'success' (agent has staged a detached
+ *     uninstaller) or 'failed' / 'cancelled' / 'skipped' / timeout.
+ *  4. On success: run the normal deleteHost cascade.
+ *  5. On failure: return the taskRunId so the UI can offer the user a choice
+ *     between retrying, viewing task history, or deleting the host record only.
+ */
+export async function uninstallAndDeleteHost(
+  orgId: string,
+  userId: string,
+  hostId: string,
+): Promise<
+  | { success: true }
+  | { error: string; taskRunId?: string; agentOffline?: boolean }
+> {
+  try {
+    const host = await db.query.hosts.findFirst({
+      where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)),
+    })
+    if (!host) return { error: 'Host not found' }
+
+    const agent = host.agentId
+      ? await db.query.agents.findFirst({ where: eq(agents.id, host.agentId) })
+      : null
+
+    if (!agent || agent.status !== 'active') {
+      return {
+        error:
+          'Agent is not currently connected — remote uninstall requires an active agent. Delete the host record only if you intend to leave the agent installed on the remote host.',
+        agentOffline: true,
+      }
+    }
+
+    const trigger = await triggerAgentUninstall(orgId, userId, hostId)
+    if ('error' in trigger) return { error: trigger.error }
+
+    // Poll until the agent reports the uninstall as scheduled, or we hit
+    // the overall deadline. Agent typically returns success within a few
+    // seconds because the handler returns as soon as it spawns the detached
+    // uninstaller goroutine.
+    const deadlineMs = Date.now() + 45_000
+    let reachedSuccess = false
+    while (Date.now() < deadlineMs) {
+      const run = await getTaskRun(orgId, trigger.taskRunId)
+      const hostRun = run?.hosts[0]
+      if (hostRun?.status === 'success') {
+        reachedSuccess = true
+        break
+      }
+      if (hostRun && ['failed', 'cancelled', 'skipped'].includes(hostRun.status)) {
+        return {
+          error: `Uninstall task did not complete (status: ${hostRun.status}). Host record was not deleted.`,
+          taskRunId: trigger.taskRunId,
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1500))
+    }
+
+    if (!reachedSuccess) {
+      return {
+        error:
+          'Timed out waiting for the agent to acknowledge the uninstall task. Host record was not deleted.',
+        taskRunId: trigger.taskRunId,
+      }
+    }
+
+    return await deleteHost(orgId, hostId)
+  } catch (err) {
+    console.error('Failed to uninstall agent and delete host:', err)
+    return { error: 'An unexpected error occurred while uninstalling the agent' }
   }
 }

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -16,6 +16,7 @@ import type {
   PatchTaskConfig,
   CustomScriptTaskConfig,
   ServiceTaskConfig,
+  AgentUninstallTaskConfig,
   Host,
 } from '@/lib/db/schema'
 
@@ -414,6 +415,33 @@ export async function triggerGroupServiceAction(
     targetedCount: pendingHostIds.length,
     skippedCount: skipHosts.length,
   }
+}
+
+// ── Agent uninstall action ────────────────────────────────────────────────────
+
+/**
+ * Triggers a remote agent uninstall on a single host.
+ *
+ * The agent handler returns a "scheduled" result as soon as it has staged
+ * a detached uninstaller child process. The actual uninstall completes
+ * out-of-band on the host — see apps/agent/internal/tasks/uninstall.go and
+ * apps/agent/internal/install/uninstall.go.
+ *
+ * Callers that need to delete the host record after the uninstall has been
+ * scheduled should poll task_run_hosts.status and then invoke deleteHost.
+ */
+export async function triggerAgentUninstall(
+  orgId: string,
+  userId: string,
+  hostId: string,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const host = await db.query.hosts.findFirst({
+    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { error: 'Host not found' }
+
+  const config: AgentUninstallTaskConfig = {}
+  return createTaskRun(orgId, userId, 'host', hostId, 'agent_uninstall', config, 1, [hostId], [])
 }
 
 // ── Deletion ──────────────────────────────────────────────────────────────────

--- a/apps/web/lib/db/schema/task-runs.ts
+++ b/apps/web/lib/db/schema/task-runs.ts
@@ -4,7 +4,7 @@ import { organisations } from './organisations'
 import { hosts } from './hosts'
 import { users } from './auth'
 
-export type TaskType = 'patch' | 'custom_script' | 'service'
+export type TaskType = 'patch' | 'custom_script' | 'service' | 'agent_uninstall'
 export type TaskRunStatus = 'pending' | 'running' | 'cancelling' | 'cancelled' | 'completed' | 'failed'
 export type TaskRunHostStatus = 'pending' | 'running' | 'cancelling' | 'cancelled' | 'success' | 'failed' | 'skipped'
 
@@ -19,7 +19,9 @@ export interface ServiceTaskConfig {
   service_name: string
   action: 'start' | 'stop' | 'restart' | 'status'
 }
-export type TaskConfig = PatchTaskConfig | CustomScriptTaskConfig | ServiceTaskConfig
+// agent_uninstall carries no parameters today; reserved for future flags.
+export type AgentUninstallTaskConfig = Record<string, never>
+export type TaskConfig = PatchTaskConfig | CustomScriptTaskConfig | ServiceTaskConfig | AgentUninstallTaskConfig
 
 // Result shapes
 export interface PackageUpdate {
@@ -39,7 +41,12 @@ export interface ServiceTaskResult {
   action: string
   is_active: boolean
 }
-export type TaskResult = PatchTaskResult | CustomScriptTaskResult | ServiceTaskResult
+// Agent reports "scheduled" once it has handed off to a detached uninstaller process.
+export interface AgentUninstallTaskResult {
+  status: 'scheduled'
+  note?: string
+}
+export type TaskResult = PatchTaskResult | CustomScriptTaskResult | ServiceTaskResult | AgentUninstallTaskResult
 
 export const taskRuns = pgTable('task_runs', {
   id: text('id').primaryKey().$defaultFn(() => createId()),


### PR DESCRIPTION
## Summary
- Closes #90 — delete dialog offers "Also uninstall agent from the remote host" when the agent is active, disabled with a tooltip/explanation otherwise
- New \`agent_uninstall\` task type plugs into the existing task-dispatch framework (proto/ingest already support arbitrary task types)
- Agent handler returns a \`{"status":"scheduled"}\` result immediately then spawns a detached child running \`infrawatch-agent -uninstall\`, so the service-manager SIGTERM on the original process never interrupts cleanup
- \`uninstallAndDeleteHost\` server action dispatches the task, polls \`task_run_hosts.status\` up to 45 s, then invokes the existing \`deleteHost\` cascade; errors expose \`taskRunId\` / \`agentOffline\` so the dialog can offer a "try without uninstall" fallback
- Fixes a latent FK violation: \`deleteHost\` didn't clean up \`task_run_hosts\` (FK \`no action\`), so any host that had ever run a task could not be deleted — now cleaned up alongside orphan host-targeted \`task_runs\`

## Test plan
- [ ] Delete a host with the box unchecked — behaves exactly like before
- [ ] With an active agent, delete with the box checked — agent uninstalls itself (service stopped, binary/config/data removed, \`/tmp/infrawatch-uninstall.log\` written), host record gone
- [ ] Delete a host that previously ran a patch/script/service task — confirm the new \`task_run_hosts\` cleanup path lets the deletion succeed
- [ ] Offline agent: box is disabled with amber text + tooltip
- [ ] If uninstall task times out (kill agent mid-flight), dialog stays open with the error and hint to retry unchecked
- [ ] Darwin + Linux + Windows cross-compile — all three pass today

🤖 Generated with [Claude Code](https://claude.com/claude-code)