### PR TITLE
fix(agents): complete deleteHost FK cascade for all referencing tables

### DIFF
--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -8,6 +8,7 @@ import {
   agentEnrolmentTokens,
   hosts,
   hostMetrics,
+  hostGroupMembers,
   checks,
   checkResults,
   alertRules,
@@ -23,6 +24,9 @@ import {
   resourceTags,
   taskRuns,
   taskRunHosts,
+  terminalSessions,
+  softwarePackages,
+  softwareScans,
 } from '@/lib/db/schema'
 import { eq, and, isNull, gt, gte, lte, asc, sql, inArray } from 'drizzle-orm'
 import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
@@ -715,7 +719,25 @@ export async function deleteHost(
           eq(taskRuns.targetId, hostId),
         ))
 
-      // 14. Host itself
+      // 14a. Terminal sessions (FK to hosts)
+      await tx
+        .delete(terminalSessions)
+        .where(and(eq(terminalSessions.hostId, hostId), eq(terminalSessions.organisationId, orgId)))
+
+      // 14b. Software scans + packages (FK to hosts)
+      await tx
+        .delete(softwarePackages)
+        .where(and(eq(softwarePackages.hostId, hostId), eq(softwarePackages.organisationId, orgId)))
+      await tx
+        .delete(softwareScans)
+        .where(and(eq(softwareScans.hostId, hostId), eq(softwareScans.organisationId, orgId)))
+
+      // 14c. Host group memberships (FK to hosts)
+      await tx
+        .delete(hostGroupMembers)
+        .where(eq(hostGroupMembers.hostId, hostId))
+
+      // 15. Host itself
       await tx
         .delete(hosts)
         .where(and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)))


### PR DESCRIPTION
## Summary

Four tables with foreign keys to `hosts.id` were missing from `deleteHost`, causing FK constraint violations when deleting hosts that had data in those tables:

- `host_group_members` → `host_group_members_host_id_hosts_id_fk`
- `terminal_sessions` → `terminal_sessions_host_id_hosts_id_fk`
- `software_packages` → `software_packages_host_id_hosts_id_fk`
- `software_scans` → `software_scans_host_id_hosts_id_fk`

All four are now deleted before the `hosts` row itself within the transaction.

## Test plan

- [ ] Delete a host that is a member of a host group — succeeds
- [ ] Delete a host that has had terminal sessions — succeeds
- [ ] Delete a host that has software inventory data — succeeds
- [ ] Delete a host with none of the above — still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)