### PR TITLE
feat(certificates): track certificates from the Certificate Checker

### DIFF
--- a/apps/docs/docs/features/certificate-checker.md
+++ b/apps/docs/docs/features/certificate-checker.md
@@ -83,3 +83,29 @@ Use the **Download** button in the results header to export the leaf certificate
 | **Expired** (red) | Certificate has passed its `Not After` date |
 | **Self-Signed** badge | Subject and issuer are identical |
 | **CA Certificate** badge | Basic Constraints `cA=TRUE` is set |
+
+## Promoting a Certificate into the Tracker
+
+Once a certificate is loaded in the Checker (from either tab), a **Track this certificate** button appears on the results panel. Clicking it adds the certificate to the [Certificate Tracker](./certificates) so expiry is monitored on an ongoing basis.
+
+Two tracking modes are available, selected automatically based on the source tab:
+
+### URL-tracked (Check URL tab)
+
+The server periodically re-opens a TLS connection to the URL you checked and refreshes the certificate data. This keeps the tracker automatically in sync across renewals.
+
+- You pick a refresh interval when you click **Track this certificate** — 15 minutes, 1 hour (default), 6 hours, or 24 hours.
+- On every refresh the server re-reads `notAfter` and recomputes status.
+- If the fingerprint changes, the tracker detects a renewal automatically: the old row is retained for history and a new row takes over as the current tracked certificate.
+- If the endpoint is temporarily unreachable (DNS failure, TCP timeout, TLS handshake error), the last known certificate data is preserved and the failure is recorded so the expiry reminder still works.
+
+### Upload-tracked (Upload File tab)
+
+Used when the certificate was uploaded or pasted — typically an air-gapped host or an out-of-band copy the server cannot reach over TLS.
+
+- The certificate is tracked as a **static expiry reminder** based on the `notAfter` baked into the certificate.
+- There is no periodic re-check. When the certificate is renewed, re-upload the new one via the Checker and click **Track this certificate** again.
+
+::: tip
+If a certificate is already tracked, the Checker will tell you and link directly to the existing row rather than creating a duplicate.
+:::

--- a/apps/docs/docs/features/certificates.md
+++ b/apps/docs/docs/features/certificates.md
@@ -4,7 +4,18 @@ Infrawatch discovers TLS certificates on your hosts automatically and tracks the
 
 ---
 
-## Discovery
+## Provenance
+
+Certificates in the tracker come from two sources:
+
+1. **Agent-discovered** — picked up by an agent's filesystem or port scan of a host. These carry a link back to the host they were found on.
+2. **Imported** — promoted from the [SSL Certificate Checker](./certificate-checker) via the **Track this certificate** button. Imported certificates are either periodically re-fetched from a URL or tracked as a static expiry reminder (see [Certificate Checker → Promoting a Certificate into the Tracker](./certificate-checker#promoting-a-certificate-into-the-tracker)).
+
+To add a certificate that was not discovered by an agent, open **Certificates** and click **Add tracked certificate**. You will be directed to the Certificate Checker, which is the single entry point for imports.
+
+---
+
+## Discovery (agent-based)
 
 The agent scans the host filesystem for PEM-encoded certificates and reports them back to the ingest service. Common locations scanned include:
 
@@ -17,6 +28,19 @@ Discovered certificates are parsed and stored with:
 - Not-before / not-after dates
 - Fingerprint (SHA-256)
 - File path on the host
+
+---
+
+## URL Refresh (imported certificates)
+
+Certificates imported from the **Check URL** tab of the Certificate Checker are re-verified by the ingest service on a schedule set when they were added (15m / 1h / 6h / 24h).
+
+- Each tick, the ingest service opens a fresh TLS connection to the stored URL and reads the leaf certificate.
+- If the fingerprint is unchanged, status and `last_refreshed_at` are updated in place.
+- If the fingerprint has changed, a renewal is recorded: the previous row is kept for history and a new row takes over as the current tracked certificate (same URL, same refresh interval).
+- If the fetch fails (DNS, TCP, TLS handshake, or expired cert), the failure is recorded and the last known certificate data is left untouched so expiry reminders continue to work.
+
+Imported upload-only certificates have no URL to re-check — when they are renewed, re-upload the new certificate via the Certificate Checker.
 
 ---
 

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -96,6 +96,9 @@ func main() {
 	// Start software inventory sweeper goroutine
 	go handlers.RunSoftwareSweeper(ctx, pool)
 
+	// Start cert URL refresh sweeper goroutine
+	go handlers.RunCertRefreshSweeper(ctx, pool, 60*time.Second)
+
 	// Start gRPC server in goroutine
 	grpcErr := make(chan error, 1)
 	go func() {

--- a/apps/ingest/internal/db/queries/certificates.sql.go
+++ b/apps/ingest/internal/db/queries/certificates.sql.go
@@ -286,6 +286,175 @@ func GetAllOrgsWithCertExpiryRules(ctx context.Context, pool *pgxpool.Pool) ([]s
 	return result, rows.Err()
 }
 
+// TrackedCertRow represents a row needed by the URL refresh sweeper.
+type TrackedCertRow struct {
+	ID                     string
+	OrgID                  string
+	Host                   string
+	Port                   int
+	ServerName             string
+	TrackedURL             string
+	RefreshIntervalSeconds int
+	FingerprintSHA256      string
+	NotAfter               time.Time
+	Status                 string
+}
+
+// ListCertsDueForUrlRefresh returns tracked certs whose next refresh is due.
+// A cert is due when last_refreshed_at is NULL or older than refresh_interval_seconds.
+func ListCertsDueForUrlRefresh(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	limit int,
+) ([]TrackedCertRow, error) {
+	const q = `
+		SELECT id, organisation_id, host, port, server_name,
+		       tracked_url, COALESCE(refresh_interval_seconds, 3600),
+		       fingerprint_sha256, not_after, status
+		FROM certificates
+		WHERE tracked_url IS NOT NULL
+		  AND deleted_at IS NULL
+		  AND (
+		    last_refreshed_at IS NULL
+		    OR last_refreshed_at + (COALESCE(refresh_interval_seconds, 3600) * interval '1 second') < NOW()
+		  )
+		ORDER BY last_refreshed_at NULLS FIRST
+		LIMIT $1
+	`
+	rows, err := pool.Query(ctx, q, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []TrackedCertRow
+	for rows.Next() {
+		var r TrackedCertRow
+		if err := rows.Scan(
+			&r.ID, &r.OrgID, &r.Host, &r.Port, &r.ServerName,
+			&r.TrackedURL, &r.RefreshIntervalSeconds,
+			&r.FingerprintSHA256, &r.NotAfter, &r.Status,
+		); err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
+// MarkCertRefreshed updates status + metadata after a successful fetch where
+// the fingerprint is unchanged (same cert, just re-verified).
+func MarkCertRefreshed(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	certID, status string,
+) error {
+	const q = `
+		UPDATE certificates
+		SET status            = $2,
+		    last_refreshed_at = NOW(),
+		    last_refresh_error = NULL,
+		    last_seen_at      = NOW(),
+		    updated_at        = NOW()
+		WHERE id = $1
+	`
+	_, err := pool.Exec(ctx, q, certID, status)
+	return err
+}
+
+// MarkCertRefreshFailed records a failed fetch attempt without overwriting cert data.
+func MarkCertRefreshFailed(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	certID, errMessage string,
+) error {
+	const q = `
+		UPDATE certificates
+		SET last_refreshed_at = NOW(),
+		    last_refresh_error = $2,
+		    updated_at         = NOW()
+		WHERE id = $1
+	`
+	_, err := pool.Exec(ctx, q, certID, errMessage)
+	return err
+}
+
+// InsertRenewedTrackedCert inserts a new certificate row for a renewal detected
+// during URL refresh. It carries over the tracked_url + refresh_interval_seconds
+// from the predecessor and also clears those fields from the old row so the
+// sweeper stops polling the retired fingerprint.
+func InsertRenewedTrackedCert(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	previousCertID, orgID string,
+	host string, port int, serverName string,
+	commonName, issuer string,
+	sans []string,
+	notBefore, notAfter time.Time,
+	fingerprint, status, trackedURL string,
+	refreshIntervalSeconds int,
+	detailsJSON []byte,
+) (newCertID string, err error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	sansJSON, _ := json.Marshal(sans)
+
+	const insertQ = `
+		INSERT INTO certificates (
+			id, organisation_id,
+			source, host, port, server_name,
+			common_name, issuer, sans,
+			not_before, not_after, fingerprint_sha256, status,
+			details,
+			tracked_url, refresh_interval_seconds, last_refreshed_at,
+			last_seen_at, created_at, updated_at
+		) VALUES (
+			$1, $2,
+			'imported', $3, $4, $5,
+			$6, $7, $8,
+			$9, $10, $11, $12,
+			$13,
+			$14, $15, NOW(),
+			NOW(), NOW(), NOW()
+		)
+		RETURNING id
+	`
+	id := newCUID()
+	err = tx.QueryRow(ctx, insertQ,
+		id, orgID,
+		host, port, serverName,
+		commonName, issuer, sansJSON,
+		notBefore, notAfter, fingerprint, status,
+		detailsJSON,
+		trackedURL, refreshIntervalSeconds,
+	).Scan(&newCertID)
+	if err != nil {
+		return "", err
+	}
+
+	const clearOldQ = `
+		UPDATE certificates
+		SET tracked_url = NULL,
+		    refresh_interval_seconds = NULL,
+		    last_refreshed_at = NOW(),
+		    last_refresh_error = NULL,
+		    updated_at = NOW()
+		WHERE id = $1
+	`
+	if _, err = tx.Exec(ctx, clearOldQ, previousCertID); err != nil {
+		return "", err
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return "", err
+	}
+	return newCertID, nil
+}
+
 // ListCertificatesExpiringWithin returns certs whose notAfter is within the given
 // number of days and that are not deleted.
 func ListCertificatesExpiringWithin(

--- a/apps/ingest/internal/handlers/cert_refresh_sweeper.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper.go
@@ -1,0 +1,324 @@
+package handlers
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/infrawatch/ingest/internal/db/queries"
+)
+
+const (
+	certRefreshBatchSize  = 50
+	certRefreshDialTimout = 10 * time.Second
+)
+
+// RunCertRefreshSweeper ticks periodically and re-fetches TLS certificates for
+// rows in the certificates table that have a tracked_url set. It refreshes
+// status + last_refreshed_at on unchanged certs, inserts a new row and clears
+// tracking on the old row when it detects a renewal (different fingerprint on
+// the same endpoint), and records a fetch error without altering cert data
+// when the endpoint is temporarily unreachable.
+func RunCertRefreshSweeper(ctx context.Context, pool *pgxpool.Pool, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	slog.Info("cert refresh sweeper started", "interval", interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("cert refresh sweeper stopped")
+			return
+		case <-ticker.C:
+			runCertRefreshTick(ctx, pool)
+		}
+	}
+}
+
+func runCertRefreshTick(ctx context.Context, pool *pgxpool.Pool) {
+	rows, err := queries.ListCertsDueForUrlRefresh(ctx, pool, certRefreshBatchSize)
+	if err != nil {
+		slog.Warn("cert refresh: querying due certs", "err", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	slog.Info("cert refresh: refreshing tracked certs", "count", len(rows))
+	for _, row := range rows {
+		refreshTrackedCert(ctx, pool, row)
+	}
+}
+
+func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.TrackedCertRow) {
+	leaf, chain, err := fetchLeafAndChain(ctx, row.TrackedURL)
+	if err != nil {
+		slog.Info("cert refresh: fetch failed", "cert_id", row.ID, "url", row.TrackedURL, "err", err)
+		if qErr := queries.MarkCertRefreshFailed(ctx, pool, row.ID, truncateError(err.Error())); qErr != nil {
+			slog.Warn("cert refresh: mark failed", "cert_id", row.ID, "err", qErr)
+		}
+		return
+	}
+
+	newFingerprint := fingerprintSha256Hex(leaf.Raw)
+	newStatus := computeCertStatus(leaf.NotAfter, 30)
+
+	if newFingerprint == row.FingerprintSHA256 {
+		// Same cert — just refresh status + timestamps.
+		if err := queries.MarkCertRefreshed(ctx, pool, row.ID, newStatus); err != nil {
+			slog.Warn("cert refresh: mark refreshed", "cert_id", row.ID, "err", err)
+			return
+		}
+		if newStatus != row.Status && row.Status != "" {
+			if evErr := queries.InsertCertificateEvent(ctx, pool,
+				row.ID, row.OrgID,
+				newStatus, row.Status, newStatus,
+				fmt.Sprintf("Certificate status changed from %s to %s", row.Status, newStatus),
+				nil,
+			); evErr != nil {
+				slog.Warn("cert refresh: insert status-change event", "err", evErr)
+			}
+		}
+		evaluateCertExpiryForCert(ctx, pool, row.OrgID, row.ID,
+			leaf.Subject.CommonName, leaf.Issuer.CommonName,
+			row.Host, row.Port, leaf.NotAfter, newStatus)
+		return
+	}
+
+	// Fingerprint changed — this is a renewal.
+	commonName := leaf.Subject.CommonName
+	if commonName == "" {
+		commonName = row.Host
+	}
+	issuer := leaf.Issuer.CommonName
+	if issuer == "" {
+		issuer = leaf.Issuer.String()
+	}
+	sans := collectSans(leaf)
+	details := buildCertDetailsFromX509(leaf, chain)
+	detailsJSON, _ := json.Marshal(details)
+
+	newCertID, err := queries.InsertRenewedTrackedCert(
+		ctx, pool,
+		row.ID, row.OrgID,
+		row.Host, row.Port, row.ServerName,
+		commonName, issuer,
+		sans,
+		leaf.NotBefore, leaf.NotAfter,
+		newFingerprint, newStatus, row.TrackedURL,
+		row.RefreshIntervalSeconds,
+		detailsJSON,
+	)
+	if err != nil {
+		slog.Warn("cert refresh: insert renewed cert", "cert_id", row.ID, "err", err)
+		return
+	}
+
+	meta, _ := json.Marshal(map[string]string{"newCertificateId": newCertID})
+	if evErr := queries.InsertCertificateEvent(ctx, pool,
+		row.ID, row.OrgID,
+		"renewed", row.Status, "",
+		fmt.Sprintf("Certificate renewed: replaced by new fingerprint on %s:%d", row.Host, row.Port),
+		meta,
+	); evErr != nil {
+		slog.Warn("cert refresh: insert renewed event (old cert)", "err", evErr)
+	}
+
+	if evErr := queries.InsertCertificateEvent(ctx, pool,
+		newCertID, row.OrgID,
+		"renewed", "", newStatus,
+		fmt.Sprintf("Certificate renewed on %s:%d (CN: %s)", row.Host, row.Port, commonName),
+		nil,
+	); evErr != nil {
+		slog.Warn("cert refresh: insert renewed event (new cert)", "err", evErr)
+	}
+
+	if newStatus == "expiring_soon" || newStatus == "expired" {
+		if evErr := queries.InsertCertificateEvent(ctx, pool,
+			newCertID, row.OrgID,
+			newStatus, "", newStatus,
+			fmt.Sprintf("Certificate %s: expires %s", newStatus, leaf.NotAfter.Format("2006-01-02")),
+			nil,
+		); evErr != nil {
+			slog.Warn("cert refresh: insert expiry event on renewal", "err", evErr)
+		}
+	}
+
+	evaluateCertExpiryForCert(ctx, pool, row.OrgID, newCertID,
+		commonName, issuer, row.Host, row.Port, leaf.NotAfter, newStatus)
+
+	slog.Info("cert refresh: renewed",
+		"old_cert_id", row.ID, "new_cert_id", newCertID,
+		"host", row.Host, "port", row.Port, "cn", commonName)
+}
+
+// fetchLeafAndChain opens a TLS connection to the trackedUrl and returns the
+// peer leaf certificate plus the intermediate chain (everything after the
+// leaf).
+func fetchLeafAndChain(ctx context.Context, trackedURL string) (*x509.Certificate, []*x509.Certificate, error) {
+	host, port, serverName, err := parseTrackedURL(trackedURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dialer := &net.Dialer{Timeout: certRefreshDialTimout}
+	rawConn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("tcp dial: %w", err)
+	}
+	defer rawConn.Close()
+
+	tlsConn := tls.Client(rawConn, &tls.Config{
+		ServerName:         serverName,
+		InsecureSkipVerify: true, // we record the cert regardless of trust chain
+	})
+	defer tlsConn.Close()
+
+	handshakeCtx, cancel := context.WithTimeout(ctx, certRefreshDialTimout)
+	defer cancel()
+	if err := tlsConn.HandshakeContext(handshakeCtx); err != nil {
+		return nil, nil, fmt.Errorf("tls handshake: %w", err)
+	}
+
+	peers := tlsConn.ConnectionState().PeerCertificates
+	if len(peers) == 0 {
+		return nil, nil, fmt.Errorf("no peer certificates")
+	}
+	leaf := peers[0]
+	chain := peers[1:]
+	return leaf, chain, nil
+}
+
+// parseTrackedURL turns a user-supplied URL into host/port/serverName for the
+// TLS dial. Supports explicit schemes (https, tls, ldaps, smtps, imaps, pop3s,
+// etc.) and bare "host:port" forms.
+func parseTrackedURL(raw string) (host string, port int, serverName string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", 0, "", fmt.Errorf("empty url")
+	}
+
+	if !strings.Contains(raw, "://") {
+		// bare host or host:port
+		return splitHostPort(raw, 443)
+	}
+
+	u, perr := url.Parse(raw)
+	if perr != nil {
+		return "", 0, "", fmt.Errorf("parse url: %w", perr)
+	}
+	if u.Hostname() == "" {
+		return "", 0, "", fmt.Errorf("url has no host")
+	}
+
+	p := u.Port()
+	if p == "" {
+		return u.Hostname(), defaultPortForScheme(u.Scheme), u.Hostname(), nil
+	}
+	parsedPort, perr := strconv.Atoi(p)
+	if perr != nil {
+		return "", 0, "", fmt.Errorf("invalid port: %w", perr)
+	}
+	return u.Hostname(), parsedPort, u.Hostname(), nil
+}
+
+func splitHostPort(s string, defaultPort int) (string, int, string, error) {
+	if !strings.Contains(s, ":") {
+		return s, defaultPort, s, nil
+	}
+	h, p, err := net.SplitHostPort(s)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("split host:port: %w", err)
+	}
+	parsedPort, err := strconv.Atoi(p)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("invalid port: %w", err)
+	}
+	return h, parsedPort, h, nil
+}
+
+func defaultPortForScheme(scheme string) int {
+	switch strings.ToLower(scheme) {
+	case "https":
+		return 443
+	case "ldaps":
+		return 636
+	case "smtps":
+		return 465
+	case "imaps":
+		return 993
+	case "pop3s":
+		return 995
+	case "ftps":
+		return 990
+	default:
+		return 443
+	}
+}
+
+func fingerprintSha256Hex(der []byte) string {
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}
+
+func collectSans(c *x509.Certificate) []string {
+	var out []string
+	for _, name := range c.DNSNames {
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	for _, ip := range c.IPAddresses {
+		out = append(out, ip.String())
+	}
+	for _, email := range c.EmailAddresses {
+		out = append(out, email)
+	}
+	for _, uri := range c.URIs {
+		out = append(out, uri.String())
+	}
+	return out
+}
+
+func buildCertDetailsFromX509(leaf *x509.Certificate, chain []*x509.Certificate) certDetails {
+	details := certDetails{
+		Subject:            leaf.Subject.String(),
+		Issuer:             leaf.Issuer.String(),
+		SerialNumber:       leaf.SerialNumber.String(),
+		SignatureAlgorithm: leaf.SignatureAlgorithm.String(),
+		KeyAlgorithm:       leaf.PublicKeyAlgorithm.String(),
+		IsSelfSigned:       leaf.Subject.String() == leaf.Issuer.String(),
+	}
+	for _, c := range chain {
+		details.Chain = append(details.Chain, certChainEntry{
+			Subject:           c.Subject.String(),
+			Issuer:            c.Issuer.String(),
+			NotBefore:         c.NotBefore,
+			NotAfter:          c.NotAfter,
+			FingerprintSHA256: fingerprintSha256Hex(c.Raw),
+		})
+	}
+	return details
+}
+
+func truncateError(msg string) string {
+	const maxLen = 500
+	if len(msg) <= maxLen {
+		return msg
+	}
+	return msg[:maxLen] + "…"
+}

--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useState, useCallback, useRef } from 'react'
+import Link from 'next/link'
 import { format } from 'date-fns'
 import {
   Upload,
   Globe,
-  Key,
   Download,
   Copy,
   Check,
@@ -18,6 +18,7 @@ import {
   Loader2,
   FileText,
   AlertCircle,
+  BookmarkPlus,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -33,6 +34,21 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Table,
   TableBody,
   TableCell,
@@ -41,6 +57,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import type { ParsedCertificate, CertCheckerResponse } from '@/app/api/tools/certificate-checker/route'
+import { trackCertificateFromUrl, trackCertificateFromUpload } from '@/lib/actions/certificates'
 
 // ─── Utility helpers ─────────────────────────────────────────────────────────
 
@@ -220,12 +237,162 @@ function FileOrPasteInput({ id, label, sublabel, accept, placeholder, file, text
   )
 }
 
+// ─── Track controls ──────────────────────────────────────────────────────────
+
+type TrackSource =
+  | { kind: 'url'; url: string }
+  | { kind: 'upload'; pem: string }
+
+type TrackState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'tracked'; certificateId: string; wasAlready: boolean }
+  | { status: 'error'; message: string }
+
+const REFRESH_OPTIONS = [
+  { value: '900', label: 'Every 15 minutes' },
+  { value: '3600', label: 'Every hour' },
+  { value: '21600', label: 'Every 6 hours' },
+  { value: '86400', label: 'Every 24 hours' },
+] as const
+
+function TrackControls({ orgId, source }: { orgId: string; source: TrackSource }) {
+  const [state, setState] = useState<TrackState>({ status: 'idle' })
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [refreshInterval, setRefreshInterval] = useState('3600')
+
+  async function submitUpload() {
+    if (source.kind !== 'upload') return
+    setState({ status: 'loading' })
+    const result = await trackCertificateFromUpload(orgId, { pem: source.pem })
+    applyResult(result)
+  }
+
+  async function submitUrl() {
+    if (source.kind !== 'url') return
+    setState({ status: 'loading' })
+    setDialogOpen(false)
+    const result = await trackCertificateFromUrl(orgId, {
+      url: source.url,
+      refreshIntervalSeconds: parseInt(refreshInterval, 10),
+    })
+    applyResult(result)
+  }
+
+  function applyResult(result: Awaited<ReturnType<typeof trackCertificateFromUrl>>) {
+    if ('error' in result) {
+      setState({ status: 'error', message: result.error })
+    } else if (result.success) {
+      setState({ status: 'tracked', certificateId: result.certificateId, wasAlready: false })
+    } else {
+      setState({ status: 'tracked', certificateId: result.certificateId, wasAlready: true })
+    }
+  }
+
+  if (state.status === 'tracked') {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-2 text-sm text-green-900">
+        <ShieldCheck className="size-4" />
+        <span className="font-medium">
+          {state.wasAlready ? 'Already tracked' : 'Added to tracker'}
+        </span>
+        <Link
+          href={`/certificates/${state.certificateId}`}
+          className="underline underline-offset-2 hover:text-green-950"
+        >
+          View in Certificate Tracker
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        {source.kind === 'url' ? (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => setDialogOpen(true)}
+            disabled={state.status === 'loading'}
+          >
+            {state.status === 'loading'
+              ? <Loader2 className="size-4 mr-2 animate-spin" />
+              : <BookmarkPlus className="size-4 mr-2" />}
+            Track this certificate
+          </Button>
+        ) : (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={submitUpload}
+            disabled={state.status === 'loading'}
+            title="This certificate will be tracked as a static expiry reminder. Re-upload after renewal."
+          >
+            {state.status === 'loading'
+              ? <Loader2 className="size-4 mr-2 animate-spin" />
+              : <BookmarkPlus className="size-4 mr-2" />}
+            Track this certificate
+          </Button>
+        )}
+        {state.status === 'error' && (
+          <span className="text-sm text-red-700">{state.message}</span>
+        )}
+      </div>
+
+      {source.kind === 'upload' && state.status !== 'error' && (
+        <p className="text-xs text-muted-foreground">
+          Uploaded certificates are tracked as static expiry reminders. We cannot re-verify them automatically — re-upload after renewal.
+        </p>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Track certificate from URL</DialogTitle>
+            <DialogDescription>
+              The server will periodically re-fetch this URL and update the tracked certificate&apos;s expiry status.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">URL</Label>
+              <p className="text-sm font-mono break-all">{source.kind === 'url' ? source.url : ''}</p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="refresh-interval">Re-check frequency</Label>
+              <Select value={refreshInterval} onValueChange={setRefreshInterval}>
+                <SelectTrigger id="refresh-interval">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {REFRESH_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+            <Button onClick={submitUrl}>Start tracking</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
 // ─── Certificate results display ─────────────────────────────────────────────
 
-function CertificateResults({ cert, keyMatch, onDownload }: {
+function CertificateResults({ cert, keyMatch, onDownload, orgId, source }: {
   cert: ParsedCertificate
   keyMatch?: boolean
   onDownload: (format: 'pem' | 'der' | 'pkcs7') => void
+  orgId: string
+  source: TrackSource | null
 }) {
   const daysAbs = Math.abs(cert.daysRemaining)
   const expiryLabel = cert.isExpired
@@ -245,26 +412,29 @@ function CertificateResults({ cert, keyMatch, onDownload }: {
           </div>
           <p className="text-sm text-muted-foreground mt-1 font-mono">{cert.subject}</p>
         </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
-              <Download className="size-4 mr-2" />
-              Download
-              <ChevronDown className="size-3 ml-1" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onDownload('pem')}>
-              <FileText className="size-4 mr-2" />PEM (.pem / .crt)
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onDownload('der')}>
-              <FileText className="size-4 mr-2" />DER (.der)
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onDownload('pkcs7')}>
-              <FileText className="size-4 mr-2" />PKCS#7 (.p7b)
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <div className="flex items-center gap-2 flex-wrap">
+          {source && <TrackControls orgId={orgId} source={source} />}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Download className="size-4 mr-2" />
+                Download
+                <ChevronDown className="size-3 ml-1" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onDownload('pem')}>
+                <FileText className="size-4 mr-2" />PEM (.pem / .crt)
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onDownload('der')}>
+                <FileText className="size-4 mr-2" />DER (.der)
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onDownload('pkcs7')}>
+                <FileText className="size-4 mr-2" />PKCS#7 (.p7b)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
 
       {/* Summary cards */}
@@ -505,7 +675,7 @@ function KeyInput({ keyFile, keyText, onKeyFile, onKeyText }: {
 
 // ─── Upload tab ───────────────────────────────────────────────────────────────
 
-function UploadTab({ onResult }: { onResult: (cert: ParsedCertificate, keyMatch?: boolean) => void }) {
+function UploadTab({ onResult }: { onResult: (cert: ParsedCertificate, source: TrackSource, keyMatch?: boolean) => void }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [certFile, setCertFile] = useState<File | null>(null)
@@ -543,7 +713,7 @@ function UploadTab({ onResult }: { onResult: (cert: ParsedCertificate, keyMatch?
       })
       const json: CertCheckerResponse = await res.json()
       if (!json.ok) { setError(json.error); return }
-      onResult(json.certificate, json.keyMatch)
+      onResult(json.certificate, { kind: 'upload', pem: json.certificate.pem }, json.keyMatch)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unexpected error')
     } finally {
@@ -601,7 +771,7 @@ function UploadTab({ onResult }: { onResult: (cert: ParsedCertificate, keyMatch?
 
 // ─── URL tab ──────────────────────────────────────────────────────────────────
 
-function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, keyMatch?: boolean) => void }) {
+function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: TrackSource, keyMatch?: boolean) => void }) {
   const [url, setUrl] = useState('')
   const [port, setPort] = useState('443')
   const [servername, setServername] = useState('')
@@ -629,7 +799,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, keyMatch?: b
       })
       const json: CertCheckerResponse = await res.json()
       if (!json.ok) { setError(json.error); return }
-      onResult(json.certificate, json.keyMatch)
+      onResult(json.certificate, { kind: 'url', url: url.trim() }, json.keyMatch)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unexpected error')
     } finally {
@@ -709,13 +879,15 @@ function readFileAsText(file: File): Promise<string> {
 
 // ─── Main page component ──────────────────────────────────────────────────────
 
-export function CertificateCheckerClient() {
+export function CertificateCheckerClient({ orgId }: { orgId: string }) {
   const [cert, setCert] = useState<ParsedCertificate | null>(null)
   const [keyMatch, setKeyMatch] = useState<boolean | undefined>(undefined)
+  const [source, setSource] = useState<TrackSource | null>(null)
 
-  function handleResult(c: ParsedCertificate, km?: boolean) {
+  function handleResult(c: ParsedCertificate, s: TrackSource, km?: boolean) {
     setCert(c)
     setKeyMatch(km)
+    setSource(s)
   }
 
   async function handleDownload(fmt: 'pem' | 'der' | 'pkcs7') {
@@ -739,6 +911,7 @@ export function CertificateCheckerClient() {
   function reset() {
     setCert(null)
     setKeyMatch(undefined)
+    setSource(null)
   }
 
   return (
@@ -783,7 +956,7 @@ export function CertificateCheckerClient() {
       </Card>
 
       {cert ? (
-        <CertificateResults cert={cert} keyMatch={keyMatch} onDownload={handleDownload} />
+        <CertificateResults cert={cert} keyMatch={keyMatch} onDownload={handleDownload} orgId={orgId} source={source} />
       ) : (
         <div className="flex flex-col items-center justify-center py-20 text-center text-muted-foreground">
           <ShieldCheck className="size-16 mb-4 opacity-20" />

--- a/apps/web/app/(dashboard)/certificate-checker/page.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next'
+import { getRequiredSession } from '@/lib/auth/session'
 import { CertificateCheckerClient } from './certificate-checker-client'
 
 export const metadata: Metadata = {
   title: 'SSL Certificate Checker',
 }
 
-export default function CertificateCheckerPage() {
-  return <CertificateCheckerClient />
+export default async function CertificateCheckerPage() {
+  const session = await getRequiredSession()
+  const orgId = session.user.organisationId!
+  return <CertificateCheckerClient orgId={orgId} />
 }

--- a/apps/web/app/(dashboard)/certificates/certificates-client.tsx
+++ b/apps/web/app/(dashboard)/certificates/certificates-client.tsx
@@ -1,13 +1,22 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import { formatDistanceToNow } from 'date-fns'
-import { ShieldCheck, ShieldAlert, ShieldX, Shield, Search, Trash2 } from 'lucide-react'
+import { ShieldCheck, ShieldAlert, ShieldX, Shield, Search, Trash2, BookmarkPlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import {
   Select,
   SelectContent,
@@ -88,6 +97,7 @@ export function CertificatesClient({
   const [statusFilter, setStatusFilter] = useState<CertificateStatus | 'all'>('all')
   const [hostFilter, setHostFilter] = useState('')
   const [sortBy, setSortBy] = useState<CertificateListFilters['sortBy']>('not_after')
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
 
   const filters: CertificateListFilters = {
     ...(statusFilter !== 'all' ? { status: statusFilter } : {}),
@@ -138,12 +148,35 @@ export function CertificatesClient({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">Certificates</h1>
-        <p className="text-muted-foreground mt-1">
-          {totalCerts} certificate{totalCerts !== 1 ? 's' : ''} tracked across your infrastructure
-        </p>
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Certificates</h1>
+          <p className="text-muted-foreground mt-1">
+            {totalCerts} certificate{totalCerts !== 1 ? 's' : ''} tracked across your infrastructure
+          </p>
+        </div>
+        <Button onClick={() => setAddDialogOpen(true)}>
+          <BookmarkPlus className="size-4 mr-2" />
+          Add tracked certificate
+        </Button>
       </div>
+
+      <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add a tracked certificate</DialogTitle>
+            <DialogDescription>
+              Tracked certificates are added from the Certificate Checker. Fetch a URL or upload a certificate, then click &quot;Track this certificate&quot; on the results panel.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddDialogOpen(false)}>Cancel</Button>
+            <Button asChild>
+              <Link href="/certificate-checker">Open Certificate Checker</Link>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Summary cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -1,445 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server'
-import * as tls from 'tls'
 import * as crypto from 'crypto'
 import * as forge from 'node-forge'
 import { z } from 'zod'
+import {
+  type ParsedCertificate,
+  checkKeyMatch,
+  fetchCertificateFromUrl,
+  parseCertificateBuffer,
+  pemToForgeCert,
+} from '@/lib/certificates/fetch'
 
-// ─── Shared types ─────────────────────────────────────────────────────────────
-
-export interface ParsedSAN {
-  type: string
-  value: string
-}
-
-export interface ChainEntry {
-  subject: string
-  issuer: string
-  notBefore: string
-  notAfter: string
-  fingerprintSha256: string
-  isCA: boolean
-}
-
-export interface ParsedCertificate {
-  // Subject info
-  subject: string
-  commonName: string
-  organization: string
-  organizationalUnit: string
-  country: string
-  state: string
-  locality: string
-
-  // Issuer info
-  issuer: string
-  issuerCommonName: string
-  issuerOrganization: string
-
-  // Validity
-  notBefore: string
-  notAfter: string
-  daysRemaining: number
-  isExpired: boolean
-  isExpiringSoon: boolean
-
-  // Identity
-  serialNumber: string
-  fingerprintSha1: string
-  fingerprintSha256: string
-  fingerprintSha512: string
-  isSelfSigned: boolean
-
-  // Key info
-  keyAlgorithm: string
-  keySize: number | null
-  curve: string | null
-  signatureAlgorithm: string
-
-  // Extensions
-  sans: ParsedSAN[]
-  keyUsage: string[]
-  extendedKeyUsage: string[]
-  isCA: boolean
-  pathLength: number | null
-  subjectKeyId: string | null
-  authorityKeyId: string | null
-  ocspUrls: string[]
-  caIssuers: string[]
-  crlUrls: string[]
-  certificatePolicies: string[]
-
-  // Chain
-  chain: ChainEntry[]
-
-  // Raw PEM for download
-  pem: string
-}
+export type { ParsedCertificate, ParsedSAN, ChainEntry } from '@/lib/certificates/fetch'
 
 export type CertCheckerResponse =
   | { ok: true; certificate: ParsedCertificate; keyMatch?: boolean }
   | { ok: false; error: string }
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function dnFromForgeCert(dn: forge.pki.Certificate['subject']): string {
-  return dn.attributes
-    .map((a) => `${a.shortName ?? a.name ?? a.type}=${a.value}`)
-    .join(', ')
-}
-
-function getAttr(dn: forge.pki.Certificate['subject'], name: string): string {
-  return (dn.getField(name)?.value as string | undefined) ?? ''
-}
-
-function colonHex(buf: string): string {
-  return buf.match(/.{1,2}/g)?.join(':') ?? buf
-}
-
-function parseForgeCert(forgeCert: forge.pki.Certificate, pemStr: string): ParsedCertificate {
-  const now = new Date()
-  const notAfter = forgeCert.validity.notAfter
-  const notBefore = forgeCert.validity.notBefore
-  const msRemaining = notAfter.getTime() - now.getTime()
-  const daysRemaining = Math.floor(msRemaining / 86_400_000)
-  const isSelfSigned = forgeCert.isIssuer(forgeCert)
-
-  // Fingerprints via forge
-  const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(forgeCert)).getBytes()
-  const sha1 = colonHex(
-    forge.md.sha1.create().update(derBytes).digest().toHex()
-  )
-  const sha256 = colonHex(
-    forge.md.sha256.create().update(derBytes).digest().toHex()
-  )
-
-  // Node crypto for SHA-512 fingerprint
-  const derBuf = Buffer.from(derBytes, 'binary')
-  const sha512 = crypto.createHash('sha512').update(derBuf).digest('hex')
-    .match(/.{1,2}/g)!.join(':')
-
-  // Key info
-  let keyAlgorithm = 'Unknown'
-  let keySize: number | null = null
-  let curve: string | null = null
-
-  const pubKey = forgeCert.publicKey as forge.pki.rsa.PublicKey & { curve?: string; n?: forge.jsbn.BigInteger }
-  if ('n' in pubKey && pubKey.n) {
-    keyAlgorithm = 'RSA'
-    keySize = pubKey.n.bitLength()
-  } else if ('curve' in pubKey) {
-    keyAlgorithm = 'EC'
-    curve = (pubKey as unknown as { curve: string }).curve ?? null
-  } else {
-    // Check OID from siginfo
-    const sigAlg = (forgeCert as unknown as { signatureOid: string }).signatureOid
-    if (sigAlg?.startsWith('1.2.840.10045')) {
-      keyAlgorithm = 'EC'
-    } else if (sigAlg?.startsWith('1.3.101')) {
-      keyAlgorithm = 'EdDSA'
-    }
-  }
-
-  // Signature algorithm
-  const sigAlgName = (forgeCert.siginfo as unknown as { algorithmOid: string })?.algorithmOid ?? ''
-  const sigAlgMap: Record<string, string> = {
-    '1.2.840.113549.1.1.5':  'SHA1withRSA',
-    '1.2.840.113549.1.1.11': 'SHA256withRSA',
-    '1.2.840.113549.1.1.12': 'SHA384withRSA',
-    '1.2.840.113549.1.1.13': 'SHA512withRSA',
-    '1.2.840.10045.4.3.2':   'SHA256withECDSA',
-    '1.2.840.10045.4.3.3':   'SHA384withECDSA',
-    '1.2.840.10045.4.3.4':   'SHA512withECDSA',
-    '1.3.101.112':           'Ed25519',
-  }
-  const signatureAlgorithm = sigAlgMap[sigAlgName] ?? (forgeCert as unknown as { signatureAlgorithm?: string }).signatureAlgorithm ?? sigAlgName
-
-  // SANs
-  const sans: ParsedSAN[] = []
-  const sanExt = forgeCert.getExtension('subjectAltName') as
-    | { altNames: Array<{ type: number; value?: string; ip?: string }> }
-    | null
-  if (sanExt) {
-    for (const alt of sanExt.altNames) {
-      const typeMap: Record<number, string> = {
-        1: 'email', 2: 'DNS', 6: 'URI', 7: 'IP',
-      }
-      sans.push({ type: typeMap[alt.type] ?? `type${alt.type}`, value: alt.value ?? alt.ip ?? '' })
-    }
-  }
-
-  // Key usage
-  const keyUsage: string[] = []
-  const kuExt = forgeCert.getExtension('keyUsage') as Record<string, boolean> | null
-  if (kuExt) {
-    const kuNames: [string, string][] = [
-      ['digitalSignature', 'Digital Signature'],
-      ['nonRepudiation', 'Non Repudiation'],
-      ['keyEncipherment', 'Key Encipherment'],
-      ['dataEncipherment', 'Data Encipherment'],
-      ['keyAgreement', 'Key Agreement'],
-      ['keyCertSign', 'Certificate Sign'],
-      ['cRLSign', 'CRL Sign'],
-      ['encipherOnly', 'Encipher Only'],
-      ['decipherOnly', 'Decipher Only'],
-    ]
-    for (const [key, label] of kuNames) {
-      if (kuExt[key]) keyUsage.push(label)
-    }
-  }
-
-  // Extended key usage
-  const extendedKeyUsage: string[] = []
-  const ekuExt = forgeCert.getExtension('extKeyUsage') as Record<string, boolean> | null
-  if (ekuExt) {
-    const ekuNames: [string, string][] = [
-      ['serverAuth', 'TLS Web Server Authentication'],
-      ['clientAuth', 'TLS Web Client Authentication'],
-      ['codeSigning', 'Code Signing'],
-      ['emailProtection', 'Email Protection'],
-      ['timeStamping', 'Time Stamping'],
-      ['OCSPSigning', 'OCSP Signing'],
-    ]
-    for (const [key, label] of ekuNames) {
-      if (ekuExt[key]) extendedKeyUsage.push(label)
-    }
-  }
-
-  // Basic constraints
-  let isCA = false
-  let pathLength: number | null = null
-  const bcExt = forgeCert.getExtension('basicConstraints') as
-    | { cA: boolean; pathLenConstraint?: number }
-    | null
-  if (bcExt) {
-    isCA = bcExt.cA ?? false
-    pathLength = bcExt.pathLenConstraint ?? null
-  }
-
-  // Subject/Authority key identifiers
-  const skiExt = forgeCert.getExtension('subjectKeyIdentifier') as { subjectKeyIdentifier?: string } | null
-  const akiExt = forgeCert.getExtension('authorityKeyIdentifier') as { keyIdentifier?: string } | null
-  const subjectKeyId = skiExt?.subjectKeyIdentifier
-    ? colonHex(forge.util.bytesToHex(skiExt.subjectKeyIdentifier))
-    : null
-  const authorityKeyId = akiExt?.keyIdentifier
-    ? colonHex(forge.util.bytesToHex(akiExt.keyIdentifier))
-    : null
-
-  // Authority Info Access (OCSP + CA issuers)
-  const ocspUrls: string[] = []
-  const caIssuers: string[] = []
-  const aiaExt = forgeCert.getExtension('authorityInfoAccessSyntax') as
-    | { accessDescriptions: Array<{ accessMethod: string; accessLocation: { value: string } }> }
-    | null
-  if (aiaExt) {
-    for (const desc of aiaExt.accessDescriptions) {
-      if (desc.accessMethod === '1.3.6.1.5.5.7.48.1') ocspUrls.push(desc.accessLocation.value)
-      if (desc.accessMethod === '1.3.6.1.5.5.7.48.2') caIssuers.push(desc.accessLocation.value)
-    }
-  }
-
-  // CRL Distribution Points
-  const crlUrls: string[] = []
-  const crlExt = forgeCert.getExtension('cRLDistributionPoints') as
-    | { distributionPoints?: Array<{ distributionPoint?: { value?: Array<{ value?: string }> } }> }
-    | null
-  if (crlExt?.distributionPoints) {
-    for (const dp of crlExt.distributionPoints) {
-      const uri = dp.distributionPoint?.value?.[0]?.value
-      if (uri) crlUrls.push(uri)
-    }
-  }
-
-  // Certificate policies
-  const certificatePolicies: string[] = []
-  const cpExt = forgeCert.getExtension('certificatePolicies') as
-    | { policies?: Array<{ policyIdentifier: string }> }
-    | null
-  if (cpExt?.policies) {
-    for (const policy of cpExt.policies) {
-      certificatePolicies.push(policy.policyIdentifier)
-    }
-  }
-
-  return {
-    subject: dnFromForgeCert(forgeCert.subject),
-    commonName: getAttr(forgeCert.subject, 'CN'),
-    organization: getAttr(forgeCert.subject, 'O'),
-    organizationalUnit: getAttr(forgeCert.subject, 'OU'),
-    country: getAttr(forgeCert.subject, 'C'),
-    state: getAttr(forgeCert.subject, 'ST'),
-    locality: getAttr(forgeCert.subject, 'L'),
-    issuer: dnFromForgeCert(forgeCert.issuer),
-    issuerCommonName: getAttr(forgeCert.issuer, 'CN'),
-    issuerOrganization: getAttr(forgeCert.issuer, 'O'),
-    notBefore: notBefore.toISOString(),
-    notAfter: notAfter.toISOString(),
-    daysRemaining,
-    isExpired: daysRemaining < 0,
-    isExpiringSoon: daysRemaining >= 0 && daysRemaining <= 30,
-    serialNumber: colonHex(forgeCert.serialNumber),
-    fingerprintSha1: sha1,
-    fingerprintSha256: sha256,
-    fingerprintSha512: sha512,
-    isSelfSigned,
-    keyAlgorithm,
-    keySize,
-    curve,
-    signatureAlgorithm,
-    sans,
-    keyUsage,
-    extendedKeyUsage,
-    isCA,
-    pathLength,
-    subjectKeyId,
-    authorityKeyId,
-    ocspUrls,
-    caIssuers,
-    crlUrls,
-    certificatePolicies,
-    chain: [], // populated by caller if needed
-    pem: pemStr,
-  }
-}
-
-/** Convert any supported format to an array of PEM strings */
-function toPemArray(input: Buffer, password?: string): string[] {
-  const pems: string[] = []
-
-  // Try PEM text first
-  const text = input.toString('utf8')
-  if (text.includes('-----BEGIN')) {
-    // May contain multiple certs (bundle)
-    const matches = text.match(/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g)
-    if (matches && matches.length > 0) return matches.map((m) => m.trim())
-    // PKCS#7 in PEM form
-    if (text.includes('BEGIN PKCS7') || text.includes('BEGIN CERTIFICATE REQUEST')) {
-      return parsePkcs7Pem(text)
-    }
-  }
-
-  // Try DER / PKCS#7 DER
-  try {
-    const asn1 = forge.asn1.fromDer(input.toString('binary'))
-    const content = asn1.value
-    // Check if it looks like a PKCS#7 (sequence with OID 1.2.840.113549.1.7.*)
-    if (Array.isArray(content) && content.length >= 1) {
-      // Attempt PKCS#7
-      try {
-        const p7 = forge.pkcs7.messageFromAsn1(asn1)
-        if ('certificates' in p7 && Array.isArray(p7.certificates)) {
-          return (p7.certificates as forge.pki.Certificate[]).map(forge.pki.certificateToPem)
-        }
-      } catch { /* not PKCS#7 */ }
-      // Attempt raw DER certificate
-      try {
-        const cert = forge.pki.certificateFromAsn1(asn1)
-        pems.push(forge.pki.certificateToPem(cert))
-        return pems
-      } catch { /* not a certificate */ }
-    }
-  } catch { /* not valid DER */ }
-
-  // Try PKCS#12
-  if (password !== undefined) {
-    try {
-      const p12Asn1 = forge.asn1.fromDer(input.toString('binary'))
-      const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password)
-      const certBags = p12.getBags({ bagType: forge.pki.oids.certBag })
-      const bags = certBags[forge.pki.oids.certBag as string] ?? []
-      for (const bag of bags) {
-        if (bag.cert) pems.push(forge.pki.certificateToPem(bag.cert))
-      }
-      if (pems.length > 0) return pems
-    } catch { /* wrong password or not PKCS#12 */ }
-  }
-
-  throw new Error('Unable to parse certificate — unsupported format or wrong password')
-}
-
-function parsePkcs7Pem(text: string): string[] {
-  const match = text.match(/-----BEGIN PKCS7-----[\s\S]+?-----END PKCS7-----/)
-  if (!match) return []
-  const der = forge.util.decode64(
-    match[0].replace('-----BEGIN PKCS7-----', '').replace('-----END PKCS7-----', '').replace(/\s/g, '')
-  )
-  const asn1 = forge.asn1.fromDer(der)
-  const p7 = forge.pkcs7.messageFromAsn1(asn1)
-  if ('certificates' in p7 && Array.isArray(p7.certificates)) {
-    return (p7.certificates as forge.pki.Certificate[]).map(forge.pki.certificateToPem)
-  }
-  return []
-}
-
-function fetchCertFromUrl(hostname: string, port: number, servername: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    const socket = tls.connect(
-      { host: hostname, port, servername, rejectUnauthorized: false, timeout: 10_000 },
-      () => {
-        const peerCert = socket.getPeerCertificate(true)
-        socket.end()
-        if (!peerCert || !peerCert.raw) {
-          return reject(new Error('No certificate received from server'))
-        }
-        const pems: string[] = []
-        let current: tls.DetailedPeerCertificate | null = peerCert
-        const seen = new Set<string>()
-        while (current && current.raw && !seen.has(current.fingerprint256)) {
-          seen.add(current.fingerprint256)
-          const b64 = current.raw.toString('base64').match(/.{1,64}/g)!.join('\n')
-          pems.push(`-----BEGIN CERTIFICATE-----\n${b64}\n-----END CERTIFICATE-----`)
-          if (current.issuerCertificate === current) break
-          current = current.issuerCertificate as tls.DetailedPeerCertificate | null
-        }
-        resolve(pems)
-      }
-    )
-    socket.on('error', reject)
-    socket.setTimeout(10_000, () => {
-      socket.destroy()
-      reject(new Error('Connection timed out'))
-    })
-  })
-}
-
-function pemToForgeCert(pem: string): forge.pki.Certificate {
-  return forge.pki.certificateFromPem(pem)
-}
-
-function buildChain(forgeCerts: forge.pki.Certificate[]): ChainEntry[] {
-  return forgeCerts.map((c) => {
-    const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(c)).getBytes()
-    const sha256 = colonHex(forge.md.sha256.create().update(derBytes).digest().toHex())
-    const bcExt = c.getExtension('basicConstraints') as { cA?: boolean } | null
-    return {
-      subject: dnFromForgeCert(c.subject),
-      issuer: dnFromForgeCert(c.issuer),
-      notBefore: c.validity.notBefore.toISOString(),
-      notAfter: c.validity.notAfter.toISOString(),
-      fingerprintSha256: sha256,
-      isCA: bcExt?.cA ?? false,
-    }
-  })
-}
-
-// ─── Key match helper ─────────────────────────────────────────────────────────
-
-function checkKeyMatch(keyPem: string, certPem: string): boolean {
-  try {
-    const privKey = crypto.createPrivateKey(keyPem)
-    const x509 = new crypto.X509Certificate(certPem)
-    return x509.checkPrivateKey(privKey)
-  } catch {
-    return false
-  }
-}
-
-// ─── Request schemas ───────────────────────────────────────────────────────────
-
 const ParseBodySchema = z.object({
   action: z.literal('parse'),
-  data: z.string().optional(),       // base64-encoded binary file
-  pemText: z.string().optional(),    // direct PEM/text paste
+  data: z.string().optional(),
+  pemText: z.string().optional(),
   password: z.string().optional(),
   keyPem: z.string().optional(),
 }).refine((v) => v.data != null || v.pemText != null, {
@@ -473,8 +53,6 @@ const BodySchema = z.discriminatedUnion('action', [
   DownloadBodySchema,
 ])
 
-// ─── Route handler ─────────────────────────────────────────────────────────────
-
 export async function POST(req: NextRequest): Promise<NextResponse> {
   let body: unknown
   try {
@@ -491,36 +69,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const data = parsed.data
 
   try {
-    // ── Parse uploaded file or pasted PEM ───────────────────────────────────
     if (data.action === 'parse') {
       const buf = data.pemText
         ? Buffer.from(data.pemText, 'utf8')
         : Buffer.from(data.data!, 'base64')
-      const pems = toPemArray(buf, data.password)
-      const forgeCerts = pems.map(pemToForgeCert)
-      const chain = forgeCerts.length > 1 ? buildChain(forgeCerts) : []
-      const cert = parseForgeCert(forgeCerts[0]!, pems[0]!)
-      cert.chain = chain
-      const keyMatch = data.keyPem ? checkKeyMatch(data.keyPem, pems[0]!) : undefined
+      const cert = parseCertificateBuffer(buf, data.password)
+      const keyMatch = data.keyPem ? checkKeyMatch(data.keyPem, cert.pem) : undefined
       return NextResponse.json({ ok: true, certificate: cert, keyMatch } satisfies CertCheckerResponse)
     }
 
-    // ── Fetch from URL ───────────────────────────────────────────────────────
     if (data.action === 'fetch-url') {
-      let hostname = data.url.trim()
-      hostname = hostname.replace(/^https?:\/\//i, '').replace(/\/.*$/, '')
-      const port = data.port ?? 443
-      const servername = data.servername ?? hostname
-      const pems = await fetchCertFromUrl(hostname, port, servername)
-      const forgeCerts = pems.map(pemToForgeCert)
-      const chain = forgeCerts.length > 1 ? buildChain(forgeCerts) : []
-      const cert = parseForgeCert(forgeCerts[0]!, pems[0]!)
-      cert.chain = chain
-      const keyMatch = data.keyPem ? checkKeyMatch(data.keyPem, pems[0]!) : undefined
-      return NextResponse.json({ ok: true, certificate: cert, keyMatch } satisfies CertCheckerResponse)
+      const { certificate } = await fetchCertificateFromUrl(data.url, data.port, data.servername)
+      const keyMatch = data.keyPem ? checkKeyMatch(data.keyPem, certificate.pem) : undefined
+      return NextResponse.json({ ok: true, certificate, keyMatch } satisfies CertCheckerResponse)
     }
 
-    // ── Validate key matches cert ────────────────────────────────────────────
     if (data.action === 'validate-key') {
       let privKey: crypto.KeyObject
       try {
@@ -540,7 +103,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ ok: true, certificate: null as unknown as ParsedCertificate, keyMatch })
     }
 
-    // ── Download / convert format ────────────────────────────────────────────
     if (data.action === 'download') {
       const forgeCert = pemToForgeCert(data.certPem)
 

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -1,9 +1,17 @@
 'use server'
 
+import { z } from 'zod'
 import { db } from '@/lib/db'
 import { certificates, certificateEvents } from '@/lib/db/schema'
 import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm'
-import type { Certificate, CertificateEvent, CertificateStatus } from '@/lib/db/schema'
+import type { Certificate, CertificateEvent, CertificateStatus, CertificateDetails } from '@/lib/db/schema'
+import { getRequiredSession } from '@/lib/auth/session'
+import { computeExpiryStatus } from '@/lib/certificates/expiry'
+import {
+  fetchCertificateFromUrl,
+  parseCertificateBuffer,
+  type ParsedCertificate,
+} from '@/lib/certificates/fetch'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -126,4 +134,224 @@ export async function deleteCertificate(
     .where(and(eq(certificates.id, certId), eq(certificates.organisationId, orgId)))
 
   return { success: true }
+}
+
+// ─── Track a certificate from the Certificate Checker ─────────────────────────
+
+const REFRESH_INTERVAL_OPTIONS = [900, 3600, 21600, 86400] as const
+
+const trackFromUrlSchema = z.object({
+  url: z.string().min(1).max(512),
+  refreshIntervalSeconds: z.number().int().refine(
+    (v) => (REFRESH_INTERVAL_OPTIONS as readonly number[]).includes(v),
+    { message: 'Refresh interval must be 15m, 1h, 6h, or 24h' },
+  ).optional(),
+})
+
+const trackFromUploadSchema = z.object({
+  pem: z.string().min(1),
+  host: z.string().max(255).optional(),
+  port: z.number().int().min(0).max(65535).optional(),
+  serverName: z.string().max(255).optional(),
+})
+
+export type TrackCertificateResult =
+  | { success: true; certificateId: string }
+  | { success: false; alreadyTracked: true; certificateId: string }
+  | { error: string }
+
+function buildDetailsFromParsed(parsed: ParsedCertificate): CertificateDetails {
+  return {
+    subject: parsed.subject,
+    issuer: parsed.issuer,
+    serialNumber: parsed.serialNumber,
+    signatureAlgorithm: parsed.signatureAlgorithm,
+    keyAlgorithm: parsed.keySize ? `${parsed.keyAlgorithm}-${parsed.keySize}` : parsed.keyAlgorithm,
+    isSelfSigned: parsed.isSelfSigned,
+    chain: parsed.chain.map((c) => ({
+      subject: c.subject,
+      issuer: c.issuer,
+      not_before: c.notBefore,
+      not_after: c.notAfter,
+      fingerprint_sha256: c.fingerprintSha256,
+    })),
+  }
+}
+
+function sanValues(parsed: ParsedCertificate): string[] {
+  return parsed.sans.map((s) => s.value).filter((v) => v.length > 0)
+}
+
+async function findExistingCertByIdentity(
+  orgId: string,
+  host: string,
+  port: number,
+  serverName: string,
+  fingerprintSha256: string,
+): Promise<Certificate | undefined> {
+  return db.query.certificates.findFirst({
+    where: and(
+      eq(certificates.organisationId, orgId),
+      eq(certificates.host, host),
+      eq(certificates.port, port),
+      eq(certificates.serverName, serverName),
+      eq(certificates.fingerprintSha256, fingerprintSha256),
+      isNull(certificates.deletedAt),
+    ),
+  })
+}
+
+export async function trackCertificateFromUrl(
+  orgId: string,
+  input: unknown,
+): Promise<TrackCertificateResult> {
+  const session = await getRequiredSession()
+  if (session.user.organisationId !== orgId) {
+    return { error: 'Organisation mismatch' }
+  }
+
+  const parsed = trackFromUrlSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
+
+  const { url, refreshIntervalSeconds = 3600 } = parsed.data
+
+  let result
+  try {
+    result = await fetchCertificateFromUrl(url)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch certificate'
+    return { error: message }
+  }
+
+  const { certificate, host, port, serverName } = result
+  const notAfter = new Date(certificate.notAfter)
+  const notBefore = new Date(certificate.notBefore)
+  const status = computeExpiryStatus(notAfter)
+
+  const existing = await findExistingCertByIdentity(
+    orgId, host, port, serverName, certificate.fingerprintSha256,
+  )
+  if (existing) {
+    if (existing.trackedUrl !== url || existing.refreshIntervalSeconds !== refreshIntervalSeconds) {
+      await db
+        .update(certificates)
+        .set({
+          trackedUrl: url,
+          refreshIntervalSeconds,
+          lastRefreshedAt: new Date(),
+          lastRefreshError: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(certificates.id, existing.id))
+    }
+    return { success: false, alreadyTracked: true, certificateId: existing.id }
+  }
+
+  const [inserted] = await db
+    .insert(certificates)
+    .values({
+      organisationId: orgId,
+      source: 'imported',
+      host,
+      port,
+      serverName,
+      commonName: certificate.commonName || host,
+      issuer: certificate.issuerCommonName || certificate.issuer,
+      sans: sanValues(certificate),
+      notBefore,
+      notAfter,
+      fingerprintSha256: certificate.fingerprintSha256,
+      status,
+      details: buildDetailsFromParsed(certificate),
+      trackedUrl: url,
+      refreshIntervalSeconds,
+      lastRefreshedAt: new Date(),
+    })
+    .returning({ id: certificates.id })
+
+  if (!inserted) return { error: 'Failed to insert certificate' }
+
+  await db.insert(certificateEvents).values({
+    organisationId: orgId,
+    certificateId: inserted.id,
+    eventType: 'discovered',
+    newStatus: status,
+    message: `Certificate tracked from URL ${url} (CN: ${certificate.commonName || host})`,
+  })
+
+  return { success: true, certificateId: inserted.id }
+}
+
+export async function trackCertificateFromUpload(
+  orgId: string,
+  input: unknown,
+): Promise<TrackCertificateResult> {
+  const session = await getRequiredSession()
+  if (session.user.organisationId !== orgId) {
+    return { error: 'Organisation mismatch' }
+  }
+
+  const parsed = trackFromUploadSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
+
+  const { pem, host: hostOverride, port: portOverride, serverName: serverNameOverride } = parsed.data
+
+  let certificate: ParsedCertificate
+  try {
+    certificate = parseCertificateBuffer(Buffer.from(pem, 'utf8'))
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to parse certificate'
+    return { error: message }
+  }
+
+  const fallback = certificate.commonName || certificate.fingerprintSha256
+  const host = (hostOverride && hostOverride.trim()) || fallback
+  const port = portOverride ?? 0
+  const serverName = (serverNameOverride && serverNameOverride.trim()) || fallback
+
+  const notAfter = new Date(certificate.notAfter)
+  const notBefore = new Date(certificate.notBefore)
+  const status = computeExpiryStatus(notAfter)
+
+  const existing = await findExistingCertByIdentity(
+    orgId, host, port, serverName, certificate.fingerprintSha256,
+  )
+  if (existing) {
+    return { success: false, alreadyTracked: true, certificateId: existing.id }
+  }
+
+  const [inserted] = await db
+    .insert(certificates)
+    .values({
+      organisationId: orgId,
+      source: 'imported',
+      host,
+      port,
+      serverName,
+      commonName: certificate.commonName || fallback,
+      issuer: certificate.issuerCommonName || certificate.issuer,
+      sans: sanValues(certificate),
+      notBefore,
+      notAfter,
+      fingerprintSha256: certificate.fingerprintSha256,
+      status,
+      details: buildDetailsFromParsed(certificate),
+    })
+    .returning({ id: certificates.id })
+
+  if (!inserted) return { error: 'Failed to insert certificate' }
+
+  await db.insert(certificateEvents).values({
+    organisationId: orgId,
+    certificateId: inserted.id,
+    eventType: 'discovered',
+    newStatus: status,
+    message: `Certificate imported from upload (CN: ${certificate.commonName || fallback})`,
+  })
+
+  return { success: true, certificateId: inserted.id }
 }

--- a/apps/web/lib/certificates/fetch.ts
+++ b/apps/web/lib/certificates/fetch.ts
@@ -1,0 +1,444 @@
+import * as tls from 'tls'
+import * as crypto from 'crypto'
+import * as forge from 'node-forge'
+
+export interface ParsedSAN {
+  type: string
+  value: string
+}
+
+export interface ChainEntry {
+  subject: string
+  issuer: string
+  notBefore: string
+  notAfter: string
+  fingerprintSha256: string
+  isCA: boolean
+}
+
+export interface ParsedCertificate {
+  subject: string
+  commonName: string
+  organization: string
+  organizationalUnit: string
+  country: string
+  state: string
+  locality: string
+
+  issuer: string
+  issuerCommonName: string
+  issuerOrganization: string
+
+  notBefore: string
+  notAfter: string
+  daysRemaining: number
+  isExpired: boolean
+  isExpiringSoon: boolean
+
+  serialNumber: string
+  fingerprintSha1: string
+  fingerprintSha256: string
+  fingerprintSha512: string
+  isSelfSigned: boolean
+
+  keyAlgorithm: string
+  keySize: number | null
+  curve: string | null
+  signatureAlgorithm: string
+
+  sans: ParsedSAN[]
+  keyUsage: string[]
+  extendedKeyUsage: string[]
+  isCA: boolean
+  pathLength: number | null
+  subjectKeyId: string | null
+  authorityKeyId: string | null
+  ocspUrls: string[]
+  caIssuers: string[]
+  crlUrls: string[]
+  certificatePolicies: string[]
+
+  chain: ChainEntry[]
+
+  pem: string
+}
+
+export interface FetchUrlResult {
+  certificate: ParsedCertificate
+  host: string
+  port: number
+  serverName: string
+}
+
+function dnFromForgeCert(dn: forge.pki.Certificate['subject']): string {
+  return dn.attributes
+    .map((a) => `${a.shortName ?? a.name ?? a.type}=${a.value}`)
+    .join(', ')
+}
+
+function getAttr(dn: forge.pki.Certificate['subject'], name: string): string {
+  return (dn.getField(name)?.value as string | undefined) ?? ''
+}
+
+function colonHex(buf: string): string {
+  return buf.match(/.{1,2}/g)?.join(':') ?? buf
+}
+
+export function pemToForgeCert(pem: string): forge.pki.Certificate {
+  return forge.pki.certificateFromPem(pem)
+}
+
+export function parseForgeCert(forgeCert: forge.pki.Certificate, pemStr: string): ParsedCertificate {
+  const now = new Date()
+  const notAfter = forgeCert.validity.notAfter
+  const notBefore = forgeCert.validity.notBefore
+  const msRemaining = notAfter.getTime() - now.getTime()
+  const daysRemaining = Math.floor(msRemaining / 86_400_000)
+  const isSelfSigned = forgeCert.isIssuer(forgeCert)
+
+  const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(forgeCert)).getBytes()
+  const sha1 = colonHex(
+    forge.md.sha1.create().update(derBytes).digest().toHex()
+  )
+  const sha256 = colonHex(
+    forge.md.sha256.create().update(derBytes).digest().toHex()
+  )
+
+  const derBuf = Buffer.from(derBytes, 'binary')
+  const sha512 = crypto.createHash('sha512').update(derBuf).digest('hex')
+    .match(/.{1,2}/g)!.join(':')
+
+  let keyAlgorithm = 'Unknown'
+  let keySize: number | null = null
+  let curve: string | null = null
+
+  const pubKey = forgeCert.publicKey as forge.pki.rsa.PublicKey & { curve?: string; n?: forge.jsbn.BigInteger }
+  if ('n' in pubKey && pubKey.n) {
+    keyAlgorithm = 'RSA'
+    keySize = pubKey.n.bitLength()
+  } else if ('curve' in pubKey) {
+    keyAlgorithm = 'EC'
+    curve = (pubKey as unknown as { curve: string }).curve ?? null
+  } else {
+    const sigAlg = (forgeCert as unknown as { signatureOid: string }).signatureOid
+    if (sigAlg?.startsWith('1.2.840.10045')) {
+      keyAlgorithm = 'EC'
+    } else if (sigAlg?.startsWith('1.3.101')) {
+      keyAlgorithm = 'EdDSA'
+    }
+  }
+
+  const sigAlgName = (forgeCert.siginfo as unknown as { algorithmOid: string })?.algorithmOid ?? ''
+  const sigAlgMap: Record<string, string> = {
+    '1.2.840.113549.1.1.5':  'SHA1withRSA',
+    '1.2.840.113549.1.1.11': 'SHA256withRSA',
+    '1.2.840.113549.1.1.12': 'SHA384withRSA',
+    '1.2.840.113549.1.1.13': 'SHA512withRSA',
+    '1.2.840.10045.4.3.2':   'SHA256withECDSA',
+    '1.2.840.10045.4.3.3':   'SHA384withECDSA',
+    '1.2.840.10045.4.3.4':   'SHA512withECDSA',
+    '1.3.101.112':           'Ed25519',
+  }
+  const signatureAlgorithm = sigAlgMap[sigAlgName] ?? (forgeCert as unknown as { signatureAlgorithm?: string }).signatureAlgorithm ?? sigAlgName
+
+  const sans: ParsedSAN[] = []
+  const sanExt = forgeCert.getExtension('subjectAltName') as
+    | { altNames: Array<{ type: number; value?: string; ip?: string }> }
+    | null
+  if (sanExt) {
+    for (const alt of sanExt.altNames) {
+      const typeMap: Record<number, string> = {
+        1: 'email', 2: 'DNS', 6: 'URI', 7: 'IP',
+      }
+      sans.push({ type: typeMap[alt.type] ?? `type${alt.type}`, value: alt.value ?? alt.ip ?? '' })
+    }
+  }
+
+  const keyUsage: string[] = []
+  const kuExt = forgeCert.getExtension('keyUsage') as Record<string, boolean> | null
+  if (kuExt) {
+    const kuNames: [string, string][] = [
+      ['digitalSignature', 'Digital Signature'],
+      ['nonRepudiation', 'Non Repudiation'],
+      ['keyEncipherment', 'Key Encipherment'],
+      ['dataEncipherment', 'Data Encipherment'],
+      ['keyAgreement', 'Key Agreement'],
+      ['keyCertSign', 'Certificate Sign'],
+      ['cRLSign', 'CRL Sign'],
+      ['encipherOnly', 'Encipher Only'],
+      ['decipherOnly', 'Decipher Only'],
+    ]
+    for (const [key, label] of kuNames) {
+      if (kuExt[key]) keyUsage.push(label)
+    }
+  }
+
+  const extendedKeyUsage: string[] = []
+  const ekuExt = forgeCert.getExtension('extKeyUsage') as Record<string, boolean> | null
+  if (ekuExt) {
+    const ekuNames: [string, string][] = [
+      ['serverAuth', 'TLS Web Server Authentication'],
+      ['clientAuth', 'TLS Web Client Authentication'],
+      ['codeSigning', 'Code Signing'],
+      ['emailProtection', 'Email Protection'],
+      ['timeStamping', 'Time Stamping'],
+      ['OCSPSigning', 'OCSP Signing'],
+    ]
+    for (const [key, label] of ekuNames) {
+      if (ekuExt[key]) extendedKeyUsage.push(label)
+    }
+  }
+
+  let isCA = false
+  let pathLength: number | null = null
+  const bcExt = forgeCert.getExtension('basicConstraints') as
+    | { cA: boolean; pathLenConstraint?: number }
+    | null
+  if (bcExt) {
+    isCA = bcExt.cA ?? false
+    pathLength = bcExt.pathLenConstraint ?? null
+  }
+
+  const skiExt = forgeCert.getExtension('subjectKeyIdentifier') as { subjectKeyIdentifier?: string } | null
+  const akiExt = forgeCert.getExtension('authorityKeyIdentifier') as { keyIdentifier?: string } | null
+  const subjectKeyId = skiExt?.subjectKeyIdentifier
+    ? colonHex(forge.util.bytesToHex(skiExt.subjectKeyIdentifier))
+    : null
+  const authorityKeyId = akiExt?.keyIdentifier
+    ? colonHex(forge.util.bytesToHex(akiExt.keyIdentifier))
+    : null
+
+  const ocspUrls: string[] = []
+  const caIssuers: string[] = []
+  const aiaExt = forgeCert.getExtension('authorityInfoAccessSyntax') as
+    | { accessDescriptions: Array<{ accessMethod: string; accessLocation: { value: string } }> }
+    | null
+  if (aiaExt) {
+    for (const desc of aiaExt.accessDescriptions) {
+      if (desc.accessMethod === '1.3.6.1.5.5.7.48.1') ocspUrls.push(desc.accessLocation.value)
+      if (desc.accessMethod === '1.3.6.1.5.5.7.48.2') caIssuers.push(desc.accessLocation.value)
+    }
+  }
+
+  const crlUrls: string[] = []
+  const crlExt = forgeCert.getExtension('cRLDistributionPoints') as
+    | { distributionPoints?: Array<{ distributionPoint?: { value?: Array<{ value?: string }> } }> }
+    | null
+  if (crlExt?.distributionPoints) {
+    for (const dp of crlExt.distributionPoints) {
+      const uri = dp.distributionPoint?.value?.[0]?.value
+      if (uri) crlUrls.push(uri)
+    }
+  }
+
+  const certificatePolicies: string[] = []
+  const cpExt = forgeCert.getExtension('certificatePolicies') as
+    | { policies?: Array<{ policyIdentifier: string }> }
+    | null
+  if (cpExt?.policies) {
+    for (const policy of cpExt.policies) {
+      certificatePolicies.push(policy.policyIdentifier)
+    }
+  }
+
+  return {
+    subject: dnFromForgeCert(forgeCert.subject),
+    commonName: getAttr(forgeCert.subject, 'CN'),
+    organization: getAttr(forgeCert.subject, 'O'),
+    organizationalUnit: getAttr(forgeCert.subject, 'OU'),
+    country: getAttr(forgeCert.subject, 'C'),
+    state: getAttr(forgeCert.subject, 'ST'),
+    locality: getAttr(forgeCert.subject, 'L'),
+    issuer: dnFromForgeCert(forgeCert.issuer),
+    issuerCommonName: getAttr(forgeCert.issuer, 'CN'),
+    issuerOrganization: getAttr(forgeCert.issuer, 'O'),
+    notBefore: notBefore.toISOString(),
+    notAfter: notAfter.toISOString(),
+    daysRemaining,
+    isExpired: daysRemaining < 0,
+    isExpiringSoon: daysRemaining >= 0 && daysRemaining <= 30,
+    serialNumber: colonHex(forgeCert.serialNumber),
+    fingerprintSha1: sha1,
+    fingerprintSha256: sha256,
+    fingerprintSha512: sha512,
+    isSelfSigned,
+    keyAlgorithm,
+    keySize,
+    curve,
+    signatureAlgorithm,
+    sans,
+    keyUsage,
+    extendedKeyUsage,
+    isCA,
+    pathLength,
+    subjectKeyId,
+    authorityKeyId,
+    ocspUrls,
+    caIssuers,
+    crlUrls,
+    certificatePolicies,
+    chain: [],
+    pem: pemStr,
+  }
+}
+
+export function buildChain(forgeCerts: forge.pki.Certificate[]): ChainEntry[] {
+  return forgeCerts.map((c) => {
+    const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(c)).getBytes()
+    const sha256 = colonHex(forge.md.sha256.create().update(derBytes).digest().toHex())
+    const bcExt = c.getExtension('basicConstraints') as { cA?: boolean } | null
+    return {
+      subject: dnFromForgeCert(c.subject),
+      issuer: dnFromForgeCert(c.issuer),
+      notBefore: c.validity.notBefore.toISOString(),
+      notAfter: c.validity.notAfter.toISOString(),
+      fingerprintSha256: sha256,
+      isCA: bcExt?.cA ?? false,
+    }
+  })
+}
+
+function parsePkcs7Pem(text: string): string[] {
+  const match = text.match(/-----BEGIN PKCS7-----[\s\S]+?-----END PKCS7-----/)
+  if (!match) return []
+  const der = forge.util.decode64(
+    match[0].replace('-----BEGIN PKCS7-----', '').replace('-----END PKCS7-----', '').replace(/\s/g, '')
+  )
+  const asn1 = forge.asn1.fromDer(der)
+  const p7 = forge.pkcs7.messageFromAsn1(asn1)
+  if ('certificates' in p7 && Array.isArray(p7.certificates)) {
+    return (p7.certificates as forge.pki.Certificate[]).map(forge.pki.certificateToPem)
+  }
+  return []
+}
+
+export function toPemArray(input: Buffer, password?: string): string[] {
+  const pems: string[] = []
+
+  const text = input.toString('utf8')
+  if (text.includes('-----BEGIN')) {
+    const matches = text.match(/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g)
+    if (matches && matches.length > 0) return matches.map((m) => m.trim())
+    if (text.includes('BEGIN PKCS7') || text.includes('BEGIN CERTIFICATE REQUEST')) {
+      return parsePkcs7Pem(text)
+    }
+  }
+
+  try {
+    const asn1 = forge.asn1.fromDer(input.toString('binary'))
+    const content = asn1.value
+    if (Array.isArray(content) && content.length >= 1) {
+      try {
+        const p7 = forge.pkcs7.messageFromAsn1(asn1)
+        if ('certificates' in p7 && Array.isArray(p7.certificates)) {
+          return (p7.certificates as forge.pki.Certificate[]).map(forge.pki.certificateToPem)
+        }
+      } catch { /* not PKCS#7 */ }
+      try {
+        const cert = forge.pki.certificateFromAsn1(asn1)
+        pems.push(forge.pki.certificateToPem(cert))
+        return pems
+      } catch { /* not a certificate */ }
+    }
+  } catch { /* not valid DER */ }
+
+  if (password !== undefined) {
+    try {
+      const p12Asn1 = forge.asn1.fromDer(input.toString('binary'))
+      const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password)
+      const certBags = p12.getBags({ bagType: forge.pki.oids.certBag })
+      const bags = certBags[forge.pki.oids.certBag as string] ?? []
+      for (const bag of bags) {
+        if (bag.cert) pems.push(forge.pki.certificateToPem(bag.cert))
+      }
+      if (pems.length > 0) return pems
+    } catch { /* wrong password or not PKCS#12 */ }
+  }
+
+  throw new Error('Unable to parse certificate — unsupported format or wrong password')
+}
+
+export function checkKeyMatch(keyPem: string, certPem: string): boolean {
+  try {
+    const privKey = crypto.createPrivateKey(keyPem)
+    const x509 = new crypto.X509Certificate(certPem)
+    return x509.checkPrivateKey(privKey)
+  } catch {
+    return false
+  }
+}
+
+export interface ResolvedUrl {
+  host: string
+  port: number
+  serverName: string
+}
+
+export function resolveUrlTarget(rawUrl: string, portOverride?: number, serverNameOverride?: string): ResolvedUrl {
+  let host = rawUrl.trim()
+  host = host.replace(/^https?:\/\//i, '').replace(/\/.*$/, '')
+  // Strip :port if included in host portion
+  const hostPortMatch = host.match(/^([^:]+)(?::(\d+))?$/)
+  let extractedPort: number | undefined
+  if (hostPortMatch) {
+    host = hostPortMatch[1]!
+    if (hostPortMatch[2]) extractedPort = parseInt(hostPortMatch[2], 10)
+  }
+  const port = portOverride ?? extractedPort ?? 443
+  const serverName = serverNameOverride ?? host
+  return { host, port, serverName }
+}
+
+export function fetchCertPemsFromUrl(host: string, port: number, serverName: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    const socket = tls.connect(
+      { host, port, servername: serverName, rejectUnauthorized: false, timeout: 10_000 },
+      () => {
+        const peerCert = socket.getPeerCertificate(true)
+        socket.end()
+        if (!peerCert || !peerCert.raw) {
+          return reject(new Error('No certificate received from server'))
+        }
+        const pems: string[] = []
+        let current: tls.DetailedPeerCertificate | null = peerCert
+        const seen = new Set<string>()
+        while (current && current.raw && !seen.has(current.fingerprint256)) {
+          seen.add(current.fingerprint256)
+          const b64 = current.raw.toString('base64').match(/.{1,64}/g)!.join('\n')
+          pems.push(`-----BEGIN CERTIFICATE-----\n${b64}\n-----END CERTIFICATE-----`)
+          if (current.issuerCertificate === current) break
+          current = current.issuerCertificate as tls.DetailedPeerCertificate | null
+        }
+        resolve(pems)
+      }
+    )
+    socket.on('error', reject)
+    socket.setTimeout(10_000, () => {
+      socket.destroy()
+      reject(new Error('Connection timed out'))
+    })
+  })
+}
+
+export async function fetchCertificateFromUrl(
+  rawUrl: string,
+  portOverride?: number,
+  serverNameOverride?: string,
+): Promise<FetchUrlResult> {
+  const { host, port, serverName } = resolveUrlTarget(rawUrl, portOverride, serverNameOverride)
+  const pems = await fetchCertPemsFromUrl(host, port, serverName)
+  const forgeCerts = pems.map(pemToForgeCert)
+  const chain = forgeCerts.length > 1 ? buildChain(forgeCerts) : []
+  const certificate = parseForgeCert(forgeCerts[0]!, pems[0]!)
+  certificate.chain = chain
+  return { certificate, host, port, serverName }
+}
+
+export function parseCertificateBuffer(input: Buffer, password?: string): ParsedCertificate {
+  const pems = toPemArray(input, password)
+  const forgeCerts = pems.map(pemToForgeCert)
+  const chain = forgeCerts.length > 1 ? buildChain(forgeCerts) : []
+  const cert = parseForgeCert(forgeCerts[0]!, pems[0]!)
+  cert.chain = chain
+  return cert
+}

--- a/apps/web/lib/db/migrations/0033_rich_tombstone.sql
+++ b/apps/web/lib/db/migrations/0033_rich_tombstone.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "certificates" ADD COLUMN "tracked_url" text;--> statement-breakpoint
+ALTER TABLE "certificates" ADD COLUMN "refresh_interval_seconds" integer;--> statement-breakpoint
+ALTER TABLE "certificates" ADD COLUMN "last_refreshed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "certificates" ADD COLUMN "last_refresh_error" text;--> statement-breakpoint
+CREATE INDEX "certificates_refresh_due_idx" ON "certificates" USING btree ("tracked_url","last_refreshed_at");

--- a/apps/web/lib/db/migrations/meta/0033_snapshot.json
+++ b/apps/web/lib/db/migrations/meta/0033_snapshot.json
@@ -1,0 +1,5807 @@
+{
+  "id": "a2d3b2f3-e423-4b16-8154-e26abc537df2",
+  "prevId": "446cbbbe-616d-4d40-8be6-2c53af27df0a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organisations": {
+      "name": "organisations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "licence_tier": {
+          "name": "licence_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'community'"
+        },
+        "licence_key": {
+          "name": "licence_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_retention_days": {
+          "name": "metric_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organisations_slug_unique": {
+          "name": "organisations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totp_credential": {
+      "name": "totp_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "totp_credential_user_id_user_id_fk": {
+          "name": "totp_credential_user_id_user_id_fk",
+          "tableFrom": "totp_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organisation_id_organisations_id_fk": {
+          "name": "user_organisation_id_organisations_id_fk",
+          "tableFrom": "user",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'engineer'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organisation_id_organisations_id_fk": {
+          "name": "invitations_organisation_id_organisations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_invited_by_id_user_id_fk": {
+          "name": "invitations_invited_by_id_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_enrolment_tokens": {
+      "name": "agent_enrolment_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_approve": {
+          "name": "auto_approve",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skip_verify": {
+          "name": "skip_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_enrolment_tokens_organisation_id_organisations_id_fk": {
+          "name": "agent_enrolment_tokens_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_enrolment_tokens",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_enrolment_tokens_created_by_id_user_id_fk": {
+          "name": "agent_enrolment_tokens_created_by_id_user_id_fk",
+          "tableFrom": "agent_enrolment_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_enrolment_tokens_token_unique": {
+          "name": "agent_enrolment_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_status_history": {
+      "name": "agent_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_status_history_agent_id_agents_id_fk": {
+          "name": "agent_status_history_agent_id_agents_id_fk",
+          "tableFrom": "agent_status_history",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_status_history_organisation_id_organisations_id_fk": {
+          "name": "agent_status_history_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_status_history",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_id": {
+          "name": "approved_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolment_token_id": {
+          "name": "enrolment_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agents_organisation_id_organisations_id_fk": {
+          "name": "agents_organisation_id_organisations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_approved_by_id_user_id_fk": {
+          "name": "agents_approved_by_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_enrolment_token_id_agent_enrolment_tokens_id_fk": {
+          "name": "agents_enrolment_token_id_agent_enrolment_tokens_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "agent_enrolment_tokens",
+          "columnsFrom": [
+            "enrolment_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_public_key_unique": {
+          "name": "agents_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosts": {
+      "name": "hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arch": {
+          "name": "arch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_addresses": {
+          "name": "ip_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_percent": {
+          "name": "disk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosts_organisation_id_organisations_id_fk": {
+          "name": "hosts_organisation_id_organisations_id_fk",
+          "tableFrom": "hosts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hosts_agent_id_agents_id_fk": {
+          "name": "hosts_agent_id_agents_id_fk",
+          "tableFrom": "hosts",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_tags": {
+      "name": "resource_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_tags_resource_idx": {
+          "name": "resource_tags_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_tags_org_kv_idx": {
+          "name": "resource_tags_org_kv_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_tags_organisation_id_organisations_id_fk": {
+          "name": "resource_tags_organisation_id_organisations_id_fk",
+          "tableFrom": "resource_tags",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_metrics": {
+      "name": "host_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_percent": {
+          "name": "memory_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_percent": {
+          "name": "disk_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uptime_seconds": {
+          "name": "uptime_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_metrics_organisation_id_organisations_id_fk": {
+          "name": "host_metrics_organisation_id_organisations_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_metrics_host_id_hosts_id_fk": {
+          "name": "host_metrics_host_id_hosts_id_fk",
+          "tableFrom": "host_metrics",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "host_metrics_id_recorded_at_pk": {
+          "name": "host_metrics_id_recorded_at_pk",
+          "columns": [
+            "id",
+            "recorded_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.check_results": {
+      "name": "check_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ran_at": {
+          "name": "ran_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "check_results_check_idx": {
+          "name": "check_results_check_idx",
+          "columns": [
+            {
+              "expression": "check_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "check_results_org_idx": {
+          "name": "check_results_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ran_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "check_results_check_id_checks_id_fk": {
+          "name": "check_results_check_id_checks_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "checks",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "check_results_host_id_hosts_id_fk": {
+          "name": "check_results_host_id_hosts_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "check_results_organisation_id_organisations_id_fk": {
+          "name": "check_results_organisation_id_organisations_id_fk",
+          "tableFrom": "check_results",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checks": {
+      "name": "checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "checks_org_host_idx": {
+          "name": "checks_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checks_organisation_id_organisations_id_fk": {
+          "name": "checks_organisation_id_organisations_id_fk",
+          "tableFrom": "checks",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "checks_host_id_hosts_id_fk": {
+          "name": "checks_host_id_hosts_id_fk",
+          "tableFrom": "checks",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_queries": {
+      "name": "agent_queries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_queries_host_status_idx": {
+          "name": "agent_queries_host_status_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_queries_org_idx": {
+          "name": "agent_queries_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_queries_organisation_id_organisations_id_fk": {
+          "name": "agent_queries_organisation_id_organisations_id_fk",
+          "tableFrom": "agent_queries",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_queries_host_id_hosts_id_fk": {
+          "name": "agent_queries_host_id_hosts_id_fk",
+          "tableFrom": "agent_queries",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_instances": {
+      "name": "alert_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'firing'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_by": {
+          "name": "acknowledged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_instances_org_status_idx": {
+          "name": "alert_instances_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_instances_rule_host_status_idx": {
+          "name": "alert_instances_rule_host_status_idx",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_instances_rule_id_alert_rules_id_fk": {
+          "name": "alert_instances_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_instances_host_id_hosts_id_fk": {
+          "name": "alert_instances_host_id_hosts_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_instances_organisation_id_organisations_id_fk": {
+          "name": "alert_instances_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_instances",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rules": {
+      "name": "alert_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warning'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_global_default": {
+          "name": "is_global_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_rules_org_host_idx": {
+          "name": "alert_rules_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_enabled_idx": {
+          "name": "alert_rules_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_rules_org_global_idx": {
+          "name": "alert_rules_org_global_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_global_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_organisation_id_organisations_id_fk": {
+          "name": "alert_rules_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_rules_host_id_hosts_id_fk": {
+          "name": "alert_rules_host_id_hosts_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_silences": {
+      "name": "alert_silences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_silences_org_host_idx": {
+          "name": "alert_silences_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_silences_org_active_idx": {
+          "name": "alert_silences_org_active_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_silences_organisation_id_organisations_id_fk": {
+          "name": "alert_silences_organisation_id_organisations_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_host_id_hosts_id_fk": {
+          "name": "alert_silences_host_id_hosts_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_rule_id_alert_rules_id_fk": {
+          "name": "alert_silences_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_silences_created_by_user_id_fk": {
+          "name": "alert_silences_created_by_user_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_channels_org_enabled_idx": {
+          "name": "notification_channels_org_enabled_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_organisation_id_organisations_id_fk": {
+          "name": "notification_channels_organisation_id_organisations_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_instance_id": {
+          "name": "alert_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_read_idx": {
+          "name": "notifications_user_read_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_org_user_idx": {
+          "name": "notifications_org_user_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_created_idx": {
+          "name": "notifications_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_organisation_id_organisations_id_fk": {
+          "name": "notifications_organisation_id_organisations_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_alert_instance_id_alert_instances_id_fk": {
+          "name": "notifications_alert_instance_id_alert_instances_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "alert_instances",
+          "columnsFrom": [
+            "alert_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate_events": {
+      "name": "certificate_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cert_events_cert_time_idx": {
+          "name": "cert_events_cert_time_idx",
+          "columns": [
+            {
+              "expression": "certificate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cert_events_org_time_idx": {
+          "name": "cert_events_org_time_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificate_events_organisation_id_organisations_id_fk": {
+          "name": "certificate_events_organisation_id_organisations_id_fk",
+          "tableFrom": "certificate_events",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_events_certificate_id_certificates_id_fk": {
+          "name": "certificate_events_certificate_id_certificates_id_fk",
+          "tableFrom": "certificate_events",
+          "tableTo": "certificates",
+          "columnsFrom": [
+            "certificate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discovered_by_host_id": {
+          "name": "discovered_by_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discovered'"
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "common_name": {
+          "name": "common_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sans": {
+          "name": "sans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "not_before": {
+          "name": "not_before",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "not_after": {
+          "name": "not_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint_sha256": {
+          "name": "fingerprint_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'valid'"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracked_url": {
+          "name": "tracked_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refreshed_at": {
+          "name": "last_refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "certificates_identity_idx": {
+          "name": "certificates_identity_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "port",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_org_expiry_idx": {
+          "name": "certificates_org_expiry_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "not_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_org_status_idx": {
+          "name": "certificates_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_org_host_idx": {
+          "name": "certificates_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discovered_by_host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificates_refresh_due_idx": {
+          "name": "certificates_refresh_due_idx",
+          "columns": [
+            {
+              "expression": "tracked_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_refreshed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificates_organisation_id_organisations_id_fk": {
+          "name": "certificates_organisation_id_organisations_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_discovered_by_host_id_hosts_id_fk": {
+          "name": "certificates_discovered_by_host_id_hosts_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "discovered_by_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificates_check_id_checks_id_fk": {
+          "name": "certificates_check_id_checks_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "checks",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_events": {
+      "name": "identity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_key_id": {
+          "name": "ssh_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "identity_events_org_time_idx": {
+          "name": "identity_events_org_time_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_events_account_time_idx": {
+          "name": "identity_events_account_time_idx",
+          "columns": [
+            {
+              "expression": "service_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_events_key_time_idx": {
+          "name": "identity_events_key_time_idx",
+          "columns": [
+            {
+              "expression": "ssh_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_events_host_time_idx": {
+          "name": "identity_events_host_time_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_events_organisation_id_organisations_id_fk": {
+          "name": "identity_events_organisation_id_organisations_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "identity_events_service_account_id_service_accounts_id_fk": {
+          "name": "identity_events_service_account_id_service_accounts_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "service_accounts",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "identity_events_ssh_key_id_ssh_keys_id_fk": {
+          "name": "identity_events_ssh_key_id_ssh_keys_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "ssh_keys",
+          "columnsFrom": [
+            "ssh_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "identity_events_host_id_hosts_id_fk": {
+          "name": "identity_events_host_id_hosts_id_fk",
+          "tableFrom": "identity_events",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_accounts": {
+      "name": "service_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gid": {
+          "name": "gid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_directory": {
+          "name": "home_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shell": {
+          "name": "shell",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service'"
+        },
+        "has_login_capability": {
+          "name": "has_login_capability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_running_processes": {
+          "name": "has_running_processes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_locked": {
+          "name": "account_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password_expires_at": {
+          "name": "password_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_last_changed_at": {
+          "name": "password_last_changed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_accounts_identity_idx": {
+          "name": "service_accounts_identity_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_accounts_org_type_idx": {
+          "name": "service_accounts_org_type_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_accounts_org_status_idx": {
+          "name": "service_accounts_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_accounts_org_host_idx": {
+          "name": "service_accounts_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_accounts_organisation_id_organisations_id_fk": {
+          "name": "service_accounts_organisation_id_organisations_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "service_accounts_host_id_hosts_id_fk": {
+          "name": "service_accounts_host_id_hosts_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_keys": {
+      "name": "ssh_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_type": {
+          "name": "key_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "bit_length": {
+          "name": "bit_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint_sha256": {
+          "name": "fingerprint_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authorized_keys'"
+        },
+        "associated_username": {
+          "name": "associated_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "key_age_seconds": {
+          "name": "key_age_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ssh_keys_identity_idx": {
+          "name": "ssh_keys_identity_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_fingerprint_idx": {
+          "name": "ssh_keys_org_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint_sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_type_idx": {
+          "name": "ssh_keys_org_type_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_status_idx": {
+          "name": "ssh_keys_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_org_host_idx": {
+          "name": "ssh_keys_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_keys_account_idx": {
+          "name": "ssh_keys_account_idx",
+          "columns": [
+            {
+              "expression": "service_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssh_keys_organisation_id_organisations_id_fk": {
+          "name": "ssh_keys_organisation_id_organisations_id_fk",
+          "tableFrom": "ssh_keys",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ssh_keys_host_id_hosts_id_fk": {
+          "name": "ssh_keys_host_id_hosts_id_fk",
+          "tableFrom": "ssh_keys",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ssh_keys_service_account_id_service_accounts_id_fk": {
+          "name": "ssh_keys_service_account_id_service_accounts_id_fk",
+          "tableFrom": "ssh_keys",
+          "tableTo": "service_accounts",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_accounts": {
+      "name": "domain_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "password_expires_at": {
+          "name": "password_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "domain_accounts_org_username_idx": {
+          "name": "domain_accounts_org_username_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_accounts_org_status_idx": {
+          "name": "domain_accounts_org_status_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_accounts_organisation_id_organisations_id_fk": {
+          "name": "domain_accounts_organisation_id_organisations_id_fk",
+          "tableFrom": "domain_accounts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_configurations": {
+      "name": "ldap_configurations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 389
+        },
+        "use_tls": {
+          "name": "use_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_start_tls": {
+          "name": "use_start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_certificate": {
+          "name": "tls_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_search_base": {
+          "name": "user_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_search_filter": {
+          "name": "user_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'(uid={{username}})'"
+        },
+        "group_search_base": {
+          "name": "group_search_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_search_filter": {
+          "name": "group_search_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uid'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mail'"
+        },
+        "display_name_attribute": {
+          "name": "display_name_attribute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cn'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allow_login": {
+          "name": "allow_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ldap_configurations_organisation_id_organisations_id_fk": {
+          "name": "ldap_configurations_organisation_id_organisations_id_fk",
+          "tableFrom": "ldap_configurations",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_group_members": {
+      "name": "host_group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_group_members_organisation_id_organisations_id_fk": {
+          "name": "host_group_members_organisation_id_organisations_id_fk",
+          "tableFrom": "host_group_members",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_group_members_group_id_host_groups_id_fk": {
+          "name": "host_group_members_group_id_host_groups_id_fk",
+          "tableFrom": "host_group_members",
+          "tableTo": "host_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_group_members_host_id_hosts_id_fk": {
+          "name": "host_group_members_host_id_hosts_id_fk",
+          "tableFrom": "host_group_members",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_groups": {
+      "name": "host_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "host_groups_organisation_id_organisations_id_fk": {
+          "name": "host_groups_organisation_id_organisations_id_fk",
+          "tableFrom": "host_groups",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_run_hosts": {
+      "name": "task_run_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_run_id": {
+          "name": "task_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_output": {
+          "name": "raw_output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_run_hosts_run_idx": {
+          "name": "task_run_hosts_run_idx",
+          "columns": [
+            {
+              "expression": "task_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_run_hosts_host_status_idx": {
+          "name": "task_run_hosts_host_status_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_run_hosts_organisation_id_organisations_id_fk": {
+          "name": "task_run_hosts_organisation_id_organisations_id_fk",
+          "tableFrom": "task_run_hosts",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_run_hosts_task_run_id_task_runs_id_fk": {
+          "name": "task_run_hosts_task_run_id_task_runs_id_fk",
+          "tableFrom": "task_run_hosts",
+          "tableTo": "task_runs",
+          "columnsFrom": [
+            "task_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_run_hosts_host_id_hosts_id_fk": {
+          "name": "task_run_hosts_host_id_hosts_id_fk",
+          "tableFrom": "task_run_hosts",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_runs": {
+      "name": "task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_parallel": {
+          "name": "max_parallel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_runs_org_idx": {
+          "name": "task_runs_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_runs_target_idx": {
+          "name": "task_runs_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_runs_organisation_id_organisations_id_fk": {
+          "name": "task_runs_organisation_id_organisations_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "task_runs_triggered_by_user_id_fk": {
+          "name": "task_runs_triggered_by_user_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terminal_sessions": {
+      "name": "terminal_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording": {
+          "name": "recording",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "terminal_sessions_org_host_idx": {
+          "name": "terminal_sessions_org_host_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminal_sessions_session_id_idx": {
+          "name": "terminal_sessions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_organisation_id_organisations_id_fk": {
+          "name": "terminal_sessions_organisation_id_organisations_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_user_id_user_id_fk": {
+          "name": "terminal_sessions_user_id_user_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "terminal_sessions_session_id_unique": {
+          "name": "terminal_sessions_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_software_reports": {
+      "name": "saved_software_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "saved_sw_reports_user_idx": {
+          "name": "saved_sw_reports_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_software_reports_organisation_id_organisations_id_fk": {
+          "name": "saved_software_reports_organisation_id_organisations_id_fk",
+          "tableFrom": "saved_software_reports",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "saved_software_reports_user_id_user_id_fk": {
+          "name": "saved_software_reports_user_id_user_id_fk",
+          "tableFrom": "saved_software_reports",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.software_packages": {
+      "name": "software_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "architecture": {
+          "name": "architecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "install_date": {
+          "name": "install_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cve_matches": {
+          "name": "cve_matches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sw_pkg_uniq": {
+          "name": "sw_pkg_uniq",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "architecture",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sw_pkg_org_name_idx": {
+          "name": "sw_pkg_org_name_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sw_pkg_host_idx": {
+          "name": "sw_pkg_host_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sw_pkg_first_seen_idx": {
+          "name": "sw_pkg_first_seen_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "software_packages_organisation_id_organisations_id_fk": {
+          "name": "software_packages_organisation_id_organisations_id_fk",
+          "tableFrom": "software_packages",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "software_packages_host_id_hosts_id_fk": {
+          "name": "software_packages_host_id_hosts_id_fk",
+          "tableFrom": "software_packages",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.software_scans": {
+      "name": "software_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_run_host_id": {
+          "name": "task_run_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_count": {
+          "name": "package_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "removed_count": {
+          "name": "removed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unchanged_count": {
+          "name": "unchanged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sw_scan_host_idx": {
+          "name": "sw_scan_host_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sw_scan_org_idx": {
+          "name": "sw_scan_org_idx",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "software_scans_organisation_id_organisations_id_fk": {
+          "name": "software_scans_organisation_id_organisations_id_fk",
+          "tableFrom": "software_scans",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "software_scans_host_id_hosts_id_fk": {
+          "name": "software_scans_host_id_hosts_id_fk",
+          "tableFrom": "software_scans",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "software_scans_task_run_host_id_task_run_hosts_id_fk": {
+          "name": "software_scans_task_run_host_id_task_run_hosts_id_fk",
+          "tableFrom": "software_scans",
+          "tableTo": "task_run_hosts",
+          "columnsFrom": [
+            "task_run_host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.host_network_memberships": {
+      "name": "host_network_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_assigned": {
+          "name": "auto_assigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "host_network_memberships_network_host_uniq": {
+          "name": "host_network_memberships_network_host_uniq",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "host_network_memberships_organisation_id_organisations_id_fk": {
+          "name": "host_network_memberships_organisation_id_organisations_id_fk",
+          "tableFrom": "host_network_memberships",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_network_memberships_network_id_networks_id_fk": {
+          "name": "host_network_memberships_network_id_networks_id_fk",
+          "tableFrom": "host_network_memberships",
+          "tableTo": "networks",
+          "columnsFrom": [
+            "network_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "host_network_memberships_host_id_hosts_id_fk": {
+          "name": "host_network_memberships_host_id_hosts_id_fk",
+          "tableFrom": "host_network_memberships",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.networks": {
+      "name": "networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cidr": {
+          "name": "cidr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "networks_organisation_id_organisations_id_fk": {
+          "name": "networks_organisation_id_organisations_id_fk",
+          "tableFrom": "networks",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1776416112233,
       "tag": "0032_tranquil_rattler",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1776505241190,
+      "tag": "0033_rich_tombstone",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/certificates.ts
+++ b/apps/web/lib/db/schema/certificates.ts
@@ -49,6 +49,10 @@ export const certificates = pgTable('certificates', {
   fingerprintSha256: text('fingerprint_sha256').notNull(),
   status: text('status').notNull().$type<CertificateStatus>().default('valid'),
   details: jsonb('details').notNull().$type<CertificateDetails>(),
+  trackedUrl: text('tracked_url'),
+  refreshIntervalSeconds: integer('refresh_interval_seconds'),
+  lastRefreshedAt: timestamp('last_refreshed_at', { withTimezone: true }),
+  lastRefreshError: text('last_refresh_error'),
   lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
@@ -61,6 +65,7 @@ export const certificates = pgTable('certificates', {
   index('certificates_org_expiry_idx').on(t.organisationId, t.notAfter),
   index('certificates_org_status_idx').on(t.organisationId, t.status),
   index('certificates_org_host_idx').on(t.organisationId, t.discoveredByHostId),
+  index('certificates_refresh_due_idx').on(t.trackedUrl, t.lastRefreshedAt),
 ])
 
 export const certificateEvents = pgTable('certificate_events', {


### PR DESCRIPTION
## Summary

- Adds a **Track this certificate** button on both Certificate Checker tabs and an **Add tracked certificate** entry on the Certificate Tracker index that routes back to the Checker.
- URL-checked certs are tracked with a server-side periodic re-fetch (15m / 1h / 6h / 24h) so status and renewals stay in sync automatically.
- Uploaded/pasted certs are tracked as a static `notAfter` reminder — supports air-gapped hosts the server can't reach.
- New Go sweeper inside the `ingest` binary opens TLS connections on a 60s ticker, refreshes unchanged certs, handles renewals by inserting a new row and clearing tracking from the old one, and preserves cert data on transient fetch failures so reminders keep working.

## What changed

**Schema** — [apps/web/lib/db/schema/certificates.ts](apps/web/lib/db/schema/certificates.ts)
- `tracked_url`, `refresh_interval_seconds`, `last_refreshed_at`, `last_refresh_error`
- `certificates_refresh_due_idx` partial index on `(tracked_url, last_refreshed_at)`
- Migration `0033_rich_tombstone.sql` generated via `pnpm run db:generate`

**Shared fetch/parse helper** — [apps/web/lib/certificates/fetch.ts](apps/web/lib/certificates/fetch.ts)
- Extracted the `tls.connect` + node-forge parsing logic out of the cert-checker API route so both the route and the new server actions share one code path. Old inline logic removed from `route.ts`.

**Server actions** — [apps/web/lib/actions/certificates.ts](apps/web/lib/actions/certificates.ts)
- `trackCertificateFromUrl({ url, refreshIntervalSeconds })` — Zod-validated, session/org scoped; upserts by natural key, emits `discovered` event.
- `trackCertificateFromUpload({ pem, host?, port?, serverName? })` — parses PEM via shared helper; defaults `host`/`serverName` to CN (or fingerprint) with `port=0` so the natural-key constraint holds for air-gapped certs.
- Both return a friendly `alreadyTracked: true` when the cert already exists under the natural key.

**Cert Checker UI** — [apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx](apps/web/app/%28dashboard%29/certificate-checker/certificate-checker-client.tsx)
- Adds a Track control on both tabs. URL tab opens a dialog for picking refresh interval; upload tab tracks with a short notice explaining there is no auto re-check.

**Tracker index UI** — [apps/web/app/(dashboard)/certificates/certificates-client.tsx](apps/web/app/%28dashboard%29/certificates/certificates-client.tsx)
- Header now has an **Add tracked certificate** button; the dialog directs the engineer to the Certificate Checker as the single import entry point.

**Refresh sweeper** — [apps/ingest/internal/handlers/cert_refresh_sweeper.go](apps/ingest/internal/handlers/cert_refresh_sweeper.go) (new)
- `RunCertRefreshSweeper` ticker (60s). Uses `crypto/tls` + `crypto/x509` only — no new deps.
- Per tick: `ListCertsDueForUrlRefresh` → dial → compare fingerprint.
- Same fingerprint: `MarkCertRefreshed` + status-change event if transitioned; re-evaluates cert_expiry alert rules.
- New fingerprint: transactional `InsertRenewedTrackedCert` carries the `tracked_url` + interval to the new row and clears them from the old row; emits `renewed` events on both.
- Fetch failure: `MarkCertRefreshFailed` records the error and leaves cert data untouched so the existing `notAfter`-based reminder still fires.
- Registered alongside existing sweepers in [apps/ingest/cmd/ingest/main.go](apps/ingest/cmd/ingest/main.go).

**Queries** — [apps/ingest/internal/db/queries/certificates.sql.go](apps/ingest/internal/db/queries/certificates.sql.go)
- `ListCertsDueForUrlRefresh`, `MarkCertRefreshed`, `MarkCertRefreshFailed`, `InsertRenewedTrackedCert` (transactional insert + clear).

**Docs** — [apps/docs/docs/features/certificate-checker.md](apps/docs/docs/features/certificate-checker.md), [apps/docs/docs/features/certificates.md](apps/docs/docs/features/certificates.md)
- Documented the Track button, URL-tracked vs upload-tracked modes, and the server-side refresh behaviour including renewal handling and failure semantics.

## Test plan

- [ ] `cd apps/web && pnpm run db:migrate` applies `0033_rich_tombstone.sql` cleanly.
- [ ] Check `https://example.com` in the Checker → click **Track this certificate** → pick 15m → confirm row appears in `/certificates` with `source=imported`, `trackedUrl` set, correct status.
- [ ] Click Track a second time on the same URL → "already tracked" message, no duplicate row.
- [ ] Paste a PEM → Track → confirm row with `trackedUrl=null`, `lastRefreshedAt=null`, message about no auto-recheck.
- [ ] Set `refreshIntervalSeconds=60` on a tracked row; watch ingest logs → `last_refreshed_at` advances, status stays accurate.
- [ ] Change a tracked row's `trackedUrl` to an unreachable host → after one tick, `last_refresh_error` populated, cert data unchanged.
- [ ] Force a fingerprint change (point `trackedUrl` at a different cert) → confirm new row inserted with carried-over tracking fields, old row has tracking cleared, `renewed` events on both.
- [ ] `/certificates` page → **Add tracked certificate** opens dialog → **Open Certificate Checker** navigates to `/certificate-checker`.
- [ ] Different-org user cannot see/track another org's certs (server action filters by `session.user.organisationId`).
- [ ] `cd apps/docs && pnpm run build` renders the updated pages.

## Out of scope (follow-ups)

- Editing a tracked cert's refresh interval from the Tracker UI.
- Alerting when a `lastRefreshError` persists across N ticks.
- PKCS#7 chain tracking — we only track the leaf.
- Bulk URL import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)