### PR TITLE
fix(reports): clickable hostnames and fix CSV/PDF export

### DIFF
--- a/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
+import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useQueryState } from 'nuqs'
 import { formatDistanceToNow } from 'date-fns'
@@ -609,7 +610,12 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                       {displayedRows.map((row) => (
                         <TableRow key={`${row.hostId}:${row.version}:${row.architecture ?? ''}`}>
                           <TableCell className="font-medium text-sm">
-                            {row.displayName ?? row.hostname}
+                            <Link
+                              href={`/hosts/${row.hostId}`}
+                              className="text-primary hover:underline"
+                            >
+                              {row.displayName ?? row.hostname}
+                            </Link>
                           </TableCell>
                           <TableCell className="text-sm text-muted-foreground">
                             {row.osVersion ?? row.os ?? '—'}

--- a/apps/web/app/api/reports/software/export/route.ts
+++ b/apps/web/app/api/reports/software/export/route.ts
@@ -81,15 +81,15 @@ export async function GET(req: NextRequest) {
   // Parse + validate query params
   const sp = req.nextUrl.searchParams
   const rawParams = {
-    format: sp.get('format'),
-    name: sp.get('name'),
-    vm: sp.get('vm'),
-    ve: sp.get('ve'),
-    vp: sp.get('vp'),
-    vl: sp.get('vl'),
-    vh: sp.get('vh'),
-    of: sp.get('of'),
-    hostId: sp.get('hostId'),
+    format: sp.get('format') ?? undefined,
+    name: sp.get('name') ?? undefined,
+    vm: sp.get('vm') ?? undefined,
+    ve: sp.get('ve') ?? undefined,
+    vp: sp.get('vp') ?? undefined,
+    vl: sp.get('vl') ?? undefined,
+    vh: sp.get('vh') ?? undefined,
+    of: sp.get('of') ?? undefined,
+    hostId: sp.get('hostId') ?? undefined,
   }
 
   const parsed = filterSchema.safeParse(rawParams)


### PR DESCRIPTION
## Summary

- Host names in the software report results table are now clickable links that navigate to `/hosts/:id`
- Fixed the CSV and PDF export buttons returning `{"error":"Invalid parameters"}` — `URLSearchParams.get()` returns `null` for absent params but Zod's `.optional()` only accepts `undefined`; added `?? undefined` coercion on each param

## Test plan

- [ ] In the Installed Software report, search for a package — confirm hostnames in the results table are underlined/clickable and navigate to the correct host detail page
- [ ] Click the CSV export button — confirm a `.csv` file downloads successfully
- [ ] Click the PDF export button — confirm a `.pdf` file downloads successfully
- [ ] Apply filters (package name, version mode, OS) and confirm exports still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)