### PR TITLE
fix(inventory): poll for scan completion and show live scan status

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/inventory-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/inventory-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow, format } from 'date-fns'
@@ -60,6 +60,11 @@ export function InventoryTab({ hostId, orgId }: Props) {
   const { data, isLoading, error } = useQuery({
     queryKey: ['host-software-inventory', hostId, showRemoved],
     queryFn: () => getHostSoftwareInventory(orgId, hostId, showRemoved),
+    // Poll every 5 s while a scan is queued or running, stop when it completes.
+    refetchInterval: (query) => {
+      const activeScan = (query.state.data as Awaited<ReturnType<typeof getHostSoftwareInventory>> | undefined)?.activeScan
+      return activeScan ? 5_000 : false
+    },
   })
 
   const triggerMutation = useMutation({
@@ -206,11 +211,20 @@ export function InventoryTab({ hostId, orgId }: Props) {
         </Alert>
       )}
 
-      {/* Trigger success */}
-      {triggerMutation.isSuccess && 'success' in (triggerMutation.data ?? {}) && (
+      {/* Active scan status */}
+      {data?.activeScan === 'pending' && (
         <Alert>
+          <Loader2 className="size-4 animate-spin" />
           <AlertDescription>
-            Scan queued — results will appear after the agent next checks in.
+            Scan queued — waiting for the agent to pick it up…
+          </AlertDescription>
+        </Alert>
+      )}
+      {data?.activeScan === 'running' && (
+        <Alert>
+          <Loader2 className="size-4 animate-spin" />
+          <AlertDescription>
+            Scan in progress — collecting packages…
           </AlertDescription>
         </Alert>
       )}

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -139,6 +139,7 @@ export interface HostSoftwareInventory {
   packages: SoftwarePackage[]
   lastScan: SoftwareScan | null
   settings: SoftwareInventorySettings
+  activeScan: 'pending' | 'running' | null
 }
 
 export async function getHostSoftwareInventory(
@@ -146,7 +147,7 @@ export async function getHostSoftwareInventory(
   hostId: string,
   includeRemoved = false,
 ): Promise<HostSoftwareInventory> {
-  const [packages, scans, settings] = await Promise.all([
+  const [packages, scans, settings, activeTaskRows] = await Promise.all([
     db.query.softwarePackages.findMany({
       where: and(
         eq(softwarePackages.organisationId, orgId),
@@ -165,9 +166,34 @@ export async function getHostSoftwareInventory(
       limit: 1,
     }),
     getSoftwareInventorySettings(orgId),
+    db
+      .select({ status: taskRunHosts.status })
+      .from(taskRunHosts)
+      .innerJoin(
+        taskRuns,
+        and(
+          eq(taskRuns.id, taskRunHosts.taskRunId),
+          eq(taskRuns.taskType, 'software_inventory'),
+          isNull(taskRuns.deletedAt),
+        ),
+      )
+      .where(
+        and(
+          eq(taskRunHosts.hostId, hostId),
+          eq(taskRunHosts.organisationId, orgId),
+          inArray(taskRunHosts.status, ['pending', 'running']),
+          isNull(taskRunHosts.deletedAt),
+        ),
+      )
+      .limit(1),
   ])
 
-  return { packages, lastScan: scans[0] ?? null, settings }
+  const activeRow = activeTaskRows[0]
+  const activeScan = activeRow
+    ? (activeRow.status as 'pending' | 'running')
+    : null
+
+  return { packages, lastScan: scans[0] ?? null, settings, activeScan }
 }
 
 // ── Global report search ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The inventory tab showed "Scan queued" after clicking Rescan but **never auto-refreshed** — results only appeared on a manual page reload
- `getHostSoftwareInventory` now returns `activeScan: 'pending' | 'running' | null` by checking `task_run_hosts` for any in-flight `software_inventory` task
- `refetchInterval` on the query polls every 5 s while a scan is active, stops automatically when it completes
- Replaced the one-shot post-trigger alert with persistent live status banners driven by real task state

## Test plan

- [ ] Click "Rescan now" — banner changes from "Scan queued" to "Scan in progress" as the agent picks it up
- [ ] After the scan completes the banner disappears and the package list updates without a manual reload
- [ ] No banner shown when there is no active scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)