### PR TITLE
fix(agents): delete notifications before alert_instances when deleting host

### DIFF
--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -13,6 +13,7 @@ import {
   alertRules,
   alertInstances,
   alertSilences,
+  notifications,
   certificates,
   certificateEvents,
   serviceAccounts,
@@ -649,7 +650,20 @@ export async function deleteHost(
         .delete(checks)
         .where(and(eq(checks.hostId, hostId), eq(checks.organisationId, orgId)))
 
-      // 7. Alert instances
+      // 7a. Notifications referencing this host's alert instances (FK constraint)
+      await tx
+        .delete(notifications)
+        .where(and(
+          inArray(
+            notifications.alertInstanceId,
+            tx
+              .select({ id: alertInstances.id })
+              .from(alertInstances)
+              .where(and(eq(alertInstances.hostId, hostId), eq(alertInstances.organisationId, orgId))),
+          ),
+        ))
+
+      // 7b. Alert instances
       await tx
         .delete(alertInstances)
         .where(and(eq(alertInstances.hostId, hostId), eq(alertInstances.organisationId, orgId)))


### PR DESCRIPTION
## Summary

- `deleteHost` was deleting `alert_instances` before the `notifications` rows that reference them via `notifications.alert_instance_id`
- This caused a FK constraint violation (`notifications_alert_instance_id_alert_instances_id_fk`) when a host had any alert notifications
- Fix: delete notifications for the host's alert instances first (via subquery), then delete the alert instances

## Test plan

- [ ] Delete a host that has triggered alerts/notifications — verify it succeeds without FK error

🤖 Generated with [Claude Code](https://claude.com/claude-code)