### PR TITLE
feat(docs): enable full-text body search in VuePress

### DIFF
--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -90,6 +90,13 @@ export default defineUserConfig({
           placeholder: 'Search documentation...',
         },
       },
+      getExtraFields: (page) => {
+        const content = page.contentRendered
+          .replace(/<[^>]+>/g, ' ')  // strip HTML tags
+          .replace(/\s+/g, ' ')       // collapse whitespace
+          .trim()
+        return content ? [content] : []
+      },
     }),
   ],
 })


### PR DESCRIPTION
## Summary
- Adds `getExtraFields` callback to `searchPlugin` in `apps/docs/docs/.vuepress/config.ts`
- At build time, each page's rendered HTML is stripped of tags and the plain text is added to the search index
- Fixes the issue where searching for terms that appear only in body content (e.g. "mTLS") returned no results — previously only page titles and headings were indexed

## Test plan
- [ ] Search for "mTLS" in the docs site — should return a result from the Introduction page
- [ ] Search for "what" — heading-matched results should still appear (regression check)
- [ ] `pnpm run docs:build` completes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)