### PR TITLE
fix: pass AGENT_DOWNLOAD_BASE_URL to web container in docker-compose

### DIFF
--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -34,6 +34,7 @@ services:
       BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:3000}
       NODE_ENV: production
       AGENT_DIST_DIR: /var/lib/infrawatch/agent-dist
+      AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
       INGEST_WS_URL: ${INGEST_WS_URL:-ws://localhost:8080}
     volumes:
       - agent_dist:/var/lib/infrawatch/agent-dist


### PR DESCRIPTION
## Summary

- `AGENT_DOWNLOAD_BASE_URL` was passed to the `ingest` service in `docker-compose.single.yml` but not to the `web` service, so `process.env.AGENT_DOWNLOAD_BASE_URL` was always `undefined` inside Next.js — causing the enrolment install URL to fall back to `window.location.origin` (localhost).
- Added `AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}` to the `web` service environment.

## Test plan

- [ ] Set `AGENT_DOWNLOAD_BASE_URL=http://192.168.x.x:3000` in `.env`, restart containers, create a new enrolment token — confirm the curl command shows the correct IP
- [ ] Without the var set, confirm it defaults to `http://localhost:3000` (no regression)

https://claude.ai/code/session_017G68coAiUoDTA9oAguxBKe