### PR TITLE
fix(agent): alias windows/registry import to avoid conflict with tasks.registry var

### DIFF
--- a/agent/internal/tasks/software_inventory_windows.go
+++ b/agent/internal/tasks/software_inventory_windows.go
@@ -8,7 +8,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"golang.org/x/sys/windows/registry"
+	winreg "golang.org/x/sys/windows/registry"
 )
 
 // collectPackages — Windows implementation: walks both 32- and 64-bit
@@ -28,7 +28,7 @@ func collectWindowsPackages() ([]collectedPackage, error) {
 	var pkgs []collectedPackage
 
 	for _, keyPath := range []string{uninstallKey64, uninstallKey32} {
-		k, err := registry.OpenKey(registry.LOCAL_MACHINE, keyPath, registry.READ)
+		k, err := winreg.OpenKey(winreg.LOCAL_MACHINE, keyPath, winreg.READ)
 		if err != nil {
 			slog.Debug("software_inventory: opening registry key", "path", keyPath, "err", err)
 			continue
@@ -41,7 +41,7 @@ func collectWindowsPackages() ([]collectedPackage, error) {
 		}
 
 		for _, sub := range subkeys {
-			sk, err := registry.OpenKey(k, sub, registry.READ)
+			sk, err := winreg.OpenKey(k, sub, winreg.READ)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
## Summary

- The software-inventory merge introduced `software_inventory_windows.go` which imported `golang.org/x/sys/windows/registry` unaliased
- `runner.go` already declares `var registry = map[string]HandlerFunc{}` at package level in the same `tasks` package
- The Windows compiler sees two `registry` declarations and fails with: `registry already declared through import of package registry`
- Fix: rename the import to `winreg` and update all call sites

## Root cause
The `linux/arm64` job in the Release workflow was cancelled as a strategy consequence of the `windows/amd64` build failing — both are fixed by this single-line import alias change.

## Test plan
- [ ] `GOOS=windows GOARCH=amd64 go build ./...` passes locally (verified ✓)
- [ ] Release workflow `Build windows/amd64` and `Build linux/arm64` jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)