### PR TITLE
fix: surface server-action errors in directory lookup typeahead

### DIFF
--- a/apps/web/app/(dashboard)/directory-lookup/directory-lookup-client.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/directory-lookup-client.tsx
@@ -91,16 +91,27 @@ export function DirectoryLookupClient({
     debounceRef.current = setTimeout(async () => {
       const cid = configIdRef.current
       setSearching(true)
-      const result = await searchLdapDirectory(orgId, cid, value.trim())
-      setSearching(false)
-      if ('error' in result) {
-        setError(result.error)
+      try {
+        const result = await searchLdapDirectory(orgId, cid, value.trim())
+        if ('error' in result) {
+          setError(result.error)
+          setSuggestions([])
+          setShowSuggestions(false)
+        } else {
+          setError(null)
+          setSuggestions(result.users)
+          setShowSuggestions(result.users.length > 0)
+        }
+      } catch (err) {
+        setError(
+          err instanceof Error && err.message.includes('Server Action')
+            ? 'This page is out of date. Please reload (Cmd+Shift+R / Ctrl+Shift+R).'
+            : err instanceof Error ? err.message : 'Directory search failed.'
+        )
         setSuggestions([])
         setShowSuggestions(false)
-      } else {
-        setError(null)
-        setSuggestions(result.users)
-        setShowSuggestions(result.users.length > 0)
+      } finally {
+        setSearching(false)
       }
     }, 300)
   }, [orgId])
@@ -115,13 +126,22 @@ export function DirectoryLookupClient({
     setGroupFilter('')
     setAttrFilter('')
 
-    const result = await lookupDirectoryUser(orgId, configId, user.dn)
-    setLoadingDetail(false)
-    if ('error' in result) {
-      setError(result.error)
-      return
+    try {
+      const result = await lookupDirectoryUser(orgId, configId, user.dn)
+      if ('error' in result) {
+        setError(result.error)
+        return
+      }
+      setSelectedUser(result.user)
+    } catch (err) {
+      setError(
+        err instanceof Error && err.message.includes('Server Action')
+          ? 'This page is out of date. Please reload (Cmd+Shift+R / Ctrl+Shift+R).'
+          : err instanceof Error ? err.message : 'Directory lookup failed.'
+      )
+    } finally {
+      setLoadingDetail(false)
     }
-    setSelectedUser(result.user)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Wrap the debounced `searchLdapDirectory` and `lookupDirectoryUser` calls in try/catch/finally so a thrown server-action error (e.g. after a deploy when the client bundle holds stale action IDs) no longer leaves the typeahead silently stuck on a spinner.
- When the thrown error message contains \"Server Action\" (the Next.js stale-bundle signature), the UI shows a friendly reload prompt; other errors surface their message.
- Spinner state is always cleared via `finally`.

## Test plan
- [ ] Load `/directory-lookup`, confirm the typeahead still works against a reachable LDAP config.
- [ ] Simulate a stale bundle (or reproduce the original deploy-window error) and confirm the visible error reads \"This page is out of date. Please reload…\" instead of silent no-op.
- [ ] Select a user from suggestions and confirm the detail fetch still works; induce an error and confirm the detail panel surfaces it instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)