### PR TITLE
fix: switch network graph context menu to React Flow onNodeContextMenu

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState, useCallback } from 'react'
 import {
   ReactFlow,
   Background,
@@ -9,13 +9,16 @@ import {
   MiniMap,
   type Node,
   type Edge,
+  type NodeMouseHandler,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import {
   NetworkNodeComponent,
   HostNodeComponent,
+  type HostNodeData,
 } from '../components/network-flow-nodes'
 import { AnimatedFlowEdge } from '../components/animated-flow-edge'
+import { HostNodeContextMenu } from '../components/host-node-context-menu'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
 const nodeTypes = {
@@ -75,6 +78,7 @@ function computeLayout(
     nodes.push({
       id: `host-${host.id}`,
       type: 'hostNode',
+      className: 'cursor-default',
       position: {
         x: rowStartX + col * (HOST_W + HOST_COL_GAP),
         y: NETWORK_H + NETWORK_HOST_GAP + row * (HOST_H + HOST_ROW_GAP),
@@ -100,16 +104,32 @@ function computeLayout(
   return { nodes, edges }
 }
 
+interface ContextMenuState {
+  x: number
+  y: number
+  data: HostNodeData
+}
+
 export function NetworkGraph({ network, hosts }: Props) {
   const { nodes, edges } = useMemo(
     () => computeLayout(network, hosts),
     [network, hosts],
   )
 
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
+
   const graphKey = `${network.id}-${hosts
     .map((h) => h.id)
     .sort()
     .join(',')}`
+
+  const handleNodeContextMenu: NodeMouseHandler = useCallback((e, node) => {
+    if (node.type !== 'hostNode') return
+    e.preventDefault()
+    setContextMenu({ x: e.clientX, y: e.clientY, data: node.data as HostNodeData })
+  }, [])
+
+  const closeContextMenu = useCallback(() => setContextMenu(null), [])
 
   return (
     <div className="w-full h-[520px] rounded-lg border overflow-hidden">
@@ -122,6 +142,9 @@ export function NetworkGraph({ network, hosts }: Props) {
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}
+        onNodeContextMenu={handleNodeContextMenu}
+        onPaneClick={closeContextMenu}
+        onMoveStart={closeContextMenu}
         fitView
         fitViewOptions={{ padding: 0.15 }}
       >
@@ -134,6 +157,15 @@ export function NetworkGraph({ network, hosts }: Props) {
         <Controls />
         <MiniMap nodeStrokeWidth={3} />
       </ReactFlow>
+
+      {contextMenu && (
+        <HostNodeContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          data={contextMenu.data}
+          onClose={closeContextMenu}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState, useCallback } from 'react'
 import {
   ReactFlow,
   Background,
@@ -9,13 +9,16 @@ import {
   MiniMap,
   type Node,
   type Edge,
+  type NodeMouseHandler,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import {
   NetworkNodeComponent,
   HostNodeComponent,
+  type HostNodeData,
 } from './components/network-flow-nodes'
 import { AnimatedFlowEdge } from './components/animated-flow-edge'
+import { HostNodeContextMenu } from './components/host-node-context-menu'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
 export type NetworkWithHosts = NetworkType & { hosts: Host[] }
@@ -81,6 +84,7 @@ function computeLayout(
         nodes.push({
           id: `host-${host.id}`,
           type: 'hostNode',
+          className: 'cursor-default',
           position: {
             x: colCenterX - HOST_W / 2,
             y: HOST_Y_START + rowIdx * (HOST_H + HOST_ROW_GAP),
@@ -113,15 +117,31 @@ interface Props {
   networksWithHosts: NetworkWithHosts[]
 }
 
+interface ContextMenuState {
+  x: number
+  y: number
+  data: HostNodeData
+}
+
 export function AllNetworksGraph({ networksWithHosts }: Props) {
   const { nodes, edges } = useMemo(
     () => computeLayout(networksWithHosts),
     [networksWithHosts],
   )
 
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
+
   const graphKey = networksWithHosts
     .map((n) => `${n.id}:${n.hosts.map((h) => h.id).join(',')}`)
     .join('|')
+
+  const handleNodeContextMenu: NodeMouseHandler = useCallback((e, node) => {
+    if (node.type !== 'hostNode') return
+    e.preventDefault()
+    setContextMenu({ x: e.clientX, y: e.clientY, data: node.data as HostNodeData })
+  }, [])
+
+  const closeContextMenu = useCallback(() => setContextMenu(null), [])
 
   return (
     <div className="w-full h-[620px] rounded-lg border overflow-hidden">
@@ -134,6 +154,9 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}
+        onNodeContextMenu={handleNodeContextMenu}
+        onPaneClick={closeContextMenu}
+        onMoveStart={closeContextMenu}
         fitView
         fitViewOptions={{ padding: 0.15 }}
       >
@@ -146,6 +169,15 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
         <Controls />
         <MiniMap nodeStrokeWidth={3} />
       </ReactFlow>
+
+      {contextMenu && (
+        <HostNodeContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          data={contextMenu.data}
+          onClose={closeContextMenu}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/hosts/networks/components/host-node-context-menu.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/host-node-context-menu.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Terminal, Server } from 'lucide-react'
+import { useTerminalPanel } from '@/components/terminal'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import type { HostNodeData } from './network-flow-nodes'
+
+interface Props {
+  x: number
+  y: number
+  data: HostNodeData
+  onClose: () => void
+}
+
+export function HostNodeContextMenu({ x, y, data, onClose }: Props) {
+  const router = useRouter()
+  const { openTerminal } = useTerminalPanel()
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [usernameDialogOpen, setUsernameDialogOpen] = useState(false)
+  const [username, setUsername] = useState('')
+
+  useEffect(() => {
+    function handlePointerDown(e: PointerEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [onClose])
+
+  const handleOpenTerminal = useCallback(() => {
+    onClose()
+    try {
+      setUsername(localStorage.getItem(`terminal-username:${data.hostId}`) ?? '')
+    } catch {
+      setUsername('')
+    }
+    setUsernameDialogOpen(true)
+  }, [data.hostId, onClose])
+
+  const handleConnect = useCallback(() => {
+    try {
+      if (username.trim()) {
+        localStorage.setItem(`terminal-username:${data.hostId}`, username.trim())
+      }
+    } catch {
+      // localStorage may be unavailable
+    }
+    openTerminal({
+      hostId: data.hostId,
+      hostname: data.name,
+      username: username.trim() || null,
+      orgId: data.orgId,
+      directAccess: false,
+    })
+    setUsernameDialogOpen(false)
+  }, [username, data, openTerminal])
+
+  return (
+    <>
+      <div
+        ref={menuRef}
+        style={{ position: 'fixed', top: y, left: x, zIndex: 9999 }}
+        className="bg-popover text-popover-foreground border rounded-md shadow-md py-1 min-w-[160px]"
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <button
+          className="flex items-center w-full px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground gap-2 cursor-default"
+          onClick={handleOpenTerminal}
+        >
+          <Terminal className="size-4 shrink-0" />
+          Open Terminal
+        </button>
+        <div className="h-px bg-border my-1" />
+        <button
+          className="flex items-center w-full px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground gap-2 cursor-default"
+          onClick={() => {
+            router.push(`/hosts/${data.hostId}`)
+            onClose()
+          }}
+        >
+          <Server className="size-4 shrink-0" />
+          View Host
+        </button>
+      </div>
+
+      <Dialog open={usernameDialogOpen} onOpenChange={setUsernameDialogOpen}>
+        <DialogContent className="sm:max-w-xs">
+          <DialogHeader>
+            <DialogTitle>Connect to {data.name}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="host-ctx-username">Username</Label>
+            <Input
+              id="host-ctx-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="e.g. jsmith"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && username.trim()) handleConnect()
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setUsernameDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConnect} disabled={!username.trim()}>
+              <Terminal className="size-4 mr-1.5" />
+              Connect
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
@@ -1,27 +1,8 @@
 'use client'
 
-import { memo, useState, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
+import { memo } from 'react'
 import { Handle, Position, type NodeProps, type Node } from '@xyflow/react'
-import { CheckCircle, WifiOff, AlertTriangle, Network, Server, Terminal } from 'lucide-react'
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
-} from '@/components/ui/context-menu'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { useTerminalPanel } from '@/components/terminal'
+import { CheckCircle, WifiOff, AlertTriangle, Network, Server } from 'lucide-react'
 
 // ── Network Node ──────────────────────────────────────────────────────────────
 
@@ -73,105 +54,25 @@ function StatusDot({ status }: { status: string }) {
 export const HostNodeComponent = memo(function HostNodeComponent({
   data,
 }: NodeProps<HostFlowNode>) {
-  const router = useRouter()
-  const { openTerminal } = useTerminalPanel()
-  const [usernameDialogOpen, setUsernameDialogOpen] = useState(false)
-  const [username, setUsername] = useState('')
-
-  const handleOpenTerminalMenu = useCallback(() => {
-    try {
-      const saved = localStorage.getItem(`terminal-username:${data.hostId}`) ?? ''
-      setUsername(saved)
-    } catch {
-      setUsername('')
-    }
-    setUsernameDialogOpen(true)
-  }, [data.hostId])
-
-  const handleConnect = useCallback(() => {
-    try {
-      if (username.trim()) {
-        localStorage.setItem(`terminal-username:${data.hostId}`, username.trim())
-      }
-    } catch {
-      // localStorage may be unavailable
-    }
-    openTerminal({
-      hostId: data.hostId,
-      hostname: data.name,
-      username: username.trim() || null,
-      orgId: data.orgId,
-      directAccess: false,
-    })
-    setUsernameDialogOpen(false)
-  }, [username, data.hostId, data.name, data.orgId, openTerminal])
-
   return (
-    <>
-      <ContextMenu>
-        <ContextMenuTrigger asChild>
-          <div className="bg-card border rounded-lg px-3 py-2.5 shadow-sm min-w-[170px] cursor-default">
-            <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
-            <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
-            <div className="flex items-center gap-1.5 mb-1">
-              <StatusDot status={data.status} />
-              <Server className="size-3 text-muted-foreground shrink-0" />
-              <span className="text-xs font-medium text-card-foreground truncate max-w-[140px]">
-                {data.name}
-              </span>
-            </div>
-            {data.ipAddresses.length > 0 && (
-              <p className="text-xs text-muted-foreground font-mono truncate">
-                {data.ipAddresses[0]}
-                {data.ipAddresses.length > 1 && (
-                  <span className="text-muted-foreground/70"> +{data.ipAddresses.length - 1}</span>
-                )}
-              </p>
-            )}
-          </div>
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          <ContextMenuItem onSelect={handleOpenTerminalMenu}>
-            <Terminal className="size-4 mr-2" />
-            Open Terminal
-          </ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem onSelect={() => router.push(`/hosts/${data.hostId}`)}>
-            <Server className="size-4 mr-2" />
-            View Host
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
-
-      <Dialog open={usernameDialogOpen} onOpenChange={setUsernameDialogOpen}>
-        <DialogContent className="sm:max-w-xs">
-          <DialogHeader>
-            <DialogTitle>Connect to {data.name}</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="node-terminal-username">Username</Label>
-            <Input
-              id="node-terminal-username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="e.g. jsmith"
-              autoFocus
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && username.trim()) handleConnect()
-              }}
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setUsernameDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleConnect} disabled={!username.trim()}>
-              <Terminal className="size-4 mr-1.5" />
-              Connect
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+    <div className="bg-card border rounded-lg px-3 py-2.5 shadow-sm min-w-[170px] cursor-default select-none">
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+      <div className="flex items-center gap-1.5 mb-1">
+        <StatusDot status={data.status} />
+        <Server className="size-3 text-muted-foreground shrink-0" />
+        <span className="text-xs font-medium text-card-foreground truncate max-w-[140px]">
+          {data.name}
+        </span>
+      </div>
+      {data.ipAddresses.length > 0 && (
+        <p className="text-xs text-muted-foreground font-mono truncate">
+          {data.ipAddresses[0]}
+          {data.ipAddresses.length > 1 && (
+            <span className="text-muted-foreground/70"> +{data.ipAddresses.length - 1}</span>
+          )}
+        </p>
+      )}
+    </div>
   )
 })


### PR DESCRIPTION
## Summary

- Fixes context menu not appearing on right-click of host nodes in the network graph
- Fixes grab/hand cursor showing when hovering over host nodes

**Root cause:** The shadcn `ContextMenu` component relies on the browser's `contextmenu` event bubbling up through the DOM, but React Flow intercepts this event at its internal pane element before it reaches individual node components. As a result, only the browser's native context menu appeared.

**Fix:** Use React Flow's `onNodeContextMenu` callback on the `ReactFlow` component, which React Flow fires explicitly after detecting a right-click on a node. A custom fixed-position overlay (`HostNodeContextMenu`) is rendered at the cursor coordinates.

**Cursor fix:** Added `className: 'cursor-default'` to host node definitions, which React Flow applies to the `.react-flow__node` wrapper element.

## Test plan

- [ ] Right-click a host node — custom context menu appears at cursor position
- [ ] Click "Open Terminal" — username dialog appears; enter username and connect
- [ ] Username is remembered for next time
- [ ] Click "View Host" — navigates to `/hosts/[id]`
- [ ] Clicking outside the menu dismisses it
- [ ] Cursor shows as arrow (not grab hand) when hovering over host nodes
- [ ] Works on both single-network and all-networks graph views

🤖 Generated with [Claude Code](https://claude.com/claude-code)