### PR TITLE
feat: add Podman runtime detection to start.sh, install.sh, and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROTO_OUT := proto/gen/go
 
 # Persistent host-directory caches for Go builds.
 # Using host dirs (owned by the current user) avoids permission errors when
-# Docker runs with --user $(id -u):$(id -g) and a root-owned named volume.
+# the container runs with --user $(id -u):$(id -g) and a root-owned named volume.
 GO_CACHE_DIR := $(HOME)/.cache/infrawatch/go-build
 GO_MOD_DIR   := $(HOME)/.cache/infrawatch/go-mod
 
@@ -14,6 +14,17 @@ GO_MOD_DIR   := $(HOME)/.cache/infrawatch/go-mod
 # running this Makefile (e.g. darwin/arm64 on Apple Silicon).
 HOST_OS   := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+
+# Detect container runtime. Override with CONTAINER_RUNTIME=podman if both are
+# installed and you want the non-default.
+CONTAINER_RUNTIME ?= $(shell \
+	if command -v docker >/dev/null 2>&1; then echo docker; \
+	elif command -v podman >/dev/null 2>&1; then echo podman; \
+	else echo MISSING; fi)
+
+ifeq ($(CONTAINER_RUNTIME),MISSING)
+$(error No container runtime found. Install docker or podman and retry.)
+endif
 
 GO_CACHE_ARGS := \
 	-e GOCACHE=/go-cache \
@@ -41,7 +52,7 @@ go-build: agent ingest
 agent:
 	@echo "Building agent binaries for all platforms..."
 	@mkdir -p $(AGENT_DIST_DIR) $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	docker run --rm \
+	$(CONTAINER_RUNTIME) run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -60,7 +71,7 @@ agent:
 ingest:
 	@echo "Building ingest service..."
 	@mkdir -p dist $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	docker run --rm \
+	$(CONTAINER_RUNTIME) run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -77,7 +88,7 @@ ingest:
 loadtest:
 	@echo "Building infrawatch-loadtest for $(HOST_OS)/$(HOST_ARCH)..."
 	@mkdir -p dist $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	docker run --rm \
+	$(CONTAINER_RUNTIME) run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -91,7 +102,7 @@ loadtest:
 
 go-test:
 	@mkdir -p $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	docker run --rm \
+	$(CONTAINER_RUNTIME) run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -102,7 +113,7 @@ go-test:
 # Download all Go dependencies.
 go-deps:
 	@mkdir -p $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	docker run --rm \
+	$(CONTAINER_RUNTIME) run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -110,10 +121,10 @@ go-deps:
 		golang:1.25 \
 		sh -c "go work sync && cd proto/gen/go && go mod tidy && cd /src/agent && go mod tidy && cd /src/apps/ingest && go mod tidy"
 
-# Generate dev TLS certificates for local development (requires Docker).
+# Generate dev TLS certificates for local development (requires a container runtime).
 dev-tls:
 	@mkdir -p deploy/dev-tls
-	docker run --rm \
+	$(CONTAINER_RUNTIME) run --rm \
 		-v "$(CURDIR)/deploy/dev-tls:/out" \
 		alpine/openssl req -x509 \
 		-newkey rsa:4096 \

--- a/apps/docs/docs/deployment/air-gap.md
+++ b/apps/docs/docs/deployment/air-gap.md
@@ -55,7 +55,7 @@ Or use a USB drive, secure FTP, or any other approved transfer mechanism.
 ```bash
 cd /opt/infrawatch
 tar -xzf infrawatch-bundle-*.tar.gz
-docker load < images.tar
+docker load < images.tar   # Podman: podman load -i images.tar
 ```
 
 ---
@@ -125,7 +125,8 @@ INFRAWATCH_VERSION=v0.4.0 bash deploy/scripts/airgap-bundle.sh
 # Transfer the new tarball
 scp infrawatch-bundle-v0.4.0.tar.gz ops@server:/opt/infrawatch/
 
-# On the target server
+# On the target server (substitute `podman load -i images.tar` and
+# `podman compose` / `podman-compose` on Podman hosts)
 docker load < images.tar
 docker compose -f docker-compose.single.yml pull   # no-op: images already loaded
 docker compose -f docker-compose.single.yml up -d  # restarts with new images

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -13,9 +13,11 @@ There are two ways to run Infrawatch:
 
 | Tool | Version | Notes |
 |---|---|---|
-| Docker + Docker Compose | v2.x | Runs the full stack and all build steps |
+| Docker + Docker Compose **or** Podman + `podman compose` / `podman-compose` | Docker v2.x / Podman 4.x+ | Runs the full stack and all build steps |
 
 That's it. No local Go, Node.js, or pnpm required.
+
+**Running on Podman:** Infrawatch also works on hosts that use Podman instead of Docker (common on RHEL, Rocky, Alma, Fedora). `install.sh`, `start.sh`, and the `Makefile` auto-detect which runtime is available. Wherever this guide shows a `docker compose …` command, substitute `podman compose …` (Podman 4.x+) or `podman-compose …` (the standalone provider).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,9 +13,11 @@ There are two ways to run Infrawatch:
 
 | Tool | Version | Why |
 |---|---|---|
-| Docker + Docker Compose | v2.x | Runs the full stack and all build steps |
+| Docker + Docker Compose **or** Podman + `podman compose` / `podman-compose` | Docker v2.x / Podman 4.x+ | Runs the full stack and all build steps |
 
 That's it. No local Go, Node.js, or pnpm required.
+
+**Running on Podman:** Infrawatch also works on hosts that use Podman instead of Docker (common on RHEL, Rocky, Alma, Fedora). `install.sh`, `start.sh`, and the `Makefile` auto-detect which runtime is available. Wherever this guide shows a `docker compose …` command, substitute `podman compose …` (Podman 4.x+) or `podman-compose …` (the standalone provider).
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ REPO_NAME="infrawatch"
 
 if [ "$(id -u)" = "0" ]; then
   echo "ERROR: do not run this installer as root." >&2
-  echo "Run it as the user that will operate Infrawatch (must be in the docker group)." >&2
+  echo "Run it as the user that will operate Infrawatch (must be able to run containers — in the 'docker' group for Docker, or a user with rootless Podman configured)." >&2
   exit 1
 fi
 
@@ -26,7 +26,11 @@ need() {
     exit 1
   fi
 }
-need docker
+if ! command -v docker >/dev/null 2>&1 && ! command -v podman >/dev/null 2>&1; then
+  echo "ERROR: neither 'docker' nor 'podman' found in PATH" >&2
+  echo "Install Docker (with the compose plugin) or Podman 4.x+ and re-run." >&2
+  exit 1
+fi
 need curl
 need unzip
 need openssl

--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# ---- Detect container runtime (Docker or Podman) ----
+# Resolves a COMPOSE array used for every compose invocation below.
+# Preference order: docker compose > podman compose > podman-compose.
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then
+  COMPOSE=(podman compose)
+elif command -v podman-compose >/dev/null 2>&1; then
+  COMPOSE=(podman-compose)
+else
+  echo "ERROR: no supported container runtime found." >&2
+  echo "Install one of the following and re-run:" >&2
+  echo "  - Docker with the compose plugin ('docker compose')" >&2
+  echo "  - Podman 4.x+ ('podman compose')" >&2
+  echo "  - podman-compose (standalone)" >&2
+  exit 1
+fi
+echo "Using container runtime: ${COMPOSE[*]}"
+
 LOCAL=false
 DB_ONLY=false
 DOWN=false
@@ -39,10 +58,10 @@ done
 # ---- Handle --down ----
 if $DOWN; then
   if $LOCAL; then
-    docker compose -f docker-compose.dev.yml down
+    "${COMPOSE[@]}" -f docker-compose.dev.yml down
     echo "Dev database stopped."
   else
-    docker compose -f docker-compose.single.yml down
+    "${COMPOSE[@]}" -f docker-compose.single.yml down
     echo "Production stack stopped."
   fi
   exit 0
@@ -67,8 +86,8 @@ if [ ! -f ".env" ]; then
 fi
 
 # Load .env so values like AGENT_DOWNLOAD_BASE_URL are available both to
-# this script and (via export) to the docker compose variable substitution
-# that follows.
+# this script and (via export) to the compose variable substitution that
+# follows.
 set -a
 # shellcheck disable=SC1091
 source .env
@@ -131,13 +150,14 @@ if ! $LOCAL; then
   echo "Agent download base URL: ${AGENT_DOWNLOAD_BASE_URL}"
 
   # Always pull the latest published images from GHCR. This is the production
-  # install path — users running Infrawatch from Docker do not have a source
+  # install path — users running Infrawatch from containers do not have a source
   # checkout to build from. To run a locally-built image instead, set
   # WEB_IMAGE / INGEST_IMAGE in your environment (or .env) before invoking this
-  # script, or run `docker compose -f docker-compose.single.yml build` manually.
-  docker compose -f docker-compose.single.yml pull db web ingest
-  docker compose -f docker-compose.single.yml down
-  docker compose -f docker-compose.single.yml up -d --pull always
+  # script, or run the equivalent `compose -f docker-compose.single.yml build`
+  # command manually.
+  "${COMPOSE[@]}" -f docker-compose.single.yml pull db web ingest
+  "${COMPOSE[@]}" -f docker-compose.single.yml down
+  "${COMPOSE[@]}" -f docker-compose.single.yml up -d --pull always
 
   # Database migrations are applied automatically by the web container on
   # startup (its CMD runs `node migrate.js && node server.js`), and the
@@ -185,10 +205,10 @@ make ingest
 
 # ---- Start database ----
 echo "Starting dev database..."
-docker compose -f docker-compose.dev.yml up -d
+"${COMPOSE[@]}" -f docker-compose.dev.yml up -d
 
 echo "Waiting for database to be healthy..."
-until docker compose -f docker-compose.dev.yml exec -T db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; do
+until "${COMPOSE[@]}" -f docker-compose.dev.yml exec -T db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; do
   sleep 1
 done
 echo "Database ready."


### PR DESCRIPTION
## Summary

- `start.sh`: detects Docker or Podman at startup, resolves a `COMPOSE` bash array (`docker compose` → `podman compose` → `podman-compose`), and uses it for all 7 compose invocations — works unchanged on both Docker and Podman hosts
- `install.sh`: replaces the hard `need docker` check with an either-or check accepting `docker` or `podman`; updates the root-user error message to mention rootless Podman
- `Makefile`: adds a `CONTAINER_RUNTIME` auto-detection variable (docker → podman) used for all 6 `docker run` build targets; can be overridden with `CONTAINER_RUNTIME=podman`
- Docs: updated prerequisites tables and added "Running on Podman" notes in `docs/getting-started.md` and `apps/docs/docs/getting-started/installation.md`; added `podman load -i` hints in the air-gap deployment guide

Targets users on RHEL, Rocky Linux, Alma Linux, and Fedora where Podman is the default and Docker is not pre-installed.

## Test plan

- [ ] On a Docker host: `./start.sh --down` prints `Using container runtime: docker compose` — no regression
- [ ] On a Docker host: `make ingest` resolves to `docker run --rm …` — no regression
- [ ] On a Podman host: `./start.sh --local --db-only` prints `Using container runtime: podman compose` (or `podman-compose`), DB starts successfully
- [ ] On a Podman host: `make ingest` uses `podman run --rm …` successfully
- [ ] On a host with neither runtime: `./start.sh` exits 1 with the three-bullet error listing install options
- [ ] `./install.sh` on a Podman-only host: does not fail at the runtime check
- [ ] `bash -n start.sh install.sh` passes syntax check ✅ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)