### PR TITLE
feat: terminal text size settings (global + per-tab)

### DIFF
--- a/apps/docs/docs/features/terminal.md
+++ b/apps/docs/docs/features/terminal.md
@@ -65,6 +65,22 @@ Open tabs, their order, colours, labels, and pane layout are persisted across na
 
 ---
 
+## Terminal Settings
+
+### Default text size
+
+Click the **settings** (gear) icon in the terminal panel toolbar to open terminal preferences. The default text size slider controls the font used by every terminal tab. Changes apply immediately to all open terminals and are remembered across browser sessions (per user, per browser — stored in `localStorage`).
+
+Preset sizes are available for quick selection, with a reset button to return to the built-in default (13px).
+
+### Per-tab text size override
+
+To change the text size for a single tab without affecting the others, right-click the tab and choose **Text size**. Pick a preset size, or select **Use default** to clear the override and follow the global setting again. Per-tab overrides are remembered with the tab and persist until the tab is closed.
+
+This is useful for giving more pixels to a log-tail pane, or boosting a shared screen so attendees can read the commands being typed.
+
+---
+
 ## Shell Detection
 
 The agent automatically selects the appropriate shell for the host:

--- a/apps/web/components/terminal/terminal-pane-tree.tsx
+++ b/apps/web/components/terminal/terminal-pane-tree.tsx
@@ -15,6 +15,7 @@ interface PaneTreeProps {
   binding: TerminalSessionBinding
   isVisible: boolean
   activePaneId: string
+  fontSize: number
   onSessionStatusChange: (paneId: string, status: TerminalSessionStatus) => void
   onFocusPane: (paneId: string) => void
   onSplitPane: (paneId: string, direction: 'row' | 'column') => void
@@ -39,6 +40,7 @@ function PaneLeaf({
   binding,
   isVisible,
   activePaneId,
+  fontSize,
   onSessionStatusChange,
   onFocusPane,
   onSplitPane,
@@ -57,6 +59,7 @@ function PaneLeaf({
         binding={binding}
         isVisible={isVisible}
         isFocused={isActive}
+        fontSize={fontSize}
         onStatusChange={onSessionStatusChange}
         onFocus={() => onFocusPane(node.id)}
       />

--- a/apps/web/components/terminal/terminal-panel-context.tsx
+++ b/apps/web/components/terminal/terminal-panel-context.tsx
@@ -41,6 +41,8 @@ export interface TerminalTabInfo {
   label: string | null
   paneTree: TerminalPaneNode
   activePaneId: string
+  /** Optional per-tab font-size override. When null, the global preference is used. */
+  fontSize: number | null
 }
 
 interface TerminalPanelState {
@@ -71,6 +73,7 @@ interface TerminalPanelActions {
   closePane: (tabId: string, paneId: string) => void
   setActivePane: (tabId: string, paneId: string) => void
   setSplitRatio: (tabId: string, splitId: string, ratio: number) => void
+  setTabFontSize: (tabId: string, fontSize: number | null) => void
 }
 
 type TerminalPanelContextValue = TerminalPanelState & TerminalPanelActions
@@ -160,6 +163,7 @@ interface PersistedTab {
   color: TerminalTabColor | null
   label: string | null
   paneTree: TerminalPaneNode
+  fontSize: number | null
 }
 
 interface PersistedTerminalState {
@@ -198,6 +202,14 @@ function isValidPersistedTab(value: unknown): value is PersistedTab {
   if (t.color !== null && !COLOR_VALUES.has(t.color as TerminalTabColor)) return false
   if (t.label !== null && typeof t.label !== 'string') return false
   if (!isValidPaneTree(t.paneTree)) return false
+  // fontSize may be absent on state from older builds — accept null/missing/number.
+  if (
+    t.fontSize !== undefined &&
+    t.fontSize !== null &&
+    (typeof t.fontSize !== 'number' || !Number.isFinite(t.fontSize))
+  ) {
+    return false
+  }
   return true
 }
 
@@ -228,6 +240,7 @@ function loadPersistedState(): TerminalPanelState | null {
       label: t.label,
       paneTree: t.paneTree,
       activePaneId: findFirstLeafId(t.paneTree),
+      fontSize: typeof t.fontSize === 'number' ? t.fontSize : null,
     }))
 
     const restoredTab =
@@ -257,6 +270,7 @@ function persistState(state: TerminalPanelState): void {
         color: t.color,
         label: t.label,
         paneTree: t.paneTree,
+        fontSize: t.fontSize,
       })),
       activeTabIndex: state.activeTabId
         ? state.tabs.findIndex((t) => t.id === state.activeTabId)
@@ -305,6 +319,7 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
         label: null,
         paneTree: { type: 'leaf', id: paneId },
         activePaneId: paneId,
+        fontSize: null,
       }
 
       setState((prev) => ({
@@ -460,6 +475,13 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
     }))
   }, [])
 
+  const setTabFontSize = useCallback((tabId: string, fontSize: number | null) => {
+    setState((prev) => ({
+      ...prev,
+      tabs: prev.tabs.map((t) => (t.id === tabId ? { ...t, fontSize } : t)),
+    }))
+  }, [])
+
   return (
     <TerminalPanelContext.Provider
       value={{
@@ -478,6 +500,7 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
         closePane,
         setActivePane,
         setSplitRatio,
+        setTabFontSize,
       }}
     >
       {children}

--- a/apps/web/components/terminal/terminal-panel.tsx
+++ b/apps/web/components/terminal/terminal-panel.tsx
@@ -27,6 +27,8 @@ import {
   SplitSquareVertical,
   Pencil,
   Palette,
+  Settings2,
+  Type,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -39,6 +41,11 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
 import {
   useTerminalPanel,
@@ -47,6 +54,13 @@ import {
   type TerminalTabInfo,
   type TerminalTabColor,
 } from './terminal-panel-context'
+import {
+  useTerminalPreferences,
+  FONT_SIZE_PRESETS,
+  MIN_FONT_SIZE,
+  MAX_FONT_SIZE,
+  DEFAULT_FONT_SIZE,
+} from './terminal-preferences'
 import { TerminalPaneTree } from './terminal-pane-tree'
 import { HostSelectorDialog } from './host-selector-dialog'
 import type { TerminalSessionStatus } from './terminal-session'
@@ -72,7 +86,9 @@ export function TerminalPanel({ orgId }: Props) {
     closePane,
     setActivePane,
     setSplitRatio,
+    setTabFontSize,
   } = useTerminalPanel()
+  const { preferences, setFontSize: setGlobalFontSize } = useTerminalPreferences()
 
   const [hostSelectorOpen, setHostSelectorOpen] = useState(false)
   // Status is now tracked per-pane, keyed by paneId
@@ -224,6 +240,8 @@ export function TerminalPanel({ orgId }: Props) {
                         const active = tabs.find((t) => t.id === tab.id)
                         if (active) splitPane(tab.id, active.activePaneId, dir)
                       }}
+                      onSetFontSize={(size) => setTabFontSize(tab.id, size)}
+                      globalFontSize={preferences.fontSize}
                     />
                   ))}
                 </div>
@@ -241,6 +259,10 @@ export function TerminalPanel({ orgId }: Props) {
             >
               <Plus className="size-3.5" />
             </Button>
+            <TerminalSettingsPopover
+              fontSize={preferences.fontSize}
+              onFontSizeChange={setGlobalFontSize}
+            />
             <Button
               variant="ghost"
               size="icon"
@@ -268,6 +290,7 @@ export function TerminalPanel({ orgId }: Props) {
                   binding={tab.binding}
                   isVisible={tab.id === activeTab.id}
                   activePaneId={tab.activePaneId}
+                  fontSize={tab.fontSize ?? preferences.fontSize}
                   onSessionStatusChange={handleSessionStatusChange}
                   onFocusPane={(paneId) => setActivePane(tab.id, paneId)}
                   onSplitPane={(paneId, dir) => splitPane(tab.id, paneId, dir)}
@@ -304,6 +327,7 @@ interface SortableTabProps {
   isActive: boolean
   statusColorClass: string
   isRenaming: boolean
+  globalFontSize: number
   onActivate: () => void
   onClose: () => void
   onStartRename: () => void
@@ -311,6 +335,7 @@ interface SortableTabProps {
   onCancelRename: () => void
   onSetColor: (color: TerminalTabColor | null) => void
   onSplitActive: (direction: 'row' | 'column') => void
+  onSetFontSize: (size: number | null) => void
 }
 
 function SortableTab({
@@ -318,6 +343,7 @@ function SortableTab({
   isActive,
   statusColorClass,
   isRenaming,
+  globalFontSize,
   onActivate,
   onClose,
   onStartRename,
@@ -325,6 +351,7 @@ function SortableTab({
   onCancelRename,
   onSetColor,
   onSplitActive,
+  onSetFontSize,
 }: SortableTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: tab.id })
@@ -422,6 +449,31 @@ function SortableTab({
             ))}
           </ContextMenuSubContent>
         </ContextMenuSub>
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <Type className="size-3.5" />
+            Text size
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent className="w-48">
+            <ContextMenuItem onClick={() => onSetFontSize(null)}>
+              <span className="text-muted-foreground w-3 text-center text-[10px]">
+                ·
+              </span>
+              Use default ({globalFontSize}px)
+              {tab.fontSize === null && <Check className="ml-auto size-3.5" />}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            {FONT_SIZE_PRESETS.map((p) => (
+              <ContextMenuItem key={p.value} onClick={() => onSetFontSize(p.value)}>
+                <span className="text-muted-foreground w-3 text-center text-[10px]">
+                  {p.value}
+                </span>
+                {p.label}
+                {tab.fontSize === p.value && <Check className="ml-auto size-3.5" />}
+              </ContextMenuItem>
+            ))}
+          </ContextMenuSubContent>
+        </ContextMenuSub>
         <ContextMenuSeparator />
         <ContextMenuItem onClick={() => onSplitActive('row')}>
           <SplitSquareVertical className="size-3.5" />
@@ -485,6 +537,81 @@ function RenameInput({
       onBlur={() => onCommit(value)}
       className="h-5 px-1 w-28 rounded-sm border border-border bg-background text-foreground text-xs outline-none focus:ring-1 focus:ring-primary"
     />
+  )
+}
+
+/**
+ * Global terminal settings. Currently exposes only the default font size, but
+ * intentionally structured as a popover so more preferences can be added here
+ * (theme, cursor style, scrollback, etc.) without redesigning the toolbar.
+ */
+function TerminalSettingsPopover({
+  fontSize,
+  onFontSizeChange,
+}: {
+  fontSize: number
+  onFontSizeChange: (size: number) => void
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          title="Terminal settings"
+        >
+          <Settings2 className="size-3.5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-3 space-y-3">
+        <div className="space-y-1">
+          <div className="text-xs font-medium text-foreground">Terminal settings</div>
+          <div className="text-xs text-muted-foreground">
+            Applies to every terminal tab. Individual tabs can override these
+            defaults from their right-click menu.
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs text-muted-foreground flex items-center justify-between">
+            <span>Default text size</span>
+            <span className="tabular-nums text-foreground">{fontSize}px</span>
+          </label>
+          <input
+            type="range"
+            min={MIN_FONT_SIZE}
+            max={MAX_FONT_SIZE}
+            step={1}
+            value={fontSize}
+            onChange={(e) => onFontSizeChange(Number(e.target.value))}
+            className="w-full accent-primary"
+          />
+          <div className="flex flex-wrap gap-1 pt-1">
+            {FONT_SIZE_PRESETS.map((p) => (
+              <button
+                key={p.value}
+                onClick={() => onFontSizeChange(p.value)}
+                className={cn(
+                  'px-2 py-0.5 text-[11px] rounded border border-border transition-colors',
+                  fontSize === p.value
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-background text-muted-foreground hover:text-foreground hover:bg-muted',
+                )}
+              >
+                {p.value}
+              </button>
+            ))}
+            <button
+              onClick={() => onFontSizeChange(DEFAULT_FONT_SIZE)}
+              className="px-2 py-0.5 text-[11px] rounded border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors ml-auto"
+              title="Reset to factory default"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/apps/web/components/terminal/terminal-preferences.ts
+++ b/apps/web/components/terminal/terminal-preferences.ts
@@ -1,0 +1,98 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Per-user terminal preferences persisted to localStorage. Survives across
+ * browser sessions and is shared by every open terminal tab/pane.
+ */
+export interface TerminalPreferences {
+  fontSize: number
+}
+
+export const DEFAULT_FONT_SIZE = 13
+export const MIN_FONT_SIZE = 8
+export const MAX_FONT_SIZE = 32
+
+export const FONT_SIZE_PRESETS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 10, label: '10 · Small' },
+  { value: 12, label: '12' },
+  { value: 13, label: '13 · Default' },
+  { value: 14, label: '14' },
+  { value: 16, label: '16 · Large' },
+  { value: 18, label: '18' },
+  { value: 20, label: '20 · Extra Large' },
+]
+
+const STORAGE_KEY = 'terminal-preferences'
+const CHANGE_EVENT = 'terminal-preferences-change'
+
+const DEFAULT_PREFERENCES: TerminalPreferences = {
+  fontSize: DEFAULT_FONT_SIZE,
+}
+
+function clampFontSize(size: number): number {
+  if (!Number.isFinite(size)) return DEFAULT_FONT_SIZE
+  return Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, Math.round(size)))
+}
+
+function loadPreferences(): TerminalPreferences {
+  if (typeof window === 'undefined') return DEFAULT_PREFERENCES
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_PREFERENCES
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return DEFAULT_PREFERENCES
+    const obj = parsed as Record<string, unknown>
+    const fontSize =
+      typeof obj.fontSize === 'number' ? clampFontSize(obj.fontSize) : DEFAULT_FONT_SIZE
+    return { fontSize }
+  } catch {
+    return DEFAULT_PREFERENCES
+  }
+}
+
+function savePreferences(prefs: TerminalPreferences): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs))
+  } catch {
+    // localStorage may be unavailable (private mode, quota exceeded)
+  }
+}
+
+/**
+ * Read + update the current terminal preferences. All consumers stay in sync
+ * via a custom event so that changing the value in the settings popover
+ * updates every live xterm instance immediately.
+ */
+export function useTerminalPreferences() {
+  const [prefs, setPrefs] = useState<TerminalPreferences>(() => loadPreferences())
+
+  useEffect(() => {
+    const handleChange = (e: Event) => {
+      const custom = e as CustomEvent<TerminalPreferences>
+      if (custom.detail) setPrefs(custom.detail)
+      else setPrefs(loadPreferences())
+    }
+    // Same-tab updates broadcast via CustomEvent.
+    window.addEventListener(CHANGE_EVENT, handleChange)
+    // Cross-tab updates arrive via native storage event.
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setPrefs(loadPreferences())
+    }
+    window.addEventListener('storage', handleStorage)
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, handleChange)
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+
+  const setFontSize = useCallback((size: number) => {
+    const next: TerminalPreferences = { fontSize: clampFontSize(size) }
+    savePreferences(next)
+    window.dispatchEvent(new CustomEvent<TerminalPreferences>(CHANGE_EVENT, { detail: next }))
+  }, [])
+
+  return { preferences: prefs, setFontSize }
+}

--- a/apps/web/components/terminal/terminal-session.tsx
+++ b/apps/web/components/terminal/terminal-session.tsx
@@ -11,6 +11,7 @@ interface Props {
   binding: TerminalSessionBinding
   isVisible: boolean
   isFocused: boolean
+  fontSize: number
   onStatusChange?: (paneId: string, status: TerminalSessionStatus) => void
   onFocus?: () => void
 }
@@ -20,6 +21,7 @@ export function TerminalSession({
   binding,
   isVisible,
   isFocused,
+  fontSize,
   onStatusChange,
   onFocus,
 }: Props) {
@@ -30,6 +32,9 @@ export function TerminalSession({
   const connectionCleanupRef = useRef<(() => void) | null>(null)
   const resizeObserverRef = useRef<ResizeObserver | null>(null)
   const hasInitializedRef = useRef(false)
+  // Hold the latest font size so the init effect doesn't need it in its deps.
+  const fontSizeRef = useRef(fontSize)
+  fontSizeRef.current = fontSize
 
   const updateStatus = useCallback(
     (s: TerminalSessionStatus) => {
@@ -64,6 +69,26 @@ export function TerminalSession({
     }
   }, [isFocused, isVisible])
 
+  // Apply font-size changes to a live terminal instance and re-fit.
+  useEffect(() => {
+    if (!termRef.current) return
+    const term = termRef.current as { options: { fontSize?: number } }
+    if (term.options.fontSize === fontSize) return
+    try {
+      term.options.fontSize = fontSize
+      const fit = fitRef.current as { fit: () => void } | null
+      requestAnimationFrame(() => {
+        try {
+          fit?.fit()
+        } catch {
+          // ignore
+        }
+      })
+    } catch {
+      // ignore
+    }
+  }, [fontSize])
+
   // Initialize terminal and start first connection
   useEffect(() => {
     if (hasInitializedRef.current) return
@@ -86,7 +111,7 @@ export function TerminalSession({
       const term = new Terminal({
         cursorBlink: true,
         fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-        fontSize: 13,
+        fontSize: fontSizeRef.current,
         theme: {
           background: '#09090b',
           foreground: '#e4e4e7',


### PR DESCRIPTION
## Summary
- Adds a **settings gear** to the terminal panel toolbar that opens a popover with a default-text-size slider, preset buttons (10–20px), and a reset control. The default is persisted in `localStorage` and shared by every open terminal.
- Adds a **Text size** submenu to the per-tab right-click menu with the same presets plus **Use default**, letting a single tab temporarily override the global size.
- Per-tab overrides persist with the tab (in `sessionStorage`) and clear when the tab is closed.
- Font-size changes apply live to running xterm sessions (including all panes in a split) and re-fit automatically.
- Updates `apps/docs/docs/features/terminal.md` with a new Terminal Settings section.

## Test plan
- [ ] Open a terminal, click the gear → drag the slider — all panes resize live without losing their shell.
- [ ] Close the browser and reopen — the global default size is still applied.
- [ ] Right-click a tab → Text size → pick a preset — only that tab changes.
- [ ] Open a second tab — it still uses the global default (unaffected by per-tab override).
- [ ] Right-click the overridden tab → Text size → Use default — it follows the global setting again.
- [ ] Split a tab with a per-tab size set — new pane inherits the tab's size.
- [ ] Change the global size while a per-tab override is active — only un-overridden tabs react; overridden tab stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)