### PR TITLE
fix: update GHCR image URLs from simonjcarr to carrtech-dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,5 +27,5 @@ INGEST_WS_URL=ws://localhost:8080
 
 # === Optional image overrides (advanced) ===
 # Pin to a specific image tag instead of :latest.
-# WEB_IMAGE=ghcr.io/simonjcarr/infrawatch/web:sha-abc1234
-# INGEST_IMAGE=ghcr.io/simonjcarr/infrawatch/ingest:sha-abc1234
+# WEB_IMAGE=ghcr.io/carrtech-dev/infrawatch/web:sha-abc1234
+# INGEST_IMAGE=ghcr.io/carrtech-dev/infrawatch/ingest:sha-abc1234

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -95,8 +95,8 @@ The web container runs database migrations automatically on first start. Once yo
 | Service | Image | Port(s) | Description |
 |---|---|---|---|
 | `db` | `timescale/timescaledb:latest-pg16` | 5432 | PostgreSQL + TimescaleDB |
-| `web` | `ghcr.io/simonjcarr/infrawatch/web:latest` | 3000 | Next.js web app |
-| `ingest` | `ghcr.io/simonjcarr/infrawatch/ingest:latest` | 9443, 8080 | gRPC ingest + JWKS |
+| `web` | `ghcr.io/carrtech-dev/infrawatch/web:latest` | 3000 | Next.js web app |
+| `ingest` | `ghcr.io/carrtech-dev/infrawatch/ingest:latest` | 9443, 8080 | gRPC ingest + JWKS |
 
 ---
 

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -2,7 +2,7 @@
 
 This bundle contains everything you need to run Infrawatch on a single host
 using Docker. The container images are pulled from GitHub Container Registry
-(`ghcr.io/simonjcarr/infrawatch/*`) the first time you start the stack.
+(`ghcr.io/carrtech-dev/infrawatch/*`) the first time you start the stack.
 
 ## Prerequisites
 

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   web:
-    image: ${WEB_IMAGE:-ghcr.io/simonjcarr/infrawatch/web:latest}
+    image: ${WEB_IMAGE:-ghcr.io/carrtech-dev/infrawatch/web:latest}
     build:
       context: .
       dockerfile: apps/web/Dockerfile
@@ -39,7 +39,7 @@ services:
       - agent_dist:/var/lib/infrawatch/agent-dist
 
   ingest:
-    image: ${INGEST_IMAGE:-ghcr.io/simonjcarr/infrawatch/ingest:latest}
+    image: ${INGEST_IMAGE:-ghcr.io/carrtech-dev/infrawatch/ingest:latest}
     build:
       context: .
       dockerfile: apps/ingest/Dockerfile


### PR DESCRIPTION
## Summary

- Updates all hardcoded `ghcr.io/simonjcarr/infrawatch/*` image references to `ghcr.io/carrtech-dev/infrawatch/*` following the repository migration to `carrtech-dev/ct-ops`
- The CI workflow already uses `${{ github.repository_owner }}` so images are published under `carrtech-dev` — the consumer-side references just needed catching up

## Files changed

- `docker-compose.single.yml` — default image tags for `web` and `ingest` services
- `.env.example` — commented pin-to-digest examples
- `deploy/customer-bundle/README.md` — registry URL in the quickstart description
- `apps/docs/docs/deployment/docker-compose.md` — service table image column

## Test plan

- [ ] `docker compose -f docker-compose.single.yml pull` resolves images from `ghcr.io/carrtech-dev/infrawatch/`
- [ ] `./start.sh` (production mode) pulls and starts the stack successfully

https://claude.ai/code/session_01BHvTRbLxTr8y8erEPQ6PgC