### PR TITLE
test: widen run-id random suffix to avoid CI flake

### DIFF
--- a/agent/internal/loadtest/config.go
+++ b/agent/internal/loadtest/config.go
@@ -62,12 +62,13 @@ func (c *Config) Validate() error {
 }
 
 // GenerateRunID returns a compact deterministic-looking identifier of the form
-// "lt-YYMMDD-HHMMSS-XXXX" where the last four characters are random hex, so
-// concurrent load-test runs from the same wall-clock second still have
-// distinct IDs.
+// "lt-YYMMDD-HHMMSS-XXXXXXXX" where the last eight characters are random hex,
+// so concurrent load-test runs from the same wall-clock second still have
+// distinct IDs. 4 random bytes (32 bits) gives ~2^-32 collision probability
+// per pair, comfortably avoiding birthday-paradox flakes in tight loops.
 func GenerateRunID() string {
 	now := time.Now().UTC()
-	var b [2]byte
+	var b [4]byte
 	_, _ = rand.Read(b[:])
 	return fmt.Sprintf("lt-%s-%s", now.Format("060102-150405"), hex.EncodeToString(b[:]))
 }


### PR DESCRIPTION
## Summary
- The flaky CI failure on main (PR #265's post-merge Go test run) was `TestGenerateRunIDUniqueness` hitting a birthday-paradox collision — 2 random bytes (16 bits) × 100 tight-loop draws ≈ 7% collision probability. Bump the random suffix to 4 bytes so flakes drop to ~2^-32.

## Test plan
- [x] `go test -run TestGenerateRunIDUniqueness -count=50 ./agent/internal/loadtest/...` — passes 50 consecutive runs
- [x] Full package `go test ./agent/internal/loadtest/...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)