### PR TITLE
feat: infrawatch-loadtest tool for capacity planning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto go-build go-test agent ingest clean
+.PHONY: proto go-build go-test agent ingest loadtest clean
 
 AGENT_DIST_DIR := apps/web/data/agent-dist
 
@@ -70,6 +70,24 @@ ingest:
 		golang:1.25 \
 		go build -o dist/ingest ./apps/ingest/cmd/ingest
 	@echo "Ingest binary: dist/ingest ($(HOST_OS)/$(HOST_ARCH))"
+
+# Build the infrawatch-loadtest binary for the host platform only. This is a
+# dev/ops tool for measuring sustainable fleet capacity of a given server
+# profile; it is not shipped as a release artefact.
+loadtest:
+	@echo "Building infrawatch-loadtest for $(HOST_OS)/$(HOST_ARCH)..."
+	@mkdir -p dist $(GO_CACHE_DIR) $(GO_MOD_DIR)
+	docker run --rm \
+		-v "$(CURDIR):/src" \
+		-w /src \
+		--user "$(shell id -u):$(shell id -g)" \
+		-e GOOS=$(HOST_OS) \
+		-e GOARCH=$(HOST_ARCH) \
+		-e CGO_ENABLED=0 \
+		$(GO_CACHE_ARGS) \
+		golang:1.25 \
+		go build -trimpath -ldflags="-s -w" -o dist/infrawatch-loadtest ./agent/cmd/loadtest
+	@echo "Load-test binary: dist/infrawatch-loadtest ($(HOST_OS)/$(HOST_ARCH))"
 
 go-test:
 	@mkdir -p $(GO_CACHE_DIR) $(GO_MOD_DIR)

--- a/agent/cmd/loadtest/main.go
+++ b/agent/cmd/loadtest/main.go
@@ -1,0 +1,175 @@
+// Command infrawatch-loadtest simulates N virtual agents against a running
+// Infrawatch server to measure sustainable fleet capacity on a given hardware
+// profile. See docs/deployment/load-testing.md for the operator guide.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/infrawatch/agent/internal/loadtest"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printRootUsage(os.Stderr)
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "run":
+		exit(runCmd(os.Args[2:]))
+	case "cleanup":
+		exit(cleanupCmd(os.Args[2:]))
+	case "-h", "--help", "help":
+		printRootUsage(os.Stdout)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n", os.Args[1])
+		printRootUsage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func exit(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func printRootUsage(w io.Writer) {
+	fmt.Fprintln(w, "infrawatch-loadtest — simulate N virtual agents against an Infrawatch server")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Subcommands:")
+	fmt.Fprintln(w, "  run      Start a load-test run")
+	fmt.Fprintln(w, "  cleanup  Delete virtual hosts created by a prior run")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Run any subcommand with --help for its full flag list.")
+}
+
+func runCmd(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	cfg := &loadtest.Config{}
+	fs.StringVar(&cfg.Address, "address", "", "ingest gRPC host:port (required)")
+	fs.StringVar(&cfg.OrgToken, "token", "", "enrolment token with auto_approve=true (required)")
+	fs.StringVar(&cfg.CACertFile, "ca-cert", "", "path to server CA cert (optional)")
+	fs.BoolVar(&cfg.TLSSkipVerify, "tls-skip-verify", false, "skip TLS server verification (dev only)")
+	fs.IntVar(&cfg.Agents, "agents", 100, "total virtual agents")
+	fs.DurationVar(&cfg.Ramp, "ramp", 30*time.Second, "duration over which registrations are spread")
+	fs.DurationVar(&cfg.Duration, "duration", 5*time.Minute, "how long to run; 0 = until Ctrl-C")
+	fs.DurationVar(&cfg.HeartbeatInterval, "heartbeat-interval", 30*time.Second, "per-agent heartbeat cadence")
+	runIDFlag := fs.String("run-id", "", "run identifier baked into hostnames; default = auto-generated")
+	fs.StringVar(&cfg.HostnamePrefix, "hostname-prefix", "loadtest", "hostname prefix for virtual agents")
+	fs.IntVar(&cfg.ConnFanout, "conn-fanout", 50, "virtual agents sharing a single gRPC connection")
+	fs.DurationVar(&cfg.StatsInterval, "stats-interval", 10*time.Second, "cadence for live stats output")
+	fs.IntVar(&cfg.RegistrationConc, "registration-concurrency", 32, "parallel Register RPCs in flight during ramp")
+	fs.Float64Var(&cfg.MetricsJitter, "metrics-jitter", 0.1, "amplitude of per-tick metric drift (0-1)")
+	fs.StringVar(&cfg.OutputJSON, "output-json", "", "optional path to write final summary as JSON")
+	fs.BoolVar(&cfg.SimulateTasks, "simulate-tasks", true, "respond to server-pushed AgentTasks with fake progress + exit-0 result")
+	fs.BoolVar(&cfg.SimulateChecks, "simulate-checks", true, "return fake CheckResults for pushed CheckDefinitions")
+	fs.BoolVar(&cfg.SimulateTerminal, "simulate-terminal", true, "open Terminal streams for pushed TerminalSessionRequests")
+	fs.BoolVar(&cfg.SimulateInventory, "simulate-inventory", true, "upload fake software inventory on software_inventory_scan tasks")
+	fs.Float64Var(&cfg.CheckFailureRate, "check-failure-rate", 0.05, "fraction of simulated check results that report 'fail'")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: infrawatch-loadtest run [flags]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *runIDFlag != "" {
+		cfg.RunID = *runIDFlag
+	} else {
+		cfg.RunID = loadtest.GenerateRunID()
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	runner := loadtest.NewRunner(cfg, os.Stdout)
+	return runner.Run(ctx)
+}
+
+type bulkDeleteRequest struct {
+	HostnamePrefix string `json:"hostnamePrefix"`
+}
+
+type bulkDeleteResponse struct {
+	Deleted int      `json:"deleted"`
+	Failed  []string `json:"failed"`
+}
+
+func cleanupCmd(args []string) error {
+	fs := flag.NewFlagSet("cleanup", flag.ContinueOnError)
+	webURL := fs.String("web-url", "", "base URL of the Infrawatch web app (required)")
+	adminKey := fs.String("admin-key", "", "admin key configured via INFRAWATCH_LOADTEST_ADMIN_KEY on the web server (required)")
+	runID := fs.String("run-id", "", "run-id of the load test to clean up (required)")
+	hostnamePrefix := fs.String("hostname-prefix", "loadtest", "same prefix passed to `run`")
+	timeout := fs.Duration("timeout", 5*time.Minute, "HTTP request timeout")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "Usage: infrawatch-loadtest cleanup [flags]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *webURL == "" || *adminKey == "" || *runID == "" {
+		fs.Usage()
+		return errors.New("--web-url, --admin-key, and --run-id are required")
+	}
+
+	prefix := fmt.Sprintf("%s-%s-", *hostnamePrefix, *runID)
+	reqBody, err := json.Marshal(bulkDeleteRequest{HostnamePrefix: prefix})
+	if err != nil {
+		return err
+	}
+
+	url := strings.TrimRight(*webURL, "/") + "/api/admin/hosts/bulk-delete"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Loadtest-Admin-Key", *adminKey)
+
+	client := &http.Client{Timeout: *timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("admin endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out bulkDeleteResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	fmt.Printf("Deleted %d virtual hosts matching %s*\n", out.Deleted, prefix)
+	if len(out.Failed) > 0 {
+		fmt.Println("Failures:")
+		for _, f := range out.Failed {
+			fmt.Println("  -", f)
+		}
+	}
+	return nil
+}

--- a/agent/internal/loadtest/config.go
+++ b/agent/internal/loadtest/config.go
@@ -1,0 +1,79 @@
+package loadtest
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// Config is the fully-validated configuration for a load-test run.
+type Config struct {
+	Address               string
+	OrgToken              string
+	CACertFile            string
+	TLSSkipVerify         bool
+	Agents                int
+	Ramp                  time.Duration
+	Duration              time.Duration
+	HeartbeatInterval     time.Duration
+	RunID                 string
+	HostnamePrefix        string
+	ConnFanout            int
+	StatsInterval         time.Duration
+	RegistrationConc      int
+	MetricsJitter         float64
+	OutputJSON            string
+	SimulateTasks         bool
+	SimulateChecks        bool
+	SimulateTerminal      bool
+	SimulateInventory     bool
+	CheckFailureRate      float64
+}
+
+// Validate returns an error if the configuration is missing required fields
+// or uses invalid values.
+func (c *Config) Validate() error {
+	if c.Address == "" {
+		return fmt.Errorf("--address is required")
+	}
+	if c.OrgToken == "" {
+		return fmt.Errorf("--token is required")
+	}
+	if c.Agents < 1 {
+		return fmt.Errorf("--agents must be >= 1")
+	}
+	if c.HeartbeatInterval < time.Second {
+		return fmt.Errorf("--heartbeat-interval must be >= 1s")
+	}
+	if c.ConnFanout < 1 {
+		return fmt.Errorf("--conn-fanout must be >= 1")
+	}
+	if c.RegistrationConc < 1 {
+		return fmt.Errorf("--registration-concurrency must be >= 1")
+	}
+	if c.MetricsJitter < 0 || c.MetricsJitter > 1 {
+		return fmt.Errorf("--metrics-jitter must be between 0 and 1")
+	}
+	if c.CheckFailureRate < 0 || c.CheckFailureRate > 1 {
+		return fmt.Errorf("--check-failure-rate must be between 0 and 1")
+	}
+	return nil
+}
+
+// GenerateRunID returns a compact deterministic-looking identifier of the form
+// "lt-YYMMDD-HHMMSS-XXXX" where the last four characters are random hex, so
+// concurrent load-test runs from the same wall-clock second still have
+// distinct IDs.
+func GenerateRunID() string {
+	now := time.Now().UTC()
+	var b [2]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("lt-%s-%s", now.Format("060102-150405"), hex.EncodeToString(b[:]))
+}
+
+// HostnameFor returns the fully-qualified virtual hostname for the agent at
+// the given index within a run, e.g. "loadtest-lt-260418-143022-a3f1-0042".
+func (c *Config) HostnameFor(index int) string {
+	return fmt.Sprintf("%s-%s-%04d", c.HostnamePrefix, c.RunID, index)
+}

--- a/agent/internal/loadtest/config_test.go
+++ b/agent/internal/loadtest/config_test.go
@@ -1,0 +1,80 @@
+package loadtest
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func validConfig() *Config {
+	return &Config{
+		Address:           "localhost:9443",
+		OrgToken:          "test-token",
+		Agents:            10,
+		HeartbeatInterval: 30 * time.Second,
+		ConnFanout:        5,
+		RegistrationConc:  4,
+		MetricsJitter:     0.1,
+		CheckFailureRate:  0.05,
+		HostnamePrefix:    "loadtest",
+		RunID:             "lt-test",
+	}
+}
+
+func TestConfigValidateHappyPath(t *testing.T) {
+	if err := validConfig().Validate(); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsMissingFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{"no address", func(c *Config) { c.Address = "" }, "--address"},
+		{"no token", func(c *Config) { c.OrgToken = "" }, "--token"},
+		{"zero agents", func(c *Config) { c.Agents = 0 }, "--agents"},
+		{"hb too fast", func(c *Config) { c.HeartbeatInterval = 500 * time.Millisecond }, "--heartbeat-interval"},
+		{"jitter too high", func(c *Config) { c.MetricsJitter = 1.5 }, "--metrics-jitter"},
+		{"failure rate < 0", func(c *Config) { c.CheckFailureRate = -0.1 }, "--check-failure-rate"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validConfig()
+			tc.mutate(c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("expected validation error for %q", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q did not mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestHostnameForFormat(t *testing.T) {
+	c := &Config{HostnamePrefix: "loadtest", RunID: "lt-261117-x"}
+	got := c.HostnameFor(42)
+	want := "loadtest-lt-261117-x-0042"
+	if got != want {
+		t.Fatalf("HostnameFor(42): got %q, want %q", got, want)
+	}
+}
+
+func TestGenerateRunIDUniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id := GenerateRunID()
+		if seen[id] {
+			t.Fatalf("duplicate run ID generated: %s", id)
+		}
+		seen[id] = true
+		if !strings.HasPrefix(id, "lt-") {
+			t.Fatalf("run ID missing 'lt-' prefix: %s", id)
+		}
+	}
+}

--- a/agent/internal/loadtest/connpool.go
+++ b/agent/internal/loadtest/connpool.go
@@ -1,0 +1,84 @@
+package loadtest
+
+import (
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+
+	agentgrpc "github.com/infrawatch/agent/internal/grpc"
+)
+
+// ConnPool is a lazy, thread-safe pool of shared gRPC connections.
+// Virtual agents share connections so that 1000 agents don't open 1000 TLS
+// connections — gRPC's HTTP/2 transport multiplexes concurrent streams over a
+// single connection, and sharing reduces handshake cost, server-side per-conn
+// bookkeeping, and file-descriptor use on the load-test VM.
+type ConnPool struct {
+	address       string
+	caCertFile    string
+	tlsSkipVerify bool
+
+	mu    sync.Mutex
+	conns []*grpc.ClientConn
+	size  int
+}
+
+// NewConnPool creates a pool that will host up to size connections. Dialing
+// happens lazily on first use of each slot.
+func NewConnPool(address, caCertFile string, tlsSkipVerify bool, size int) *ConnPool {
+	if size < 1 {
+		size = 1
+	}
+	return &ConnPool{
+		address:       address,
+		caCertFile:    caCertFile,
+		tlsSkipVerify: tlsSkipVerify,
+		conns:         make([]*grpc.ClientConn, size),
+		size:          size,
+	}
+}
+
+// Get returns the connection for the given agent index, dialling or re-dialling
+// if the slot is unset or in a non-recoverable state. Safe for concurrent use.
+func (p *ConnPool) Get(agentIndex int) (*grpc.ClientConn, error) {
+	slot := agentIndex % p.size
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	conn := p.conns[slot]
+	if conn != nil {
+		state := conn.GetState()
+		if state != connectivity.Shutdown {
+			return conn, nil
+		}
+		// Shutdown — dial a replacement below.
+		conn = nil
+	}
+
+	fresh, err := agentgrpc.Connect(p.address, p.caCertFile, p.tlsSkipVerify)
+	if err != nil {
+		return nil, fmt.Errorf("dialling %s: %w", p.address, err)
+	}
+	p.conns[slot] = fresh
+	return fresh, nil
+}
+
+// Close closes every dialled connection in the pool.
+func (p *ConnPool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, c := range p.conns {
+		if c != nil {
+			_ = c.Close()
+			p.conns[i] = nil
+		}
+	}
+}
+
+// Size returns the number of connection slots managed by the pool.
+func (p *ConnPool) Size() int {
+	return p.size
+}

--- a/agent/internal/loadtest/inventory.go
+++ b/agent/internal/loadtest/inventory.go
@@ -1,0 +1,53 @@
+package loadtest
+
+import (
+	"context"
+	"fmt"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+const inventoryChunkSize = 500
+
+// simulateInventoryStream opens a SubmitSoftwareInventory client-streaming RPC
+// and uploads two chunks of fake packages followed by an is_last marker.
+// Matches the real agent's chunked-upload contract so the ingest handler
+// exercises the full persistence path.
+func (v *VirtualAgent) simulateInventoryStream(ctx context.Context, client agentv1.IngestServiceClient, scanID string) {
+	stream, err := client.SubmitSoftwareInventory(ctx)
+	if err != nil {
+		v.stats.RecordError(truncate("inventory stream open: "+err.Error(), 200))
+		return
+	}
+
+	const totalChunks = 2
+	for c := 0; c < totalChunks; c++ {
+		pkgs := make([]*agentv1.SoftwarePackage, inventoryChunkSize)
+		for i := 0; i < inventoryChunkSize; i++ {
+			pkgs[i] = &agentv1.SoftwarePackage{
+				Name:         fmt.Sprintf("loadtest-pkg-%d-%d", c, i),
+				Version:      "1.0.0",
+				Architecture: "amd64",
+				Publisher:    "loadtest",
+			}
+		}
+		chunk := &agentv1.SoftwareInventoryChunk{
+			ScanId:     scanID,
+			AgentId:    v.agentID,
+			Source:     "loadtest",
+			ChunkIndex: int32(c),
+			IsLast:     c == totalChunks-1,
+			Packages:   pkgs,
+		}
+		if err := stream.Send(chunk); err != nil {
+			v.stats.RecordError(truncate("inventory send: "+err.Error(), 200))
+			return
+		}
+	}
+
+	if _, err := stream.CloseAndRecv(); err != nil {
+		v.stats.RecordError(truncate("inventory close: "+err.Error(), 200))
+		return
+	}
+	v.stats.InventoryScans.Add(1)
+}

--- a/agent/internal/loadtest/keypair.go
+++ b/agent/internal/loadtest/keypair.go
@@ -1,0 +1,30 @@
+package loadtest
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/infrawatch/agent/internal/identity"
+)
+
+// GenerateInMemoryKeypair returns a fresh Ed25519 keypair without touching
+// disk. The real agent persists keys to the data directory; the load tester
+// creates hundreds of ephemeral keypairs per run, so disk I/O is skipped to
+// keep ramp-up fast and leave no cleanup state on the tester VM.
+func GenerateInMemoryKeypair() (*identity.Keypair, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating keypair: %w", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pub,
+	})
+	return &identity.Keypair{
+		PublicKey:    pub,
+		PrivateKey:   priv,
+		PublicKeyPEM: string(pubPEM),
+	}, nil
+}

--- a/agent/internal/loadtest/metrics.go
+++ b/agent/internal/loadtest/metrics.go
@@ -1,0 +1,125 @@
+package loadtest
+
+import (
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"time"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+// SyntheticMetrics generates plausible-looking CPU/memory/disk/network metrics
+// for one virtual agent. Values follow a bounded random walk around a
+// per-agent baseline seeded from the agent index, so fleet-wide dashboards
+// look heterogeneous instead of a single flat line replicated N times.
+type SyntheticMetrics struct {
+	cpuPct       float64
+	memPct       float64
+	diskPct      float64
+	uptimeSec    int64
+	lastTick     time.Time
+	disks        []*agentv1.DiskInfo
+	netIfaces    []*agentv1.NetworkInterface
+	rng          *rand.Rand
+	jitter       float64
+	osVersionStr string
+	hostname     string
+}
+
+// NewSyntheticMetrics builds the initial metric state for the agent at the
+// given index. jitter controls the amplitude of the per-tick random walk
+// (0 = constant values; 1 = ±5% drift per tick).
+func NewSyntheticMetrics(agentIndex int, hostname string, jitter float64) *SyntheticMetrics {
+	h := fnv.New32a()
+	_, _ = fmt.Fprintf(h, "%d:%s", agentIndex, hostname)
+	seed := int64(h.Sum32())
+	r := rand.New(rand.NewSource(seed))
+
+	ip := fmt.Sprintf("10.255.%d.%d", (agentIndex>>8)&0xff, agentIndex&0xff)
+	mac := fmt.Sprintf("02:00:%02x:%02x:%02x:%02x",
+		(agentIndex>>24)&0xff,
+		(agentIndex>>16)&0xff,
+		(agentIndex>>8)&0xff,
+		agentIndex&0xff,
+	)
+
+	return &SyntheticMetrics{
+		cpuPct:       20 + float64(r.Intn(40)),
+		memPct:       30 + float64(r.Intn(40)),
+		diskPct:      40 + float64(r.Intn(30)),
+		uptimeSec:    int64(3600 + r.Intn(86400*7)),
+		lastTick:     time.Now(),
+		rng:          r,
+		jitter:       jitter,
+		osVersionStr: "Loadtest Linux 1.0",
+		hostname:     hostname,
+		disks: []*agentv1.DiskInfo{
+			{MountPoint: "/", Device: "/dev/loadtest-root", FsType: "ext4", TotalBytes: 50 * 1024 * 1024 * 1024},
+			{MountPoint: "/var", Device: "/dev/loadtest-var", FsType: "ext4", TotalBytes: 100 * 1024 * 1024 * 1024},
+		},
+		netIfaces: []*agentv1.NetworkInterface{
+			{Name: "eth0", IpAddresses: []string{ip}, MacAddress: mac, IsUp: true},
+		},
+	}
+}
+
+// Tick advances all metric values one step along their random walks and
+// returns the current metric snapshot ready to stamp into a HeartbeatRequest.
+func (s *SyntheticMetrics) Tick() *Snapshot {
+	now := time.Now()
+	if !s.lastTick.IsZero() {
+		s.uptimeSec += int64(now.Sub(s.lastTick).Seconds())
+	}
+	s.lastTick = now
+
+	step := s.jitter * 5.0
+	s.cpuPct = clamp(s.cpuPct+s.rng.NormFloat64()*step, 1, 99)
+	s.memPct = clamp(s.memPct+s.rng.NormFloat64()*step*0.6, 5, 95)
+	s.diskPct = clamp(s.diskPct+s.rng.NormFloat64()*step*0.1, 10, 98)
+
+	disks := make([]*agentv1.DiskInfo, len(s.disks))
+	for i, d := range s.disks {
+		used := uint64(float64(d.TotalBytes) * s.diskPct / 100.0)
+		disks[i] = &agentv1.DiskInfo{
+			MountPoint:  d.MountPoint,
+			Device:      d.Device,
+			FsType:      d.FsType,
+			TotalBytes:  d.TotalBytes,
+			UsedBytes:   used,
+			FreeBytes:   d.TotalBytes - used,
+			PercentUsed: float32(s.diskPct),
+		}
+	}
+
+	return &Snapshot{
+		CPUPercent:    float32(s.cpuPct),
+		MemoryPercent: float32(s.memPct),
+		DiskPercent:   float32(s.diskPct),
+		UptimeSeconds: s.uptimeSec,
+		Disks:         disks,
+		NetIfaces:     s.netIfaces,
+		OSVersion:     s.osVersionStr,
+	}
+}
+
+// Snapshot holds the values produced by a single Tick.
+type Snapshot struct {
+	CPUPercent    float32
+	MemoryPercent float32
+	DiskPercent   float32
+	UptimeSeconds int64
+	Disks         []*agentv1.DiskInfo
+	NetIfaces     []*agentv1.NetworkInterface
+	OSVersion     string
+}
+
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/agent/internal/loadtest/metrics_test.go
+++ b/agent/internal/loadtest/metrics_test.go
@@ -1,0 +1,69 @@
+package loadtest
+
+import (
+	"testing"
+)
+
+func TestSyntheticMetricsTickStaysInBounds(t *testing.T) {
+	m := NewSyntheticMetrics(42, "loadtest-abc-0042", 1.0)
+
+	for i := 0; i < 10_000; i++ {
+		snap := m.Tick()
+		if snap.CPUPercent < 1 || snap.CPUPercent > 99 {
+			t.Fatalf("cpu out of bounds after %d ticks: %f", i, snap.CPUPercent)
+		}
+		if snap.MemoryPercent < 5 || snap.MemoryPercent > 95 {
+			t.Fatalf("memory out of bounds after %d ticks: %f", i, snap.MemoryPercent)
+		}
+		if snap.DiskPercent < 10 || snap.DiskPercent > 98 {
+			t.Fatalf("disk out of bounds after %d ticks: %f", i, snap.DiskPercent)
+		}
+	}
+}
+
+func TestSyntheticMetricsSeededByIndex(t *testing.T) {
+	a := NewSyntheticMetrics(1, "host-1", 0.1)
+	b := NewSyntheticMetrics(2, "host-2", 0.1)
+
+	// The first-tick values are seeded from (agentIndex, hostname) so two
+	// different indexes should produce different baselines — otherwise all N
+	// agents would look identical on dashboards.
+	sa := a.Tick()
+	sb := b.Tick()
+	if sa.CPUPercent == sb.CPUPercent && sa.MemoryPercent == sb.MemoryPercent {
+		t.Fatalf("expected different baselines across agent indexes, got identical snapshots")
+	}
+}
+
+func TestSyntheticMetricsTickDiskUsagePopulated(t *testing.T) {
+	m := NewSyntheticMetrics(7, "host-7", 0.1)
+	snap := m.Tick()
+
+	if len(snap.Disks) == 0 {
+		t.Fatal("expected at least one disk in snapshot")
+	}
+	for _, d := range snap.Disks {
+		if d.UsedBytes+d.FreeBytes != d.TotalBytes {
+			t.Fatalf("disk %s: used+free != total (%d + %d != %d)", d.MountPoint, d.UsedBytes, d.FreeBytes, d.TotalBytes)
+		}
+		if d.PercentUsed <= 0 {
+			t.Fatalf("disk %s percent_used should be > 0, got %f", d.MountPoint, d.PercentUsed)
+		}
+	}
+}
+
+func TestClampBounds(t *testing.T) {
+	cases := []struct{ v, lo, hi, want float64 }{
+		{5, 0, 10, 5},
+		{-1, 0, 10, 0},
+		{11, 0, 10, 10},
+		{0, 0, 10, 0},
+		{10, 0, 10, 10},
+	}
+	for _, c := range cases {
+		got := clamp(c.v, c.lo, c.hi)
+		if got != c.want {
+			t.Errorf("clamp(%v, %v, %v) = %v, want %v", c.v, c.lo, c.hi, got, c.want)
+		}
+	}
+}

--- a/agent/internal/loadtest/runner.go
+++ b/agent/internal/loadtest/runner.go
@@ -1,0 +1,224 @@
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Runner orchestrates a full load-test run: preflight token check, ramp-up
+// registrations, steady-state heartbeats, final summary.
+type Runner struct {
+	cfg    *Config
+	stats  *Stats
+	pool   *ConnPool
+	output io.Writer
+}
+
+// NewRunner constructs a Runner. The caller owns the ConnPool's lifecycle
+// after Run returns, though Run will call Close on it on exit.
+func NewRunner(cfg *Config, output io.Writer) *Runner {
+	pool := NewConnPool(cfg.Address, cfg.CACertFile, cfg.TLSSkipVerify, ceilDiv(cfg.Agents, cfg.ConnFanout))
+	return &Runner{
+		cfg:    cfg,
+		stats:  NewStats(),
+		pool:   pool,
+		output: output,
+	}
+}
+
+// Run executes the full load-test. It blocks until the test duration elapses
+// or ctx is cancelled (e.g. Ctrl-C), then prints the final summary.
+func (r *Runner) Run(ctx context.Context) error {
+	defer r.pool.Close()
+
+	fmt.Fprintf(r.output, "Run ID: %s\n", r.cfg.RunID)
+	fmt.Fprintf(r.output, "Target: %s | Agents: %d | Heartbeat: %s | Ramp: %s | Duration: %s\n",
+		r.cfg.Address, r.cfg.Agents, r.cfg.HeartbeatInterval, r.cfg.Ramp, durOrInfinite(r.cfg.Duration))
+	fmt.Fprintf(r.output, "Conn pool size: %d (fanout %d agents/conn)\n", r.pool.Size(), r.cfg.ConnFanout)
+
+	if err := r.preflight(ctx); err != nil {
+		return err
+	}
+
+	agents := make([]*VirtualAgent, 0, r.cfg.Agents)
+	for i := 0; i < r.cfg.Agents; i++ {
+		va, err := NewVirtualAgent(i, r.cfg, r.pool, r.stats)
+		if err != nil {
+			return fmt.Errorf("creating virtual agent %d: %w", i, err)
+		}
+		agents = append(agents, va)
+	}
+
+	// Statistics ticker.
+	statsTicker := time.NewTicker(r.cfg.StatsInterval)
+	defer statsTicker.Stop()
+	statsDone := make(chan struct{})
+	go func() {
+		defer close(statsDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-statsTicker.C:
+				r.stats.PrintInterval(r.output, r.cfg.Agents)
+			}
+		}
+	}()
+
+	// Ramp-up schedule: spread registrations across r.cfg.Ramp so we don't
+	// thundering-herd the ingest DB on the first second.
+	rampCtx, rampCancel := context.WithCancel(ctx)
+	defer rampCancel()
+
+	var runWG sync.WaitGroup
+	sem := make(chan struct{}, r.cfg.RegistrationConc)
+
+	interval := time.Duration(0)
+	if r.cfg.Agents > 1 && r.cfg.Ramp > 0 {
+		interval = r.cfg.Ramp / time.Duration(r.cfg.Agents)
+	}
+
+	startAt := time.Now()
+	for i, va := range agents {
+		targetDelay := time.Duration(i) * interval
+		if wait := time.Until(startAt.Add(targetDelay)); wait > 0 {
+			select {
+			case <-rampCtx.Done():
+				break
+			case <-time.After(wait):
+			}
+		}
+		if rampCtx.Err() != nil {
+			break
+		}
+
+		select {
+		case sem <- struct{}{}:
+		case <-rampCtx.Done():
+			break
+		}
+
+		runWG.Add(1)
+		r.stats.RegistrationsStarted.Add(1)
+		go func(a *VirtualAgent) {
+			defer runWG.Done()
+			defer func() { <-sem }()
+
+			status, err := a.Register(rampCtx)
+			if err != nil {
+				r.stats.RegistrationsFailed.Add(1)
+				r.stats.RecordError(truncate("register: "+err.Error(), 200))
+				return
+			}
+			switch status {
+			case "active":
+				r.stats.RegistrationsActive.Add(1)
+			case "pending":
+				r.stats.RegistrationsPending.Add(1)
+				r.stats.RecordError("register returned pending (token lacks auto_approve)")
+				return
+			default:
+				r.stats.RegistrationsFailed.Add(1)
+				return
+			}
+			a.Run(rampCtx)
+		}(va)
+	}
+
+	// Optional fixed-duration test window. Duration=0 means run until ctx
+	// cancellation (Ctrl-C).
+	if r.cfg.Duration > 0 {
+		select {
+		case <-ctx.Done():
+		case <-time.After(r.cfg.Duration):
+		}
+		rampCancel()
+	} else {
+		<-ctx.Done()
+		rampCancel()
+	}
+
+	// Wait briefly for agent goroutines to drain so final counters reflect the
+	// most recent successful heartbeats.
+	drained := make(chan struct{})
+	go func() {
+		runWG.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(10 * time.Second):
+	}
+
+	<-statsDone
+	r.stats.Finalise(r.output, r.cfg.RunID, r.cfg.Agents, r.cfg.OutputJSON)
+	r.printCleanupHint()
+
+	return nil
+}
+
+// preflight does one throw-away Register call with a fresh keypair to verify
+// the enrolment token has auto_approve=true before the real ramp-up begins.
+// If the token is misconfigured, aborting here saves the operator from an
+// opaque hang where every virtual agent sits in "pending".
+func (r *Runner) preflight(ctx context.Context) error {
+	fmt.Fprintln(r.output, "Preflight: verifying enrolment token has auto_approve=true...")
+
+	probe, err := NewVirtualAgent(-1, &Config{
+		Address:           r.cfg.Address,
+		OrgToken:          r.cfg.OrgToken,
+		CACertFile:        r.cfg.CACertFile,
+		TLSSkipVerify:     r.cfg.TLSSkipVerify,
+		HostnamePrefix:    r.cfg.HostnamePrefix,
+		RunID:             r.cfg.RunID,
+		HeartbeatInterval: r.cfg.HeartbeatInterval,
+		MetricsJitter:     r.cfg.MetricsJitter,
+	}, r.pool, r.stats)
+	if err != nil {
+		return fmt.Errorf("preflight setup: %w", err)
+	}
+	probe.hostname = fmt.Sprintf("%s-%s-preflight", r.cfg.HostnamePrefix, r.cfg.RunID)
+
+	pfCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	status, err := probe.Register(pfCtx)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("preflight registration timed out — enrolment token likely lacks auto_approve=true")
+		}
+		return fmt.Errorf("preflight register: %w", err)
+	}
+	if status != "active" {
+		return fmt.Errorf("preflight registration returned status=%q (need auto_approve=true on enrolment token)", status)
+	}
+	fmt.Fprintln(r.output, "Preflight OK.")
+	return nil
+}
+
+func (r *Runner) printCleanupHint() {
+	prefix := fmt.Sprintf("%s-%s-", r.cfg.HostnamePrefix, r.cfg.RunID)
+	fmt.Fprintln(r.output, "")
+	fmt.Fprintln(r.output, "Cleanup — these virtual hosts remain registered on the server:")
+	fmt.Fprintf(r.output, "  Hostname filter:  %s*\n", prefix)
+	fmt.Fprintf(r.output, "  Bulk-delete CLI:  infrawatch-loadtest cleanup --web-url <url> --admin-key <key> --run-id %s\n", r.cfg.RunID)
+	fmt.Fprintf(r.output, "  Dev-only SQL:     DELETE FROM hosts WHERE hostname LIKE '%s%%';\n", prefix)
+}
+
+func ceilDiv(a, b int) int {
+	if b == 0 {
+		return 1
+	}
+	return (a + b - 1) / b
+}
+
+func durOrInfinite(d time.Duration) string {
+	if d == 0 {
+		return "until Ctrl-C"
+	}
+	return d.String()
+}

--- a/agent/internal/loadtest/stats.go
+++ b/agent/internal/loadtest/stats.go
@@ -1,0 +1,290 @@
+package loadtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Stats aggregates run-wide counters and latency samples. All operations are
+// safe for concurrent use.
+type Stats struct {
+	RegistrationsStarted atomic.Int64
+	RegistrationsActive  atomic.Int64
+	RegistrationsPending atomic.Int64
+	RegistrationsFailed  atomic.Int64
+	StreamsOpen          atomic.Int64
+	Reconnects           atomic.Int64
+	HeartbeatsSent       atomic.Int64
+	HeartbeatsFailed     atomic.Int64
+	TasksCompleted       atomic.Int64
+	ChecksReported       atomic.Int64
+	QueriesAnswered      atomic.Int64
+	TerminalSessions     atomic.Int64
+	InventoryScans       atomic.Int64
+	BytesSent            atomic.Int64
+
+	mu            sync.Mutex
+	sendLatencyUs []int64
+	rttUs         []int64
+	errorCounts   map[string]int
+
+	start time.Time
+}
+
+// NewStats initialises an empty Stats.
+func NewStats() *Stats {
+	return &Stats{
+		sendLatencyUs: make([]int64, 0, 4096),
+		rttUs:         make([]int64, 0, 1024),
+		errorCounts:   make(map[string]int),
+		start:         time.Now(),
+	}
+}
+
+// RecordSendLatency records the microsecond duration of a single stream.Send
+// call. Sampling is unbounded per interval; the slice is reset on each call to
+// snapshotLatencies.
+func (s *Stats) RecordSendLatency(d time.Duration) {
+	s.mu.Lock()
+	s.sendLatencyUs = append(s.sendLatencyUs, d.Microseconds())
+	s.mu.Unlock()
+}
+
+// RecordRTT records the observed server-round-trip time for a single request
+// that has a correlated response (we only do this for the first heartbeat of
+// each stream — the streaming RPC has no request/response correlation ID).
+func (s *Stats) RecordRTT(d time.Duration) {
+	s.mu.Lock()
+	s.rttUs = append(s.rttUs, d.Microseconds())
+	s.mu.Unlock()
+}
+
+// RecordError bumps the distinct-error counter. The first 10 distinct error
+// strings are kept in the final summary.
+func (s *Stats) RecordError(msg string) {
+	s.mu.Lock()
+	s.errorCounts[msg]++
+	s.mu.Unlock()
+}
+
+type percentileSnapshot struct {
+	count int
+	p50   int64
+	p90   int64
+	p95   int64
+	p99   int64
+	p999  int64
+}
+
+func (s *Stats) snapshotLatencies() (send, rtt percentileSnapshot) {
+	s.mu.Lock()
+	sendSamples := s.sendLatencyUs
+	rttSamples := s.rttUs
+	s.sendLatencyUs = make([]int64, 0, 4096)
+	s.rttUs = make([]int64, 0, 1024)
+	s.mu.Unlock()
+
+	return computePercentiles(sendSamples), computePercentiles(rttSamples)
+}
+
+func computePercentiles(samples []int64) percentileSnapshot {
+	if len(samples) == 0 {
+		return percentileSnapshot{}
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	pick := func(p float64) int64 {
+		idx := int(float64(len(samples)-1) * p)
+		return samples[idx]
+	}
+	return percentileSnapshot{
+		count: len(samples),
+		p50:   pick(0.50),
+		p90:   pick(0.90),
+		p95:   pick(0.95),
+		p99:   pick(0.99),
+		p999:  pick(0.999),
+	}
+}
+
+// PrintInterval emits a one-line running snapshot. Called on a ticker driven
+// by --stats-interval.
+func (s *Stats) PrintInterval(w io.Writer, total int) {
+	elapsed := time.Since(s.start).Round(time.Second)
+	active := s.RegistrationsActive.Load()
+	hbSent := s.HeartbeatsSent.Load()
+	hbFail := s.HeartbeatsFailed.Load()
+	streamsOpen := s.StreamsOpen.Load()
+	reconns := s.Reconnects.Load()
+	bytes := s.BytesSent.Load()
+
+	sendPct, rttPct := s.snapshotLatencies()
+
+	fmt.Fprintf(w, "[t+%s] agents: %d/%d active | streams: %d | hb_sent: %d | failed: %d\n",
+		elapsed, active, total, streamsOpen, hbSent, hbFail)
+	fmt.Fprintf(w, "        send_latency p50=%s p95=%s p99=%s (n=%d) | rtt p50=%s p95=%s (n=%d)\n",
+		fmtUs(sendPct.p50), fmtUs(sendPct.p95), fmtUs(sendPct.p99), sendPct.count,
+		fmtUs(rttPct.p50), fmtUs(rttPct.p95), rttPct.count)
+	fmt.Fprintf(w, "        reconnects: %d | bytes_sent: %s | tasks: %d | checks: %d | queries: %d\n",
+		reconns, fmtBytes(bytes),
+		s.TasksCompleted.Load(), s.ChecksReported.Load(), s.QueriesAnswered.Load())
+}
+
+// FinalSummary holds the complete run statistics, suitable for JSON dump or
+// human-readable printing.
+type FinalSummary struct {
+	RunID                string            `json:"run_id"`
+	StartedAt            time.Time         `json:"started_at"`
+	Duration             time.Duration     `json:"duration"`
+	TargetAgents         int               `json:"target_agents"`
+	RegistrationsStarted int64             `json:"registrations_started"`
+	RegistrationsActive  int64             `json:"registrations_active"`
+	RegistrationsPending int64             `json:"registrations_pending"`
+	RegistrationsFailed  int64             `json:"registrations_failed"`
+	Reconnects           int64             `json:"reconnects"`
+	HeartbeatsSent       int64             `json:"heartbeats_sent"`
+	HeartbeatsFailed     int64             `json:"heartbeats_failed"`
+	TasksCompleted       int64             `json:"tasks_completed"`
+	ChecksReported       int64             `json:"checks_reported"`
+	QueriesAnswered      int64             `json:"queries_answered"`
+	TerminalSessions     int64             `json:"terminal_sessions"`
+	InventoryScans       int64             `json:"inventory_scans"`
+	BytesSent            int64             `json:"bytes_sent"`
+	SendLatencyP50Us     int64             `json:"send_latency_p50_us"`
+	SendLatencyP90Us     int64             `json:"send_latency_p90_us"`
+	SendLatencyP95Us     int64             `json:"send_latency_p95_us"`
+	SendLatencyP99Us     int64             `json:"send_latency_p99_us"`
+	SendLatencyP999Us    int64             `json:"send_latency_p999_us"`
+	RTTP50Us             int64             `json:"rtt_p50_us"`
+	RTTP95Us             int64             `json:"rtt_p95_us"`
+	TopErrors            map[string]int    `json:"top_errors"`
+}
+
+// Finalise produces the run summary and prints it to w. If outputPath is
+// non-empty the summary is also written as JSON to that file.
+func (s *Stats) Finalise(w io.Writer, runID string, targetAgents int, outputPath string) {
+	send, rtt := s.snapshotLatencies()
+	summary := FinalSummary{
+		RunID:                runID,
+		StartedAt:            s.start,
+		Duration:             time.Since(s.start),
+		TargetAgents:         targetAgents,
+		RegistrationsStarted: s.RegistrationsStarted.Load(),
+		RegistrationsActive:  s.RegistrationsActive.Load(),
+		RegistrationsPending: s.RegistrationsPending.Load(),
+		RegistrationsFailed:  s.RegistrationsFailed.Load(),
+		Reconnects:           s.Reconnects.Load(),
+		HeartbeatsSent:       s.HeartbeatsSent.Load(),
+		HeartbeatsFailed:     s.HeartbeatsFailed.Load(),
+		TasksCompleted:       s.TasksCompleted.Load(),
+		ChecksReported:       s.ChecksReported.Load(),
+		QueriesAnswered:      s.QueriesAnswered.Load(),
+		TerminalSessions:     s.TerminalSessions.Load(),
+		InventoryScans:       s.InventoryScans.Load(),
+		BytesSent:            s.BytesSent.Load(),
+		SendLatencyP50Us:     send.p50,
+		SendLatencyP90Us:     send.p90,
+		SendLatencyP95Us:     send.p95,
+		SendLatencyP99Us:     send.p99,
+		SendLatencyP999Us:    send.p999,
+		RTTP50Us:             rtt.p50,
+		RTTP95Us:             rtt.p95,
+		TopErrors:            s.topErrors(10),
+	}
+
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "=== Load test summary ===")
+	fmt.Fprintf(w, "run_id:              %s\n", summary.RunID)
+	fmt.Fprintf(w, "duration:            %s\n", summary.Duration.Round(time.Second))
+	fmt.Fprintf(w, "agents:              %d active / %d target\n", summary.RegistrationsActive, summary.TargetAgents)
+	fmt.Fprintf(w, "registrations:       started=%d active=%d pending=%d failed=%d\n",
+		summary.RegistrationsStarted, summary.RegistrationsActive, summary.RegistrationsPending, summary.RegistrationsFailed)
+	fmt.Fprintf(w, "heartbeats:          sent=%d failed=%d reconnects=%d\n",
+		summary.HeartbeatsSent, summary.HeartbeatsFailed, summary.Reconnects)
+	fmt.Fprintf(w, "tasks/checks:        tasks=%d checks=%d queries=%d terminal=%d inventory=%d\n",
+		summary.TasksCompleted, summary.ChecksReported, summary.QueriesAnswered, summary.TerminalSessions, summary.InventoryScans)
+	fmt.Fprintf(w, "send_latency_us:     p50=%d p90=%d p95=%d p99=%d p99.9=%d\n",
+		summary.SendLatencyP50Us, summary.SendLatencyP90Us, summary.SendLatencyP95Us,
+		summary.SendLatencyP99Us, summary.SendLatencyP999Us)
+	fmt.Fprintf(w, "rtt_us:              p50=%d p95=%d\n", summary.RTTP50Us, summary.RTTP95Us)
+	fmt.Fprintf(w, "bytes_sent:          %s\n", fmtBytes(summary.BytesSent))
+
+	if len(summary.TopErrors) > 0 {
+		fmt.Fprintln(w, "top_errors:")
+		for msg, count := range summary.TopErrors {
+			fmt.Fprintf(w, "  [%d] %s\n", count, msg)
+		}
+	}
+
+	if outputPath != "" {
+		data, err := json.MarshalIndent(summary, "", "  ")
+		if err != nil {
+			fmt.Fprintf(w, "failed to marshal JSON summary: %v\n", err)
+			return
+		}
+		if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+			fmt.Fprintf(w, "failed to write JSON summary to %s: %v\n", outputPath, err)
+			return
+		}
+		fmt.Fprintf(w, "json_summary:        %s\n", outputPath)
+	}
+}
+
+func (s *Stats) topErrors(n int) map[string]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	type kv struct {
+		msg   string
+		count int
+	}
+	entries := make([]kv, 0, len(s.errorCounts))
+	for m, c := range s.errorCounts {
+		entries = append(entries, kv{m, c})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].count > entries[j].count })
+	if len(entries) > n {
+		entries = entries[:n]
+	}
+	out := make(map[string]int, len(entries))
+	for _, e := range entries {
+		out[e.msg] = e.count
+	}
+	return out
+}
+
+func fmtUs(us int64) string {
+	if us == 0 {
+		return "-"
+	}
+	if us < 1000 {
+		return fmt.Sprintf("%dus", us)
+	}
+	if us < 1_000_000 {
+		return fmt.Sprintf("%.1fms", float64(us)/1000)
+	}
+	return fmt.Sprintf("%.1fs", float64(us)/1_000_000)
+}
+
+func fmtBytes(n int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+	)
+	switch {
+	case n >= GB:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(GB))
+	case n >= MB:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(MB))
+	case n >= KB:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/agent/internal/loadtest/stats_test.go
+++ b/agent/internal/loadtest/stats_test.go
@@ -1,0 +1,94 @@
+package loadtest
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestComputePercentilesMonotonic(t *testing.T) {
+	samples := make([]int64, 0, 1000)
+	for i := int64(1); i <= 1000; i++ {
+		samples = append(samples, i)
+	}
+	p := computePercentiles(samples)
+	if p.count != 1000 {
+		t.Fatalf("count: got %d, want 1000", p.count)
+	}
+	if !(p.p50 <= p.p90 && p.p90 <= p.p95 && p.p95 <= p.p99 && p.p99 <= p.p999) {
+		t.Fatalf("percentiles not monotonic: %+v", p)
+	}
+	// On a uniform 1..1000 distribution p50 is ~500, p99 is ~990. Allow ±5.
+	if p.p50 < 495 || p.p50 > 505 {
+		t.Errorf("p50 out of expected range: %d", p.p50)
+	}
+	if p.p99 < 985 || p.p99 > 995 {
+		t.Errorf("p99 out of expected range: %d", p.p99)
+	}
+}
+
+func TestComputePercentilesEmpty(t *testing.T) {
+	p := computePercentiles(nil)
+	if p.count != 0 || p.p50 != 0 || p.p999 != 0 {
+		t.Fatalf("empty input should produce zero snapshot, got %+v", p)
+	}
+}
+
+func TestStatsSnapshotResetsSamples(t *testing.T) {
+	s := NewStats()
+	for i := 0; i < 100; i++ {
+		s.RecordSendLatency(time.Duration(i+1) * time.Microsecond)
+	}
+	snap1, _ := s.snapshotLatencies()
+	if snap1.count != 100 {
+		t.Fatalf("first snapshot count: got %d, want 100", snap1.count)
+	}
+
+	// The second snapshot taken immediately should observe zero samples — the
+	// stats printer relies on this reset to report *interval* latencies, not
+	// cumulative ones.
+	snap2, _ := s.snapshotLatencies()
+	if snap2.count != 0 {
+		t.Fatalf("second snapshot count: got %d, want 0 (samples should reset)", snap2.count)
+	}
+}
+
+func TestStatsRecordErrorCaps(t *testing.T) {
+	s := NewStats()
+	for i := 0; i < 50; i++ {
+		s.RecordError("connection reset")
+	}
+	s.RecordError("permission denied")
+	top := s.topErrors(10)
+	if top["connection reset"] != 50 {
+		t.Fatalf("expected 50 hits for 'connection reset', got %d", top["connection reset"])
+	}
+	if top["permission denied"] != 1 {
+		t.Fatalf("expected 1 hit for 'permission denied', got %d", top["permission denied"])
+	}
+}
+
+func TestStatsFinaliseIncludesCoreLines(t *testing.T) {
+	s := NewStats()
+	s.RegistrationsActive.Add(42)
+	s.HeartbeatsSent.Add(1000)
+	s.BytesSent.Add(2 * 1024 * 1024)
+
+	buf := &bytes.Buffer{}
+	s.Finalise(buf, "lt-261117-demo", 42, "")
+	out := buf.String()
+
+	for _, want := range []string{
+		"Load test summary",
+		"run_id:",
+		"lt-261117-demo",
+		"heartbeats:",
+		"sent=1000",
+		"bytes_sent:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/agent/internal/loadtest/tasks.go
+++ b/agent/internal/loadtest/tasks.go
@@ -1,0 +1,42 @@
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+// simulateTask emits 2-4 fake progress chunks spread over a few seconds, then
+// a final exit-0 result. If the task type looks like a software-inventory
+// scan, it additionally opens a SubmitSoftwareInventory stream.
+func (v *VirtualAgent) simulateTask(ctx context.Context, client agentv1.IngestServiceClient, t *agentv1.AgentTask) {
+	chunks := 2 + v.rng.Intn(3)
+	for i := 0; i < chunks; i++ {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(500+v.rng.Intn(1500)) * time.Millisecond):
+		}
+		v.mu.Lock()
+		v.pendingProgress = append(v.pendingProgress, &agentv1.AgentTaskProgress{
+			TaskId:      t.TaskId,
+			OutputChunk: fmt.Sprintf("[loadtest] task %s progress chunk %d/%d\n", t.TaskId, i+1, chunks),
+		})
+		v.mu.Unlock()
+	}
+
+	if v.cfg.SimulateInventory && t.TaskType == "software_inventory_scan" {
+		v.simulateInventoryStream(ctx, client, t.TaskId)
+	}
+
+	v.mu.Lock()
+	v.pendingResults = append(v.pendingResults, &agentv1.AgentTaskResult{
+		TaskId:     t.TaskId,
+		TaskType:   t.TaskType,
+		ExitCode:   0,
+		ResultJson: `{"source":"loadtest","ok":true}`,
+	})
+	v.mu.Unlock()
+}

--- a/agent/internal/loadtest/terminal.go
+++ b/agent/internal/loadtest/terminal.go
@@ -1,0 +1,46 @@
+package loadtest
+
+import (
+	"context"
+	"time"
+
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+// simulateTerminalSession opens a Terminal bidi stream, emits a short fake
+// shell banner, then sends a clean "closed" message. This is enough to
+// exercise the server's terminal-session lifecycle path without simulating a
+// real PTY — the v1 load tester treats every terminal session as a very
+// short-lived ping.
+func (v *VirtualAgent) simulateTerminalSession(ctx context.Context, client agentv1.IngestServiceClient, req *agentv1.TerminalSessionRequest) {
+	stream, err := client.Terminal(ctx)
+	if err != nil {
+		v.stats.RecordError(truncate("terminal open: "+err.Error(), 200))
+		return
+	}
+
+	// Handshake message — first send must carry the session_id with no payload.
+	if err := stream.Send(&agentv1.TerminalAgentMessage{SessionId: req.SessionId}); err != nil {
+		v.stats.RecordError(truncate("terminal handshake: "+err.Error(), 200))
+		return
+	}
+
+	// Short delay + one banner, then clean close.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	_ = stream.Send(&agentv1.TerminalAgentMessage{
+		SessionId: req.SessionId,
+		Payload:   &agentv1.TerminalAgentMessage_Output{Output: []byte("loadtest-virtual-shell$ \r\n")},
+	})
+	_ = stream.Send(&agentv1.TerminalAgentMessage{
+		SessionId: req.SessionId,
+		Payload:   &agentv1.TerminalAgentMessage_Closed{Closed: &agentv1.TerminalClosedMsg{ExitCode: 0}},
+	})
+	_ = stream.CloseSend()
+
+	v.stats.TerminalSessions.Add(1)
+}

--- a/agent/internal/loadtest/virtualagent.go
+++ b/agent/internal/loadtest/virtualagent.go
@@ -1,0 +1,361 @@
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/infrawatch/agent/internal/identity"
+	"github.com/infrawatch/agent/internal/registration"
+	agentv1 "github.com/infrawatch/proto/agent/v1"
+)
+
+const agentVersion = "loadtest-v1"
+
+// VirtualAgent represents one simulated agent within a load-test run. It owns
+// its keypair, JWT, and heartbeat-stream lifecycle.
+type VirtualAgent struct {
+	index    int
+	hostname string
+	cfg      *Config
+	pool     *ConnPool
+	stats    *Stats
+
+	keypair  *identity.Keypair
+	agentID  string
+	jwtToken string
+	metrics  *SyntheticMetrics
+
+	// Result queues populated by server-push handlers, drained on next heartbeat.
+	mu              sync.Mutex
+	pendingChecks   []*agentv1.CheckResult
+	pendingQueries  []*agentv1.AgentQueryResult
+	pendingProgress []*agentv1.AgentTaskProgress
+	pendingResults  []*agentv1.AgentTaskResult
+
+	// Dedupe maps so the same server-pushed work is not processed twice after
+	// a stream reconnect (matches the real agent's seenQueryIDs/seenTaskIDs
+	// pattern).
+	seenChecks    map[string]bool
+	seenQueries   map[string]bool
+	seenTasks     map[string]bool
+	seenTerminals map[string]bool
+
+	rng *rand.Rand
+}
+
+// NewVirtualAgent constructs an un-registered virtual agent for the given
+// slot index. Call Register to do the first contact, then Run to start the
+// heartbeat loop.
+func NewVirtualAgent(index int, cfg *Config, pool *ConnPool, stats *Stats) (*VirtualAgent, error) {
+	kp, err := GenerateInMemoryKeypair()
+	if err != nil {
+		return nil, err
+	}
+	hostname := cfg.HostnameFor(index)
+	return &VirtualAgent{
+		index:         index,
+		hostname:      hostname,
+		cfg:           cfg,
+		pool:          pool,
+		stats:         stats,
+		keypair:       kp,
+		metrics:       NewSyntheticMetrics(index, hostname, cfg.MetricsJitter),
+		seenChecks:    make(map[string]bool),
+		seenQueries:   make(map[string]bool),
+		seenTasks:     make(map[string]bool),
+		seenTerminals: make(map[string]bool),
+		rng:           rand.New(rand.NewSource(int64(index) + time.Now().UnixNano())),
+	}, nil
+}
+
+// Register performs the RegisterRequest RPC and stores the resulting JWT.
+// Returns the response status so the caller can surface "pending" to the
+// operator (typically an enrolment-token misconfiguration).
+func (v *VirtualAgent) Register(ctx context.Context) (status string, err error) {
+	conn, err := v.pool.Get(v.index)
+	if err != nil {
+		return "", fmt.Errorf("acquiring conn: %w", err)
+	}
+	client := agentv1.NewIngestServiceClient(conn)
+
+	reg := registration.New(client, v.keypair, v.cfg.OrgToken, agentVersion)
+	reg.SetHostnameOverride(v.hostname)
+	// Empty IP list — critical for the load tester so the server's hostname/IP
+	// collision check does not adopt an existing host onto this virtual agent's
+	// keypair. See CLAUDE planning notes for full justification.
+	reg.SetIPAddressesOverride([]string{})
+
+	// Short deadline on the Register call itself — the registrar polls
+	// internally if status is pending, but we only surface the first response.
+	regCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	state, err := reg.Register(regCtx, "")
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return "pending", fmt.Errorf("register timed out (token likely lacks auto_approve=true)")
+		}
+		return "", fmt.Errorf("register RPC: %w", err)
+	}
+
+	v.agentID = state.AgentID
+	v.jwtToken = state.JWTToken
+	return "active", nil
+}
+
+// Run drives the heartbeat loop until the context is cancelled. On stream
+// error it reconnects with exponential backoff.
+func (v *VirtualAgent) Run(ctx context.Context) {
+	backoff := time.Second
+	const maxBackoff = 60 * time.Second
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		err := v.runStream(ctx)
+		if err == nil || errors.Is(err, context.Canceled) {
+			return
+		}
+		v.stats.RecordError(truncate(err.Error(), 200))
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		v.stats.Reconnects.Add(1)
+	}
+}
+
+func (v *VirtualAgent) runStream(ctx context.Context) error {
+	conn, err := v.pool.Get(v.index)
+	if err != nil {
+		return fmt.Errorf("acquiring conn: %w", err)
+	}
+	client := agentv1.NewIngestServiceClient(conn)
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := client.Heartbeat(streamCtx)
+	if err != nil {
+		return fmt.Errorf("opening heartbeat: %w", err)
+	}
+
+	v.stats.StreamsOpen.Add(1)
+	defer v.stats.StreamsOpen.Add(-1)
+
+	// First heartbeat carries the JWT as the agent_id field (matches the
+	// server's JWT-in-first-message auth behaviour).
+	firstSentAt := time.Now()
+	if err := v.sendHeartbeat(stream, v.jwtToken); err != nil {
+		return fmt.Errorf("first heartbeat: %w", err)
+	}
+
+	// Drain the first response inline so we can record RTT and bootstrap any
+	// pending state. Failures here usually mean the JWT was rejected.
+	resp, err := stream.Recv()
+	if err != nil {
+		return fmt.Errorf("first recv: %w", err)
+	}
+	v.stats.RecordRTT(time.Since(firstSentAt))
+	v.handleServerPush(streamCtx, client, resp)
+
+	// From here the server responses stream back out-of-band; a goroutine
+	// drains them and forwards server-pushed work to the dispatch handler.
+	recvErrCh := make(chan error, 1)
+	go func() {
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				recvErrCh <- err
+				return
+			}
+			v.handleServerPush(streamCtx, client, msg)
+		}
+	}()
+
+	// Jitter the first tick by up to ±10% of the interval so N agents don't
+	// fire at the same millisecond on a shared clock.
+	jitter := time.Duration(v.rng.Float64()*0.2*float64(v.cfg.HeartbeatInterval)) - (v.cfg.HeartbeatInterval / 10)
+	initialDelay := v.cfg.HeartbeatInterval + jitter
+
+	tick := time.NewTimer(initialDelay)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-streamCtx.Done():
+			return streamCtx.Err()
+		case err := <-recvErrCh:
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("recv: %w", err)
+		case <-tick.C:
+			if err := v.sendHeartbeat(stream, v.agentID); err != nil {
+				v.stats.HeartbeatsFailed.Add(1)
+				return fmt.Errorf("heartbeat send: %w", err)
+			}
+			tick.Reset(v.cfg.HeartbeatInterval)
+		}
+	}
+}
+
+// sendHeartbeat marshals a single HeartbeatRequest carrying current synthetic
+// metrics plus any pending results accumulated since the last heartbeat.
+func (v *VirtualAgent) sendHeartbeat(stream agentv1.IngestService_HeartbeatClient, agentIDField string) error {
+	snap := v.metrics.Tick()
+
+	v.mu.Lock()
+	checks := v.pendingChecks
+	queries := v.pendingQueries
+	progress := v.pendingProgress
+	results := v.pendingResults
+	v.pendingChecks = nil
+	v.pendingQueries = nil
+	v.pendingProgress = nil
+	v.pendingResults = nil
+	v.mu.Unlock()
+
+	req := &agentv1.HeartbeatRequest{
+		AgentId:           agentIDField,
+		CpuPercent:        snap.CPUPercent,
+		MemoryPercent:     snap.MemoryPercent,
+		DiskPercent:       snap.DiskPercent,
+		UptimeSeconds:     snap.UptimeSeconds,
+		TimestampUnix:     time.Now().Unix(),
+		AgentVersion:      agentVersion,
+		OsVersion:         snap.OSVersion,
+		Os:                "linux",
+		Arch:              "amd64",
+		Disks:             snap.Disks,
+		NetworkInterfaces: snap.NetIfaces,
+		CheckResults:      checks,
+		QueryResults:      queries,
+		TaskProgress:      progress,
+		TaskResults:       results,
+	}
+
+	started := time.Now()
+	if err := stream.Send(req); err != nil {
+		return err
+	}
+	v.stats.RecordSendLatency(time.Since(started))
+	v.stats.HeartbeatsSent.Add(1)
+	v.stats.BytesSent.Add(int64(proto.Size(req)))
+	v.stats.ChecksReported.Add(int64(len(checks)))
+	v.stats.QueriesAnswered.Add(int64(len(queries)))
+	if len(results) > 0 {
+		v.stats.TasksCompleted.Add(int64(len(results)))
+	}
+	return nil
+}
+
+// handleServerPush dispatches each of the push-type fields on a
+// HeartbeatResponse to its simulation handler.
+func (v *VirtualAgent) handleServerPush(ctx context.Context, client agentv1.IngestServiceClient, resp *agentv1.HeartbeatResponse) {
+	if resp == nil {
+		return
+	}
+
+	if v.cfg.SimulateChecks {
+		for _, c := range resp.Checks {
+			if c == nil || v.seenChecks[c.CheckId] {
+				continue
+			}
+			v.seenChecks[c.CheckId] = true
+			v.queueCheckResult(c)
+		}
+	}
+
+	for _, q := range resp.PendingQueries {
+		if q == nil || v.seenQueries[q.QueryId] {
+			continue
+		}
+		v.seenQueries[q.QueryId] = true
+		v.queueQueryResult(q)
+	}
+
+	if v.cfg.SimulateTasks && resp.PendingTask != nil {
+		t := resp.PendingTask
+		if !v.seenTasks[t.TaskId] {
+			v.seenTasks[t.TaskId] = true
+			go v.simulateTask(ctx, client, t)
+		}
+	}
+
+	if v.cfg.SimulateTerminal {
+		for _, tsr := range resp.PendingTerminalSessions {
+			if tsr == nil || v.seenTerminals[tsr.SessionId] {
+				continue
+			}
+			v.seenTerminals[tsr.SessionId] = true
+			go v.simulateTerminalSession(ctx, client, tsr)
+		}
+	}
+}
+
+func (v *VirtualAgent) queueCheckResult(def *agentv1.CheckDefinition) {
+	status := "pass"
+	if v.rng.Float64() < v.cfg.CheckFailureRate {
+		status = "fail"
+	}
+	res := &agentv1.CheckResult{
+		CheckId:    def.CheckId,
+		Status:     status,
+		Output:     fmt.Sprintf("loadtest synthetic result for check_type=%s", def.CheckType),
+		DurationMs: int32(10 + v.rng.Intn(200)),
+		RanAtUnix:  time.Now().Unix(),
+	}
+	v.mu.Lock()
+	v.pendingChecks = append(v.pendingChecks, res)
+	v.mu.Unlock()
+}
+
+func (v *VirtualAgent) queueQueryResult(q *agentv1.AgentQuery) {
+	res := &agentv1.AgentQueryResult{
+		QueryId:   q.QueryId,
+		QueryType: q.QueryType,
+		Status:    "ok",
+	}
+	switch q.QueryType {
+	case "list_ports":
+		res.Ports = []*agentv1.PortInfo{
+			{Port: 22, Protocol: "tcp", Process: "sshd"},
+			{Port: 80, Protocol: "tcp", Process: "nginx"},
+			{Port: 443, Protocol: "tcp", Process: "nginx"},
+		}
+	case "list_services":
+		res.Services = []*agentv1.ServiceInfo{
+			{Name: "sshd.service", LoadState: "loaded", ActiveSub: "running"},
+			{Name: "cron.service", LoadState: "loaded", ActiveSub: "running"},
+		}
+	}
+	v.mu.Lock()
+	v.pendingQueries = append(v.pendingQueries, res)
+	v.mu.Unlock()
+}
+
+// truncate clips a string to max bytes. Used to keep error samples small so
+// the distinct-error map doesn't blow up on verbose gRPC errors.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+

--- a/agent/internal/registration/registrar.go
+++ b/agent/internal/registration/registrar.go
@@ -22,6 +22,14 @@ type Registrar struct {
 	keypair  *identity.Keypair
 	orgToken string
 	version  string
+
+	// Optional overrides. When hostnameOverride is non-empty it replaces
+	// os.Hostname(). When ipsOverride is non-nil it replaces localIPs() —
+	// passing an empty (but non-nil) slice intentionally sends no IP
+	// addresses, which the load tester uses to avoid IP-collision adoption
+	// on the server when many virtual agents share a single host IP.
+	hostnameOverride string
+	ipsOverride      *[]string
 }
 
 // New creates a new Registrar.
@@ -34,14 +42,40 @@ func New(client agentv1.IngestServiceClient, keypair *identity.Keypair, orgToken
 	}
 }
 
+// SetHostnameOverride forces the registration payload's hostname to the given
+// value instead of the OS-reported hostname. Used by the load tester to give
+// each virtual agent a unique hostname.
+func (r *Registrar) SetHostnameOverride(hostname string) {
+	r.hostnameOverride = hostname
+}
+
+// SetIPAddressesOverride replaces the OS-discovered IP address list with the
+// provided slice. Pass an empty slice to register with no IP addresses — the
+// server's IP-collision check is skipped when the list is empty.
+func (r *Registrar) SetIPAddressesOverride(ips []string) {
+	r.ipsOverride = &ips
+}
+
 // Register calls the ingest service Register RPC.
 // If the response status is "pending", it polls until the agent becomes
 // "active" or the context is cancelled.
 // Returns the final agent state once active.
 func (r *Registrar) Register(ctx context.Context, existingAgentID string) (*identity.AgentState, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "unknown"
+	hostname := r.hostnameOverride
+	if hostname == "" {
+		h, err := os.Hostname()
+		if err != nil {
+			hostname = "unknown"
+		} else {
+			hostname = h
+		}
+	}
+
+	var ips []string
+	if r.ipsOverride != nil {
+		ips = *r.ipsOverride
+	} else {
+		ips = localIPs()
 	}
 
 	req := &agentv1.RegisterRequest{
@@ -50,7 +84,7 @@ func (r *Registrar) Register(ctx context.Context, existingAgentID string) (*iden
 		PlatformInfo: &agentv1.PlatformInfo{
 			Os:          runtime.GOOS,
 			Arch:        runtime.GOARCH,
-			IpAddresses: localIPs(),
+			IpAddresses: ips,
 		},
 		AgentInfo: &agentv1.AgentInfo{
 			AgentId:  existingAgentID,

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -82,6 +82,7 @@ export default defineUserConfig({
         children: [
           '/deployment/docker-compose.md',
           '/deployment/air-gap.md',
+          '/deployment/load-testing.md',
         ],
       },
     ],

--- a/apps/docs/docs/deployment/load-testing.md
+++ b/apps/docs/docs/deployment/load-testing.md
@@ -1,0 +1,158 @@
+# Load Testing
+
+`infrawatch-loadtest` is an operator tool that simulates **N virtual agents** against a running Infrawatch server so you can measure the sustainable fleet capacity of a given hardware profile before recommending sizing to customers.
+
+Virtual agents exercise the real wire protocol (gRPC `Register` + `Heartbeat` + `Terminal` + `SubmitSoftwareInventory`), so the numbers reflect the production code path — ingest, queue, consumers, and database — not a bypass.
+
+---
+
+## When to use it
+
+- Capacity-planning a single-box or HA install on a new VM profile.
+- Reproducing a reported scaling issue under controlled conditions.
+- Validating that a server-side change hasn't regressed throughput.
+
+**Not** intended as a smoke test for local development — the full agent binary is easier for that.
+
+---
+
+## Building
+
+The load tester is a dev/ops tool; it is **not shipped as a release artefact**. Build it locally from the repo root:
+
+```bash
+make loadtest
+# produces: dist/infrawatch-loadtest (host platform)
+```
+
+---
+
+## Prerequisites on the target server
+
+1. An enrolment token with `auto_approve=true` (virtual agents cannot wait for manual approval).
+2. The server is reachable from the load-tester VM on the ingest gRPC port (default `9443`).
+3. If the server uses a self-signed certificate, either pass `--ca-cert <path>` or `--tls-skip-verify` (dev only).
+4. For `cleanup` to work, set `INFRAWATCH_LOADTEST_ADMIN_KEY` on the **web** server and pass the same key with `--admin-key` below.
+
+Running the tool on a **separate VM** from the server under test is strongly recommended — otherwise your measurements include the load-generator's own CPU/network overhead.
+
+---
+
+## Running a test
+
+```bash
+dist/infrawatch-loadtest run \
+  --address ingest.example.com:9443 \
+  --token <enrolment-token-with-auto-approve> \
+  --agents 1000 \
+  --ramp 30s \
+  --duration 10m \
+  --heartbeat-interval 30s \
+  --tls-skip-verify \
+  --stats-interval 10s
+```
+
+The tool prints a live counter every `--stats-interval` and a final summary (including latency percentiles) on shutdown. Ctrl-C ends the run early and still prints the summary.
+
+### Common flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--address` | *(required)* | Ingest `host:port`. |
+| `--token` | *(required)* | Enrolment token — must have `auto_approve=true`. |
+| `--agents` | `100` | Total virtual agents. |
+| `--ramp` | `30s` | Duration over which registrations are spread. |
+| `--duration` | `5m` | Test length. `0` = run until Ctrl-C. |
+| `--heartbeat-interval` | `30s` | Per-agent heartbeat cadence. |
+| `--ca-cert` | *(unset)* | Path to server CA cert. |
+| `--tls-skip-verify` | `false` | Skip TLS verification (dev only). |
+| `--conn-fanout` | `50` | Virtual agents sharing a single gRPC connection. |
+| `--registration-concurrency` | `32` | Parallel `Register` RPCs during ramp-up. |
+| `--run-id` | *(auto)* | Identifier baked into each virtual hostname. |
+| `--hostname-prefix` | `loadtest` | Hostname prefix for virtual agents. |
+| `--simulate-tasks` | `true` | Respond to server-pushed tasks with fake progress + exit-0. |
+| `--simulate-checks` | `true` | Return fake `CheckResult`s for pushed checks. |
+| `--simulate-terminal` | `true` | Open short-lived Terminal streams for pushed sessions. |
+| `--simulate-inventory` | `true` | Upload fake software inventory on `software_inventory_scan` tasks. |
+| `--check-failure-rate` | `0.05` | Fraction of simulated check results reporting `fail`. |
+| `--metrics-jitter` | `0.1` | Amplitude of per-tick metric drift (0–1). |
+| `--output-json` | *(unset)* | Write final summary as JSON (useful for CI). |
+
+Run `infrawatch-loadtest run --help` for the full list.
+
+---
+
+## What the tool simulates
+
+Every virtual agent:
+
+1. Generates an **in-memory Ed25519 keypair** (nothing persists to disk on the load-tester VM).
+2. Calls `Register` with a unique hostname (`loadtest-<run-id>-<nnnn>`) and an **empty IP list** — this is intentional; it sidesteps the server's IP-collision check so N agents don't all adopt the same DB row.
+3. Opens a long-lived `Heartbeat` bidi stream, sending a synthetic-metrics heartbeat every `--heartbeat-interval` (±10% jitter).
+4. Responds to server pushes:
+   - `CheckDefinition` → returns a synthetic `CheckResult` on the next heartbeat.
+   - `AgentTask` → emits 2–4 fake progress chunks over a few seconds, then a success result.
+   - `AgentQuery` (`list_ports`, `list_services`) → returns canned results.
+   - `TerminalSessionRequest` → opens a Terminal stream, sends one banner, closes cleanly.
+   - `software_inventory_scan` task → streams 2 chunks of 500 fake packages via `SubmitSoftwareInventory`.
+5. Reconnects with exponential backoff (1s → 60s) on stream error.
+
+A **preflight check** runs one throw-away `Register` at startup to verify the token has `auto_approve=true`. If it doesn't, the tool aborts loudly instead of leaving you staring at 1000 agents stuck in `pending`.
+
+---
+
+## Reading the output
+
+Live lines look like:
+
+```
+[ 30s] regs: 1000 active / 0 pend / 0 fail | streams: 1000 | hb: 1024 sent (0 failed) | rtt p95: 18ms | recent errors: 0
+```
+
+The final summary adds full latency percentiles (p50/p90/p95/p99/p99.9) plus a capped distinct-errors list.
+
+Comparing these numbers to the server's own resource graphs (CPU / memory / disk IO / DB connection count) is what tells you whether a given hardware profile can sustain a given fleet size. Typical failure modes to watch for:
+
+- **Rising p95 heartbeat RTT** → ingest is CPU-bound or DB-bound.
+- **Heartbeats failed climbing** → ingest is evicting connections or the DB is refusing.
+- **Reconnects rising** → server is dropping streams (check ingest logs).
+- **Task completions lagging** → consumer / queue backlog.
+
+---
+
+## Cleanup
+
+Virtual hosts are real rows in `hosts` and related tables; leaving them around will skew dashboards and eventually fill the metrics hypertable. Always clean up after each run.
+
+### One-shot cleanup (recommended)
+
+The load tester ships with a `cleanup` subcommand that calls a narrow admin endpoint on the web app. Because the endpoint wraps the same `deleteHost()` action used everywhere else in the product, any foreign-key added in future is handled automatically.
+
+1. On the web server, set `INFRAWATCH_LOADTEST_ADMIN_KEY` to a secret of your choice.
+2. From the load-tester VM:
+
+   ```bash
+   dist/infrawatch-loadtest cleanup \
+     --web-url https://infrawatch.example.com \
+     --admin-key <key> \
+     --run-id <id-printed-at-end-of-run>
+   ```
+
+The command prints the number of hosts deleted and any failures.
+
+### Fallback: manual UI cleanup
+
+If the admin endpoint is not configured (e.g. the env var is unset — the endpoint returns `503` in that case), the run's end-of-test output also prints a hostname filter you can paste into the hosts-list search box (`loadtest-<run-id>-*`) and delete in bulk via the UI.
+
+### Fallback: raw SQL (dev only)
+
+The cleanup hint also prints a `DELETE FROM hosts WHERE hostname LIKE 'loadtest-<run-id>-%'` snippet. **This is not safe for production** — it bypasses the FK cascade — but is occasionally useful against throw-away dev databases. Prefer the `cleanup` subcommand.
+
+---
+
+## Out of scope (v1)
+
+- Agent self-update simulation — `update_available` responses are ignored.
+- Adaptive ramp — the tool does not auto-slow if server errors spike. Watch the live stats and abort with Ctrl-C if the server is struggling.
+- mTLS client certificates — the server uses server-only TLS today.
+- Published release artefacts — host-local build only via `make loadtest`.

--- a/apps/web/app/api/admin/hosts/bulk-delete/route.ts
+++ b/apps/web/app/api/admin/hosts/bulk-delete/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { and, isNull, like } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { hosts } from '@/lib/db/schema'
+import { deleteHost } from '@/lib/actions/agents'
+
+export const dynamic = 'force-dynamic'
+
+const bodySchema = z.object({
+  hostnamePrefix: z
+    .string()
+    .min(1)
+    .max(200)
+    .regex(/^loadtest-/, "hostnamePrefix must start with 'loadtest-'"),
+})
+
+// POST /api/admin/hosts/bulk-delete
+// Admin-key-gated endpoint used by the `infrawatch-loadtest cleanup` CLI to
+// remove all virtual hosts registered by a prior load-test run. Runs the same
+// deleteHost() cascade used elsewhere in the app so any FK added in future is
+// handled automatically.
+export async function POST(request: NextRequest) {
+  const configuredKey = process.env.INFRAWATCH_LOADTEST_ADMIN_KEY
+  if (!configuredKey) {
+    return Response.json(
+      { error: 'Load-test admin endpoint is disabled (INFRAWATCH_LOADTEST_ADMIN_KEY not set)' },
+      { status: 503 },
+    )
+  }
+  const presented = request.headers.get('x-loadtest-admin-key')
+  if (!presented || presented !== configuredKey) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+  const parsed = bodySchema.safeParse(body)
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.issues[0]?.message ?? 'Invalid body' }, { status: 400 })
+  }
+  const { hostnamePrefix } = parsed.data
+
+  const matching = await db
+    .select({ id: hosts.id, organisationId: hosts.organisationId, hostname: hosts.hostname })
+    .from(hosts)
+    .where(and(like(hosts.hostname, `${hostnamePrefix}%`), isNull(hosts.deletedAt)))
+
+  const failed: string[] = []
+  let deleted = 0
+  for (const h of matching) {
+    const result = await deleteHost(h.organisationId, h.id)
+    if ('error' in result) {
+      failed.push(`${h.hostname}: ${result.error}`)
+    } else {
+      deleted++
+    }
+  }
+
+  return Response.json({ deleted, failed })
+}


### PR DESCRIPTION
## Summary
- New `infrawatch-loadtest` CLI that simulates N virtual agents against a running Infrawatch server so we can measure sustainable fleet capacity per hardware profile. Exercises the real wire protocol (Register + Heartbeat + Terminal + SubmitSoftwareInventory) — no bypass.
- Admin-key-gated `POST /api/admin/hosts/bulk-delete` endpoint that wraps the existing `deleteHost()` cascade, so the load tester's cleanup inherits any future host-linked FK automatically.
- `make loadtest` host-only build target (dev/ops tool, not a release artefact) plus operator guide at `apps/docs/docs/deployment/load-testing.md`.

## Test plan
- [x] `go test ./agent/internal/loadtest/...` — metrics / stats / config tests pass
- [x] `go build ./agent/... ./apps/ingest/...` — clean
- [x] Web `tsc --noEmit` — clean
- [x] `dist/infrawatch-loadtest run --help` and `cleanup --help` render the expected flag lists
- [ ] Smoke: `--agents 10 --duration 2m --tls-skip-verify` against `docker-compose.single.yml`, then `cleanup --run-id <id>` removes all 10 virtual hosts (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)