### PR TITLE
docs: update PROGRESS.md with sessions 48-53 and refresh tool docs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,130 @@
 **Phase 5 — Tooling (in progress)**
 
 ## Current Status
-🟢 Phase 5 progressing — VuePress docs site live; networks (CIDR auto-assignment) and interactive network topology graphs shipped; terminal panel evolved into a full tabbed/split VS Code-style workspace with per-tab colours, reorder, splits, and adjustable text size.
+🟢 Phase 5 progressing — two new Tooling utilities shipped (Directory User Lookup for live LDAP/AD queries, SSL Certificate Checker for parse/fetch/validate/convert of X.509 certs); offline agent install bundle (zip) for air-gapped enrolment; ingest-side host deduplication by hostname / IP overlap; repo/image rename to `carrtech-dev` and enrolment-URL env-var plumbing; plus the established VuePress docs, networks (CIDR + graph view), and split-pane terminal workspace.
 
 ---
 
 ## What Has Been Built
+
+### Session 53 — SSL Certificate Checker tool
+
+**New tooling page** (`apps/web/app/(dashboard)/certificate-checker/`, `apps/web/app/api/tools/certificate-checker/route.ts`)
+- Interactive X.509 cert inspector — no `openssl` needed locally
+- Supply the cert three ways on one tab: drag-and-drop a file, click to browse, or paste PEM text directly — PEM drops auto-populate the textarea, binary drops (DER/PKCS#12) are sent as base64
+- **Check URL** tab: server-side TLS connect to any host:port with optional SNI override — internal hosts reachable from the web container are inspectable
+- **Private key validation** is upfront on both tabs; match result returned in the same API call as parse/fetch
+- Download the leaf cert in PEM, DER, or PKCS#7
+- Supports PEM, DER, PKCS#7 (`.p7b`), PKCS#12 (`.pfx`/`.p12` with password) input formats
+- Full detail rendering: subject/issuer DN, validity, SHA-1/256/512 fingerprints, key algo/size/curve, all extensions (KU, EKU, SANs, policies, basic constraints, AKI/SKI), OCSP/CRL/CA-issuer URLs, chain table, raw PEM with copy
+- `node-forge` added for PKCS#7/PKCS#12 parsing; new `tabs.tsx` shadcn primitive from Radix
+- Docs: new `apps/docs/docs/features/certificate-checker.md` (updated for paste + drag-drop + inline key validation)
+- PRs: carrtech-dev/ct-ops#252 (initial tool), #257 (paste + drag-drop)
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
+
+### Session 52 — Repo rename + agent enrolment URL env var plumbing
+
+**Repo/image rename** — the repository moved to `carrtech-dev/ct-ops`, so container images now publish to `ghcr.io/carrtech-dev/infrawatch/*`
+- Updated hardcoded references in `docker-compose.single.yml`, `.env.example`, customer-bundle README, and `apps/docs/docs/deployment/docker-compose.md`
+- PR: carrtech-dev/ct-ops#253
+
+**Enrolment URL env var** (`apps/web/app/(dashboard)/settings/agents/`, `apps/web/.env.example`, `docker-compose.single.yml`)
+- Agent enrolment `curl` install command was showing `localhost` when the UI was reached via port-forward/proxy
+- New `getAppOrigin()` helper initially backed by `NEXT_PUBLIC_APP_URL`, then unified onto the existing `AGENT_DOWNLOAD_BASE_URL` env var so one variable drives both the ingest service and the web UI's install command
+- `AGENT_DOWNLOAD_BASE_URL` also propagated to the web service in `docker-compose.single.yml` (previously only wired to ingest, so `process.env` was undefined in the Next.js server component)
+- Falls back to `window.location.origin` when unset, preserving zero-config local dev
+- PRs: carrtech-dev/ct-ops#254, #258
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
+
+### Session 51 — Host registration deduplication (hostname / IP overlap)
+
+**Ingest-side dedup** (`apps/ingest/internal/handlers/register.go`, `apps/ingest/internal/db/queries/hosts.sql.go`, `agent/internal/registration/registrar.go`)
+- Two live hosts in the same org cannot share a hostname or IP — guard now runs at `Register` and at `approveAgent`
+- **Online or revoked match** → reject with `ALREADY_EXISTS` so the admin deletes the stale record first
+- **Offline / unknown match** → adopt the existing `agents`/`hosts` rows, rotate the new public key onto the existing agent, and preserve approval state — covers reinstall-with-wiped-data-dir cases that previously produced a duplicate "Offline" record
+- Agents now report non-loopback IPs in `PlatformInfo` at register time so the server can run the overlap check
+- Key rotation appended to agent status history with reason `"adopted re-registration (keypair rotated; matched by hostname or IP)"` for audit
+- `apps/web/lib/actions/agents.ts` also hardened against approving a pending agent that now collides with a live host
+
+**Docs**
+- `apps/docs/docs/architecture/ingest.md` + `apps/docs/docs/features/hosts.md` — new Duplicate-Host Protection section
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+- `go build ./...` — zero errors ✅
+
+---
+
+### Session 50 — Offline agent install bundle (zip download)
+
+**New download route** (`apps/web/app/api/agent/bundle/route.ts`, `apps/web/lib/agent/bundle.ts`, `apps/web/lib/agent/binary.ts`)
+- **Settings → Agent Enrolment → Download Install Bundle** — produces a per-OS/arch zip containing the agent binary, install helper (`install.sh` on Linux/macOS, `install.ps1` on Windows), pre-populated `agent.toml`, `SHA256SUMS`, and a `README.md`
+- Three token options: generate a fresh single-use token (default 7-day expiry), embed an existing active token, or ship without a token (operator exports `INFRAWATCH_ORG_TOKEN` before install)
+- Gated to `super_admin` / `org_admin`; scoped by `organisationId`; single-use tokens persisted via `agent_enrolment_tokens` with `metadata.source = 'install-bundle'` and `metadata.os` / `metadata.arch` for audit
+- Shared binary resolver extracted to `apps/web/lib/agent/binary.ts` so the new route reuses the download route's cache / GitHub-release / baked-binary fallback
+- Zip built with `jszip`
+- Closes carrtech-dev/ct-ops#244; PR #250
+
+**Docs**
+- New `apps/docs/docs/getting-started/agent-install-bundle.md` (full install walk-through, token audit-trail, troubleshooting)
+- Cross-links added to `apps/docs/docs/deployment/air-gap.md`, `apps/docs/docs/architecture/agent.md`, and top-level `README.md` so the bundle is discoverable as the air-gap enrolment path
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
+
+### Session 49 — Terminal panel SSR hydration fix
+
+**Root cause** (`apps/web/components/terminal/terminal-panel-context.tsx`)
+- `useState` initialiser was reading `sessionStorage` on the client, producing HTML that differed from the server render whenever the terminal panel had persisted tabs
+- Resulting React #418 hydration mismatch aborted hydration for the entire dashboard tree, leaving client components (notably the directory-lookup typeahead) non-interactive
+
+**Fix**
+- Start with `DEFAULT_STATE` on server and client; load persisted state in a post-mount effect gated by a `hasHydrated` flag so the initial empty state doesn't wipe `sessionStorage`
+- `set-state-in-effect` lint rule disabled around the one-shot hydration effect with a comment explaining the canonical pattern
+- PRs: carrtech-dev/ct-ops#243, #246
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
+
+### Session 48 — Directory User Lookup (live LDAP/AD query)
+
+**New tooling page** (`apps/web/app/(dashboard)/directory-lookup/`, `apps/web/lib/actions/ldap-lookup.ts`)
+- **Tooling → Directory User Lookup** — on-demand queries against any configured LDAP/AD server; nothing is synced or stored
+- Username typeahead (debounced, prefix-matched via `{{username}}*` on the configured `userSearchFilter`), directory picker when multiple configs exist
+- Selecting a user fetches the full attribute set (including operational attrs via `+`) and renders:
+  - Summary: display name, username, lock/active status, email, sAMAccountName, UPN, copyable DN
+  - Password: expires, last changed, lock status — parses both AD (`msDS-UserPasswordExpiryTimeComputed`, `accountExpires`, `pwdLastSet`, `lockoutTime`, `userAccountControl`) and OpenLDAP/shadow (`shadowLastChange`, `shadowMax`, `pwdChangedTime`, `pwdAccountLockedTime`)
+  - Groups: full `memberOf` list with CN + DN, copy button, and client-side filter visible whenever the user has any groups
+  - All LDAP Attributes: searchable table of every returned attribute, with Windows file-time / LDAP generalized-time values rendered as human-readable dates and the raw value shown below; binary values as `[binary NB]`; password-hash attributes excluded for safety
+- Removed unused sync scaffolding from `ldap_configurations` (`lastSyncAt`, `syncIntervalMinutes`, etc.) and LDAP-sourced columns from `domain_accounts` (`ldapConfigurationId`, `distinguishedName`, `groups`) — the Service Accounts register is now manual-only; live queries go through this tool
+- Any authenticated org user can run a lookup; managing LDAP configs remains `org_admin` / `super_admin`
+
+**Follow-up fixes during the same afternoon**
+- **Server-action error surfacing** — `searchLdapDirectory` / `lookupDirectoryUser` wrapped in try/catch/finally so a stale client bundle (e.g. after a deploy) no longer leaves the typeahead silently stuck on the spinner; users see a "please reload" message (PR #242)
+- **Portal the suggestions dropdown** — the Card ancestor's `overflow-hidden` clipped the absolutely-positioned dropdown; now rendered via `createPortal` on `document.body` with the input's `getBoundingClientRect` tracked on resize/scroll (PR #247)
+- **Group filter always visible + humanised LDAP timestamps** — filter shows whenever there is any group (was >5); attribute table humanises Windows file-time / LDAP generalized-time (PR #249)
+
+**Docs**
+- New `apps/docs/docs/features/directory-lookup.md` (+ sidebar)
+- `apps/docs/docs/features/service-accounts.md` updated to direct live lookups to the new tool
+- Earlier in the same day, `apps/docs/docs/features/networks.md` gained a Graph View section covering the Table/Graph toggle, dashed-bezier edges, dark-mode, and the right-click host-node context menu shipped in Session 45; CLAUDE.md's stale Docusaurus reference replaced with the VuePress path (PR #239)
+
+**Build state**
+- `pnpm run build` — zero TypeScript errors ✅
+
+---
 
 ### Session 47 — Terminal text size settings
 

--- a/apps/docs/docs/features/certificate-checker.md
+++ b/apps/docs/docs/features/certificate-checker.md
@@ -4,21 +4,28 @@ The SSL Certificate Checker is an interactive tool in the **Tooling** section th
 
 ## Features
 
-- **Upload a certificate** in PEM, DER, PKCS#7 (.p7b), or PKCS#12 (.pfx/.p12) formats
+- **Three ways to supply a certificate** — drag-and-drop a file, click to browse, or paste PEM text directly
 - **Fetch live certificates** directly from any TLS-protected URL or hostname
-- **Validate a private key** against the loaded certificate to confirm they match
+- **Inline private key validation** — optionally supply a private key (dropped, uploaded, or pasted) and the match result is returned alongside the certificate details
+- **Supports PEM, DER, PKCS#7 (.p7b), and PKCS#12 (.pfx/.p12)** formats
 - **Download certificates** in PEM, DER, or PKCS#7 format
 - **Full certificate detail** — every field extracted and displayed in a readable layout
 
 ## How to Use
 
-### 1. Upload a Certificate File
+### 1. Supply a Certificate (Upload / Paste)
 
 1. Navigate to **Tooling → SSL Certificate Checker** in the sidebar.
-2. Select the **Upload File** tab.
-3. Drag-and-drop or click to browse for your certificate file.
+2. Select the **Upload / Paste** tab.
+3. Provide the certificate in whichever way is easiest:
+   - **Drag-and-drop** a file onto the drop zone
+   - **Click** the drop zone to browse for a file
+   - **Paste** PEM-encoded text directly into the textarea
 4. For PKCS#12 (`.pfx` / `.p12`) files, enter the password in the **Password** field that appears.
-5. Click **Analyse Certificate**.
+5. (Optional) Supply a private key in the **Private Key** field — drop, browse, or paste — to validate it against the certificate in the same request.
+6. Click **Analyse Certificate**.
+
+PEM/text files (`.pem`, `.crt`, `.cer`, `.key`) dropped onto the zone are read as text and auto-populate the paste area so you can review the content before submitting. Binary files (DER, PKCS#12) are kept as file references and sent as base64.
 
 Supported formats:
 
@@ -35,17 +42,16 @@ Supported formats:
 2. Enter a hostname or full URL (e.g. `example.com` or `https://example.com`).
 3. Adjust **Port** if the service isn't on 443.
 4. Optionally set an **SNI Override** if the TLS server name differs from the hostname (useful for IP addresses or CDN backends).
-5. Click **Fetch Certificate**.
+5. (Optional) Supply a private key in the **Private Key** field to validate it against the fetched certificate.
+6. Click **Fetch Certificate**.
 
 The tool connects server-side, so it can reach internal hosts that your browser cannot access directly.
 
-### 3. Validate a Private Key
+### 3. Private Key Validation
 
-After loading a certificate, a **Validate Private Key** panel appears at the bottom of the results.
+The private key field is available **upfront** on both the Upload/Paste and Check URL tabs — you don't need to wait for the certificate to load first. Validation runs in the same API call as certificate parsing/fetching, and the match result appears alongside the certificate details.
 
-1. Paste the PEM-encoded private key into the text area.
-2. Click **Validate Key**.
-3. A green or red banner will confirm whether the key matches the certificate's public key.
+A green banner confirms the key matches the certificate's public key; a red banner indicates a mismatch.
 
 ::: tip
 The private key is transmitted to the server for validation and is not stored. For sensitive keys, use this tool only on trusted internal deployments.

--- a/apps/docs/docs/features/directory-lookup.md
+++ b/apps/docs/docs/features/directory-lookup.md
@@ -34,8 +34,8 @@ Once a user is selected, Infrawatch queries the directory for all attributes on 
 - **Password** — expires, last changed, account locked status
     - Active Directory: parses `msDS-UserPasswordExpiryTimeComputed`, `accountExpires`, `pwdLastSet`, `lockoutTime`, `userAccountControl`
     - OpenLDAP / shadow: parses `shadowLastChange`, `shadowMax`, `pwdChangedTime`, `pwdAccountLockedTime`
-- **Groups** — full list of `memberOf` group DNs, with a client-side filter for directories where a single user may belong to hundreds of groups. Each entry shows the group's common name with the full DN beneath, and a copy button.
-- **All LDAP Attributes** — a collapsible table showing every attribute returned for the user, with its own search filter so you can quickly find what you need. Binary values render as `[binary NB]`; password-hash attributes are excluded for safety.
+- **Groups** — full list of `memberOf` group DNs, with a client-side filter that appears whenever the user has any group memberships. Each entry shows the group's common name with the full DN beneath, and a copy button.
+- **All LDAP Attributes** — a collapsible table showing every attribute returned for the user, with its own search filter so you can quickly find what you need. Windows file-time and LDAP generalized-time values are converted to human-readable dates with the raw value shown below in smaller text. Binary values render as `[binary NB]`; password-hash attributes are excluded for safety.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add sessions 48–53 to PROGRESS.md covering Directory User Lookup, terminal SSR hydration fix, offline agent install bundle, host registration dedup, repo/image rename + enrolment URL env vars, and the SSL Certificate Checker
- Refresh `certificate-checker.md` for paste + drag-drop and upfront inline private key validation (doc still described the old separate Validate Key panel)
- Refresh `directory-lookup.md` for the always-visible group filter and humanised LDAP/Windows timestamps

## Test plan
- [x] `apps/docs` build: VuePress picks up edited pages (no new sidebar entries required)
- [x] PROGRESS.md renders cleanly (session headers, code spans, status line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)