### PR TITLE
fix(reports): chart labels visible in dark mode, reduce export rate limit

### DIFF
--- a/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
@@ -629,8 +629,9 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
               {/* Distribution charts — shown when results are available */}
               {!detailsLoading && displayedRows.length > 0 && (
                 <div className="grid grid-cols-2 gap-4">
-                  <div className="rounded-md border p-4">
-                    <p className="text-xs font-medium text-muted-foreground mb-3">OS distribution</p>
+                  {/* text-muted-foreground sets `color` on the div; SVG currentColor inherits it */}
+                  <div className="rounded-md border p-4 text-muted-foreground">
+                    <p className="text-xs font-medium mb-3">OS distribution</p>
                     <ResponsiveContainer width="100%" height={Math.max(80, osChartData.length * 36)}>
                       <BarChart
                         data={osChartData}
@@ -642,9 +643,16 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                           type="category"
                           dataKey="name"
                           width={80}
-                          tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+                          tick={{ fontSize: 11, fill: 'currentColor' }}
                         />
-                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <Tooltip
+                          contentStyle={{
+                            fontSize: 12,
+                            backgroundColor: 'hsl(var(--popover))',
+                            border: '1px solid hsl(var(--border))',
+                            color: 'hsl(var(--popover-foreground))',
+                          }}
+                        />
                         <Bar dataKey="count" radius={[0, 3, 3, 0]}>
                           {osChartData.map((_, i) => (
                             <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
@@ -653,8 +661,8 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                       </BarChart>
                     </ResponsiveContainer>
                   </div>
-                  <div className="rounded-md border p-4">
-                    <p className="text-xs font-medium text-muted-foreground mb-3">Version distribution</p>
+                  <div className="rounded-md border p-4 text-muted-foreground">
+                    <p className="text-xs font-medium mb-3">Version distribution</p>
                     <ResponsiveContainer width="100%" height={Math.max(80, versionChartData.length * 36)}>
                       <BarChart
                         data={versionChartData}
@@ -666,9 +674,16 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                           type="category"
                           dataKey="version"
                           width={160}
-                          tick={{ fontSize: 10, fontFamily: 'monospace', fill: 'hsl(var(--muted-foreground))' }}
+                          tick={{ fontSize: 10, fontFamily: 'monospace', fill: 'currentColor' }}
                         />
-                        <Tooltip contentStyle={{ fontSize: 12 }} />
+                        <Tooltip
+                          contentStyle={{
+                            fontSize: 12,
+                            backgroundColor: 'hsl(var(--popover))',
+                            border: '1px solid hsl(var(--border))',
+                            color: 'hsl(var(--popover-foreground))',
+                          }}
+                        />
                         <Bar dataKey="count" radius={[0, 3, 3, 0]}>
                           {versionChartData.map((_, i) => (
                             <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />

--- a/apps/web/app/api/reports/software/export/route.ts
+++ b/apps/web/app/api/reports/software/export/route.ts
@@ -15,7 +15,7 @@ import { compareVersions } from '@/lib/version-compare'
  * Note: this is per-process; a multi-instance deployment needs Redis.
  */
 const rateLimitMap = new Map<string, number>()
-const RATE_LIMIT_MS = 30_000
+const RATE_LIMIT_MS = 10_000
 
 function checkRateLimit(userId: string): boolean {
   const last = rateLimitMap.get(userId) ?? 0


### PR DESCRIPTION
## Summary

- **Dark mode chart labels**: SVG `fill` attributes cannot resolve CSS custom properties (`hsl(var(--muted-foreground))` was rendering as literal black). Fixed by using `fill: currentColor` on axis tick labels and adding `text-muted-foreground` to the chart wrapper div — SVG inherits `currentColor` from the element's CSS `color` property, which Tailwind sets correctly in both light and dark modes. Tooltip styled with `--popover`/`--border`/`--popover-foreground` CSS variables.
- **Rate limit**: Reduced from 30 seconds to 10 seconds between exports.

## Test plan

- [ ] In dark mode, search for a package — confirm axis labels on both charts are visible (muted foreground colour)
- [ ] Hover a chart bar — confirm tooltip has readable text and dark background in dark mode
- [ ] Download a CSV, then immediately download a PDF — confirm both succeed within 10 seconds of each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)