### PR TITLE
fix: forward INFRAWATCH_LOADTEST_ADMIN_KEY into web container

### DIFF
--- a/apps/docs/docs/deployment/load-testing.md
+++ b/apps/docs/docs/deployment/load-testing.md
@@ -128,7 +128,19 @@ Virtual hosts are real rows in `hosts` and related tables; leaving them around w
 
 The load tester ships with a `cleanup` subcommand that calls a narrow admin endpoint on the web app. Because the endpoint wraps the same `deleteHost()` action used everywhere else in the product, any foreign-key added in future is handled automatically.
 
-1. On the web server, set `INFRAWATCH_LOADTEST_ADMIN_KEY` to a secret of your choice.
+1. On the web server, set `INFRAWATCH_LOADTEST_ADMIN_KEY` in the `.env` file sitting next to `docker-compose.single.yml`, then recreate the web container so the new env is injected:
+
+   ```bash
+   # on the server under test
+   echo "INFRAWATCH_LOADTEST_ADMIN_KEY=$(openssl rand -hex 32)" >> .env
+   docker compose -f docker-compose.single.yml up -d --force-recreate web
+   ```
+
+   The key is read by the web container at startup only — editing `.env` without restarting the container leaves the endpoint returning `503`. Verify with:
+
+   ```bash
+   docker compose -f docker-compose.single.yml exec web env | grep INFRAWATCH_LOADTEST_ADMIN_KEY
+   ```
 2. From the load-tester VM:
 
    ```bash

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -36,6 +36,7 @@ services:
       AGENT_DIST_DIR: /var/lib/infrawatch/agent-dist
       AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
       INGEST_WS_URL: ${INGEST_WS_URL:-ws://localhost:8080}
+      INFRAWATCH_LOADTEST_ADMIN_KEY: ${INFRAWATCH_LOADTEST_ADMIN_KEY:-}
     volumes:
       - agent_dist:/var/lib/infrawatch/agent-dist
 


### PR DESCRIPTION
## Summary
- Teach `docker-compose.single.yml`'s web service to forward `INFRAWATCH_LOADTEST_ADMIN_KEY` from `.env` into the container's process environment — without this the load-tester `cleanup` subcommand's admin endpoint returns 503 even with the key set.
- Clarify the docs: recreate the web container after editing `.env`, plus a one-liner to verify the env var actually made it in.

## Test plan
- [ ] After merge, on the server under test: `git pull && docker compose -f docker-compose.single.yml up -d --force-recreate web && docker compose -f docker-compose.single.yml exec web env | grep INFRAWATCH_LOADTEST_ADMIN_KEY` prints the expected key.
- [ ] `infrawatch-loadtest cleanup --web-url … --admin-key … --run-id …` succeeds (no 503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)