### PR TITLE
fix: restore pointer-events on host nodes so right-click context menu works

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -132,7 +132,7 @@ export function NetworkGraph({ network, hosts }: Props) {
   const closeContextMenu = useCallback(() => setContextMenu(null), [])
 
   return (
-    <div className="w-full h-[520px] rounded-lg border overflow-hidden">
+    <div className="w-full h-[520px] rounded-lg border overflow-hidden" onContextMenu={(e) => e.preventDefault()}>
       <ReactFlow
         key={graphKey}
         defaultNodes={nodes}

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -144,7 +144,7 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
   const closeContextMenu = useCallback(() => setContextMenu(null), [])
 
   return (
-    <div className="w-full h-[620px] rounded-lg border overflow-hidden">
+    <div className="w-full h-[620px] rounded-lg border overflow-hidden" onContextMenu={(e) => e.preventDefault()}>
       <ReactFlow
         key={graphKey}
         defaultNodes={nodes}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -176,6 +176,15 @@
   stroke: var(--border);
 }
 
+/* ── React Flow host node pointer-events fix ─────────────────────────────────── */
+/* xyflow sets pointer-events:none on all nodes when nodesDraggable, nodesConnectable,
+   and elementsSelectable are all false. This overrides that for host nodes so
+   right-click (onNodeContextMenu) and cursor work correctly. */
+.react-flow__node-hostNode {
+  pointer-events: all !important;
+  cursor: default !important;
+}
+
 /* ── React Flow animated edge — flowing dash keyframe ────────────────────────── */
 /* Drives the stroke-dashoffset animation on the dashed bezier edges.
    dasharray: 6 4 → total pattern = 10 → animate from 10 → 0 for


### PR DESCRIPTION
## Summary

- Fixes right-click context menu still showing browser native menu instead of custom menu
- Fixes grab/hand cursor showing when hovering over host nodes

## Root cause

xyflow (React Flow v12) computes `isInteractive = nodesDraggable || nodesConnectable || elementsSelectable`. With all three set to `false`, `isInteractive = false` and xyflow applies `pointer-events: none` as an **inline style** to every node wrapper. This means:

1. All mouse events fall through nodes to the pane behind them
2. `onNodeContextMenu` never fires (node never receives the event)
3. The pane's grab cursor shows when hovering over nodes (pane receives hover events)

## Fix

Added a CSS rule targeting `.react-flow__node-hostNode` (the auto-generated class for our custom node type) to override the inline style:

```css
.react-flow__node-hostNode {
  pointer-events: all !important;
  cursor: default !important;
}
```

Also added `onContextMenu={(e) => e.preventDefault()}` on the graph container divs as a safety net to prevent the browser's native menu even if anything else goes wrong.

## Test plan

- [ ] Right-clicking a host node shows the custom context menu (not browser native menu)
- [ ] Cursor shows as arrow (not grab hand) when hovering over host nodes
- [ ] "Open Terminal" opens username dialog then launches terminal
- [ ] "View Host" navigates to the host detail page
- [ ] Works on both single-network and all-networks graph views

🤖 Generated with [Claude Code](https://claude.com/claude-code)