### PR TITLE
fix(agent): escape systemd cgroup when uninstalling remotely

### DIFF
--- a/agent/internal/tasks/uninstall.go
+++ b/agent/internal/tasks/uninstall.go
@@ -43,6 +43,7 @@ func RunUninstall(ctx context.Context, configJSON string, progressFn func(chunk 
 	progressFn("Agent uninstall requested.\n")
 	progressFn(fmt.Sprintf("Binary: %s\n", binPath))
 	progressFn("Spawning detached uninstaller process in 3 seconds.\n")
+	progressFn("On systemd hosts the uninstaller is launched as a transient systemd unit (systemd-run) so it survives the agent cgroup being torn down.\n")
 	progressFn("The agent service will stop shortly after; uninstaller output is written to /tmp/infrawatch-uninstall.log on the host.\n")
 
 	// Run the launcher in a goroutine so the result below is shipped first.

--- a/agent/internal/tasks/uninstall_unix.go
+++ b/agent/internal/tasks/uninstall_unix.go
@@ -6,16 +6,61 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"syscall"
 )
 
-// launchDetachedUninstaller spawns the agent binary with -uninstall in a new
-// session so it survives when systemd / launchd terminates the current process.
-// Stdout and stderr are redirected to /tmp/infrawatch-uninstall.log so an
-// operator can see the uninstall outcome after the agent has gone.
+const uninstallLogPath = "/tmp/infrawatch-uninstall.log"
+
+// launchDetachedUninstaller spawns the agent binary with -uninstall so it
+// survives the service manager terminating the current agent process.
+//
+// Linux/systemd requires special handling: the agent runs in a systemd cgroup
+// with the default KillMode=control-group, so `systemctl stop infrawatch-agent`
+// sends SIGTERM to every process in that cgroup — including any children we
+// detach via setsid, because cgroup membership is inherited regardless of
+// session. We therefore hand the uninstall off to `systemd-run` which creates
+// a transient unit in its own cgroup, so it is not affected when the agent's
+// cgroup is torn down. If systemd-run is missing (non-systemd Linux) we fall
+// back to the setsid path, which at least survives ordinary parent death even
+// if it does not survive a systemctl stop.
+//
+// macOS/launchd tracks processes by pid, not cgroup, so a new session (setsid)
+// is sufficient to escape launchd's termination of the agent.
 func launchDetachedUninstaller(binPath string) error {
-	const logPath = "/tmp/infrawatch-uninstall.log"
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if runtime.GOOS == "linux" {
+		if err := launchViaSystemdRun(binPath); err == nil {
+			return nil
+		}
+		// fall through to setsid fallback
+	}
+	return launchViaSetsid(binPath)
+}
+
+// launchViaSystemdRun registers a transient systemd service that runs the
+// uninstaller. --no-block returns once systemd has accepted the job, --collect
+// ensures the unit is garbage-collected after it exits so repeat invocations
+// don't collide. A shell wrapper is used so we can redirect stdout/stderr to
+// the log file (systemd-run doesn't proxy the caller's stdio to the grandchild).
+func launchViaSystemdRun(binPath string) error {
+	cmd := exec.Command(
+		"systemd-run",
+		"--no-block",
+		"--collect",
+		"--description=Infrawatch agent self-uninstall",
+		"/bin/sh", "-c",
+		fmt.Sprintf("exec %s -uninstall >%s 2>&1", binPath, uninstallLogPath),
+	)
+	// Inherit stdio so the (brief) systemd-run output appears in the agent log.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// launchViaSetsid is the non-systemd fallback: start the uninstaller in a new
+// session and return immediately. Sufficient on macOS and non-systemd Linux.
+func launchViaSetsid(binPath string) error {
+	logFile, err := os.OpenFile(uninstallLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		// Logging is best-effort — don't abort the uninstall just because
 		// we can't open a log file (unusual but possible on read-only /tmp).


### PR DESCRIPTION
## Summary
- The remote agent uninstall feature (#171) left the binary in `/usr/local/bin/` and, depending on timing, the service could remain running. Root cause: on Linux/systemd, `Setsid: true` creates a new session but does **not** escape the cgroup. When the uninstaller called `systemctl stop infrawatch-agent`, systemd sent SIGTERM to the entire cgroup — killing the "detached" uninstaller mid-operation, before `os.Remove` was reached.
- Fix: on Linux, launch the uninstaller via `systemd-run --no-block --collect`, which creates a transient systemd unit in its own cgroup, independent of the agent's. The unit survives the agent cgroup being torn down and completes the full uninstall sequence.
- The setsid path is kept as a fallback for non-systemd Linux; it is still correct on macOS (launchd tracks by pid, so a new session does escape).

## Test plan
- [ ] Build agent for linux/darwin/windows (verified locally, all OK).
- [ ] Deploy updated agent to a Linux host, trigger "Delete host + uninstall agent" from the UI.
- [ ] Confirm service is stopped, `/usr/local/bin/infrawatch-agent` is removed, `/etc/systemd/system/infrawatch-agent.service` is gone, and `/tmp/infrawatch-uninstall.log` shows the full sequence.
- [ ] `journalctl` should show a short-lived transient `run-*.service` (or similarly named) that ran the uninstall.
- [ ] Confirm the same flow still works on macOS (fallback setsid path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)