### PR TITLE
feat: add right-click context menu to network graph host nodes

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -83,6 +83,8 @@ function computeLayout(
         name: host.displayName ?? host.hostname ?? host.id,
         ipAddresses: (host.ipAddresses as string[] | null) ?? [],
         status: host.status ?? 'unknown',
+        hostId: host.id,
+        orgId: host.organisationId,
       },
     })
 

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -89,6 +89,8 @@ function computeLayout(
             name: host.displayName ?? host.hostname ?? host.id,
             ipAddresses: (host.ipAddresses as string[] | null) ?? [],
             status: host.status ?? 'unknown',
+            hostId: host.id,
+            orgId: host.organisationId,
           },
         })
       }

--- a/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
@@ -1,8 +1,27 @@
 'use client'
 
-import { memo } from 'react'
+import { memo, useState, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
 import { Handle, Position, type NodeProps, type Node } from '@xyflow/react'
-import { CheckCircle, WifiOff, AlertTriangle, Network, Server } from 'lucide-react'
+import { CheckCircle, WifiOff, AlertTriangle, Network, Server, Terminal } from 'lucide-react'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useTerminalPanel } from '@/components/terminal'
 
 // ── Network Node ──────────────────────────────────────────────────────────────
 
@@ -39,6 +58,8 @@ export type HostNodeData = {
   name: string
   ipAddresses: string[]
   status: string
+  hostId: string
+  orgId: string
 }
 
 export type HostFlowNode = Node<HostNodeData, 'hostNode'>
@@ -52,25 +73,105 @@ function StatusDot({ status }: { status: string }) {
 export const HostNodeComponent = memo(function HostNodeComponent({
   data,
 }: NodeProps<HostFlowNode>) {
+  const router = useRouter()
+  const { openTerminal } = useTerminalPanel()
+  const [usernameDialogOpen, setUsernameDialogOpen] = useState(false)
+  const [username, setUsername] = useState('')
+
+  const handleOpenTerminalMenu = useCallback(() => {
+    try {
+      const saved = localStorage.getItem(`terminal-username:${data.hostId}`) ?? ''
+      setUsername(saved)
+    } catch {
+      setUsername('')
+    }
+    setUsernameDialogOpen(true)
+  }, [data.hostId])
+
+  const handleConnect = useCallback(() => {
+    try {
+      if (username.trim()) {
+        localStorage.setItem(`terminal-username:${data.hostId}`, username.trim())
+      }
+    } catch {
+      // localStorage may be unavailable
+    }
+    openTerminal({
+      hostId: data.hostId,
+      hostname: data.name,
+      username: username.trim() || null,
+      orgId: data.orgId,
+      directAccess: false,
+    })
+    setUsernameDialogOpen(false)
+  }, [username, data.hostId, data.name, data.orgId, openTerminal])
+
   return (
-    <div className="bg-card border rounded-lg px-3 py-2.5 shadow-sm min-w-[170px]">
-      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
-      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
-      <div className="flex items-center gap-1.5 mb-1">
-        <StatusDot status={data.status} />
-        <Server className="size-3 text-muted-foreground shrink-0" />
-        <span className="text-xs font-medium text-card-foreground truncate max-w-[140px]">
-          {data.name}
-        </span>
-      </div>
-      {data.ipAddresses.length > 0 && (
-        <p className="text-xs text-muted-foreground font-mono truncate">
-          {data.ipAddresses[0]}
-          {data.ipAddresses.length > 1 && (
-            <span className="text-muted-foreground/70"> +{data.ipAddresses.length - 1}</span>
-          )}
-        </p>
-      )}
-    </div>
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="bg-card border rounded-lg px-3 py-2.5 shadow-sm min-w-[170px] cursor-default">
+            <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+            <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+            <div className="flex items-center gap-1.5 mb-1">
+              <StatusDot status={data.status} />
+              <Server className="size-3 text-muted-foreground shrink-0" />
+              <span className="text-xs font-medium text-card-foreground truncate max-w-[140px]">
+                {data.name}
+              </span>
+            </div>
+            {data.ipAddresses.length > 0 && (
+              <p className="text-xs text-muted-foreground font-mono truncate">
+                {data.ipAddresses[0]}
+                {data.ipAddresses.length > 1 && (
+                  <span className="text-muted-foreground/70"> +{data.ipAddresses.length - 1}</span>
+                )}
+              </p>
+            )}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onSelect={handleOpenTerminalMenu}>
+            <Terminal className="size-4 mr-2" />
+            Open Terminal
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem onSelect={() => router.push(`/hosts/${data.hostId}`)}>
+            <Server className="size-4 mr-2" />
+            View Host
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <Dialog open={usernameDialogOpen} onOpenChange={setUsernameDialogOpen}>
+        <DialogContent className="sm:max-w-xs">
+          <DialogHeader>
+            <DialogTitle>Connect to {data.name}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="node-terminal-username">Username</Label>
+            <Input
+              id="node-terminal-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="e.g. jsmith"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && username.trim()) handleConnect()
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setUsernameDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConnect} disabled={!username.trim()}>
+              <Terminal className="size-4 mr-1.5" />
+              Connect
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 })

--- a/apps/web/components/ui/context-menu.tsx
+++ b/apps/web/components/ui/context-menu.tsx
@@ -1,0 +1,263 @@
+"use client"
+
+import * as React from "react"
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function ContextMenu({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      className={cn("select-none", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  )
+}
+
+function ContextMenuPortal({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
+
+function ContextMenuSub({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn("z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn("z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-lg duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  )
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon
+          />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}


### PR DESCRIPTION
## Summary

- Right-clicking a host node in the network topology graph now displays a context menu
- Menu options: **Open Terminal** (opens the in-app terminal panel with username prompt) and **View Host** (navigates to the host detail page)
- Username is pre-filled from localStorage if previously used for that host
- Added `hostId` and `orgId` to `HostNodeData` so the context menu has the data it needs
- Installed shadcn `context-menu` component

## Test plan

- [ ] Navigate to a network's topology graph
- [ ] Right-click a host node — context menu should appear
- [ ] Click "Open Terminal" — username dialog appears; enter a username and click Connect; terminal panel opens connected to that host
- [ ] Right-click same host again — username field should be pre-filled from last session
- [ ] Click "View Host" — navigates to `/hosts/[id]`
- [ ] Repeat on the "All Networks" graph
- [ ] Verify dark mode styling of the context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)