### PR TITLE
fix(docs): pin pnpm version in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: '10.6.5'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Fixes the `Deploy Docs` GitHub Actions workflow which failed on first run
- `pnpm/action-setup@v4` errors when `version: latest` is specified alongside a `packageManager` field in `package.json`
- Pin to `10.6.5` to match the other CI workflows in this repo

## Root cause

`pnpm/action-setup@v4` detects conflicting pnpm versions: `latest` in the action config vs `pnpm@10.6.5` in `package.json#packageManager`. Pinning to the explicit version removes the ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)