### PR TITLE
feat: add network topology graph visualizations

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
@@ -16,6 +16,8 @@ import {
   Network,
   Zap,
   User,
+  LayoutGrid,
+  GitBranch,
 } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
@@ -58,6 +60,7 @@ import {
   listMembershipsForNetwork,
 } from '@/lib/actions/networks'
 import { listHosts } from '@/lib/actions/agents'
+import { NetworkGraph } from './network-graph'
 import type { HostWithAgent } from '@/lib/actions/agents'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
@@ -77,6 +80,7 @@ function HostStatusIcon({ status }: { status: string }) {
 
 export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: Props) {
   const queryClient = useQueryClient()
+  const [viewMode, setViewMode] = useState<'table' | 'graph'>('table')
   const [addOpen, setAddOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [removeTarget, setRemoveTarget] = useState<Host | null>(null)
@@ -157,105 +161,135 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
               </div>
             </div>
           </div>
-          <Button onClick={() => setAddOpen(true)}>
-            <Plus className="size-4 mr-1" />
-            Add Host
-          </Button>
-        </div>
-
-        {/* Members table */}
-        {network.members.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-12 text-center">
-            <Server className="size-8 mx-auto text-muted-foreground mb-3" />
-            <p className="text-sm font-medium text-foreground">No hosts in this network</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Hosts are added automatically when their IP falls within{' '}
-              <code className="font-mono">{network.cidr}</code>, or you can add them manually.
-            </p>
-            <Button className="mt-4" onClick={() => setAddOpen(true)}>
+          <div className="flex items-center gap-2">
+            {/* View toggle */}
+            <div className="flex gap-0.5 rounded-md border p-0.5">
+              <Button
+                size="sm"
+                variant={viewMode === 'table' ? 'secondary' : 'ghost'}
+                className="h-7 px-2 text-xs"
+                onClick={() => setViewMode('table')}
+              >
+                <LayoutGrid className="size-3.5 mr-1" />
+                Table
+              </Button>
+              <Button
+                size="sm"
+                variant={viewMode === 'graph' ? 'secondary' : 'ghost'}
+                className="h-7 px-2 text-xs"
+                onClick={() => setViewMode('graph')}
+              >
+                <GitBranch className="size-3.5 mr-1" />
+                Graph
+              </Button>
+            </div>
+            <Button onClick={() => setAddOpen(true)}>
               <Plus className="size-4 mr-1" />
               Add Host
             </Button>
           </div>
-        ) : (
-          <div className="rounded-lg border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Host</TableHead>
-                  <TableHead>IP Addresses</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Assignment</TableHead>
-                  <TableHead>Added</TableHead>
-                  <TableHead className="w-16" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {network.members.map((host) => {
-                  const isAuto = autoAssignedMap.get(host.id) ?? false
-                  return (
-                    <TableRow key={host.id}>
-                      <TableCell>
-                        <Link
-                          href={`/hosts/${host.id}`}
-                          className="font-medium text-foreground hover:underline"
-                        >
-                          {host.displayName ?? host.hostname ?? host.id}
-                        </Link>
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {(host.ipAddresses as string[] | null)?.join(', ') ?? '—'}
-                      </TableCell>
-                      <TableCell>
-                        <span className="inline-flex items-center gap-1.5 text-sm">
-                          <HostStatusIcon status={host.status ?? 'unknown'} />
-                          <span className="capitalize text-muted-foreground">
-                            {host.status ?? 'unknown'}
+        </div>
+
+        {/* Graph view */}
+        {viewMode === 'graph' && (
+          <NetworkGraph network={network} hosts={network.members} />
+        )}
+
+        {/* Table view */}
+        {viewMode === 'table' && (
+          network.members.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-12 text-center">
+              <Server className="size-8 mx-auto text-muted-foreground mb-3" />
+              <p className="text-sm font-medium text-foreground">No hosts in this network</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Hosts are added automatically when their IP falls within{' '}
+                <code className="font-mono">{network.cidr}</code>, or you can add them manually.
+              </p>
+              <Button className="mt-4" onClick={() => setAddOpen(true)}>
+                <Plus className="size-4 mr-1" />
+                Add Host
+              </Button>
+            </div>
+          ) : (
+            <div className="rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Host</TableHead>
+                    <TableHead>IP Addresses</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Assignment</TableHead>
+                    <TableHead>Added</TableHead>
+                    <TableHead className="w-16" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {network.members.map((host) => {
+                    const isAuto = autoAssignedMap.get(host.id) ?? false
+                    return (
+                      <TableRow key={host.id}>
+                        <TableCell>
+                          <Link
+                            href={`/hosts/${host.id}`}
+                            className="font-medium text-foreground hover:underline"
+                          >
+                            {host.displayName ?? host.hostname ?? host.id}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {(host.ipAddresses as string[] | null)?.join(', ') ?? '—'}
+                        </TableCell>
+                        <TableCell>
+                          <span className="inline-flex items-center gap-1.5 text-sm">
+                            <HostStatusIcon status={host.status ?? 'unknown'} />
+                            <span className="capitalize text-muted-foreground">
+                              {host.status ?? 'unknown'}
+                            </span>
                           </span>
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        {isAuto ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Badge variant="secondary" className="gap-1 text-xs cursor-default">
-                                <Zap className="size-3" />
-                                Auto
-                              </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p className="max-w-xs text-xs">
-                                Auto-assigned based on IP match. Will be re-added on the next
-                                heartbeat if the IP still falls within the CIDR.
-                              </p>
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <Badge variant="outline" className="gap-1 text-xs">
-                            <User className="size-3" />
-                            Manual
-                          </Badge>
-                        )}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {formatDistanceToNow(new Date(host.createdAt), { addSuffix: true })}
-                      </TableCell>
-                      <TableCell>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-8 text-destructive hover:text-destructive"
-                          onClick={() => setRemoveTarget(host)}
-                        >
-                          <Trash2 className="size-3.5" />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-          </div>
+                        </TableCell>
+                        <TableCell>
+                          {isAuto ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge variant="secondary" className="gap-1 text-xs cursor-default">
+                                  <Zap className="size-3" />
+                                  Auto
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p className="max-w-xs text-xs">
+                                  Auto-assigned based on IP match. Will be re-added on the next
+                                  heartbeat if the IP still falls within the CIDR.
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <Badge variant="outline" className="gap-1 text-xs">
+                              <User className="size-3" />
+                              Manual
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {formatDistanceToNow(new Date(host.createdAt), { addSuffix: true })}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 text-destructive hover:text-destructive"
+                            onClick={() => setRemoveTarget(host)}
+                          >
+                            <Trash2 className="size-3.5" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )
         )}
 
         {/* Add Host Dialog */}

--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import {
+  NetworkNodeComponent,
+  HostNodeComponent,
+} from '../components/network-flow-nodes'
+import type { Network as NetworkType, Host } from '@/lib/db/schema'
+
+const nodeTypes = {
+  networkNode: NetworkNodeComponent,
+  hostNode: HostNodeComponent,
+}
+
+const NETWORK_W = 220
+const NETWORK_H = 84
+const HOST_W = 190
+const HOST_H = 72
+const HOSTS_PER_ROW = 5
+const HOST_COL_GAP = 20
+const HOST_ROW_GAP = 30
+const NETWORK_HOST_GAP = 80
+
+interface Props {
+  network: NetworkType
+  hosts: Host[]
+}
+
+function computeLayout(
+  network: NetworkType,
+  hosts: Host[],
+): { nodes: Node[]; edges: Edge[] } {
+  const n = hosts.length
+  const cols = Math.min(Math.max(n, 1), HOSTS_PER_ROW)
+  const totalGridW = cols * HOST_W + (cols - 1) * HOST_COL_GAP
+
+  const networkX = Math.max(0, (totalGridW - NETWORK_W) / 2)
+
+  const nodes: Node[] = [
+    {
+      id: 'network',
+      type: 'networkNode',
+      position: { x: networkX, y: 0 },
+      data: { name: network.name, cidr: network.cidr },
+    },
+  ]
+
+  const edges: Edge[] = []
+
+  hosts.forEach((host, i) => {
+    const row = Math.floor(i / HOSTS_PER_ROW)
+    const col = i % HOSTS_PER_ROW
+
+    // Center the last (possibly partial) row
+    const isLastRow = row === Math.floor((n - 1) / HOSTS_PER_ROW)
+    const rowCols = isLastRow ? ((n - 1) % HOSTS_PER_ROW) + 1 : HOSTS_PER_ROW
+    const rowW = rowCols * HOST_W + (rowCols - 1) * HOST_COL_GAP
+    const rowStartX = (totalGridW - rowW) / 2
+
+    nodes.push({
+      id: `host-${host.id}`,
+      type: 'hostNode',
+      position: {
+        x: rowStartX + col * (HOST_W + HOST_COL_GAP),
+        y: NETWORK_H + NETWORK_HOST_GAP + row * (HOST_H + HOST_ROW_GAP),
+      },
+      data: {
+        name: host.displayName ?? host.hostname ?? host.id,
+        ipAddresses: (host.ipAddresses as string[] | null) ?? [],
+        status: host.status ?? 'unknown',
+      },
+    })
+
+    edges.push({
+      id: `e-${host.id}`,
+      source: 'network',
+      target: `host-${host.id}`,
+      type: 'smoothstep',
+      style: { stroke: 'hsl(var(--border))', strokeWidth: 1.5 },
+    })
+  })
+
+  return { nodes, edges }
+}
+
+export function NetworkGraph({ network, hosts }: Props) {
+  const { nodes, edges } = useMemo(
+    () => computeLayout(network, hosts),
+    [network, hosts],
+  )
+
+  const graphKey = `${network.id}-${hosts
+    .map((h) => h.id)
+    .sort()
+    .join(',')}`
+
+  return (
+    <div className="w-full h-[520px] rounded-lg border overflow-hidden">
+      <ReactFlow
+        key={graphKey}
+        defaultNodes={nodes}
+        defaultEdges={edges}
+        nodeTypes={nodeTypes}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={1}
+          color="hsl(var(--border))"
+        />
+        <Controls />
+        <MiniMap nodeStrokeWidth={3} />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import {
+  NetworkNodeComponent,
+  HostNodeComponent,
+} from './components/network-flow-nodes'
+import type { Network as NetworkType, Host } from '@/lib/db/schema'
+
+export type NetworkWithHosts = NetworkType & { hosts: Host[] }
+
+const nodeTypes = {
+  networkNode: NetworkNodeComponent,
+  hostNode: HostNodeComponent,
+}
+
+const NETWORK_W = 220
+const HOST_W = 190
+const HOST_H = 72
+const COL_WIDTH = 270
+const HOST_Y_START = 220
+const HOST_ROW_GAP = 20
+
+function computeLayout(
+  networksWithHosts: NetworkWithHosts[],
+): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+
+  // Place network nodes in a horizontal row
+  networksWithHosts.forEach((network, colIdx) => {
+    const colCenterX = colIdx * COL_WIDTH + COL_WIDTH / 2
+    nodes.push({
+      id: `net-${network.id}`,
+      type: 'networkNode',
+      position: { x: colCenterX - NETWORK_W / 2, y: 0 },
+      data: { name: network.name, cidr: network.cidr },
+    })
+  })
+
+  // Track which column "owns" each host (first network encountered)
+  const hostPrimaryCol = new Map<string, number>()
+
+  networksWithHosts.forEach((network, colIdx) => {
+    network.hosts.forEach((host) => {
+      if (!hostPrimaryCol.has(host.id)) {
+        hostPrimaryCol.set(host.id, colIdx)
+      }
+    })
+  })
+
+  // Place host nodes under their primary column
+  const colRowCounters = new Map<number, number>()
+  const placedHosts = new Set<string>()
+
+  networksWithHosts.forEach((network) => {
+    network.hosts.forEach((host) => {
+      const primaryCol = hostPrimaryCol.get(host.id) ?? 0
+
+      if (!placedHosts.has(host.id)) {
+        placedHosts.add(host.id)
+        const rowIdx = colRowCounters.get(primaryCol) ?? 0
+        colRowCounters.set(primaryCol, rowIdx + 1)
+
+        const colCenterX = primaryCol * COL_WIDTH + COL_WIDTH / 2
+        nodes.push({
+          id: `host-${host.id}`,
+          type: 'hostNode',
+          position: {
+            x: colCenterX - HOST_W / 2,
+            y: HOST_Y_START + rowIdx * (HOST_H + HOST_ROW_GAP),
+          },
+          data: {
+            name: host.displayName ?? host.hostname ?? host.id,
+            ipAddresses: (host.ipAddresses as string[] | null) ?? [],
+            status: host.status ?? 'unknown',
+          },
+        })
+      }
+
+      // Edge from this network to the host
+      edges.push({
+        id: `e-${network.id}-${host.id}`,
+        source: `net-${network.id}`,
+        target: `host-${host.id}`,
+        type: 'smoothstep',
+        style: { stroke: 'hsl(var(--border))', strokeWidth: 1.5 },
+      })
+    })
+  })
+
+  return { nodes, edges }
+}
+
+interface Props {
+  networksWithHosts: NetworkWithHosts[]
+}
+
+export function AllNetworksGraph({ networksWithHosts }: Props) {
+  const { nodes, edges } = useMemo(
+    () => computeLayout(networksWithHosts),
+    [networksWithHosts],
+  )
+
+  const graphKey = networksWithHosts
+    .map((n) => `${n.id}:${n.hosts.map((h) => h.id).join(',')}`)
+    .join('|')
+
+  return (
+    <div className="w-full h-[620px] rounded-lg border overflow-hidden">
+      <ReactFlow
+        key={graphKey}
+        defaultNodes={nodes}
+        defaultEdges={edges}
+        nodeTypes={nodeTypes}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={1}
+          color="hsl(var(--border))"
+        />
+        <Controls />
+        <MiniMap nodeStrokeWidth={3} />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { memo } from 'react'
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react'
+import { CheckCircle, WifiOff, AlertTriangle, Network, Server } from 'lucide-react'
+
+// ── Network Node ──────────────────────────────────────────────────────────────
+
+export type NetworkNodeData = {
+  name: string
+  cidr: string
+}
+
+export type NetworkFlowNode = Node<NetworkNodeData, 'networkNode'>
+
+export const NetworkNodeComponent = memo(function NetworkNodeComponent({
+  data,
+}: NodeProps<NetworkFlowNode>) {
+  return (
+    <div className="bg-card border-2 border-primary/40 rounded-lg px-4 py-3 shadow-md min-w-[200px]">
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+      <div className="flex items-center gap-2 mb-1.5">
+        <Network className="size-4 text-primary shrink-0" />
+        <span className="font-semibold text-sm text-card-foreground truncate max-w-[170px]">
+          {data.name}
+        </span>
+      </div>
+      <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono text-muted-foreground">
+        {data.cidr}
+      </code>
+    </div>
+  )
+})
+
+// ── Host Node ─────────────────────────────────────────────────────────────────
+
+export type HostNodeData = {
+  name: string
+  ipAddresses: string[]
+  status: string
+}
+
+export type HostFlowNode = Node<HostNodeData, 'hostNode'>
+
+function StatusDot({ status }: { status: string }) {
+  if (status === 'online') return <CheckCircle className="size-3 text-green-500 shrink-0" />
+  if (status === 'offline') return <WifiOff className="size-3 text-red-500 shrink-0" />
+  return <AlertTriangle className="size-3 text-yellow-500 shrink-0" />
+}
+
+export const HostNodeComponent = memo(function HostNodeComponent({
+  data,
+}: NodeProps<HostFlowNode>) {
+  return (
+    <div className="bg-card border rounded-lg px-3 py-2.5 shadow-sm min-w-[170px]">
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+      <div className="flex items-center gap-1.5 mb-1">
+        <StatusDot status={data.status} />
+        <Server className="size-3 text-muted-foreground shrink-0" />
+        <span className="text-xs font-medium text-card-foreground truncate max-w-[140px]">
+          {data.name}
+        </span>
+      </div>
+      {data.ipAddresses.length > 0 && (
+        <p className="text-xs text-muted-foreground font-mono truncate">
+          {data.ipAddresses[0]}
+          {data.ipAddresses.length > 1 && (
+            <span className="text-muted-foreground/70"> +{data.ipAddresses.length - 1}</span>
+          )}
+        </p>
+      )}
+    </div>
+  )
+})

--- a/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { formatDistanceToNow } from 'date-fns'
-import { Plus, Pencil, Trash2, Loader2, Network, Server } from 'lucide-react'
+import { Plus, Pencil, Trash2, Loader2, Network, Server, LayoutGrid, GitBranch } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -41,7 +41,9 @@ import {
   createNetwork,
   updateNetwork,
   deleteNetwork,
+  listNetworksWithHosts,
 } from '@/lib/actions/networks'
+import { AllNetworksGraph } from './all-networks-graph'
 import type { NetworkWithCount } from '@/lib/actions/networks'
 
 const networkSchema = z.object({
@@ -130,6 +132,7 @@ function NetworkForm({
 
 export function NetworksClient({ orgId, initialNetworks }: Props) {
   const queryClient = useQueryClient()
+  const [viewMode, setViewMode] = useState<'table' | 'graph'>('table')
   const [createOpen, setCreateOpen] = useState(false)
   const [editNetwork, setEditNetwork] = useState<NetworkWithCount | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<NetworkWithCount | null>(null)
@@ -138,6 +141,12 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
     queryKey: ['networks', orgId],
     queryFn: () => listNetworks(orgId),
     initialData: initialNetworks,
+  })
+
+  const { data: networksWithHosts = [] } = useQuery({
+    queryKey: ['networks-with-hosts', orgId],
+    queryFn: () => listNetworksWithHosts(orgId),
+    enabled: viewMode === 'graph',
   })
 
   const { mutate: doCreate, isPending: isCreating } = useMutation({
@@ -189,14 +198,42 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
             </p>
           </div>
         </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="size-4 mr-1" />
-          New Network
-        </Button>
+        <div className="flex items-center gap-2">
+          {/* View toggle */}
+          <div className="flex gap-0.5 rounded-md border p-0.5">
+            <Button
+              size="sm"
+              variant={viewMode === 'table' ? 'secondary' : 'ghost'}
+              className="h-7 px-2 text-xs"
+              onClick={() => setViewMode('table')}
+            >
+              <LayoutGrid className="size-3.5 mr-1" />
+              Table
+            </Button>
+            <Button
+              size="sm"
+              variant={viewMode === 'graph' ? 'secondary' : 'ghost'}
+              className="h-7 px-2 text-xs"
+              onClick={() => setViewMode('graph')}
+            >
+              <GitBranch className="size-3.5 mr-1" />
+              Graph
+            </Button>
+          </div>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4 mr-1" />
+            New Network
+          </Button>
+        </div>
       </div>
 
+      {/* Graph view */}
+      {viewMode === 'graph' && (
+        <AllNetworksGraph networksWithHosts={networksWithHosts} />
+      )}
+
       {/* Table */}
-      {networkList.length === 0 ? (
+      {viewMode === 'table' && (networkList.length === 0 ? (
         <div className="rounded-lg border border-dashed p-12 text-center">
           <Network className="size-8 mx-auto text-muted-foreground mb-3" />
           <p className="text-sm font-medium text-foreground">No networks yet</p>
@@ -274,7 +311,7 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
             </TableBody>
           </Table>
         </div>
-      )}
+      ))}
 
       {/* Create Dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -281,6 +281,44 @@ export async function listMembershipsForNetwork(
   return rows
 }
 
+export type NetworkWithHosts = Network & { hosts: Host[] }
+
+export async function listNetworksWithHosts(orgId: string): Promise<NetworkWithHosts[]> {
+  const networkRows = await db.query.networks.findMany({
+    where: and(eq(networks.organisationId, orgId), isNull(networks.deletedAt)),
+    orderBy: (n, { asc }) => [asc(n.name)],
+  })
+
+  if (networkRows.length === 0) return []
+
+  const memberships = await db
+    .select({
+      networkId: hostNetworkMemberships.networkId,
+      host: hosts,
+    })
+    .from(hostNetworkMemberships)
+    .innerJoin(hosts, eq(hostNetworkMemberships.hostId, hosts.id))
+    .where(
+      and(
+        eq(hostNetworkMemberships.organisationId, orgId),
+        isNull(hostNetworkMemberships.deletedAt),
+        isNull(hosts.deletedAt),
+      ),
+    )
+
+  const hostsByNetwork = new Map<string, Host[]>()
+  memberships.forEach(({ networkId, host }) => {
+    const arr = hostsByNetwork.get(networkId) ?? []
+    arr.push(host)
+    hostsByNetwork.set(networkId, arr)
+  })
+
+  return networkRows.map((network) => ({
+    ...network,
+    hosts: hostsByNetwork.get(network.id) ?? [],
+  }))
+}
+
 export async function listNetworksForHost(orgId: string, hostId: string): Promise<NetworkWithMembership[]> {
   const members = await db.query.hostNetworkMemberships.findMany({
     where: and(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "^12.10.2",
     "better-auth": "^1.5.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       better-auth:
         specifier: ^1.5.6
         version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.99.0))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vue@3.5.32(typescript@5.9.3))
@@ -2432,6 +2435,9 @@ packages:
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
@@ -2444,6 +2450,9 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -2452,6 +2461,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -2906,6 +2921,15 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
   abs-svg-path@0.1.1:
     resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
 
@@ -3252,6 +3276,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -3392,6 +3419,14 @@ packages:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
@@ -3412,6 +3447,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -3426,6 +3465,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
@@ -6231,6 +6280,21 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -8292,6 +8356,10 @@ snapshots:
 
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-ease@3.0.2': {}
 
   '@types/d3-interpolate@3.0.4':
@@ -8304,6 +8372,8 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
@@ -8311,6 +8381,15 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/debug@4.1.13':
     dependencies:
@@ -8998,6 +9077,29 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   abs-svg-path@0.1.1: {}
 
   accepts@2.0.0:
@@ -9351,6 +9453,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -9466,6 +9570,13 @@ snapshots:
 
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
@@ -9484,6 +9595,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -9497,6 +9610,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -9865,7 +9995,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -9888,7 +10018,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9903,14 +10033,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9925,7 +10055,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12663,5 +12793,13 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.4
+      react: 19.2.4
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- Add **Table | Graph toggle** to both the individual network detail page and the all-networks list page
- Individual network graph: network node at top, member hosts arranged in a grid below with smoothstep edges — built with `@xyflow/react` (MIT licensed)
- All-networks graph: all networks in a horizontal row, hosts in columns below their primary network; hosts in multiple networks appear once with edges to each of their networks
- New `listNetworksWithHosts` server action: single JOIN query (networks → memberships → hosts) used lazily only when graph view is active
- Shared `NetworkNodeComponent` and `HostNodeComponent` — `memo`-wrapped custom React Flow nodes with status indicators (online/offline/unknown) and CIDR badges

## Test plan

- [ ] Navigate to `/hosts/networks` → click **Graph** tab → all networks and hosts render as a connected graph; switching back to Table shows the original table
- [ ] Navigate to `/hosts/networks/[id]` → click **Graph** tab → network node at top, hosts in grid below with edges; Table tab shows existing table
- [ ] Verify hosts in multiple networks appear once with multiple edges in the all-networks graph
- [ ] Verify status colours: online = green, offline = red, unknown = yellow
- [ ] Pan, zoom, minimap, and controls all work correctly
- [ ] Run `pnpm run build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)