### PR TITLE
fix(inventory): accept expired JWT tokens in inventory stream handler

### DIFF
--- a/apps/ingest/internal/handlers/inventory.go
+++ b/apps/ingest/internal/handlers/inventory.go
@@ -232,9 +232,12 @@ func (h *InventoryHandler) authenticateStream(stream agentv1.IngestService_Submi
 	if len(token) > 7 && strings.EqualFold(token[:7], "bearer ") {
 		token = token[7:]
 	}
-	agentID, _, err := h.issuer.ValidateAgentToken(token)
+	// Accept expired tokens (same as terminal/heartbeat handlers) — the agent
+	// may have a token that hasn't been refreshed yet but is otherwise valid.
+	// The RSA signature is still verified; only the expiry check is relaxed.
+	agentID, _, err := h.issuer.ValidateAgentTokenAllowExpired(token)
 	if err != nil {
-		return "", status.Error(codes.Unauthenticated, "invalid or expired token")
+		return "", status.Error(codes.Unauthenticated, "invalid token")
 	}
 	return agentID, nil
 }


### PR DESCRIPTION
## Summary

- The inventory gRPC stream handler was using `ValidateAgentToken` which strictly rejects expired JWTs
- This caused `stream.CloseAndRecv()` to fail with `Unauthenticated` **after** the agent had already successfully sent all package chunks — making the scan appear to work from the agent's perspective but fail silently on the server
- The heartbeat handler already uses `ValidateAgentTokenAllowExpired` to handle this case; this PR applies the same approach to the inventory stream handler
- The RSA signature is still fully verified — only the expiry check is relaxed

## Root cause

Agents with JWTs older than 24 hours (the token TTL) would successfully stream packages but get rejected on `CloseAndRecv()`. The heartbeat's JWT fallback masked the expiry for heartbeating, but the inventory handler had no such fallback, causing software inventory to fail silently on hosts that hadn't re-registered recently.

## Test plan

- [ ] Trigger a software inventory scan on a host whose agent JWT is expired — verify packages are stored successfully
- [ ] Verify that completely invalid tokens (bad signature) are still rejected with `Unauthenticated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)