### PR TITLE
feat: tab colours, reorder, rename, and split panes for terminal

### DIFF
--- a/apps/docs/docs/features/terminal.md
+++ b/apps/docs/docs/features/terminal.md
@@ -35,9 +35,33 @@ Each host session opens in its own tab. You can have multiple simultaneous sessi
 - Click a tab to switch between sessions
 - Close a tab to end the session
 
+### Reordering tabs
+
+Drag a tab left or right along the tab bar to reorder it. The new order is persisted with the rest of the terminal state.
+
+### Renaming tabs
+
+Double-click a tab (or right-click → **Rename**) to give it a custom label. Press **Enter** to commit or **Escape** to cancel. Clearing the label reverts to the host's name. The username, when shown, is hidden once a custom label is set.
+
+### Tab colours
+
+Right-click a tab and choose **Tab colour** to assign one of the preset colours (slate, red, amber, emerald, sky, violet, pink). The chosen colour is shown as a thin accent bar on the left edge of the tab and a subtle tint on the active tab — useful for distinguishing production hosts from staging, or grouping related sessions visually. Select **No colour** to clear the assignment.
+
+### Split panes
+
+Each tab can host multiple terminal panes connected to the same host. Splits are useful for running `tail -f` in one pane while you work in another, or watching a process while reading its logs.
+
+- **Right-click a tab → Split right / Split down** — splits the currently focused pane in the chosen direction and opens a new session on the same host.
+- **Hover over a pane** — action buttons appear in the top-right for Split right, Split down, and Close pane.
+- **Drag the divider** between two panes to resize them.
+- **Click inside a pane** to make it active; split actions operate on the active pane.
+- Closing the last pane in a tab also closes the tab.
+
+All panes in a tab share the same host/user binding — they are independent shell sessions, not a shared shell.
+
 ### Tab persistence
 
-Open tabs (and which host they're connected to) are persisted across browser refreshes via `localStorage`. Your session layout is restored when you reopen the browser.
+Open tabs, their order, colours, labels, and pane layout are persisted across navigation and browser refreshes via `sessionStorage`. The live shell sessions themselves are not restored on refresh — each pane reconnects and starts a new shell when the page loads.
 
 ---
 

--- a/apps/web/components/terminal/terminal-pane-tree.tsx
+++ b/apps/web/components/terminal/terminal-pane-tree.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useRef, useCallback } from 'react'
+import { SplitSquareHorizontal, SplitSquareVertical, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type {
+  TerminalPaneNode,
+  TerminalSessionBinding,
+} from './terminal-panel-context'
+import { TerminalSession, type TerminalSessionStatus } from './terminal-session'
+
+interface PaneTreeProps {
+  tabId: string
+  node: TerminalPaneNode
+  binding: TerminalSessionBinding
+  isVisible: boolean
+  activePaneId: string
+  onSessionStatusChange: (paneId: string, status: TerminalSessionStatus) => void
+  onFocusPane: (paneId: string) => void
+  onSplitPane: (paneId: string, direction: 'row' | 'column') => void
+  onClosePane: (paneId: string) => void
+  onSplitRatioChange: (splitId: string, ratio: number) => void
+}
+
+export function TerminalPaneTree(props: PaneTreeProps) {
+  return <PaneNode {...props} node={props.node} />
+}
+
+function PaneNode(props: PaneTreeProps) {
+  const { node } = props
+  if (node.type === 'leaf') {
+    return <PaneLeaf {...props} node={node} />
+  }
+  return <PaneSplit {...props} node={node} />
+}
+
+function PaneLeaf({
+  node,
+  binding,
+  isVisible,
+  activePaneId,
+  onSessionStatusChange,
+  onFocusPane,
+  onSplitPane,
+  onClosePane,
+}: PaneTreeProps & { node: { type: 'leaf'; id: string } }) {
+  const isActive = node.id === activePaneId
+  return (
+    <div
+      className={cn(
+        'relative h-full w-full overflow-hidden',
+        isActive && 'ring-1 ring-inset ring-primary/40',
+      )}
+    >
+      <TerminalSession
+        paneId={node.id}
+        binding={binding}
+        isVisible={isVisible}
+        isFocused={isActive}
+        onStatusChange={onSessionStatusChange}
+        onFocus={() => onFocusPane(node.id)}
+      />
+      {/* Per-pane action toolbar (top-right) */}
+      <div
+        className={cn(
+          'absolute top-1 right-1 z-10 flex items-center gap-0.5 rounded-md border border-border bg-background/80 backdrop-blur-sm px-0.5 py-0.5 shadow-sm',
+          'opacity-0 hover:opacity-100 focus-within:opacity-100 transition-opacity',
+          isActive && 'opacity-70',
+        )}
+      >
+        <button
+          title="Split right (vertical)"
+          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+          onClick={(e) => {
+            e.stopPropagation()
+            onSplitPane(node.id, 'row')
+          }}
+        >
+          <SplitSquareVertical className="size-3.5" />
+        </button>
+        <button
+          title="Split down (horizontal)"
+          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+          onClick={(e) => {
+            e.stopPropagation()
+            onSplitPane(node.id, 'column')
+          }}
+        >
+          <SplitSquareHorizontal className="size-3.5" />
+        </button>
+        <button
+          title="Close pane"
+          className="p-1 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive"
+          onClick={(e) => {
+            e.stopPropagation()
+            onClosePane(node.id)
+          }}
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function PaneSplit({
+  node,
+  ...rest
+}: PaneTreeProps & {
+  node: Extract<TerminalPaneNode, { type: 'split' }>
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const isRow = node.direction === 'row'
+
+  const handleSplitterDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const container = containerRef.current
+      if (!container) return
+
+      const rect = container.getBoundingClientRect()
+      const total = isRow ? rect.width : rect.height
+      const origin = isRow ? rect.left : rect.top
+
+      const handleMove = (me: MouseEvent) => {
+        const pos = isRow ? me.clientX : me.clientY
+        const ratio = (pos - origin) / total
+        rest.onSplitRatioChange(node.id, ratio)
+      }
+
+      const handleUp = () => {
+        document.removeEventListener('mousemove', handleMove)
+        document.removeEventListener('mouseup', handleUp)
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+
+      document.body.style.cursor = isRow ? 'col-resize' : 'row-resize'
+      document.body.style.userSelect = 'none'
+      document.addEventListener('mousemove', handleMove)
+      document.addEventListener('mouseup', handleUp)
+    },
+    [isRow, node.id, rest],
+  )
+
+  const primaryPct = `${(node.ratio * 100).toFixed(2)}%`
+  const secondaryPct = `${((1 - node.ratio) * 100).toFixed(2)}%`
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('flex h-full w-full', isRow ? 'flex-row' : 'flex-col')}
+    >
+      <div
+        className="overflow-hidden"
+        style={{ [isRow ? 'width' : 'height']: primaryPct }}
+      >
+        <PaneNode {...rest} node={node.children[0]} />
+      </div>
+      <div
+        onMouseDown={handleSplitterDown}
+        className={cn(
+          'shrink-0 bg-border hover:bg-primary/40 active:bg-primary/60 transition-colors z-10',
+          isRow ? 'w-[2px] cursor-col-resize' : 'h-[2px] cursor-row-resize',
+        )}
+      />
+      <div
+        className="overflow-hidden"
+        style={{ [isRow ? 'width' : 'height']: secondaryPct }}
+      >
+        <PaneNode {...rest} node={node.children[1]} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/terminal/terminal-panel-context.tsx
+++ b/apps/web/components/terminal/terminal-panel-context.tsx
@@ -3,13 +3,44 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react'
 import { createId } from '@paralleldrive/cuid2'
 
-export interface TerminalTabInfo {
-  id: string
+export type TerminalTabColor =
+  | 'slate'
+  | 'red'
+  | 'amber'
+  | 'emerald'
+  | 'sky'
+  | 'violet'
+  | 'pink'
+
+/**
+ * Identity used to establish a terminal session (host + user).
+ * Splits always reuse the parent tab's binding so new panes connect to the same host.
+ */
+export interface TerminalSessionBinding {
   hostId: string
   hostname: string
   username: string | null
   orgId: string
   directAccess: boolean
+}
+
+export type TerminalPaneNode =
+  | { type: 'leaf'; id: string }
+  | {
+      type: 'split'
+      id: string
+      direction: 'row' | 'column'
+      ratio: number
+      children: [TerminalPaneNode, TerminalPaneNode]
+    }
+
+export interface TerminalTabInfo {
+  id: string
+  binding: TerminalSessionBinding
+  color: TerminalTabColor | null
+  label: string | null
+  paneTree: TerminalPaneNode
+  activePaneId: string
 }
 
 interface TerminalPanelState {
@@ -33,6 +64,13 @@ interface TerminalPanelActions {
   openPanel: () => void
   closePanel: () => void
   setPanelHeight: (height: number) => void
+  reorderTabs: (fromTabId: string, toTabId: string) => void
+  setTabColor: (tabId: string, color: TerminalTabColor | null) => void
+  renameTab: (tabId: string, label: string) => void
+  splitPane: (tabId: string, paneId: string, direction: 'row' | 'column') => void
+  closePane: (tabId: string, paneId: string) => void
+  setActivePane: (tabId: string, paneId: string) => void
+  setSplitRatio: (tabId: string, splitId: string, ratio: number) => void
 }
 
 type TerminalPanelContextValue = TerminalPanelState & TerminalPanelActions
@@ -43,37 +81,134 @@ const DEFAULT_PANEL_HEIGHT = 350
 const MIN_PANEL_HEIGHT = 150
 const MAX_PANEL_HEIGHT_RATIO = 0.7
 
+// --- pane tree helpers ---
+
+function findFirstLeafId(node: TerminalPaneNode): string {
+  return node.type === 'leaf' ? node.id : findFirstLeafId(node.children[0])
+}
+
+function mapPaneTree(
+  node: TerminalPaneNode,
+  leafId: string,
+  replacer: (leaf: { type: 'leaf'; id: string }) => TerminalPaneNode,
+): TerminalPaneNode {
+  if (node.type === 'leaf') {
+    return node.id === leafId ? replacer(node) : node
+  }
+  return {
+    ...node,
+    children: [
+      mapPaneTree(node.children[0], leafId, replacer),
+      mapPaneTree(node.children[1], leafId, replacer),
+    ],
+  }
+}
+
+function removeLeafFromTree(
+  node: TerminalPaneNode,
+  leafId: string,
+): TerminalPaneNode | null {
+  if (node.type === 'leaf') {
+    return node.id === leafId ? null : node
+  }
+  const left = removeLeafFromTree(node.children[0], leafId)
+  const right = removeLeafFromTree(node.children[1], leafId)
+  if (left && right) {
+    return { ...node, children: [left, right] }
+  }
+  return left ?? right ?? null
+}
+
+function setSplitRatioInTree(
+  node: TerminalPaneNode,
+  splitId: string,
+  ratio: number,
+): TerminalPaneNode {
+  if (node.type === 'leaf') return node
+  if (node.id === splitId) {
+    return { ...node, ratio: Math.max(0.1, Math.min(0.9, ratio)) }
+  }
+  return {
+    ...node,
+    children: [
+      setSplitRatioInTree(node.children[0], splitId, ratio),
+      setSplitRatioInTree(node.children[1], splitId, ratio),
+    ],
+  }
+}
+
+function isValidPaneTree(value: unknown): value is TerminalPaneNode {
+  if (typeof value !== 'object' || value === null) return false
+  const n = value as Record<string, unknown>
+  if (n.type === 'leaf') return typeof n.id === 'string'
+  if (n.type === 'split') {
+    if (typeof n.id !== 'string') return false
+    if (n.direction !== 'row' && n.direction !== 'column') return false
+    if (typeof n.ratio !== 'number') return false
+    if (!Array.isArray(n.children) || n.children.length !== 2) return false
+    return isValidPaneTree(n.children[0]) && isValidPaneTree(n.children[1])
+  }
+  return false
+}
+
 // --- sessionStorage persistence ---
 
 const STORAGE_KEY = 'terminal-panel-state'
 
+interface PersistedTab {
+  binding: TerminalSessionBinding
+  color: TerminalTabColor | null
+  label: string | null
+  paneTree: TerminalPaneNode
+}
+
 interface PersistedTerminalState {
-  tabs: Omit<TerminalTabInfo, 'id'>[]
+  tabs: PersistedTab[]
   activeTabIndex: number | null
   isOpen: boolean
   panelHeight: number
 }
 
+const COLOR_VALUES = new Set<TerminalTabColor>([
+  'slate',
+  'red',
+  'amber',
+  'emerald',
+  'sky',
+  'violet',
+  'pink',
+])
+
+function isValidBinding(value: unknown): value is TerminalSessionBinding {
+  if (typeof value !== 'object' || value === null) return false
+  const b = value as Record<string, unknown>
+  return (
+    typeof b.hostId === 'string' &&
+    typeof b.hostname === 'string' &&
+    (b.username === null || typeof b.username === 'string') &&
+    typeof b.orgId === 'string' &&
+    typeof b.directAccess === 'boolean'
+  )
+}
+
+function isValidPersistedTab(value: unknown): value is PersistedTab {
+  if (typeof value !== 'object' || value === null) return false
+  const t = value as Record<string, unknown>
+  if (!isValidBinding(t.binding)) return false
+  if (t.color !== null && !COLOR_VALUES.has(t.color as TerminalTabColor)) return false
+  if (t.label !== null && typeof t.label !== 'string') return false
+  if (!isValidPaneTree(t.paneTree)) return false
+  return true
+}
+
 function isValidPersistedState(value: unknown): value is PersistedTerminalState {
   if (typeof value !== 'object' || value === null) return false
   const obj = value as Record<string, unknown>
-
   if (typeof obj.isOpen !== 'boolean') return false
   if (typeof obj.panelHeight !== 'number' || !Number.isFinite(obj.panelHeight)) return false
   if (obj.activeTabIndex !== null && typeof obj.activeTabIndex !== 'number') return false
   if (!Array.isArray(obj.tabs)) return false
-
-  return obj.tabs.every((tab: unknown) => {
-    if (typeof tab !== 'object' || tab === null) return false
-    const t = tab as Record<string, unknown>
-    return (
-      typeof t.hostId === 'string' &&
-      typeof t.hostname === 'string' &&
-      (t.username === null || typeof t.username === 'string') &&
-      typeof t.orgId === 'string' &&
-      typeof t.directAccess === 'boolean'
-    )
-  })
+  return obj.tabs.every(isValidPersistedTab)
 }
 
 function loadPersistedState(): TerminalPanelState | null {
@@ -88,7 +223,11 @@ function loadPersistedState(): TerminalPanelState | null {
 
     const tabs: TerminalTabInfo[] = parsed.tabs.map((t) => ({
       id: createId(),
-      ...t,
+      binding: t.binding,
+      color: t.color,
+      label: t.label,
+      paneTree: t.paneTree,
+      activePaneId: findFirstLeafId(t.paneTree),
     }))
 
     const restoredTab =
@@ -114,11 +253,10 @@ function persistState(state: TerminalPanelState): void {
     }
     const toPersist: PersistedTerminalState = {
       tabs: state.tabs.map((t) => ({
-        hostId: t.hostId,
-        hostname: t.hostname,
-        username: t.username,
-        orgId: t.orgId,
-        directAccess: t.directAccess,
+        binding: t.binding,
+        color: t.color,
+        label: t.label,
+        paneTree: t.paneTree,
       })),
       activeTabIndex: state.activeTabId
         ? state.tabs.findIndex((t) => t.id === state.activeTabId)
@@ -159,7 +297,15 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
       directAccess: boolean
     }) => {
       const tabId = createId()
-      const tab: TerminalTabInfo = { id: tabId, ...params }
+      const paneId = createId()
+      const tab: TerminalTabInfo = {
+        id: tabId,
+        binding: { ...params },
+        color: null,
+        label: null,
+        paneTree: { type: 'leaf', id: paneId },
+        activePaneId: paneId,
+      }
 
       setState((prev) => ({
         ...prev,
@@ -213,6 +359,107 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
     }))
   }, [])
 
+  const reorderTabs = useCallback((fromTabId: string, toTabId: string) => {
+    if (fromTabId === toTabId) return
+    setState((prev) => {
+      const fromIdx = prev.tabs.findIndex((t) => t.id === fromTabId)
+      const toIdx = prev.tabs.findIndex((t) => t.id === toTabId)
+      if (fromIdx === -1 || toIdx === -1) return prev
+      const next = [...prev.tabs]
+      const [moved] = next.splice(fromIdx, 1)
+      if (!moved) return prev
+      next.splice(toIdx, 0, moved)
+      return { ...prev, tabs: next }
+    })
+  }, [])
+
+  const setTabColor = useCallback((tabId: string, color: TerminalTabColor | null) => {
+    setState((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) => (t.id === tabId ? { ...t, color } : t)),
+    }))
+  }, [])
+
+  const renameTab = useCallback((tabId: string, label: string) => {
+    const trimmed = label.trim()
+    setState((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) =>
+        t.id === tabId ? { ...t, label: trimmed.length === 0 ? null : trimmed } : t,
+      ),
+    }))
+  }, [])
+
+  const splitPane = useCallback(
+    (tabId: string, paneId: string, direction: 'row' | 'column') => {
+      setState((prev) => ({
+        ...prev,
+        tabs: prev.tabs.map((t) => {
+          if (t.id !== tabId) return t
+          const newLeafId = createId()
+          const splitId = createId()
+          const nextTree = mapPaneTree(t.paneTree, paneId, (leaf) => ({
+            type: 'split',
+            id: splitId,
+            direction,
+            ratio: 0.5,
+            children: [leaf, { type: 'leaf', id: newLeafId }],
+          }))
+          return { ...t, paneTree: nextTree, activePaneId: newLeafId }
+        }),
+      }))
+    },
+    [],
+  )
+
+  const closePane = useCallback((tabId: string, paneId: string) => {
+    setState((prev) => {
+      const target = prev.tabs.find((t) => t.id === tabId)
+      if (!target) return prev
+      const nextTree = removeLeafFromTree(target.paneTree, paneId)
+      if (!nextTree) {
+        // Closed the last pane — close the tab itself.
+        const remaining = prev.tabs.filter((t) => t.id !== tabId)
+        let nextActive = prev.activeTabId
+        if (prev.activeTabId === tabId) {
+          const closedIdx = prev.tabs.findIndex((t) => t.id === tabId)
+          nextActive =
+            remaining[Math.max(0, closedIdx - 1)]?.id ?? remaining[0]?.id ?? null
+        }
+        return {
+          ...prev,
+          tabs: remaining,
+          activeTabId: nextActive,
+          isOpen: remaining.length > 0 ? prev.isOpen : false,
+        }
+      }
+      return {
+        ...prev,
+        tabs: prev.tabs.map((t) =>
+          t.id === tabId
+            ? { ...t, paneTree: nextTree, activePaneId: findFirstLeafId(nextTree) }
+            : t,
+        ),
+      }
+    })
+  }, [])
+
+  const setActivePane = useCallback((tabId: string, paneId: string) => {
+    setState((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) => (t.id === tabId ? { ...t, activePaneId: paneId } : t)),
+    }))
+  }, [])
+
+  const setSplitRatio = useCallback((tabId: string, splitId: string, ratio: number) => {
+    setState((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) =>
+        t.id === tabId ? { ...t, paneTree: setSplitRatioInTree(t.paneTree, splitId, ratio) } : t,
+      ),
+    }))
+  }, [])
+
   return (
     <TerminalPanelContext.Provider
       value={{
@@ -224,6 +471,13 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
         openPanel,
         closePanel,
         setPanelHeight,
+        reorderTabs,
+        setTabColor,
+        renameTab,
+        splitPane,
+        closePane,
+        setActivePane,
+        setSplitRatio,
       }}
     >
       {children}
@@ -237,4 +491,27 @@ export function useTerminalPanel(): TerminalPanelContextValue {
     throw new Error('useTerminalPanel must be used within a TerminalPanelProvider')
   }
   return ctx
+}
+
+// --- Shared color presets (used by UI) ---
+
+export const TERMINAL_TAB_COLOR_PRESETS: ReadonlyArray<{
+  value: TerminalTabColor
+  label: string
+  swatch: string
+  accent: string
+  tint: string
+}> = [
+  { value: 'slate', label: 'Slate', swatch: 'bg-slate-500', accent: 'bg-slate-500', tint: 'bg-slate-500/10' },
+  { value: 'red', label: 'Red', swatch: 'bg-red-500', accent: 'bg-red-500', tint: 'bg-red-500/10' },
+  { value: 'amber', label: 'Amber', swatch: 'bg-amber-500', accent: 'bg-amber-500', tint: 'bg-amber-500/10' },
+  { value: 'emerald', label: 'Emerald', swatch: 'bg-emerald-500', accent: 'bg-emerald-500', tint: 'bg-emerald-500/10' },
+  { value: 'sky', label: 'Sky', swatch: 'bg-sky-500', accent: 'bg-sky-500', tint: 'bg-sky-500/10' },
+  { value: 'violet', label: 'Violet', swatch: 'bg-violet-500', accent: 'bg-violet-500', tint: 'bg-violet-500/10' },
+  { value: 'pink', label: 'Pink', swatch: 'bg-pink-500', accent: 'bg-pink-500', tint: 'bg-pink-500/10' },
+]
+
+export function getTabColorPreset(color: TerminalTabColor | null | undefined) {
+  if (!color) return null
+  return TERMINAL_TAB_COLOR_PRESETS.find((c) => c.value === color) ?? null
 }

--- a/apps/web/components/terminal/terminal-panel.tsx
+++ b/apps/web/components/terminal/terminal-panel.tsx
@@ -1,6 +1,20 @@
 'use client'
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import {
   X,
   Plus,
@@ -8,18 +22,38 @@ import {
   ChevronUp,
   Terminal,
   Circle,
+  Check,
+  SplitSquareHorizontal,
+  SplitSquareVertical,
+  Pencil,
+  Palette,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu'
 import { cn } from '@/lib/utils'
-import { useTerminalPanel } from './terminal-panel-context'
-import { TerminalSession } from './terminal-session'
+import {
+  useTerminalPanel,
+  TERMINAL_TAB_COLOR_PRESETS,
+  getTabColorPreset,
+  type TerminalTabInfo,
+  type TerminalTabColor,
+} from './terminal-panel-context'
+import { TerminalPaneTree } from './terminal-pane-tree'
 import { HostSelectorDialog } from './host-selector-dialog'
+import type { TerminalSessionStatus } from './terminal-session'
 
 interface Props {
   orgId: string
 }
-
-type TabStatus = 'connecting' | 'connected' | 'error' | 'closed'
 
 export function TerminalPanel({ orgId }: Props) {
   const {
@@ -31,18 +65,30 @@ export function TerminalPanel({ orgId }: Props) {
     setActiveTab,
     togglePanel,
     setPanelHeight,
+    reorderTabs,
+    setTabColor,
+    renameTab,
+    splitPane,
+    closePane,
+    setActivePane,
+    setSplitRatio,
   } = useTerminalPanel()
 
   const [hostSelectorOpen, setHostSelectorOpen] = useState(false)
-  const [tabStatuses, setTabStatuses] = useState<Record<string, TabStatus>>({})
+  // Status is now tracked per-pane, keyed by paneId
+  const [paneStatuses, setPaneStatuses] = useState<Record<string, TerminalSessionStatus>>({})
+  const [renamingTabId, setRenamingTabId] = useState<string | null>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const isResizing = useRef(false)
   const startY = useRef(0)
   const startHeight = useRef(0)
 
-  const handleStatusChange = useCallback((tabId: string, status: TabStatus) => {
-    setTabStatuses((prev) => ({ ...prev, [tabId]: status }))
-  }, [])
+  const handleSessionStatusChange = useCallback(
+    (paneId: string, status: TerminalSessionStatus) => {
+      setPaneStatuses((prev) => ({ ...prev, [paneId]: status }))
+    },
+    [],
+  )
 
   // Resize drag handlers
   const handleMouseDown = useCallback(
@@ -74,6 +120,21 @@ export function TerminalPanel({ orgId }: Props) {
     [panelHeight, setPanelHeight],
   )
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+  )
+
+  const handleDragEnd = useCallback(
+    (e: DragEndEvent) => {
+      const { active, over } = e
+      if (!over || active.id === over.id) return
+      reorderTabs(String(active.id), String(over.id))
+    },
+    [reorderTabs],
+  )
+
   if (tabs.length === 0) {
     return (
       <HostSelectorDialog
@@ -84,13 +145,33 @@ export function TerminalPanel({ orgId }: Props) {
     )
   }
 
-  const statusColor = (tabId: string) => {
-    const s = tabStatuses[tabId]
+  // Aggregate status across all panes in a tab (worst state wins for the dot).
+  const tabAggregateStatus = (tab: TerminalTabInfo): TerminalSessionStatus | undefined => {
+    const paneIds = collectLeafIds(tab.paneTree)
+    let result: TerminalSessionStatus | undefined
+    const priority: Record<TerminalSessionStatus, number> = {
+      error: 4,
+      connecting: 3,
+      closed: 2,
+      connected: 1,
+    }
+    for (const id of paneIds) {
+      const s = paneStatuses[id]
+      if (!s) continue
+      if (!result || priority[s] > priority[result]) result = s
+    }
+    return result
+  }
+
+  const statusColor = (tab: TerminalTabInfo) => {
+    const s = tabAggregateStatus(tab)
     if (s === 'connected') return 'text-green-500'
     if (s === 'connecting') return 'text-amber-500 animate-pulse'
     if (s === 'error') return 'text-red-500'
     return 'text-zinc-500'
   }
+
+  const activeTab = tabs.find((t) => t.id === activeTabId) ?? null
 
   return (
     <>
@@ -110,38 +191,44 @@ export function TerminalPanel({ orgId }: Props) {
         {/* Tab bar */}
         <div className="flex items-center border-b border-border bg-muted/30 shrink-0">
           <div className="flex-1 flex items-center overflow-x-auto min-w-0">
-            {tabs.map((tab) => (
-              <div
-                key={tab.id}
-                className={cn(
-                  'group flex items-center gap-1.5 px-3 py-1.5 text-xs border-r border-border cursor-pointer select-none shrink-0 max-w-48',
-                  tab.id === activeTabId
-                    ? 'bg-background text-foreground'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-                )}
-                onClick={() => {
-                  setActiveTab(tab.id)
-                  if (!isOpen) togglePanel()
-                }}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={tabs.map((t) => t.id)}
+                strategy={horizontalListSortingStrategy}
               >
-                <Circle className={cn('size-2 shrink-0 fill-current', statusColor(tab.id))} />
-                <span className="truncate">
-                  {tab.hostname}
-                  {tab.username && (
-                    <span className="text-muted-foreground ml-1">({tab.username})</span>
-                  )}
-                </span>
-                <button
-                  className="ml-1 opacity-0 group-hover:opacity-100 hover:text-destructive transition-opacity shrink-0"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    closeTab(tab.id)
-                  }}
-                >
-                  <X className="size-3" />
-                </button>
-              </div>
-            ))}
+                <div className="flex items-center min-w-0">
+                  {tabs.map((tab) => (
+                    <SortableTab
+                      key={tab.id}
+                      tab={tab}
+                      isActive={tab.id === activeTabId}
+                      statusColorClass={statusColor(tab)}
+                      isRenaming={renamingTabId === tab.id}
+                      onActivate={() => {
+                        setActiveTab(tab.id)
+                        if (!isOpen) togglePanel()
+                      }}
+                      onClose={() => closeTab(tab.id)}
+                      onStartRename={() => setRenamingTabId(tab.id)}
+                      onFinishRename={(label) => {
+                        renameTab(tab.id, label)
+                        setRenamingTabId(null)
+                      }}
+                      onCancelRename={() => setRenamingTabId(null)}
+                      onSetColor={(c) => setTabColor(tab.id, c)}
+                      onSplitActive={(dir) => {
+                        const active = tabs.find((t) => t.id === tab.id)
+                        if (active) splitPane(tab.id, active.activePaneId, dir)
+                      }}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
           </div>
 
           <div className="flex items-center gap-0.5 px-2 shrink-0">
@@ -167,15 +254,29 @@ export function TerminalPanel({ orgId }: Props) {
         </div>
 
         {/* Terminal content */}
-        {isOpen && (
+        {isOpen && activeTab && (
           <div className="flex-1 min-h-0 relative">
             {tabs.map((tab) => (
-              <TerminalSession
+              <div
                 key={tab.id}
-                tab={tab}
-                isVisible={tab.id === activeTabId}
-                onStatusChange={handleStatusChange}
-              />
+                className="absolute inset-0"
+                style={{ display: tab.id === activeTab.id ? 'block' : 'none' }}
+              >
+                <TerminalPaneTree
+                  tabId={tab.id}
+                  node={tab.paneTree}
+                  binding={tab.binding}
+                  isVisible={tab.id === activeTab.id}
+                  activePaneId={tab.activePaneId}
+                  onSessionStatusChange={handleSessionStatusChange}
+                  onFocusPane={(paneId) => setActivePane(tab.id, paneId)}
+                  onSplitPane={(paneId, dir) => splitPane(tab.id, paneId, dir)}
+                  onClosePane={(paneId) => closePane(tab.id, paneId)}
+                  onSplitRatioChange={(splitId, ratio) =>
+                    setSplitRatio(tab.id, splitId, ratio)
+                  }
+                />
+              </div>
             ))}
           </div>
         )}
@@ -187,6 +288,203 @@ export function TerminalPanel({ orgId }: Props) {
         orgId={orgId}
       />
     </>
+  )
+}
+
+/**
+ * Collect all leaf paneIds from a pane tree so we can aggregate status.
+ */
+function collectLeafIds(node: TerminalTabInfo['paneTree']): string[] {
+  if (node.type === 'leaf') return [node.id]
+  return [...collectLeafIds(node.children[0]), ...collectLeafIds(node.children[1])]
+}
+
+interface SortableTabProps {
+  tab: TerminalTabInfo
+  isActive: boolean
+  statusColorClass: string
+  isRenaming: boolean
+  onActivate: () => void
+  onClose: () => void
+  onStartRename: () => void
+  onFinishRename: (label: string) => void
+  onCancelRename: () => void
+  onSetColor: (color: TerminalTabColor | null) => void
+  onSplitActive: (direction: 'row' | 'column') => void
+}
+
+function SortableTab({
+  tab,
+  isActive,
+  statusColorClass,
+  isRenaming,
+  onActivate,
+  onClose,
+  onStartRename,
+  onFinishRename,
+  onCancelRename,
+  onSetColor,
+  onSplitActive,
+}: SortableTabProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: tab.id })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  const preset = getTabColorPreset(tab.color)
+  const displayLabel = tab.label ?? tab.binding.hostname
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          ref={setNodeRef}
+          style={style}
+          className={cn(
+            'group relative flex items-center gap-1.5 px-3 py-1.5 text-xs border-r border-border cursor-pointer select-none shrink-0 max-w-48',
+            isActive
+              ? 'bg-background text-foreground'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+            preset && isActive && preset.tint,
+          )}
+          onClick={onActivate}
+          onDoubleClick={(e) => {
+            e.stopPropagation()
+            onStartRename()
+          }}
+          {...attributes}
+          {...listeners}
+        >
+          {/* Left colour accent bar */}
+          {preset && (
+            <span
+              aria-hidden
+              className={cn('absolute left-0 top-0 bottom-0 w-0.5', preset.accent)}
+            />
+          )}
+          <Circle className={cn('size-2 shrink-0 fill-current', statusColorClass)} />
+          {isRenaming ? (
+            <RenameInput
+              initial={tab.label ?? ''}
+              placeholder={tab.binding.hostname}
+              onCommit={onFinishRename}
+              onCancel={onCancelRename}
+            />
+          ) : (
+            <span className="truncate">
+              {displayLabel}
+              {tab.binding.username && !tab.label && (
+                <span className="text-muted-foreground ml-1">
+                  ({tab.binding.username})
+                </span>
+              )}
+            </span>
+          )}
+          <button
+            className="ml-1 opacity-0 group-hover:opacity-100 hover:text-destructive transition-opacity shrink-0"
+            onClick={(e) => {
+              e.stopPropagation()
+              onClose()
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        <ContextMenuItem onClick={onStartRename}>
+          <Pencil className="size-3.5" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <Palette className="size-3.5" />
+            Tab colour
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-40">
+            <ContextMenuItem onClick={() => onSetColor(null)}>
+              <span className="size-3 rounded-full border border-border" />
+              No colour
+              {!tab.color && <Check className="ml-auto size-3.5" />}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            {TERMINAL_TAB_COLOR_PRESETS.map((c) => (
+              <ContextMenuItem key={c.value} onClick={() => onSetColor(c.value)}>
+                <span className={cn('size-3 rounded-full', c.swatch)} />
+                {c.label}
+                {tab.color === c.value && <Check className="ml-auto size-3.5" />}
+              </ContextMenuItem>
+            ))}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => onSplitActive('row')}>
+          <SplitSquareVertical className="size-3.5" />
+          Split right
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => onSplitActive('column')}>
+          <SplitSquareHorizontal className="size-3.5" />
+          Split down
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          onClick={onClose}
+          variant="destructive"
+        >
+          <X className="size-3.5" />
+          Close tab
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+function RenameInput({
+  initial,
+  placeholder,
+  onCommit,
+  onCancel,
+}: {
+  initial: string
+  placeholder: string
+  onCommit: (value: string) => void
+  onCancel: () => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [value, setValue] = useState(initial)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      placeholder={placeholder}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          onCommit(value)
+        } else if (e.key === 'Escape') {
+          e.preventDefault()
+          onCancel()
+        }
+        e.stopPropagation()
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={() => onCommit(value)}
+      className="h-5 px-1 w-28 rounded-sm border border-border bg-background text-foreground text-xs outline-none focus:ring-1 focus:ring-primary"
+    />
   )
 }
 

--- a/apps/web/components/terminal/terminal-session.tsx
+++ b/apps/web/components/terminal/terminal-session.tsx
@@ -2,17 +2,27 @@
 
 import { useRef, useEffect, useCallback } from 'react'
 import { createTerminalSession } from '@/lib/actions/terminal'
-import type { TerminalTabInfo } from './terminal-panel-context'
+import type { TerminalSessionBinding } from './terminal-panel-context'
 
-type Status = 'connecting' | 'connected' | 'error' | 'closed'
+export type TerminalSessionStatus = 'connecting' | 'connected' | 'error' | 'closed'
 
 interface Props {
-  tab: TerminalTabInfo
+  paneId: string
+  binding: TerminalSessionBinding
   isVisible: boolean
-  onStatusChange?: (tabId: string, status: Status) => void
+  isFocused: boolean
+  onStatusChange?: (paneId: string, status: TerminalSessionStatus) => void
+  onFocus?: () => void
 }
 
-export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
+export function TerminalSession({
+  paneId,
+  binding,
+  isVisible,
+  isFocused,
+  onStatusChange,
+  onFocus,
+}: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<unknown>(null)
   const fitRef = useRef<unknown>(null)
@@ -22,10 +32,10 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
   const hasInitializedRef = useRef(false)
 
   const updateStatus = useCallback(
-    (s: Status) => {
-      onStatusChange?.(tab.id, s)
+    (s: TerminalSessionStatus) => {
+      onStatusChange?.(paneId, s)
     },
-    [tab.id, onStatusChange],
+    [paneId, onStatusChange],
   )
 
   // Refit when visibility changes
@@ -41,6 +51,18 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
       })
     }
   }, [isVisible])
+
+  // Focus the xterm when this pane becomes the active one.
+  useEffect(() => {
+    if (isFocused && isVisible && termRef.current) {
+      const term = termRef.current as { focus: () => void }
+      try {
+        term.focus()
+      } catch {
+        // ignore
+      }
+    }
+  }, [isFocused, isVisible])
 
   // Initialize terminal and start first connection
   useEffect(() => {
@@ -101,22 +123,21 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
       const connectSession = async () => {
         if (cancelled) return
 
-        // Tear down previous WebSocket connection if any
         connectionCleanupRef.current?.()
         connectionCleanupRef.current = null
 
         updateStatus('connecting')
         term.clear()
 
-        const connectMsg = tab.directAccess
-          ? `Connecting to ${tab.hostname}...`
-          : `Connecting to ${tab.hostname} as ${tab.username}...`
+        const connectMsg = binding.directAccess
+          ? `Connecting to ${binding.hostname}...`
+          : `Connecting to ${binding.hostname} as ${binding.username}...`
         term.writeln(`\x1b[90m${connectMsg}\x1b[0m`)
 
         const result = await createTerminalSession(
-          tab.orgId,
-          tab.hostId,
-          tab.directAccess ? undefined : (tab.username ?? undefined),
+          binding.orgId,
+          binding.hostId,
+          binding.directAccess ? undefined : (binding.username ?? undefined),
         )
 
         if (cancelled) return
@@ -227,7 +248,7 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
             } catch {
               // ignore send errors on closing socket
             }
-            ws.close(1000, 'tab closed')
+            ws.close(1000, 'pane closed')
           }
           wsRef.current = null
         }
@@ -250,16 +271,18 @@ export function TerminalSession({ tab, isVisible, onStatusChange }: Props) {
       fitRef.current = null
       wsRef.current = null
     }
-  }, [tab, updateStatus])
+  }, [binding, updateStatus])
 
   return (
     <div
-      ref={containerRef}
+      onMouseDown={onFocus}
       className="h-full w-full bg-zinc-950"
       style={{
         display: isVisible ? 'block' : 'none',
         padding: '4px',
       }}
-    />
+    >
+      <div ref={containerRef} className="h-full w-full" />
+    </div>
   )
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,9 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@paralleldrive/cuid2": "^3.3.0",
     "@react-pdf/renderer": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.0(react@19.2.4))
@@ -388,6 +397,28 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.58.0':
     resolution: {integrity: sha512-xizSguxyyvH5eqGWJrhTomUdXFSRaweXBEXxTpkbaalIjHZeKPNPHpevwxCXXqdXPe5bTIeEtBSKD+zStadGFw==}
@@ -6543,6 +6574,31 @@ snapshots:
   '@better-fetch/fetch@1.1.21': {}
 
   '@bufbuild/protobuf@2.11.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.58.0':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds tab drag-to-reorder (via @dnd-kit), right-click context menu, and inline rename (double-click or context menu).
- Adds preset tab colours (slate/red/amber/emerald/sky/violet/pink) shown as a left accent bar and subtle tint on the active tab.
- Converts each tab to a pane tree so a single host session can be split horizontally/vertically; new panes open fresh shells on the same host with draggable dividers. Closing the last pane closes the tab.
- Status indicator on each tab is now aggregated across all its panes.
- Persists order, colours, labels, and pane layout in `sessionStorage`.
- Updates `apps/docs/docs/features/terminal.md` with the new capabilities.

## Test plan
- [ ] Open two terminal tabs; drag one past the other — order updates and persists on refresh.
- [ ] Double-click a tab, rename it, press Enter — custom label shown; clear the label to revert to hostname.
- [ ] Right-click a tab → Tab colour → pick a colour — accent bar appears; select "No colour" to clear.
- [ ] Right-click tab → Split right / Split down — a new pane opens on the same host with a working shell.
- [ ] Hover a pane; use the toolbar buttons to split and close.
- [ ] Drag the divider between two panes — both resize smoothly.
- [ ] Close the last pane in a tab — tab closes; panel closes if it was the last tab.
- [ ] Reload the page — tabs, order, colours, labels, and pane layout restore; sessions reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)