### PR TITLE
fix(reports): sliding window rate limit (3/10s), errors in modal

### DIFF
--- a/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
@@ -132,6 +132,8 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
   const [saveName, setSaveName] = useState('')
   const [savedReportsOpen, setSavedReportsOpen] = useState(false)
   const [newWindowDays, setNewWindowDays] = useState<7 | 30>(7)
+  const [exportError, setExportError] = useState<string | null>(null)
+  const [exportLoading, setExportLoading] = useState(false)
 
   // Sort state for the unified results table
   const [sortKey, setSortKey] = useState<SortKey>('version')
@@ -241,7 +243,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
     setActiveView('search')
   }
 
-  function handleExport(format: 'csv' | 'pdf') {
+  async function handleExport(format: 'csv' | 'pdf') {
     const params = new URLSearchParams()
     params.set('format', format)
     if (filters.name) params.set('name', filters.name)
@@ -251,7 +253,29 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
     if (filters.versionLow) params.set('vl', filters.versionLow)
     if (filters.versionHigh) params.set('vh', filters.versionHigh)
     if (filters.osFamily) params.set('of', filters.osFamily)
-    window.open(`/api/reports/software/export?${params.toString()}`, '_blank')
+
+    setExportLoading(true)
+    try {
+      const res = await fetch(`/api/reports/software/export?${params.toString()}`)
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setExportError((data as { error?: string }).error ?? 'Export failed. Please try again.')
+        return
+      }
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      const disposition = res.headers.get('Content-Disposition') ?? ''
+      const match = disposition.match(/filename="(.+?)"/)
+      a.download = match?.[1] ?? `software-report.${format}`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      setExportError('Export failed due to a network error. Please try again.')
+    } finally {
+      setExportLoading(false)
+    }
   }
 
 // Client-side version filtering + flattening + sorting of package detail rows
@@ -615,12 +639,12 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                     <Save className="size-3.5 mr-1.5" />
                     Save filters
                   </Button>
-                  <Button variant="outline" size="sm" onClick={() => handleExport('csv')}>
-                    <Download className="size-3.5 mr-1.5" />
+                  <Button variant="outline" size="sm" onClick={() => handleExport('csv')} disabled={exportLoading}>
+                    {exportLoading ? <Loader2 className="size-3.5 mr-1.5 animate-spin" /> : <Download className="size-3.5 mr-1.5" />}
                     CSV
                   </Button>
-                  <Button variant="outline" size="sm" onClick={() => handleExport('pdf')}>
-                    <Download className="size-3.5 mr-1.5" />
+                  <Button variant="outline" size="sm" onClick={() => handleExport('pdf')} disabled={exportLoading}>
+                    {exportLoading ? <Loader2 className="size-3.5 mr-1.5 animate-spin" /> : <Download className="size-3.5 mr-1.5" />}
                     PDF
                   </Button>
                 </div>
@@ -884,6 +908,19 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
           )}
         </div>
       )}
+
+      {/* Export error dialog */}
+      <Dialog open={!!exportError} onOpenChange={() => setExportError(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Export failed</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">{exportError}</p>
+          <DialogFooter>
+            <Button onClick={() => setExportError(null)}>OK</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Save report dialog */}
       <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>

--- a/apps/web/app/api/reports/software/export/route.ts
+++ b/apps/web/app/api/reports/software/export/route.ts
@@ -11,17 +11,20 @@ import { compareVersions } from '@/lib/version-compare'
 
 /**
  * Simple in-memory per-user rate limiter.
- * One export per user per 30 seconds.
+ * Allows up to 3 exports per user per 10 seconds (sliding window).
  * Note: this is per-process; a multi-instance deployment needs Redis.
  */
-const rateLimitMap = new Map<string, number>()
-const RATE_LIMIT_MS = 10_000
+const rateLimitMap = new Map<string, number[]>()
+const RATE_LIMIT_WINDOW_MS = 10_000
+const RATE_LIMIT_MAX = 3
 
 function checkRateLimit(userId: string): boolean {
-  const last = rateLimitMap.get(userId) ?? 0
   const now = Date.now()
-  if (now - last < RATE_LIMIT_MS) return false
-  rateLimitMap.set(userId, now)
+  const timestamps = rateLimitMap.get(userId) ?? []
+  const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS)
+  if (recent.length >= RATE_LIMIT_MAX) return false
+  recent.push(now)
+  rateLimitMap.set(userId, recent)
   return true
 }
 
@@ -70,7 +73,7 @@ export async function GET(req: NextRequest) {
   // Rate limit
   if (!checkRateLimit(session.user.id)) {
     return NextResponse.json(
-      { error: 'Rate limited — please wait 30 seconds between exports.' },
+      { error: 'Rate limited — you can export up to 3 times per 10 seconds. Please wait a moment and try again.' },
       { status: 429 },
     )
   }


### PR DESCRIPTION
## Summary

- **Rate limit**: changed to a sliding window allowing 3 exports per 10 seconds per user (was 1 per 10 s). Error message updated to reflect actual limit.
- **Error display**: replaced `window.open()` with `fetch()` + blob download. Error responses (rate limit, oversized results, etc.) are now caught and shown in a `Dialog` modal instead of displaying raw JSON in a new browser tab.
- **UX**: export buttons disable and show a spinner while a download is in progress.

## Test plan

- [ ] Download CSV then PDF in quick succession — both should succeed (3 allowed per 10 s)
- [ ] Hit the rate limit (4 downloads in <10 s) — confirm a modal appears with a readable error message, no new tab opens
- [ ] Dismiss the modal with OK — confirm it closes cleanly
- [ ] Normal export still downloads the file to disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)