### PR TITLE
fix(reports): use sentinel for "All sources" Select value

### DIFF
--- a/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
@@ -85,8 +85,10 @@ const VERSION_MODE_LABELS: Record<VersionMode, string> = {
   between: 'Between',
 }
 
+const ALL_SOURCES = '__all__'
+
 const SOURCE_OPTIONS = [
-  { value: '', label: 'All sources' },
+  { value: ALL_SOURCES, label: 'All sources' },
   { value: 'dpkg', label: 'dpkg (Debian/Ubuntu)' },
   { value: 'rpm', label: 'rpm (RHEL/Fedora)' },
   { value: 'pacman', label: 'pacman (Arch)' },
@@ -421,8 +423,11 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
               <div className="space-y-1">
                 <Label className="text-xs">Source</Label>
                 <Select
-                  value={sourceFilter}
-                  onValueChange={(v) => { setSourceFilter(v); setPage('1') }}
+                  value={sourceFilter || ALL_SOURCES}
+                  onValueChange={(v) => {
+                    setSourceFilter(v === ALL_SOURCES ? '' : v)
+                    setPage('1')
+                  }}
                 >
                   <SelectTrigger className="h-8 text-sm w-[180px]">
                     <SelectValue />


### PR DESCRIPTION
## Summary
- Radix `<Select.Item>` treats `value=""` as reserved for "no selection / show placeholder" and throws at render time.
- `SOURCE_OPTIONS[0]` in the software report had `value: ''`, which crashed the page during SSR→hydration (surfaced as React error #418 and a Chrome "This page couldn't load").
- Introduce an `ALL_SOURCES = '__all__'` sentinel and translate to/from empty string at the `Select`/`nuqs` boundary so the server-action filter contract (`source: sourceFilter || undefined`) is unchanged.

## Test plan
- [ ] Navigate to `/reports/software` — page renders without hydration error
- [ ] Source filter defaults to "All sources"; selecting a specific source (e.g. `dpkg`) updates the URL `?src=dpkg` and filters results
- [ ] Choosing "All sources" again clears `?src=` from the URL
- [ ] No `<Select.Item />` console errors in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)