### PR TITLE
fix(inventory): add per-collector logging and ingest scan diagnostics

### DIFF
--- a/agent/internal/tasks/software_inventory_unix.go
+++ b/agent/internal/tasks/software_inventory_unix.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -40,9 +41,16 @@ func collectLinuxPackages(ctx context.Context) ([]collectedPackage, string, erro
 		{"apk", collectApk},
 	} {
 		pkgs, err := c.fn(ctx)
-		if err == nil && len(pkgs) > 0 {
-			return pkgs, c.source, nil
+		if err != nil {
+			slog.Info("software_inventory: collector failed, trying next", "source", c.source, "err", err)
+			continue
 		}
+		if len(pkgs) == 0 {
+			slog.Warn("software_inventory: collector returned 0 packages, trying next", "source", c.source)
+			continue
+		}
+		slog.Info("software_inventory: collector succeeded", "source", c.source, "packages", len(pkgs))
+		return pkgs, c.source, nil
 	}
 	return nil, "other", fmt.Errorf("no supported package manager found (dpkg/rpm/pacman/apk)")
 }

--- a/apps/ingest/internal/handlers/inventory.go
+++ b/apps/ingest/internal/handlers/inventory.go
@@ -76,6 +76,8 @@ func (h *InventoryHandler) SubmitSoftwareInventory(stream agentv1.IngestService_
 		return status.Error(codes.Internal, "internal error")
 	}
 
+	slog.Info("inventory: scan started", "scan_id", scanID, "agent_id", agentID, "host_id", hostOrg.HostID, "source", source)
+
 	// ── Create software_scans row ─────────────────────────────────────────────
 	startedAt := time.Now()
 	softwareScanID, err := queries.InsertSoftwareScan(ctx, h.pool, hostOrg.OrgID, hostOrg.HostID, scanID, source, startedAt)


### PR DESCRIPTION
## Summary

- Agent now logs each package collector's outcome at `INFO`/`WARN` level so the exact failure mode (RPM error, 0 packages, etc.) is visible in the systemd journal on AlmaLinux 9
- Ingest handler logs a `scan started` line when `SubmitSoftwareInventory` is accepted, confirming the stream reached the server

## Why

AlmaLinux 9 shows tasks completing with exit_code=0 but no software packages appearing in the database. The root cause is obscured because the old `collectLinuxPackages` silently skipped failing collectors with no log output. These diagnostic logs let us pinpoint whether `rpm` is failing (SELinux? permission?) or returning 0 packages.

## Test plan

- [ ] Trigger a software scan on AlmaLinux 9 after deploying the new agent binary
- [ ] Check `journalctl -u infrawatch-agent` — should see either "collector succeeded" or "collector failed, trying next" with the error reason
- [ ] Check ingest logs — should see "inventory: scan started" confirming the stream arrived

🤖 Generated with [Claude Code](https://claude.com/claude-code)