### PR TITLE
fix: Open Terminal from network graph context menu now works

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -19,6 +19,7 @@ import {
 } from '../components/network-flow-nodes'
 import { AnimatedFlowEdge } from '../components/animated-flow-edge'
 import { HostNodeContextMenu } from '../components/host-node-context-menu'
+import { HostNodeTerminalDialog } from '../components/host-node-terminal-dialog'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
 const nodeTypes = {
@@ -117,6 +118,8 @@ export function NetworkGraph({ network, hosts }: Props) {
   )
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
+  const [terminalTarget, setTerminalTarget] = useState<HostNodeData | null>(null)
+  const [terminalDialogOpen, setTerminalDialogOpen] = useState(false)
 
   const graphKey = `${network.id}-${hosts
     .map((h) => h.id)
@@ -164,8 +167,21 @@ export function NetworkGraph({ network, hosts }: Props) {
           y={contextMenu.y}
           data={contextMenu.data}
           onClose={closeContextMenu}
+          onOpenTerminal={(data) => {
+            setTerminalTarget(data)
+            setTerminalDialogOpen(true)
+          }}
         />
       )}
+
+      <HostNodeTerminalDialog
+        data={terminalTarget}
+        open={terminalDialogOpen}
+        onOpenChange={(open) => {
+          setTerminalDialogOpen(open)
+          if (!open) setTerminalTarget(null)
+        }}
+      />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -19,6 +19,7 @@ import {
 } from './components/network-flow-nodes'
 import { AnimatedFlowEdge } from './components/animated-flow-edge'
 import { HostNodeContextMenu } from './components/host-node-context-menu'
+import { HostNodeTerminalDialog } from './components/host-node-terminal-dialog'
 import type { Network as NetworkType, Host } from '@/lib/db/schema'
 
 export type NetworkWithHosts = NetworkType & { hosts: Host[] }
@@ -130,6 +131,8 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
   )
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
+  const [terminalTarget, setTerminalTarget] = useState<HostNodeData | null>(null)
+  const [terminalDialogOpen, setTerminalDialogOpen] = useState(false)
 
   const graphKey = networksWithHosts
     .map((n) => `${n.id}:${n.hosts.map((h) => h.id).join(',')}`)
@@ -176,8 +179,21 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
           y={contextMenu.y}
           data={contextMenu.data}
           onClose={closeContextMenu}
+          onOpenTerminal={(data) => {
+            setTerminalTarget(data)
+            setTerminalDialogOpen(true)
+          }}
         />
       )}
+
+      <HostNodeTerminalDialog
+        data={terminalTarget}
+        open={terminalDialogOpen}
+        onOpenChange={(open) => {
+          setTerminalDialogOpen(open)
+          if (!open) setTerminalTarget(null)
+        }}
+      />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/hosts/networks/components/host-node-context-menu.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/host-node-context-menu.tsx
@@ -1,19 +1,8 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Terminal, Server } from 'lucide-react'
-import { useTerminalPanel } from '@/components/terminal'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import type { HostNodeData } from './network-flow-nodes'
 
 interface Props {
@@ -21,14 +10,12 @@ interface Props {
   y: number
   data: HostNodeData
   onClose: () => void
+  onOpenTerminal: (data: HostNodeData) => void
 }
 
-export function HostNodeContextMenu({ x, y, data, onClose }: Props) {
+export function HostNodeContextMenu({ x, y, data, onClose, onOpenTerminal }: Props) {
   const router = useRouter()
-  const { openTerminal } = useTerminalPanel()
   const menuRef = useRef<HTMLDivElement>(null)
-  const [usernameDialogOpen, setUsernameDialogOpen] = useState(false)
-  const [username, setUsername] = useState('')
 
   useEffect(() => {
     function handlePointerDown(e: PointerEvent) {
@@ -40,91 +27,34 @@ export function HostNodeContextMenu({ x, y, data, onClose }: Props) {
     return () => document.removeEventListener('pointerdown', handlePointerDown)
   }, [onClose])
 
-  const handleOpenTerminal = useCallback(() => {
-    onClose()
-    try {
-      setUsername(localStorage.getItem(`terminal-username:${data.hostId}`) ?? '')
-    } catch {
-      setUsername('')
-    }
-    setUsernameDialogOpen(true)
-  }, [data.hostId, onClose])
-
-  const handleConnect = useCallback(() => {
-    try {
-      if (username.trim()) {
-        localStorage.setItem(`terminal-username:${data.hostId}`, username.trim())
-      }
-    } catch {
-      // localStorage may be unavailable
-    }
-    openTerminal({
-      hostId: data.hostId,
-      hostname: data.name,
-      username: username.trim() || null,
-      orgId: data.orgId,
-      directAccess: false,
-    })
-    setUsernameDialogOpen(false)
-  }, [username, data, openTerminal])
-
   return (
-    <>
-      <div
-        ref={menuRef}
-        style={{ position: 'fixed', top: y, left: x, zIndex: 9999 }}
-        className="bg-popover text-popover-foreground border rounded-md shadow-md py-1 min-w-[160px]"
-        onContextMenu={(e) => e.preventDefault()}
+    <div
+      ref={menuRef}
+      style={{ position: 'fixed', top: y, left: x, zIndex: 9999 }}
+      className="bg-popover text-popover-foreground border rounded-md shadow-md py-1 min-w-[160px]"
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <button
+        className="flex items-center w-full px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground gap-2 cursor-default"
+        onClick={() => {
+          onOpenTerminal(data)
+          onClose()
+        }}
       >
-        <button
-          className="flex items-center w-full px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground gap-2 cursor-default"
-          onClick={handleOpenTerminal}
-        >
-          <Terminal className="size-4 shrink-0" />
-          Open Terminal
-        </button>
-        <div className="h-px bg-border my-1" />
-        <button
-          className="flex items-center w-full px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground gap-2 cursor-default"
-          onClick={() => {
-            router.push(`/hosts/${data.hostId}`)
-            onClose()
-          }}
-        >
-          <Server className="size-4 shrink-0" />
-          View Host
-        </button>
-      </div>
-
-      <Dialog open={usernameDialogOpen} onOpenChange={setUsernameDialogOpen}>
-        <DialogContent className="sm:max-w-xs">
-          <DialogHeader>
-            <DialogTitle>Connect to {data.name}</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="host-ctx-username">Username</Label>
-            <Input
-              id="host-ctx-username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="e.g. jsmith"
-              autoFocus
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && username.trim()) handleConnect()
-              }}
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setUsernameDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleConnect} disabled={!username.trim()}>
-              <Terminal className="size-4 mr-1.5" />
-              Connect
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+        <Terminal className="size-4 shrink-0" />
+        Open Terminal
+      </button>
+      <div className="h-px bg-border my-1" />
+      <button
+        className="flex items-center w-full px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground gap-2 cursor-default"
+        onClick={() => {
+          router.push(`/hosts/${data.hostId}`)
+          onClose()
+        }}
+      >
+        <Server className="size-4 shrink-0" />
+        View Host
+      </button>
+    </div>
   )
 }

--- a/apps/web/app/(dashboard)/hosts/networks/components/host-node-terminal-dialog.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/host-node-terminal-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { Terminal } from 'lucide-react'
 import { useTerminalPanel } from '@/components/terminal'
 import {
@@ -21,22 +21,24 @@ interface Props {
   onOpenChange: (open: boolean) => void
 }
 
-export function HostNodeTerminalDialog({ data, open, onOpenChange }: Props) {
+// Inner form — keyed by hostId so it remounts (and re-initialises username) on each new host
+function TerminalConnectForm({
+  data,
+  onOpenChange,
+}: {
+  data: HostNodeData
+  onOpenChange: (open: boolean) => void
+}) {
   const { openTerminal } = useTerminalPanel()
-  const [username, setUsername] = useState('')
-
-  // Load saved username whenever the target host changes
-  useEffect(() => {
-    if (!data) return
+  const [username, setUsername] = useState(() => {
     try {
-      setUsername(localStorage.getItem(`terminal-username:${data.hostId}`) ?? '')
+      return localStorage.getItem(`terminal-username:${data.hostId}`) ?? ''
     } catch {
-      setUsername('')
+      return ''
     }
-  }, [data])
+  })
 
   const handleConnect = useCallback(() => {
-    if (!data) return
     try {
       if (username.trim()) {
         localStorage.setItem(`terminal-username:${data.hostId}`, username.trim())
@@ -54,36 +56,44 @@ export function HostNodeTerminalDialog({ data, open, onOpenChange }: Props) {
     onOpenChange(false)
   }, [data, username, openTerminal, onOpenChange])
 
-  if (!data) return null
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Connect to {data.name}</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-2">
+        <Label htmlFor="host-graph-username">Username</Label>
+        <Input
+          id="host-graph-username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="e.g. jsmith"
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && username.trim()) handleConnect()
+          }}
+        />
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button onClick={handleConnect} disabled={!username.trim()}>
+          <Terminal className="size-4 mr-1.5" />
+          Connect
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
 
+export function HostNodeTerminalDialog({ data, open, onOpenChange }: Props) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xs">
-        <DialogHeader>
-          <DialogTitle>Connect to {data.name}</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-2">
-          <Label htmlFor="host-graph-username">Username</Label>
-          <Input
-            id="host-graph-username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder="e.g. jsmith"
-            autoFocus
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && username.trim()) handleConnect()
-            }}
-          />
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleConnect} disabled={!username.trim()}>
-            <Terminal className="size-4 mr-1.5" />
-            Connect
-          </Button>
-        </DialogFooter>
+        {data && (
+          <TerminalConnectForm key={data.hostId} data={data} onOpenChange={onOpenChange} />
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/app/(dashboard)/hosts/networks/components/host-node-terminal-dialog.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/host-node-terminal-dialog.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Terminal } from 'lucide-react'
+import { useTerminalPanel } from '@/components/terminal'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import type { HostNodeData } from './network-flow-nodes'
+
+interface Props {
+  data: HostNodeData | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function HostNodeTerminalDialog({ data, open, onOpenChange }: Props) {
+  const { openTerminal } = useTerminalPanel()
+  const [username, setUsername] = useState('')
+
+  // Load saved username whenever the target host changes
+  useEffect(() => {
+    if (!data) return
+    try {
+      setUsername(localStorage.getItem(`terminal-username:${data.hostId}`) ?? '')
+    } catch {
+      setUsername('')
+    }
+  }, [data])
+
+  const handleConnect = useCallback(() => {
+    if (!data) return
+    try {
+      if (username.trim()) {
+        localStorage.setItem(`terminal-username:${data.hostId}`, username.trim())
+      }
+    } catch {
+      // localStorage may be unavailable
+    }
+    openTerminal({
+      hostId: data.hostId,
+      hostname: data.name,
+      username: username.trim() || null,
+      orgId: data.orgId,
+      directAccess: false,
+    })
+    onOpenChange(false)
+  }, [data, username, openTerminal, onOpenChange])
+
+  if (!data) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xs">
+        <DialogHeader>
+          <DialogTitle>Connect to {data.name}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="host-graph-username">Username</Label>
+          <Input
+            id="host-graph-username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="e.g. jsmith"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && username.trim()) handleConnect()
+            }}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleConnect} disabled={!username.trim()}>
+            <Terminal className="size-4 mr-1.5" />
+            Connect
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Fixes "Open Terminal" in the network graph right-click menu doing nothing

## Root cause

`HostNodeContextMenu` rendered the username dialog (`Dialog`) as a child component. When "Open Terminal" was clicked, the handler called `onClose()` first, which set `contextMenu` to `null` in the parent — **unmounting** `HostNodeContextMenu` before `setUsernameDialogOpen(true)` could take effect. The dialog was never shown.

## Fix

Moved the username `Dialog` into a new `HostNodeTerminalDialog` component rendered directly in the parent graph components (`NetworkGraph` / `AllNetworksGraph`), independent of the context menu's lifecycle. The context menu now emits `onOpenTerminal(data)`, which sets state in the parent — the dialog stays mounted even after the menu closes.

```
Before: HostNodeContextMenu → [dialog inside, unmounted with menu]
After:  HostNodeContextMenu → onOpenTerminal(data) → parent state → HostNodeTerminalDialog (always mounted)
```

## Test plan

- [ ] Right-click a host node → context menu appears
- [ ] Click "Open Terminal" → username dialog appears with previously-used username pre-filled
- [ ] Enter username and click Connect → terminal panel opens at bottom of screen connected to that host
- [ ] Click Cancel → dialog closes, nothing opens
- [ ] Works on single-network and all-networks graph views

🤖 Generated with [Claude Code](https://claude.com/claude-code)