### PR TITLE
fix: release registration semaphore before heartbeat loop

### DIFF
--- a/agent/internal/loadtest/runner.go
+++ b/agent/internal/loadtest/runner.go
@@ -106,9 +106,16 @@ func (r *Runner) Run(ctx context.Context) error {
 		r.stats.RegistrationsStarted.Add(1)
 		go func(a *VirtualAgent) {
 			defer runWG.Done()
-			defer func() { <-sem }()
 
+			// The semaphore bounds *Register* concurrency only — it must be
+			// released as soon as Register returns, otherwise the long-lived
+			// heartbeat loop inside a.Run() pins sem slots and the ramp loop
+			// stalls once --registration-concurrency agents are alive. The
+			// symptom is the stats line showing exactly that many streams
+			// forever and no further registrations starting.
 			status, err := a.Register(rampCtx)
+			<-sem
+
 			if err != nil {
 				r.stats.RegistrationsFailed.Add(1)
 				r.stats.RecordError(truncate("register: "+err.Error(), 200))


### PR DESCRIPTION
## Summary
- The `--registration-concurrency` semaphore (default 32) was meant to bound parallel `Register` RPCs during ramp-up, but the ramp goroutine held the slot for the entire agent lifetime — so once 32 agents were heartbeating, the ramp loop deadlocked and no further registrations began.
- Observed at `--agents 400`: stats showed `streams: 32` indefinitely and `agents` plateaued far below the target. The first ~21 of the initial batch had failed/returned pending, releasing slots, which is why totals were closer to ~53 than exactly 32.
- Fix: release the sem slot as soon as `Register` returns. The heartbeat loop is unbounded by design — we *want* all N agents streaming concurrently.

## Test plan
- [x] `go test ./agent/internal/loadtest/...` — green
- [ ] Operator re-runs `--agents 400 --ramp 30s` and sees all 400 reach active, with streams tracking agents over the ramp window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)