### PR TITLE
fix: terminal panel hydration mismatch breaking dashboard interactivity

### DIFF
--- a/apps/web/components/terminal/terminal-panel-context.tsx
+++ b/apps/web/components/terminal/terminal-panel-context.tsx
@@ -294,13 +294,23 @@ const DEFAULT_STATE: TerminalPanelState = {
 // --- Provider ---
 
 export function TerminalPanelProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState<TerminalPanelState>(
-    () => loadPersistedState() ?? DEFAULT_STATE,
-  )
+  // Always start with DEFAULT_STATE so the server-rendered HTML matches the
+  // client's first render. Persisted state is loaded in a post-mount effect —
+  // reading sessionStorage during useState init would cause a hydration
+  // mismatch (React error #418) and break interactivity for the whole tree.
+  const [state, setState] = useState<TerminalPanelState>(DEFAULT_STATE)
+  const [hasHydrated, setHasHydrated] = useState(false)
 
   useEffect(() => {
+    const persisted = loadPersistedState()
+    if (persisted) setState(persisted)
+    setHasHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hasHydrated) return
     persistState(state)
-  }, [state])
+  }, [state, hasHydrated])
 
   const openTerminal = useCallback(
     (params: {

--- a/apps/web/components/terminal/terminal-panel-context.tsx
+++ b/apps/web/components/terminal/terminal-panel-context.tsx
@@ -301,11 +301,16 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
   const [state, setState] = useState<TerminalPanelState>(DEFAULT_STATE)
   const [hasHydrated, setHasHydrated] = useState(false)
 
+  // Hydrating from sessionStorage after mount is the canonical pattern for
+  // avoiding SSR/CSR mismatch; hasHydrated flips once to gate the persistence
+  // effect below.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     const persisted = loadPersistedState()
     if (persisted) setState(persisted)
     setHasHydrated(true)
   }, [])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
     if (!hasHydrated) return


### PR DESCRIPTION
## Summary
- Reading `sessionStorage` during `useState` initialisation in `TerminalPanelProvider` produced different initial HTML on the server (empty tabs) vs. the client (restored tabs), throwing React error #418 (hydration mismatch) and leaving client components like the directory-lookup input non-interactive
- Start with `DEFAULT_STATE` on both server and client, then load persisted state in a post-mount effect
- Gate the persistence effect behind a `hasHydrated` flag so the initial empty state doesn't wipe the stored tabs before they're restored

## Test plan
- [ ] Open `/directory-lookup` — typing in the username input shows live LDAP suggestions after 300ms debounce
- [ ] Selecting a suggestion loads the full user detail card
- [ ] Browser console no longer shows React error #418 on page load
- [ ] Open a terminal tab, navigate away and back — tab is restored from sessionStorage (persistence still works)
- [ ] Reload a page with tabs open — tabs reappear and the dashboard is still interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)