### PR TITLE
feat(reports): first-seen column, OS/version charts, and fix export data

### DIFF
--- a/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
@@ -2,6 +2,15 @@
 
 import { useState, useMemo } from 'react'
 import Link from 'next/link'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useQueryState } from 'nuqs'
 import { formatDistanceToNow } from 'date-fns'
@@ -79,7 +88,7 @@ interface Props {
 
 type ActiveView = 'search' | 'new-packages' | 'drift'
 
-type SortKey = 'host' | 'os' | 'version' | 'source' | 'architecture' | 'lastSeen'
+type SortKey = 'host' | 'os' | 'version' | 'source' | 'architecture' | 'firstSeen' | 'lastSeen'
 type SortDir = 'asc' | 'desc'
 
 const VERSION_MODE_LABELS: Record<VersionMode, string> = {
@@ -133,8 +142,8 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
     } else {
       setSortKey(key)
-      // Version and lastSeen feel more natural starting desc; others asc.
-      setSortDir(key === 'version' || key === 'lastSeen' ? 'desc' : 'asc')
+      // Version and date columns feel more natural starting desc; others asc.
+      setSortDir(key === 'version' || key === 'lastSeen' || key === 'firstSeen' ? 'desc' : 'asc')
     }
   }
 
@@ -293,6 +302,10 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
             (a.architecture ?? '').toLowerCase(),
             (b.architecture ?? '').toLowerCase(),
           )
+        case 'firstSeen':
+          return (
+            (new Date(a.firstSeenAt).getTime() - new Date(b.firstSeenAt).getTime()) * dirMul
+          )
         case 'lastSeen':
           return (
             (new Date(a.lastSeenAt).getTime() - new Date(b.lastSeenAt).getTime()) * dirMul
@@ -309,6 +322,31 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
     sortKey,
     sortDir,
   ])
+
+  // Chart data derived from the filtered/sorted rows
+  const osChartData = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const row of displayedRows) {
+      const label = row.os ?? 'Unknown'
+      counts.set(label, (counts.get(label) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count)
+  }, [displayedRows])
+
+  const versionChartData = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const row of displayedRows) {
+      counts.set(row.version, (counts.get(row.version) ?? 0) + 1)
+    }
+    return [...counts.entries()]
+      .map(([version, count]) => ({ version, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 15)
+  }, [displayedRows])
+
+  const CHART_COLORS = ['#6366f1', '#8b5cf6', '#ec4899', '#f59e0b', '#10b981', '#3b82f6', '#14b8a6', '#f97316', '#a855f7', '#84cc16']
 
   return (
     <div className="space-y-6 max-w-5xl">
@@ -588,6 +626,60 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                 </div>
               </div>
 
+              {/* Distribution charts — shown when results are available */}
+              {!detailsLoading && displayedRows.length > 0 && (
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="rounded-md border p-4">
+                    <p className="text-xs font-medium text-muted-foreground mb-3">OS distribution</p>
+                    <ResponsiveContainer width="100%" height={Math.max(80, osChartData.length * 36)}>
+                      <BarChart
+                        data={osChartData}
+                        layout="vertical"
+                        margin={{ top: 0, right: 24, left: 0, bottom: 0 }}
+                      >
+                        <XAxis type="number" hide />
+                        <YAxis
+                          type="category"
+                          dataKey="name"
+                          width={80}
+                          tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                        />
+                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <Bar dataKey="count" radius={[0, 3, 3, 0]}>
+                          {osChartData.map((_, i) => (
+                            <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <div className="rounded-md border p-4">
+                    <p className="text-xs font-medium text-muted-foreground mb-3">Version distribution</p>
+                    <ResponsiveContainer width="100%" height={Math.max(80, versionChartData.length * 36)}>
+                      <BarChart
+                        data={versionChartData}
+                        layout="vertical"
+                        margin={{ top: 0, right: 24, left: 0, bottom: 0 }}
+                      >
+                        <XAxis type="number" hide />
+                        <YAxis
+                          type="category"
+                          dataKey="version"
+                          width={160}
+                          tick={{ fontSize: 10, fontFamily: 'monospace', fill: 'hsl(var(--muted-foreground))' }}
+                        />
+                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <Bar dataKey="count" radius={[0, 3, 3, 0]}>
+                          {versionChartData.map((_, i) => (
+                            <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+              )}
+
               {detailsLoading ? (
                 <div className="flex items-center gap-2 text-muted-foreground py-8 justify-center">
                   <Loader2 className="size-4 animate-spin" />
@@ -603,6 +695,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                         <SortableTh label="Version" sortKey="version" currentKey={sortKey} dir={sortDir} onClick={toggleSort} />
                         <SortableTh label="Source" sortKey="source" currentKey={sortKey} dir={sortDir} onClick={toggleSort} />
                         <SortableTh label="Architecture" sortKey="architecture" currentKey={sortKey} dir={sortDir} onClick={toggleSort} />
+                        <SortableTh label="First seen" sortKey="firstSeen" currentKey={sortKey} dir={sortDir} onClick={toggleSort} />
                         <SortableTh label="Last seen" sortKey="lastSeen" currentKey={sortKey} dir={sortDir} onClick={toggleSort} />
                       </TableRow>
                     </TableHeader>
@@ -630,6 +723,9 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                           </TableCell>
                           <TableCell className="text-xs text-muted-foreground">
                             {row.architecture ?? '—'}
+                          </TableCell>
+                          <TableCell className="text-xs text-muted-foreground">
+                            {formatDistanceToNow(new Date(row.firstSeenAt), { addSuffix: true })}
                           </TableCell>
                           <TableCell className="text-xs text-muted-foreground">
                             {formatDistanceToNow(new Date(row.lastSeenAt), { addSuffix: true })}

--- a/apps/web/app/api/reports/software/export/route.ts
+++ b/apps/web/app/api/reports/software/export/route.ts
@@ -3,13 +3,11 @@ import { z } from 'zod'
 import { renderToBuffer, type DocumentProps } from '@react-pdf/renderer'
 import { createElement, type ReactElement } from 'react'
 import { getRequiredSession } from '@/lib/auth/session'
-import { getSoftwareReport } from '@/lib/actions/software-inventory'
 import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
-import { escapeLikePattern } from '@/lib/utils'
+import { organisations, softwarePackages, hosts } from '@/lib/db/schema'
+import { eq, and, isNull, ilike } from 'drizzle-orm'
 import { SoftwareReportPDF } from '@/lib/pdf/software-report'
-import type { SoftwareReportFilters, VersionMode } from '@/lib/actions/software-inventory'
+import { compareVersions } from '@/lib/version-compare'
 
 /**
  * Simple in-memory per-user rate limiter.
@@ -36,13 +34,12 @@ const filterSchema = z.object({
   vl: z.string().max(100).optional(),
   vh: z.string().max(100).optional(),
   of: z.string().max(20).optional(),
-  hostId: z.string().max(50).optional(), // single-host CSV from the inventory tab
+  hostId: z.string().max(50).optional(),
 })
 
 /** Escape a CSV cell value. Prefixes formula-injection chars with a literal '. */
 function escapeCsvCell(value: string | number | null | undefined): string {
   const str = String(value ?? '')
-  // Guard against CSV injection
   if (/^[=+\-@\t\r\n]/.test(str)) {
     return `"'${str.replace(/"/g, '""')}"`
   }
@@ -97,43 +94,80 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 })
   }
 
-  const { format, name, vm, ve, vp, vl, vh, of: osFamily, hostId } = parsed.data
+  const { format, name, vm, ve, vp, vl, vh, of: osFamily } = parsed.data
 
-  const filters: SoftwareReportFilters = {
-    name: name || undefined,
-    versionMode: (vm ?? 'any') as VersionMode,
-    versionExact: ve || undefined,
-    versionPrefix: vp || undefined,
-    versionLow: vl || undefined,
-    versionHigh: vh || undefined,
-    osFamily: osFamily || undefined,
-    page: 1,
-    pageSize: 250_000, // hard cap enforced below
-  }
+  // ── Fetch per-host rows (exact name match — same as the UI table) ─────────────
+  const whereConditions = and(
+    eq(softwarePackages.organisationId, orgId),
+    name ? eq(softwarePackages.name, name) : undefined,
+    isNull(softwarePackages.removedAt),
+    isNull(softwarePackages.deletedAt),
+    isNull(hosts.deletedAt),
+    osFamily ? ilike(hosts.os, `%${osFamily}%`) : undefined,
+  )
 
-  // Run report
-  const report = await getSoftwareReport(orgId, filters)
+  let rows = await db
+    .select({
+      name: softwarePackages.name,
+      version: softwarePackages.version,
+      source: softwarePackages.source,
+      architecture: softwarePackages.architecture,
+      firstSeenAt: softwarePackages.firstSeenAt,
+      lastSeenAt: softwarePackages.lastSeenAt,
+      hostname: hosts.hostname,
+      displayName: hosts.displayName,
+      os: hosts.os,
+      osVersion: hosts.osVersion,
+    })
+    .from(softwarePackages)
+    .innerJoin(hosts, eq(hosts.id, softwarePackages.hostId))
+    .where(whereConditions)
+    .orderBy(softwarePackages.name, softwarePackages.version, hosts.hostname)
+    .limit(250_001)
 
-  // Enforce row cap
-  if (report.total > 250_000) {
+  if (rows.length > 250_000) {
     return NextResponse.json(
-      {
-        error: `Result set too large (${report.total.toLocaleString()} rows). Narrow your filters and try again.`,
-      },
+      { error: 'Result set too large (>250,000 rows). Narrow your filters and try again.' },
       { status: 413 },
     )
   }
 
+  // Apply version filtering server-side (mirrors client-side logic)
+  const versionMode = vm ?? 'any'
+  if (versionMode !== 'any') {
+    if (versionMode === 'exact' && ve) {
+      rows = rows.filter((r) => r.version === ve)
+    } else if (versionMode === 'prefix' && vp) {
+      rows = rows.filter((r) => r.version.startsWith(vp))
+    } else if (versionMode === 'between' && vl && vh) {
+      rows = rows.filter((r) => {
+        const cmpLow = compareVersions(r.version, vl)
+        const cmpHigh = compareVersions(r.version, vh)
+        return cmpLow >= 0 && cmpHigh <= 0
+      })
+    }
+  }
+
   const generatedAt = new Date()
+  const packageName = name ?? 'All packages'
 
   // ── CSV ──────────────────────────────────────────────────────────────────────
   if (format === 'csv') {
     const lines: string[] = [
-      rowToCsv(['Package', 'Version', 'Hosts', 'Sources', 'Host names']),
+      rowToCsv(['Package', 'Host', 'OS', 'Version', 'Source', 'Architecture', 'First seen', 'Last seen']),
     ]
-    for (const row of report.rows) {
+    for (const row of rows) {
       lines.push(
-        rowToCsv([row.name, row.version, row.hostCount, row.sources.join('; '), row.hostNames.join('; ')]),
+        rowToCsv([
+          row.name,
+          row.displayName ?? row.hostname,
+          row.osVersion ?? row.os ?? '',
+          row.version,
+          row.source,
+          row.architecture ?? '',
+          row.firstSeenAt.toISOString().slice(0, 10),
+          row.lastSeenAt.toISOString().slice(0, 10),
+        ]),
       )
     }
     const csv = lines.join('\r\n')
@@ -156,15 +190,13 @@ export async function GET(req: NextRequest) {
 
   const pdfElement = createElement(SoftwareReportPDF, {
     orgName,
-    filters,
-    rows: report.rows,
-    total: report.total,
-    uniquePackages: report.uniquePackages,
-    hostsWithData: report.hostsWithData,
+    packageName,
+    versionFilter: vm && vm !== 'any' ? { mode: vm, exact: ve, prefix: vp, low: vl, high: vh } : undefined,
+    osFamily,
+    rows,
     generatedAt,
   }) as ReactElement<DocumentProps>
   const pdfBuffer = await renderToBuffer(pdfElement)
-  // renderToBuffer returns a Node.js Buffer; NextResponse accepts Uint8Array.
   const pdfBytes = new Uint8Array(pdfBuffer as unknown as ArrayBuffer)
 
   const filename = `software-report-${generatedAt.toISOString().slice(0, 10)}.pdf`

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -550,6 +550,7 @@ export interface PackageHostInfo {
   source: string
   architecture: string | null
   version: string
+  firstSeenAt: Date
   lastSeenAt: Date
 }
 
@@ -575,6 +576,7 @@ export async function getPackageDetails(
       version: softwarePackages.version,
       source: softwarePackages.source,
       architecture: softwarePackages.architecture,
+      firstSeenAt: softwarePackages.firstSeenAt,
       lastSeenAt: softwarePackages.lastSeenAt,
       hostname: hosts.hostname,
       displayName: hosts.displayName,
@@ -614,6 +616,7 @@ export async function getPackageDetails(
       source: pkg.source,
       architecture: pkg.architecture,
       version: pkg.version,
+      firstSeenAt: pkg.firstSeenAt,
       lastSeenAt: pkg.lastSeenAt,
     }
     const existing = versionMap.get(pkg.version)

--- a/apps/web/lib/pdf/software-report.tsx
+++ b/apps/web/lib/pdf/software-report.tsx
@@ -4,37 +4,35 @@ import {
   Text,
   View,
   StyleSheet,
-  Font,
 } from '@react-pdf/renderer'
-import type { SoftwareReportRow, SoftwareReportFilters } from '@/lib/actions/software-inventory'
 
 const styles = StyleSheet.create({
   page: {
     fontFamily: 'Helvetica',
     fontSize: 9,
-    padding: 36,
+    padding: 32,
     color: '#111827',
   },
   header: {
-    marginBottom: 20,
+    marginBottom: 16,
     borderBottomWidth: 1,
     borderBottomColor: '#e5e7eb',
-    paddingBottom: 12,
+    paddingBottom: 10,
   },
   title: {
-    fontSize: 18,
+    fontSize: 16,
     fontFamily: 'Helvetica-Bold',
     color: '#111827',
-    marginBottom: 4,
+    marginBottom: 3,
   },
   subtitle: {
-    fontSize: 10,
+    fontSize: 9,
     color: '#6b7280',
   },
   metaRow: {
     flexDirection: 'row',
-    gap: 24,
-    marginTop: 8,
+    gap: 20,
+    marginTop: 6,
   },
   metaItem: {
     fontSize: 8,
@@ -48,86 +46,35 @@ const styles = StyleSheet.create({
     backgroundColor: '#f9fafb',
     borderWidth: 1,
     borderColor: '#e5e7eb',
-    borderRadius: 4,
-    padding: 8,
-    marginBottom: 16,
+    borderRadius: 3,
+    padding: 7,
+    marginBottom: 14,
   },
   filterTitle: {
     fontSize: 8,
     fontFamily: 'Helvetica-Bold',
     color: '#374151',
-    marginBottom: 4,
+    marginBottom: 3,
   },
   filterText: {
     fontSize: 8,
     color: '#6b7280',
   },
-  table: {
-    width: '100%',
-  },
-  tableHeader: {
-    flexDirection: 'row',
-    backgroundColor: '#f3f4f6',
-    paddingVertical: 5,
-    paddingHorizontal: 6,
-    borderBottomWidth: 1,
-    borderBottomColor: '#d1d5db',
-  },
-  tableRow: {
-    flexDirection: 'row',
-    paddingVertical: 4,
-    paddingHorizontal: 6,
-    borderBottomWidth: 1,
-    borderBottomColor: '#f3f4f6',
-  },
-  colName: { flex: 3, fontFamily: 'Helvetica-Bold' },
-  colVersion: { flex: 2 },
-  colHosts: { flex: 1, textAlign: 'right' },
-  colSources: { flex: 1.5 },
-  colHostList: { flex: 4 },
-  thText: {
-    fontSize: 8,
-    fontFamily: 'Helvetica-Bold',
-    color: '#374151',
-  },
-  tdText: {
-    fontSize: 8,
-    color: '#374151',
-  },
-  monoText: {
-    fontFamily: 'Courier',
-    fontSize: 8,
-  },
-  footer: {
-    position: 'absolute',
-    bottom: 24,
-    left: 36,
-    right: 36,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    borderTopWidth: 1,
-    borderTopColor: '#e5e7eb',
-    paddingTop: 6,
-  },
-  footerText: {
-    fontSize: 7,
-    color: '#9ca3af',
-  },
   summaryRow: {
     flexDirection: 'row',
-    gap: 16,
-    marginBottom: 16,
+    gap: 12,
+    marginBottom: 14,
   },
   summaryCard: {
     flex: 1,
     borderWidth: 1,
     borderColor: '#e5e7eb',
-    borderRadius: 4,
-    padding: 8,
+    borderRadius: 3,
+    padding: 7,
     alignItems: 'center',
   },
   summaryNumber: {
-    fontSize: 16,
+    fontSize: 14,
     fontFamily: 'Helvetica-Bold',
     color: '#111827',
   },
@@ -136,43 +83,122 @@ const styles = StyleSheet.create({
     color: '#6b7280',
     marginTop: 2,
   },
+  table: {
+    width: '100%',
+  },
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: '#f3f4f6',
+    paddingVertical: 4,
+    paddingHorizontal: 5,
+    borderBottomWidth: 1,
+    borderBottomColor: '#d1d5db',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    paddingVertical: 3,
+    paddingHorizontal: 5,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f3f4f6',
+  },
+  thText: {
+    fontSize: 7,
+    fontFamily: 'Helvetica-Bold',
+    color: '#374151',
+  },
+  tdText: {
+    fontSize: 7,
+    color: '#374151',
+  },
+  monoText: {
+    fontFamily: 'Courier',
+    fontSize: 7,
+  },
+  colHost: { flex: 2 },
+  colOs: { flex: 2.5 },
+  colVersion: { flex: 2 },
+  colSource: { flex: 0.8 },
+  colArch: { flex: 1 },
+  colFirstSeen: { flex: 1.2 },
+  colLastSeen: { flex: 1.2 },
+  footer: {
+    position: 'absolute',
+    bottom: 20,
+    left: 32,
+    right: 32,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    borderTopWidth: 1,
+    borderTopColor: '#e5e7eb',
+    paddingTop: 5,
+  },
+  footerText: {
+    fontSize: 7,
+    color: '#9ca3af',
+  },
 })
+
+export interface HostExportRow {
+  name: string
+  hostname: string
+  displayName: string | null
+  os: string | null
+  osVersion: string | null
+  version: string
+  source: string
+  architecture: string | null
+  firstSeenAt: Date
+  lastSeenAt: Date
+}
+
+interface VersionFilter {
+  mode: 'exact' | 'prefix' | 'between'
+  exact?: string
+  prefix?: string
+  low?: string
+  high?: string
+}
 
 interface Props {
   orgName: string
-  filters: SoftwareReportFilters
-  rows: SoftwareReportRow[]
-  total: number
-  uniquePackages: number
-  hostsWithData: number
+  packageName: string
+  versionFilter?: VersionFilter
+  osFamily?: string
+  rows: HostExportRow[]
   generatedAt: Date
 }
 
-function filterSummary(filters: SoftwareReportFilters): string {
+function filterSummary(packageName: string, versionFilter?: VersionFilter, osFamily?: string): string {
   const parts: string[] = []
-  if (filters.name) parts.push(`Package: ${filters.name}`)
-  if (filters.versionMode && filters.versionMode !== 'any') {
-    if (filters.versionMode === 'exact') parts.push(`Version: ${filters.versionExact}`)
-    else if (filters.versionMode === 'prefix') parts.push(`Version starts with: ${filters.versionPrefix}`)
-    else if (filters.versionMode === 'between')
-      parts.push(`Version between: ${filters.versionLow} – ${filters.versionHigh}`)
+  parts.push(`Package: ${packageName}`)
+  if (versionFilter) {
+    if (versionFilter.mode === 'exact' && versionFilter.exact) parts.push(`Version: ${versionFilter.exact}`)
+    else if (versionFilter.mode === 'prefix' && versionFilter.prefix) parts.push(`Version starts with: ${versionFilter.prefix}`)
+    else if (versionFilter.mode === 'between' && versionFilter.low && versionFilter.high)
+      parts.push(`Version between: ${versionFilter.low} – ${versionFilter.high}`)
   }
-  if (filters.source) parts.push(`Source: ${filters.source}`)
-  return parts.length > 0 ? parts.join(' | ') : 'All packages'
+  if (osFamily) parts.push(`OS: ${osFamily}`)
+  return parts.join(' | ')
+}
+
+function fmtDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
 }
 
 export function SoftwareReportPDF({
   orgName,
-  filters,
+  packageName,
+  versionFilter,
+  osFamily,
   rows,
-  total,
-  uniquePackages,
-  hostsWithData,
   generatedAt,
 }: Props) {
+  const uniqueHosts = new Set(rows.map((r) => r.displayName ?? r.hostname)).size
+  const uniqueVersions = new Set(rows.map((r) => r.version)).size
+
   return (
     <Document>
-      <Page size="A4" style={styles.page}>
+      <Page size="A4" orientation="landscape" style={styles.page}>
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.title}>Installed Software Report</Text>
@@ -187,44 +213,45 @@ export function SoftwareReportPDF({
         {/* Summary cards */}
         <View style={styles.summaryRow}>
           <View style={styles.summaryCard}>
-            <Text style={styles.summaryNumber}>{total.toLocaleString()}</Text>
+            <Text style={styles.summaryNumber}>{rows.length.toLocaleString()}</Text>
             <Text style={styles.summaryLabel}>Results</Text>
           </View>
           <View style={styles.summaryCard}>
-            <Text style={styles.summaryNumber}>{uniquePackages.toLocaleString()}</Text>
-            <Text style={styles.summaryLabel}>Unique packages</Text>
+            <Text style={styles.summaryNumber}>{uniqueHosts.toLocaleString()}</Text>
+            <Text style={styles.summaryLabel}>Hosts</Text>
           </View>
           <View style={styles.summaryCard}>
-            <Text style={styles.summaryNumber}>{hostsWithData.toLocaleString()}</Text>
-            <Text style={styles.summaryLabel}>Hosts with data</Text>
+            <Text style={styles.summaryNumber}>{uniqueVersions.toLocaleString()}</Text>
+            <Text style={styles.summaryLabel}>Versions</Text>
           </View>
         </View>
 
         {/* Filters */}
         <View style={styles.filterBox}>
           <Text style={styles.filterTitle}>Applied filters</Text>
-          <Text style={styles.filterText}>{filterSummary(filters)}</Text>
+          <Text style={styles.filterText}>{filterSummary(packageName, versionFilter, osFamily)}</Text>
         </View>
 
         {/* Table */}
         <View style={styles.table}>
           <View style={styles.tableHeader}>
-            <Text style={[styles.thText, styles.colName]}>Package</Text>
+            <Text style={[styles.thText, styles.colHost]}>Host</Text>
+            <Text style={[styles.thText, styles.colOs]}>OS</Text>
             <Text style={[styles.thText, styles.colVersion]}>Version</Text>
-            <Text style={[styles.thText, styles.colHosts]}>Hosts</Text>
-            <Text style={[styles.thText, styles.colSources]}>Source</Text>
-            <Text style={[styles.thText, styles.colHostList]}>Hosts</Text>
+            <Text style={[styles.thText, styles.colSource]}>Source</Text>
+            <Text style={[styles.thText, styles.colArch]}>Architecture</Text>
+            <Text style={[styles.thText, styles.colFirstSeen]}>First seen</Text>
+            <Text style={[styles.thText, styles.colLastSeen]}>Last seen</Text>
           </View>
           {rows.map((row, i) => (
             <View key={i} style={styles.tableRow} wrap={false}>
-              <Text style={[styles.monoText, styles.colName]}>{row.name}</Text>
+              <Text style={[styles.tdText, styles.colHost]}>{row.displayName ?? row.hostname}</Text>
+              <Text style={[styles.tdText, styles.colOs]}>{row.osVersion ?? row.os ?? '—'}</Text>
               <Text style={[styles.monoText, styles.colVersion]}>{row.version}</Text>
-              <Text style={[styles.tdText, styles.colHosts]}>{row.hostCount}</Text>
-              <Text style={[styles.tdText, styles.colSources]}>{row.sources.join(', ')}</Text>
-              <Text style={[styles.tdText, styles.colHostList]}>
-                {row.hostNames.slice(0, 5).join(', ')}
-                {row.hostNames.length > 5 ? ` +${row.hostNames.length - 5} more` : ''}
-              </Text>
+              <Text style={[styles.tdText, styles.colSource]}>{row.source}</Text>
+              <Text style={[styles.tdText, styles.colArch]}>{row.architecture ?? '—'}</Text>
+              <Text style={[styles.tdText, styles.colFirstSeen]}>{fmtDate(row.firstSeenAt)}</Text>
+              <Text style={[styles.tdText, styles.colLastSeen]}>{fmtDate(row.lastSeenAt)}</Text>
             </View>
           ))}
         </View>


### PR DESCRIPTION
## Summary

- **First seen column**: added to the results table (sortable, same position as Last seen)
- **Distribution charts**: two horizontal bar charts appear below the action bar when results are loaded — OS distribution (by OS family) and version distribution (top 15 versions by host count)
- **Export fix**: CSV and PDF now export exactly what the UI table shows — per-host rows with an exact package name match, rather than the old LIKE-search grouped query that was pulling in unrelated packages (e.g. searching `python3` was exporting `libpython3-stdlib`, `python3-libs`, etc.)
- **CSV columns**: Package, Host, OS, Version, Source, Architecture, First seen, Last seen
- **PDF**: landscape layout with the same per-host columns; dates formatted as ISO date strings

## Test plan

- [ ] Search for `python3` — confirm table shows **First seen** column with sortable header
- [ ] Confirm two charts appear: OS distribution and version distribution
- [ ] Click **CSV** — confirm file contains only `python3` rows (not `libpython3-*` etc.) with the new column set
- [ ] Click **PDF** — confirm landscape PDF with per-host rows, correct package name filter summary
- [ ] Apply version filter (e.g. "Starts with 3.12") — confirm charts and exports respect the filter
- [ ] Apply OS type filter — confirm charts and exports respect the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)