### PR TITLE
Prevent duplicate hosts: reject online dupes, adopt offline ones

### DIFF
--- a/agent/internal/registration/registrar.go
+++ b/agent/internal/registration/registrar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"runtime"
 	"time"
@@ -47,8 +48,9 @@ func (r *Registrar) Register(ctx context.Context, existingAgentID string) (*iden
 		OrgToken:  r.orgToken,
 		PublicKey: r.keypair.PublicKeyPEM,
 		PlatformInfo: &agentv1.PlatformInfo{
-			Os:   runtime.GOOS,
-			Arch: runtime.GOARCH,
+			Os:          runtime.GOOS,
+			Arch:        runtime.GOARCH,
+			IpAddresses: localIPs(),
 		},
 		AgentInfo: &agentv1.AgentInfo{
 			AgentId:  existingAgentID,
@@ -90,4 +92,35 @@ func (r *Registrar) Register(ctx context.Context, existingAgentID string) (*iden
 			return nil, fmt.Errorf("unexpected registration status %q: %s", resp.Status, resp.Message)
 		}
 	}
+}
+
+// localIPs returns the non-loopback IP addresses currently bound on this host,
+// so the server can detect duplicate-host registrations by IP overlap.
+// Mirrors the filtering used by the heartbeat's network interface reporter.
+func localIPs() []string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var ips []string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			ips = append(ips, ip.String())
+		}
+	}
+	return ips
 }

--- a/apps/docs/docs/architecture/ingest.md
+++ b/apps/docs/docs/architecture/ingest.md
@@ -18,6 +18,7 @@ The ingest service is a stateless gRPC server that sits between the agents and t
 - Write agent status and host vitals to PostgreSQL
 - Publish metrics to the internal queue (for consumer processing)
 - Expose a JWKS endpoint for JWT public key distribution
+- Deduplicate host records on registration (see [Duplicate-Host Protection](../features/hosts#duplicate-host-protection))
 
 ---
 

--- a/apps/docs/docs/features/hosts.md
+++ b/apps/docs/docs/features/hosts.md
@@ -40,6 +40,26 @@ To reject a pending agent, click **Revoke**.
 
 ---
 
+## Duplicate-Host Protection
+
+Two live hosts in the same organisation cannot share a hostname or IP address — on a real network that would be a configuration error. Infrawatch enforces this at two points:
+
+- **At registration time** — when an agent calls `Register`, the ingest service checks for an existing non-deleted host in the same organisation whose hostname matches or whose reported IP addresses overlap any of the new agent's IPs.
+- **At approval time** — the same check runs when an admin approves a pending agent, in case a collision emerged while the agent was queued.
+
+What happens on a match depends on the state of the existing host:
+
+| Existing host state | Result |
+|---|---|
+| **Online** (heartbeating) or agent **revoked** | Registration is rejected with `ALREADY_EXISTS` — delete the existing host record first |
+| **Offline** or **unknown** | The existing row is **adopted**: the new public key is rotated onto the existing `agents` row, the host record is kept, and approval state is preserved |
+
+Adoption covers the common re-registration path: an agent is reinstalled on the same physical machine with its data directory wiped, so it generates a fresh keypair. Without adoption this would leave a stale "Offline" duplicate that the admin has to clean up manually; with adoption the host silently resumes using its existing record.
+
+The key rotation is recorded in the agent's status history (`reason: "adopted re-registration (keypair rotated; matched by hostname or IP)"`) so the event is auditable.
+
+---
+
 ## Host Detail Page
 
 The host detail page (`/hosts/[id]`) provides a full view of a single host:

--- a/apps/ingest/internal/db/queries/hosts.sql.go
+++ b/apps/ingest/internal/db/queries/hosts.sql.go
@@ -4,10 +4,84 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// HostCollision describes an existing host whose identity (hostname or IP) overlaps
+// with a newly registering agent. Used to reject online duplicates and adopt offline
+// ones rather than creating a second row for the same physical machine.
+type HostCollision struct {
+	HostID      string
+	AgentID     string
+	Hostname    string
+	HostStatus  string // hosts.status: online | offline | unknown
+	AgentStatus string // agents.status: pending | active | offline | revoked
+}
+
+// FindHostCollision looks for a non-deleted host in the given org whose hostname
+// matches or whose ip_addresses jsonb array overlaps any of the provided ips.
+// Returns nil, nil when no collision exists.
+//
+// An "online" match means the physical machine is still heartbeating under a
+// different keypair — the new registration must be rejected. An "offline" or
+// "unknown" match is treated as a re-registration of the same machine and the
+// caller will rotate the keypair onto the existing row.
+func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname string, ips []string) (*HostCollision, error) {
+	const q = `
+		SELECT h.id, COALESCE(h.agent_id, ''), h.hostname, h.status, COALESCE(a.status, '')
+		FROM hosts h
+		LEFT JOIN agents a ON a.id = h.agent_id
+		WHERE h.organisation_id = $1
+		  AND h.deleted_at IS NULL
+		  AND (
+		    h.hostname = $2
+		    OR (cardinality($3::text[]) > 0 AND h.ip_addresses ?| $3::text[])
+		  )
+		ORDER BY
+		  CASE WHEN h.status = 'online' THEN 0 ELSE 1 END,
+		  h.last_seen_at DESC NULLS LAST
+		LIMIT 1
+	`
+	if ips == nil {
+		ips = []string{}
+	}
+	row := pool.QueryRow(ctx, q, orgID, hostname, ips)
+	var c HostCollision
+	if err := row.Scan(&c.HostID, &c.AgentID, &c.Hostname, &c.HostStatus, &c.AgentStatus); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &c, nil
+}
+
+// RotateAgentPublicKey replaces the public key on an existing agent row. Used
+// during re-registration adoption: the physical machine is the same (hostname
+// or IP match) but the agent has generated a fresh keypair (e.g. data dir wiped).
+func RotateAgentPublicKey(ctx context.Context, pool *pgxpool.Pool, agentID, publicKey string) error {
+	const q = `UPDATE agents SET public_key = $1, updated_at = NOW() WHERE id = $2`
+	_, err := pool.Exec(ctx, q, publicKey, agentID)
+	return err
+}
+
+// ReattachHostToAgent ensures a host row is linked to the given agent id. Used
+// when adopting an existing host during re-registration.
+func ReattachHostToAgent(ctx context.Context, pool *pgxpool.Pool, hostID, agentID, hostname string) error {
+	const q = `
+		UPDATE hosts
+		SET agent_id   = $2,
+		    hostname   = $3,
+		    updated_at = NOW()
+		WHERE id = $1
+	`
+	_, err := pool.Exec(ctx, q, hostID, agentID, hostname)
+	return err
+}
 
 // InsertHost inserts a new host row linked to an agent and returns the host ID.
 // Caller should verify no host exists for this agentID before calling.

--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -31,9 +31,12 @@ func NewRegisterHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer) *RegisterHan
 // Flow:
 //  1. Validate org_token → UNAUTHENTICATED if invalid/expired
 //  2. Check if public_key already registered → return existing state (idempotent)
-//  3. Insert agent (status=pending) + host row
-//  4. If auto_approve on token → set active, issue JWT
-//  5. Return RegisterResponse
+//  3. Check for a colliding host (same hostname or overlapping IP) in the org:
+//     - Online match → reject with ALREADY_EXISTS (two live hosts can't share identity)
+//     - Offline/unknown match → adopt: rotate public key onto the existing agent row
+//  4. Insert agent (status=pending) + host row
+//  5. If auto_approve on token → set active, issue JWT
+//  6. Return RegisterResponse
 func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error) {
 	if req.OrgToken == "" || req.PublicKey == "" {
 		return nil, status.Error(codes.InvalidArgument, "org_token and public_key are required")
@@ -42,6 +45,11 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	hostname := "unknown"
 	if req.AgentInfo != nil && req.AgentInfo.Hostname != "" {
 		hostname = req.AgentInfo.Hostname
+	}
+
+	var reportedIPs []string
+	if req.PlatformInfo != nil {
+		reportedIPs = req.PlatformInfo.IpAddresses
 	}
 
 	// Step 1: Validate enrolment token
@@ -84,12 +92,95 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		}, nil
 	}
 
-	// Step 3: Insert new agent
 	var agentOS, agentArch string
 	if req.PlatformInfo != nil {
 		agentOS = req.PlatformInfo.Os
 		agentArch = req.PlatformInfo.Arch
 	}
+
+	// Step 3: Check for identity collision with an existing host in the org.
+	// Hostname or IP overlap indicates the same physical machine — either
+	// actively duplicating (reject) or re-registering after a data-dir wipe
+	// (adopt the existing row to avoid stale duplicate records).
+	collision, err := queries.FindHostCollision(ctx, h.pool, orgID, hostname, reportedIPs)
+	if err != nil {
+		slog.Error("checking host collision", "err", err)
+		return nil, status.Error(codes.Internal, "internal error")
+	}
+	if collision != nil {
+		// An active/online match means a live agent is still heartbeating under
+		// a different keypair. The network can't hold two machines with the same
+		// hostname/IP, so this is an error — delete the existing host first.
+		if collision.HostStatus == "online" || collision.AgentStatus == "active" || collision.AgentStatus == "revoked" {
+			reason := "online duplicate"
+			if collision.AgentStatus == "revoked" {
+				reason = "existing agent revoked"
+			}
+			slog.Warn("rejecting registration due to host collision",
+				"hostname", hostname,
+				"existing_host_id", collision.HostID,
+				"existing_agent_id", collision.AgentID,
+				"existing_host_status", collision.HostStatus,
+				"existing_agent_status", collision.AgentStatus,
+				"reason", reason,
+			)
+			return nil, status.Errorf(codes.AlreadyExists,
+				"a host matching this hostname or IP is already registered in this organisation (%s) — delete the existing host before re-registering",
+				reason,
+			)
+		}
+
+		// Offline or unknown: treat as a re-registration of the same machine.
+		// Rotate the public key onto the existing agent row and reuse the host.
+		if collision.AgentID == "" {
+			slog.Warn("host collision has no linked agent; falling through to fresh insert",
+				"host_id", collision.HostID)
+		} else {
+			if err := queries.RotateAgentPublicKey(ctx, h.pool, collision.AgentID, req.PublicKey); err != nil {
+				slog.Error("rotating public key on adopted agent", "err", err)
+				return nil, status.Error(codes.Internal, "failed to adopt existing registration")
+			}
+			if err := queries.ReattachHostToAgent(ctx, h.pool, collision.HostID, collision.AgentID, hostname); err != nil {
+				slog.Warn("reattaching host during adoption", "err", err)
+			}
+			if err := queries.InsertAgentStatusHistory(ctx, h.pool, collision.AgentID, orgID, collision.AgentStatus, nil,
+				"adopted re-registration (keypair rotated; matched by hostname or IP)"); err != nil {
+				slog.Warn("inserting adoption history", "err", err)
+			}
+			if err := queries.IncrementUsageCount(ctx, h.pool, token.ID); err != nil {
+				slog.Warn("incrementing enrolment token usage", "err", err)
+			}
+			slog.Info("adopted existing host for re-registering agent",
+				"agent_id", collision.AgentID,
+				"host_id", collision.HostID,
+				"hostname", hostname,
+				"prior_status", collision.AgentStatus,
+			)
+			// Preserve prior approval state. If the existing agent was active
+			// before going offline, return active + JWT immediately so the
+			// machine resumes without requiring re-approval.
+			if collision.AgentStatus == "active" {
+				jwtToken, err := h.issuer.IssueAgentToken(collision.AgentID, orgID)
+				if err != nil {
+					slog.Error("issuing JWT for adopted agent", "err", err)
+					return nil, status.Error(codes.Internal, "internal error")
+				}
+				return &agentv1.RegisterResponse{
+					AgentId:  collision.AgentID,
+					Status:   "active",
+					Message:  "re-registration adopted existing host; resumed active state",
+					JwtToken: jwtToken,
+				}, nil
+			}
+			return &agentv1.RegisterResponse{
+				AgentId: collision.AgentID,
+				Status:  collision.AgentStatus,
+				Message: "re-registration adopted existing host; status: " + collision.AgentStatus,
+			}, nil
+		}
+	}
+
+	// Step 4: Insert new agent
 	agentStatus := "pending"
 	agentID, err := queries.InsertAgent(ctx, h.pool, orgID, hostname, req.PublicKey, agentStatus, token.ID, agentOS, agentArch)
 	if err != nil {
@@ -113,7 +204,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 
 	slog.Info("agent registered", "agent_id", agentID, "hostname", hostname, "auto_approve", token.AutoApprove)
 
-	// Step 4: Auto-approve if configured
+	// Step 5: Auto-approve if configured
 	if token.AutoApprove {
 		if err := queries.ApproveAgent(ctx, h.pool, agentID); err != nil {
 			slog.Error("auto-approving agent", "err", err)
@@ -138,7 +229,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		}, nil
 	}
 
-	// Step 5: Pending — waiting for admin approval
+	// Step 6: Pending — waiting for admin approval
 	return &agentv1.RegisterResponse{
 		AgentId: agentID,
 		Status:  "pending",

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -67,6 +67,27 @@ export async function approveAgent(
     if (!agent) return { error: 'Agent not found' }
     if (agent.status !== 'pending') return { error: 'Agent is not in pending state' }
 
+    // Guard against duplicate hosts: a pending agent that shares a hostname or
+    // any IP with a currently-online host in the same org must not be approved,
+    // because activating it would leave two live rows for the same physical
+    // machine. The ingest register handler enforces the same rule at first
+    // contact, but a collision can emerge later (e.g. another host with the
+    // same hostname came online after this agent was queued for approval).
+    const pendingHost = await db.query.hosts.findFirst({
+      where: and(
+        eq(hosts.agentId, agentId),
+        eq(hosts.organisationId, orgId),
+        isNull(hosts.deletedAt),
+      ),
+    })
+    const pendingIps = (pendingHost?.ipAddresses ?? []) as string[]
+    const collision = await findOnlineHostCollision(orgId, agentId, pendingHost?.hostname ?? agent.hostname, pendingIps)
+    if (collision) {
+      return {
+        error: `Cannot approve: another host (${collision.hostname}) matching this hostname or IP is already online in this organisation. Delete the existing host first.`,
+      }
+    }
+
     await db.transaction(async (tx) => {
       await tx
         .update(agents)
@@ -111,6 +132,35 @@ export async function approveAgent(
     console.error('Failed to approve agent:', err)
     return { error: 'An unexpected error occurred' }
   }
+}
+
+// findOnlineHostCollision returns the first online host in the org (excluding
+// the one linked to excludeAgentId) whose hostname matches or whose
+// ip_addresses jsonb array overlaps any of the provided ips. Used by
+// approveAgent to block activation when doing so would produce a duplicate.
+async function findOnlineHostCollision(
+  orgId: string,
+  excludeAgentId: string,
+  hostname: string,
+  ips: string[],
+): Promise<{ id: string; hostname: string } | null> {
+  const ipOverlap = ips.length > 0
+    ? sql`ip_addresses ?| ${ips}::text[]`
+    : sql`false`
+  const rows = await db
+    .select({ id: hosts.id, hostname: hosts.hostname })
+    .from(hosts)
+    .where(
+      and(
+        eq(hosts.organisationId, orgId),
+        isNull(hosts.deletedAt),
+        eq(hosts.status, 'online'),
+        sql`(${hosts.agentId} IS NULL OR ${hosts.agentId} <> ${excludeAgentId})`,
+        sql`(${hosts.hostname} = ${hostname} OR ${ipOverlap})`,
+      ),
+    )
+    .limit(1)
+  return rows[0] ?? null
 }
 
 export async function rejectAgent(


### PR DESCRIPTION
## Summary

- Two live hosts in the same org cannot share a hostname or IP on a real network — treat any overlap at registration/approval time as a duplicate.
- **Online** match (or **revoked** agent): reject registration with `ALREADY_EXISTS` — admin must delete the stale host first.
- **Offline / unknown** match: adopt the existing `agents` / `hosts` rows, rotate the new public key onto the existing agent, and preserve prior approval state so a reinstall-with-wiped-data-dir silently resumes the same host record.
- Agents now report their non-loopback IPs in `PlatformInfo` at register time so the server can run the overlap check.
- `approveAgent` runs the same guard in the web app so an admin can't approve a pending agent whose identity now collides with an online host.

## Why

Previously the server only identified agents by their Ed25519 public key. If an agent's data directory was wiped (reimage, fresh install, etc.) the agent generated a new keypair and registered as a brand-new host, leaving a stale `Offline` duplicate that couldn't easily be removed (the delete dialog disables remote uninstall for offline agents).

## Files changed

- `apps/ingest/internal/db/queries/hosts.sql.go` — `FindHostCollision`, `RotateAgentPublicKey`, `ReattachHostToAgent`
- `apps/ingest/internal/handlers/register.go` — reject / adopt branches after the idempotent public-key check
- `agent/internal/registration/registrar.go` — collect local IPs and send in `PlatformInfo.ip_addresses`
- `apps/web/lib/actions/agents.ts` — `findOnlineHostCollision` guard in `approveAgent`
- `apps/docs/docs/features/hosts.md` + `apps/docs/docs/architecture/ingest.md` — documented the new behaviour

## Test plan

- [ ] Register a new agent normally → creates host as expected
- [ ] Wipe agent data dir, re-register with same hostname while existing host is **Offline** → existing row is reused, agent resumes (or remains pending if it was pending before)
- [ ] Attempt to register a second agent while an existing host with matching hostname/IP is **Online** → agent sees `ALREADY_EXISTS` and existing host is untouched
- [ ] Pending agent A in org, online host B with same hostname exists → approving A returns an error, B remains
- [ ] Agent status history contains the `adopted re-registration (keypair rotated; matched by hostname or IP)` entry after adoption

🤖 Generated with [Claude Code](https://claude.com/claude-code)