### PR TITLE
feat: animated flowing dots on network graph edges

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -15,11 +15,16 @@ import {
   NetworkNodeComponent,
   HostNodeComponent,
 } from '../components/network-flow-nodes'
+import { AnimatedFlowEdge } from '../components/animated-flow-edge'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
 const nodeTypes = {
   networkNode: NetworkNodeComponent,
   hostNode: HostNodeComponent,
+}
+
+const edgeTypes = {
+  animatedFlow: AnimatedFlowEdge,
 }
 
 const NETWORK_W = 220
@@ -85,8 +90,8 @@ function computeLayout(
       id: `e-${host.id}`,
       source: 'network',
       target: `host-${host.id}`,
-      type: 'smoothstep',
-      style: { stroke: 'hsl(var(--border))', strokeWidth: 1.5 },
+      type: 'animatedFlow',
+      data: { hostStatus: host.status ?? 'unknown' },
     })
   })
 
@@ -111,6 +116,7 @@ export function NetworkGraph({ network, hosts }: Props) {
         defaultNodes={nodes}
         defaultEdges={edges}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -15,6 +15,7 @@ import {
   NetworkNodeComponent,
   HostNodeComponent,
 } from './components/network-flow-nodes'
+import { AnimatedFlowEdge } from './components/animated-flow-edge'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
 export type NetworkWithHosts = NetworkType & { hosts: Host[] }
@@ -22,6 +23,10 @@ export type NetworkWithHosts = NetworkType & { hosts: Host[] }
 const nodeTypes = {
   networkNode: NetworkNodeComponent,
   hostNode: HostNodeComponent,
+}
+
+const edgeTypes = {
+  animatedFlow: AnimatedFlowEdge,
 }
 
 const NETWORK_W = 220
@@ -93,8 +98,8 @@ function computeLayout(
         id: `e-${network.id}-${host.id}`,
         source: `net-${network.id}`,
         target: `host-${host.id}`,
-        type: 'smoothstep',
-        style: { stroke: 'hsl(var(--border))', strokeWidth: 1.5 },
+        type: 'animatedFlow',
+        data: { hostStatus: host.status ?? 'unknown' },
       })
     })
   })
@@ -123,6 +128,7 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
         defaultNodes={nodes}
         defaultEdges={edges}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}

--- a/apps/web/app/(dashboard)/hosts/networks/components/animated-flow-edge.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/animated-flow-edge.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { memo } from 'react'
+import { getSmoothStepPath, type EdgeProps } from '@xyflow/react'
+
+function dotColor(status: string | undefined): string {
+  if (status === 'online') return '#22c55e'   // green-500
+  if (status === 'offline') return '#ef4444'  // red-500
+  return '#94a3b8'                             // slate-400
+}
+
+export const AnimatedFlowEdge = memo(function AnimatedFlowEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}: EdgeProps) {
+  const status = (data as { hostStatus?: string } | undefined)?.hostStatus
+
+  const [edgePath] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  })
+
+  const color = dotColor(status)
+
+  return (
+    <>
+      {/* Edge line — use muted-foreground which is visible in both light and dark mode */}
+      <path
+        d={edgePath}
+        fill="none"
+        stroke="hsl(var(--muted-foreground))"
+        strokeWidth={1.5}
+        opacity={0.35}
+      />
+      {/* Leading dot */}
+      <circle r="4" fill={color}>
+        <animateMotion dur="2s" repeatCount="indefinite" begin="0s" path={edgePath} />
+      </circle>
+      {/* Trailing dot */}
+      <circle r="2.5" fill={color} opacity={0.5}>
+        <animateMotion dur="2s" repeatCount="indefinite" begin="0.7s" path={edgePath} />
+      </circle>
+    </>
+  )
+})

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -128,3 +128,50 @@
     @apply font-sans;
   }
 }
+
+/* ── React Flow dark mode overrides ─────────────────────────────────────────── */
+/* The React Flow library ships with hardcoded light-mode whites.
+   These overrides make the Controls and MiniMap respect the app's dark theme. */
+
+.dark .react-flow {
+  background-color: var(--background);
+}
+
+.dark .react-flow__controls {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: none;
+}
+
+.dark .react-flow__controls-button {
+  background-color: var(--card);
+  border-bottom-color: var(--border);
+  color: var(--card-foreground);
+  fill: var(--card-foreground);
+}
+
+.dark .react-flow__controls-button:hover {
+  background-color: var(--muted);
+}
+
+.dark .react-flow__controls-button svg {
+  fill: var(--card-foreground);
+}
+
+.dark .react-flow__minimap {
+  background-color: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.dark .react-flow__minimap-mask {
+  fill: var(--background);
+  opacity: 0.75;
+}
+
+.dark .react-flow__minimap-node {
+  fill: var(--muted);
+  stroke: var(--border);
+}


### PR DESCRIPTION
## Summary

- Fix invisible edges: the previous `hsl(var(--border))` stroke colour was near-black in dark mode, making edges invisible
- Add a custom `AnimatedFlowEdge` component using SVG `animateMotion` to animate two circles along each edge path
- Dot colour reflects host status: **green** (online), **red** (offline), **slate-400** (unknown)
- Two dots per edge (leading r=4, trailing r=2.5 at 70% opacity) staggered 0.7s apart for a data-flow effect
- Edge line itself uses `hsl(var(--muted-foreground))` at 35% opacity — visible in both light and dark modes

## Test plan

- [ ] Navigate to `/hosts/networks/[id]` → Graph view → edges visible with dots moving from network node to host nodes
- [ ] Online hosts show green dots; offline hosts show red dots
- [ ] Navigate to `/hosts/networks` → Graph view → same animated edges across all networks
- [ ] Verify edges are visible in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)