### PR TITLE
fix(monitoring): eliminate false 100% CPU spikes and fix alert double-evaluation

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -48,6 +48,13 @@ type Runner struct {
 	prevCPUIdle    uint64
 	prevCPUSampled bool
 
+	// cachedMetrics holds the most recently collected system metrics.
+	// It is updated only on regular ticker fires and the initial startup
+	// heartbeat. Immediate heartbeats triggered by resultsReady reuse these
+	// values so that the CPU delta is always measured over a full tick interval
+	// rather than a near-zero window that would inflate the reading to 100%.
+	cachedMetrics hostMetricsSnapshot
+
 	// Buffered ad-hoc query results, drained on each heartbeat send.
 	queryResultsMu sync.Mutex
 	queryResults   []*agentv1.AgentQueryResult
@@ -184,7 +191,8 @@ func (r *Runner) runStream(ctx context.Context) error {
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
 
-	// Send first heartbeat immediately
+	// Collect metrics and send first heartbeat immediately.
+	r.refreshMetrics()
 	if err := r.sendHeartbeat(stream); err != nil {
 		return err
 	}
@@ -200,13 +208,18 @@ func (r *Runner) runStream(ctx context.Context) error {
 			return err
 
 		case <-ticker.C:
+			// Full metric refresh on every scheduled tick.
+			r.refreshMetrics()
 			if err := r.sendHeartbeat(stream); err != nil {
 				return err
 			}
 
 		case <-r.resultsReady:
-			// A query result is waiting — fire an immediate heartbeat rather
-			// than making the user wait up to 30s for the next tick.
+			// A check/task result is ready — fire an immediate heartbeat to
+			// deliver it without waiting up to 30s for the next tick.
+			// Do NOT refresh metrics here: the CPU delta since the last tick
+			// would be near-zero, inflating the reading towards 100%.
+			// sendHeartbeat reuses the cached values from the last tick.
 			if err := r.sendHeartbeat(stream); err != nil {
 				return err
 			}
@@ -437,22 +450,50 @@ func (r *Runner) drainTaskResults() []*agentv1.AgentTaskResult {
 	return results
 }
 
-func (r *Runner) sendHeartbeat(stream agentv1.IngestService_HeartbeatClient) error {
-	cpu, mem, disk, uptime, osVersion, disks, nets := r.collectMetrics()
+// hostMetricsSnapshot holds a point-in-time snapshot of system metrics.
+type hostMetricsSnapshot struct {
+	cpu       float32
+	memory    float32
+	disk      float32
+	uptime    int64
+	osVersion string
+	disks     []*agentv1.DiskInfo
+	nets      []*agentv1.NetworkInterface
+}
 
+// refreshMetrics collects fresh system metrics and stores them in the cache.
+// Call this only on regular ticker fires (and the initial startup heartbeat) so
+// that the CPU delta is always measured over a full tick interval. Immediate
+// heartbeats triggered by resultsReady must NOT call this — they must reuse the
+// cached values to avoid inflating CPU% to ~100% from a near-zero delta window.
+func (r *Runner) refreshMetrics() {
+	cpu, mem, disk, uptime, osVersion, disks, nets := r.collectMetrics()
+	r.cachedMetrics = hostMetricsSnapshot{
+		cpu:       cpu,
+		memory:    mem,
+		disk:      disk,
+		uptime:    uptime,
+		osVersion: osVersion,
+		disks:     disks,
+		nets:      nets,
+	}
+}
+
+func (r *Runner) sendHeartbeat(stream agentv1.IngestService_HeartbeatClient) error {
+	m := r.cachedMetrics
 	req := &agentv1.HeartbeatRequest{
 		AgentId:           r.agentID,
-		CpuPercent:        cpu,
-		MemoryPercent:     mem,
-		DiskPercent:       disk,
-		UptimeSeconds:     uptime,
+		CpuPercent:        m.cpu,
+		MemoryPercent:     m.memory,
+		DiskPercent:       m.disk,
+		UptimeSeconds:     m.uptime,
 		TimestampUnix:     time.Now().Unix(),
 		AgentVersion:      r.version,
-		OsVersion:         osVersion,
+		OsVersion:         m.osVersion,
 		Os:                runtime.GOOS,
 		Arch:              runtime.GOARCH,
-		Disks:             disks,
-		NetworkInterfaces: nets,
+		Disks:             m.disks,
+		NetworkInterfaces: m.nets,
 		CheckResults:      r.executor.DrainResults(),
 		QueryResults:      r.drainQueryResults(),
 		TaskProgress:      r.drainTaskProgress(),
@@ -501,6 +542,8 @@ func readUptime() int64 {
 
 // readCPUPercent returns the CPU usage percentage using a two-sample delta
 // from /proc/stat. Returns 0 on the first call (stores the baseline sample).
+// This must only be called via refreshMetrics() which is invoked on the regular
+// ticker, ensuring the delta always spans a full tick interval.
 func (r *Runner) readCPUPercent() float32 {
 	data, err := os.ReadFile("/proc/stat")
 	if err != nil {

--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -42,7 +42,9 @@ type WebhookChannelRow struct {
 }
 
 // GetAlertRulesForHost returns all enabled, non-deleted alert rules scoped to the
-// given host OR org-wide (host_id IS NULL).
+// given host OR org-wide (host_id IS NULL, isGlobalDefault = false).
+// Global defaults (is_global_default = true) are excluded — they are cloned as
+// host-specific rules at approval time and must not be double-evaluated.
 func GetAlertRulesForHost(ctx context.Context, pool *pgxpool.Pool, orgID, hostID string) ([]AlertRuleRow, error) {
 	const q = `
 		SELECT id, host_id, organisation_id, name, condition_type, config::text, severity
@@ -50,6 +52,7 @@ func GetAlertRulesForHost(ctx context.Context, pool *pgxpool.Pool, orgID, hostID
 		WHERE organisation_id = $1
 		  AND enabled = true
 		  AND deleted_at IS NULL
+		  AND is_global_default = false
 		  AND (host_id = $2 OR host_id IS NULL)
 	`
 	rows, err := pool.Query(ctx, q, orgID, hostID)

--- a/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/table'
 import {
   getAlertRules,
+  getGlobalAlertDefaults,
   createAlertRule,
   updateAlertRule,
   deleteAlertRule,
@@ -545,6 +546,12 @@ export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
     refetchInterval: 30_000,
   })
 
+  const { data: globalDefaults = [] } = useQuery({
+    queryKey: ['alert-global-defaults', orgId],
+    queryFn: () => getGlobalAlertDefaults(orgId),
+    refetchInterval: 60_000,
+  })
+
   const { data: activeAlerts = [] } = useQuery({
     queryKey: ['alerts', orgId, 'firing', hostId],
     queryFn: () => getAlertInstances(orgId, { status: 'firing', hostId }),
@@ -558,7 +565,6 @@ export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
   })
 
   const hostRules = allRules.filter((r) => r.hostId === hostId)
-  const orgWideRules = allRules.filter((r) => r.hostId === null)
 
   const toggleMutation = useMutation({
     mutationFn: ({ ruleId, enabled }: { ruleId: string; enabled: boolean }) =>
@@ -695,14 +701,27 @@ export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
         </CardContent>
       </Card>
 
-      {/* Org-wide rules (read-only) */}
-      {orgWideRules.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Organisation-wide Rules</CardTitle>
-            <CardDescription>These rules apply to all hosts in your organisation</CardDescription>
-          </CardHeader>
-          <CardContent>
+      {/* Global default rules (read-only) — these also apply to this host */}
+      <Card>
+        <CardHeader>
+          <div>
+            <CardTitle className="text-base">Organisation-wide Default Rules</CardTitle>
+            <CardDescription className="mt-1">
+              These rules apply to <strong>all hosts</strong> in your organisation and are
+              evaluated in addition to the host-specific rules above.{' '}
+              <a href="/settings/alerts" className="underline underline-offset-2">
+                Manage in Settings → Alerts
+              </a>
+              .
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {globalDefaults.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              No organisation-wide default rules configured.
+            </p>
+          ) : (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -710,11 +729,10 @@ export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
                   <TableHead>Condition</TableHead>
                   <TableHead>Severity</TableHead>
                   <TableHead>Enabled</TableHead>
-                  <TableHead>Created</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {orgWideRules.map((rule) => (
+                {globalDefaults.map((rule) => (
                   <TableRow key={rule.id}>
                     <TableCell className="font-medium">{rule.name}</TableCell>
                     <TableCell className="text-sm text-muted-foreground">
@@ -726,16 +744,13 @@ export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
                     <TableCell>
                       <Switch checked={rule.enabled} disabled />
                     </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {formatDistanceToNow(new Date(rule.createdAt), { addSuffix: true })}
-                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
-          </CardContent>
-        </Card>
-      )}
+          )}
+        </CardContent>
+      </Card>
 
       <AddRuleDialog
         orgId={orgId}


### PR DESCRIPTION
## Summary

- **False 100% CPU spikes**: Immediate heartbeats (triggered by check/task result delivery) were calling `collectMetrics()` with a near-zero delta window milliseconds after the previous regular tick. Any system activity in that window inflated the CPU reading to ~100% on otherwise idle hosts. Fixed by introducing `refreshMetrics()` that caches the metric snapshot; only the regular 30-second ticker refreshes the cache — immediate heartbeats reuse it.
- **Alert double-evaluation**: `GetAlertRulesForHost` fetched all rules where `host_id IS NULL`, including `is_global_default = true` templates. When a host is approved these templates are cloned as host-specific rules, but the originals continued firing alongside the clones. Disabling the clones had no effect. Fixed by adding `AND is_global_default = false` to the query.
- **Global defaults invisible in host Alerts tab**: Users couldn't see org-wide default rules from the host page, so had no way to understand why alerts kept firing after disabling all visible rules. Added a read-only "Organisation-wide Default Rules" section that fetches and displays the global defaults with a link to Settings → Alerts.

## Test plan
- [ ] Deploy updated agent; verify CPU chart shows steady low values with no false 100% spikes during check execution
- [ ] Disable all host-specific alert rules; verify no alerts fire from global defaults
- [ ] Navigate to host Alerts tab; verify "Organisation-wide Default Rules" section appears and lists configured defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)