### PR TITLE
feat: enforce Pro/Enterprise licence gates on certs, service accounts, and reports

### DIFF
--- a/apps/docs/docs/licensing.md
+++ b/apps/docs/docs/licensing.md
@@ -23,9 +23,7 @@ LDAP / AD login is included in **Community** — it is expected in any serious o
 - Notification channels: in-app, webhook, SMTP, Slack, Telegram
 - Interactive terminal (multi-tab, split-pane)
 - Custom script runner, service management
-- Certificate **discovery** and inventory
-- Service account **inventory**
-- SSL Certificate Checker tool
+- SSL Certificate Checker tool (one-off URL lookup)
 - Metric graphs + retention up to **180 days**
 - Air-gap deployment
 
@@ -100,6 +98,14 @@ If a licence includes a `maxHosts` cap, agent approval is blocked once that coun
 ## Enforcement
 
 The authoritative licence check happens server-side on every gated action. UI controls for paid features are disabled on Community and hidden or badged appropriately, but the server never trusts the client — attempting to invoke a gated action without a valid licence returns an error.
+
+Currently enforced on Community tier:
+
+- Certificate tracker (`/certificates`) — requires `certExpiryTracker`
+- Service account tracker (`/service-accounts`) — requires `serviceAccountTracker`
+- Reports (`/reports/*`) — requires `reportsExport`; scheduled software scans require `reportsScheduled`
+
+Community installs see a **"Pro"** badge on each locked entry in the sidebar and an "Upgrade required" screen when the page is visited.
 
 ## Circumvention and support
 

--- a/apps/web/app/(dashboard)/certificates/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/certificates/[id]/page.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getCertificate } from '@/lib/actions/certificates'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { hasFeature } from '@/lib/features'
+import { LockedFeature } from '@/components/shared/locked-feature'
 import { CertificateDetailClient } from './certificate-detail-client'
 
 export const metadata: Metadata = {
@@ -16,6 +19,11 @@ export default async function CertificateDetailPage({
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
   const { id } = await params
+
+  const licence = await getEffectiveLicence(orgId)
+  if (!hasFeature(licence.tier, 'certExpiryTracker')) {
+    return <LockedFeature feature="certExpiryTracker" tier={licence.tier} />
+  }
 
   const result = await getCertificate(orgId, id)
   if (!result) notFound()

--- a/apps/web/app/(dashboard)/certificates/page.tsx
+++ b/apps/web/app/(dashboard)/certificates/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getCertificates, getCertificateCounts } from '@/lib/actions/certificates'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { hasFeature } from '@/lib/features'
+import { LockedFeature } from '@/components/shared/locked-feature'
 import { CertificatesClient } from './certificates-client'
 
 export const metadata: Metadata = {
@@ -10,6 +13,11 @@ export const metadata: Metadata = {
 export default async function CertificatesPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
+
+  const licence = await getEffectiveLicence(orgId)
+  if (!hasFeature(licence.tier, 'certExpiryTracker')) {
+    return <LockedFeature feature="certExpiryTracker" tier={licence.tier} />
+  }
 
   const [initialCertificates, initialCounts] = await Promise.all([
     getCertificates(orgId, { sortBy: 'not_after', sortDir: 'asc', limit: 100 }),

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import { SidebarProvider } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/shared/sidebar'
 import { Topbar } from '@/components/shared/topbar'
 import { getRequiredSession } from '@/lib/auth/session'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
 import { TerminalProviderWrapper, TerminalContentWrapper } from '@/components/terminal/terminal-layout-wrapper'
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -21,11 +22,12 @@ export default async function DashboardLayout({ children }: { children: React.Re
   }
 
   const orgId = session.user.organisationId
+  const licence = await getEffectiveLicence(orgId)
 
   return (
     <TerminalProviderWrapper>
       <SidebarProvider className="h-svh overflow-hidden">
-        <AppSidebar orgId={orgId} />
+        <AppSidebar orgId={orgId} tier={licence.tier} />
         <TerminalContentWrapper orgId={orgId}>
           <Topbar orgId={orgId} />
           <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>

--- a/apps/web/app/(dashboard)/reports/software/page.tsx
+++ b/apps/web/app/(dashboard)/reports/software/page.tsx
@@ -5,6 +5,9 @@ import { organisations, hostGroups } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { SoftwareReportClient } from './software-report-client'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { hasFeature } from '@/lib/features'
+import { LockedFeature } from '@/components/shared/locked-feature'
 
 export const metadata: Metadata = {
   title: 'Installed Software Report',
@@ -13,6 +16,11 @@ export const metadata: Metadata = {
 export default async function SoftwareReportPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
+
+  const licence = await getEffectiveLicence(orgId)
+  if (!hasFeature(licence.tier, 'reportsExport')) {
+    return <LockedFeature feature="reportsExport" tier={licence.tier} />
+  }
 
   const [org, groups] = await Promise.all([
     db.query.organisations.findFirst({

--- a/apps/web/app/(dashboard)/service-accounts/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/service-accounts/[id]/page.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getDomainAccount } from '@/lib/actions/domain-accounts'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { hasFeature } from '@/lib/features'
+import { LockedFeature } from '@/components/shared/locked-feature'
 import { ServiceAccountDetailClient } from './service-account-detail-client'
 
 export const metadata: Metadata = {
@@ -16,6 +19,11 @@ export default async function ServiceAccountDetailPage({
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
   const { id } = await params
+
+  const licence = await getEffectiveLicence(orgId)
+  if (!hasFeature(licence.tier, 'serviceAccountTracker')) {
+    return <LockedFeature feature="serviceAccountTracker" tier={licence.tier} />
+  }
 
   const account = await getDomainAccount(orgId, id)
   if (!account) notFound()

--- a/apps/web/app/(dashboard)/service-accounts/page.tsx
+++ b/apps/web/app/(dashboard)/service-accounts/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getDomainAccounts, getDomainAccountCounts } from '@/lib/actions/domain-accounts'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { hasFeature } from '@/lib/features'
+import { LockedFeature } from '@/components/shared/locked-feature'
 import { ServiceAccountsClient } from './service-accounts-client'
 
 export const metadata: Metadata = {
@@ -10,6 +13,11 @@ export const metadata: Metadata = {
 export default async function ServiceAccountsPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
+
+  const licence = await getEffectiveLicence(orgId)
+  if (!hasFeature(licence.tier, 'serviceAccountTracker')) {
+    return <LockedFeature feature="serviceAccountTracker" tier={licence.tier} />
+  }
 
   const [initialAccounts, initialCounts] = await Promise.all([
     getDomainAccounts(orgId, { sortBy: 'username', sortDir: 'asc', limit: 100 }),

--- a/apps/web/app/api/certificates/counts/route.ts
+++ b/apps/web/app/api/certificates/counts/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { getCertificateCounts } from '@/lib/actions/certificates'
+import { LicenceRequiredError } from '@/lib/actions/licence-guard'
 
 export const dynamic = 'force-dynamic'
 
@@ -21,6 +22,13 @@ export async function GET() {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const counts = await getCertificateCounts(user.organisationId)
-  return Response.json(counts)
+  try {
+    const counts = await getCertificateCounts(user.organisationId)
+    return Response.json(counts)
+  } catch (err) {
+    if (err instanceof LicenceRequiredError) {
+      return Response.json({ error: err.message }, { status: 402 })
+    }
+    throw err
+  }
 }

--- a/apps/web/app/api/certificates/route.ts
+++ b/apps/web/app/api/certificates/route.ts
@@ -7,6 +7,7 @@ import { eq } from 'drizzle-orm'
 import { getCertificates } from '@/lib/actions/certificates'
 import type { CertificateListFilters } from '@/lib/actions/certificates'
 import type { CertificateStatus } from '@/lib/db/schema'
+import { LicenceRequiredError } from '@/lib/actions/licence-guard'
 
 export const dynamic = 'force-dynamic'
 
@@ -34,6 +35,13 @@ export async function GET(request: NextRequest) {
     offset: searchParams.has('offset') ? Number(searchParams.get('offset')) : undefined,
   }
 
-  const certificates = await getCertificates(user.organisationId, filters)
-  return Response.json(certificates)
+  try {
+    const certificates = await getCertificates(user.organisationId, filters)
+    return Response.json(certificates)
+  } catch (err) {
+    if (err instanceof LicenceRequiredError) {
+      return Response.json({ error: err.message }, { status: 402 })
+    }
+    throw err
+  }
 }

--- a/apps/web/app/api/domain-accounts/counts/route.ts
+++ b/apps/web/app/api/domain-accounts/counts/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { getDomainAccountCounts } from '@/lib/actions/domain-accounts'
+import { LicenceRequiredError } from '@/lib/actions/licence-guard'
 
 export const dynamic = 'force-dynamic'
 
@@ -20,6 +21,13 @@ export async function GET() {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const counts = await getDomainAccountCounts(user.organisationId)
-  return Response.json(counts)
+  try {
+    const counts = await getDomainAccountCounts(user.organisationId)
+    return Response.json(counts)
+  } catch (err) {
+    if (err instanceof LicenceRequiredError) {
+      return Response.json({ error: err.message }, { status: 402 })
+    }
+    throw err
+  }
 }

--- a/apps/web/app/api/domain-accounts/route.ts
+++ b/apps/web/app/api/domain-accounts/route.ts
@@ -7,6 +7,7 @@ import { eq } from 'drizzle-orm'
 import { getDomainAccounts } from '@/lib/actions/domain-accounts'
 import type { DomainAccountListFilters } from '@/lib/actions/domain-accounts'
 import type { DomainAccountStatus } from '@/lib/db/schema'
+import { LicenceRequiredError } from '@/lib/actions/licence-guard'
 
 export const dynamic = 'force-dynamic'
 
@@ -33,6 +34,13 @@ export async function GET(request: NextRequest) {
     offset: searchParams.has('offset') ? Number(searchParams.get('offset')) : undefined,
   }
 
-  const accounts = await getDomainAccounts(user.organisationId, filters)
-  return Response.json(accounts)
+  try {
+    const accounts = await getDomainAccounts(user.organisationId, filters)
+    return Response.json(accounts)
+  } catch (err) {
+    if (err instanceof LicenceRequiredError) {
+      return Response.json({ error: err.message }, { status: 402 })
+    }
+    throw err
+  }
 }

--- a/apps/web/app/api/service-accounts/counts/route.ts
+++ b/apps/web/app/api/service-accounts/counts/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { getServiceAccountCounts } from '@/lib/actions/service-accounts'
+import { LicenceRequiredError } from '@/lib/actions/licence-guard'
 
 export const dynamic = 'force-dynamic'
 
@@ -21,6 +22,13 @@ export async function GET() {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const counts = await getServiceAccountCounts(user.organisationId)
-  return Response.json(counts)
+  try {
+    const counts = await getServiceAccountCounts(user.organisationId)
+    return Response.json(counts)
+  } catch (err) {
+    if (err instanceof LicenceRequiredError) {
+      return Response.json({ error: err.message }, { status: 402 })
+    }
+    throw err
+  }
 }

--- a/apps/web/app/api/service-accounts/route.ts
+++ b/apps/web/app/api/service-accounts/route.ts
@@ -7,6 +7,7 @@ import { eq } from 'drizzle-orm'
 import { getServiceAccounts } from '@/lib/actions/service-accounts'
 import type { ServiceAccountListFilters } from '@/lib/actions/service-accounts'
 import type { ServiceAccountStatus, ServiceAccountType } from '@/lib/db/schema'
+import { LicenceRequiredError } from '@/lib/actions/licence-guard'
 
 export const dynamic = 'force-dynamic'
 
@@ -36,6 +37,13 @@ export async function GET(request: NextRequest) {
     offset: searchParams.has('offset') ? Number(searchParams.get('offset')) : undefined,
   }
 
-  const accounts = await getServiceAccounts(user.organisationId, filters)
-  return Response.json(accounts)
+  try {
+    const accounts = await getServiceAccounts(user.organisationId, filters)
+    return Response.json(accounts)
+  } catch (err) {
+    if (err instanceof LicenceRequiredError) {
+      return Response.json({ error: err.message }, { status: 402 })
+    }
+    throw err
+  }
 }

--- a/apps/web/components/shared/locked-feature.tsx
+++ b/apps/web/components/shared/locked-feature.tsx
@@ -1,0 +1,135 @@
+import Link from 'next/link'
+import { Lock } from 'lucide-react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import type { Feature, LicenceTier } from '@/lib/features'
+
+const FEATURE_COPY: Record<Feature, { title: string; description: string; requiredTier: LicenceTier }> = {
+  ssoOidc: {
+    title: 'OIDC Single Sign-On',
+    description: 'Connect Google, Entra, Okta, or Keycloak for organisation-wide sign-in.',
+    requiredTier: 'pro',
+  },
+  auditLog: {
+    title: 'Audit Log',
+    description: 'Full audit trail of user and admin actions with export and retention controls.',
+    requiredTier: 'pro',
+  },
+  certExpiryTracker: {
+    title: 'Certificate Expiry Tracker',
+    description: 'Dashboards, scheduled expiry notifications, and bulk export for every tracked certificate.',
+    requiredTier: 'pro',
+  },
+  serviceAccountTracker: {
+    title: 'Service Account Tracker',
+    description: 'Track service account password and token expiry across hosts and directories.',
+    requiredTier: 'pro',
+  },
+  reportsExport: {
+    title: 'Reports',
+    description: 'Generate, save, and export inventory reports as CSV or PDF.',
+    requiredTier: 'pro',
+  },
+  reportsScheduled: {
+    title: 'Scheduled Reports',
+    description: 'Deliver reports on a schedule to email or webhook destinations.',
+    requiredTier: 'pro',
+  },
+  metricRetentionExtended: {
+    title: 'Extended Metric Retention',
+    description: 'Retain metrics for up to 365 days and export via the metric API.',
+    requiredTier: 'pro',
+  },
+  scheduledTasks: {
+    title: 'Scheduled Task Runner',
+    description: 'Run custom scripts on a schedule across host groups.',
+    requiredTier: 'pro',
+  },
+  alertRouting: {
+    title: 'Alert Routing Policies',
+    description: 'On-call rotations, escalation policies, and advanced routing.',
+    requiredTier: 'pro',
+  },
+  csrInternalCa: {
+    title: 'CSR & Internal CA',
+    description: 'Generate CSRs, run an approval workflow, and issue certificates from an internal CA.',
+    requiredTier: 'pro',
+  },
+  sshKeyInventory: {
+    title: 'SSH Key Inventory',
+    description: 'Track SSH keys and rotation across every host.',
+    requiredTier: 'pro',
+  },
+  ssoSaml: {
+    title: 'SAML 2.0 SSO',
+    description: 'Enterprise identity provider integration via SAML 2.0.',
+    requiredTier: 'enterprise',
+  },
+  advancedRbac: {
+    title: 'Advanced RBAC',
+    description: 'Tag-based resource scoping and custom role definitions.',
+    requiredTier: 'enterprise',
+  },
+  whiteLabel: {
+    title: 'White Labelling',
+    description: 'Custom logo, theme, login page, and email sender.',
+    requiredTier: 'enterprise',
+  },
+  compliancePack: {
+    title: 'Compliance Packs',
+    description: 'SOC 2, ISO 27001, and HIPAA-style evidence templates.',
+    requiredTier: 'enterprise',
+  },
+  airgapBundlers: {
+    title: 'Air-gap Bundlers',
+    description: 'Bundlers for Jenkins, Docker, Ansible, and Terraform.',
+    requiredTier: 'enterprise',
+  },
+  haDeployment: {
+    title: 'HA Deployment',
+    description: 'High-availability deployment profile and migration tooling.',
+    requiredTier: 'enterprise',
+  },
+}
+
+const TIER_LABEL: Record<LicenceTier, string> = {
+  community: 'Community',
+  pro: 'Pro',
+  enterprise: 'Enterprise',
+}
+
+export function LockedFeature({ feature, tier }: { feature: Feature; tier: LicenceTier }) {
+  const copy = FEATURE_COPY[feature]
+  return (
+    <div className="mx-auto max-w-xl py-12">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Lock className="size-5" />
+            </div>
+            <div className="flex-1">
+              <CardTitle>{copy.title}</CardTitle>
+              <CardDescription>Upgrade required to access this feature</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{copy.description}</p>
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">Your plan:</span>
+            <Badge variant="outline">{TIER_LABEL[tier]}</Badge>
+            <span className="text-muted-foreground">Required:</span>
+            <Badge>{TIER_LABEL[copy.requiredTier]}</Badge>
+          </div>
+          <div className="pt-2">
+            <Button asChild>
+              <Link href="/settings">Manage licence</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
 import { TerminalPanelTrigger } from '@/components/terminal'
+import { hasFeature, type Feature, type LicenceTier } from '@/lib/features'
 import pkg from '../../package.json'
 
 const WEB_VERSION = `v${pkg.version}`
@@ -50,6 +51,7 @@ interface NavChild {
   href: string
   icon: React.ComponentType<{ className?: string }>
   badge?: string
+  feature?: Feature
 }
 
 interface NavItem {
@@ -57,6 +59,7 @@ interface NavItem {
   href: string
   icon: React.ComponentType<{ className?: string }>
   badge?: string
+  feature?: Feature
   children?: NavChild[]
 }
 
@@ -74,8 +77,8 @@ const primaryNav: NavItem[] = [
   },
   { title: 'Checks & Alerts', href: '/alerts', icon: Bell },
   { title: 'Notifications', href: '/notifications', icon: BellPlus },
-  { title: 'Certificates', href: '/certificates', icon: ShieldCheck },
-  { title: 'Service Accounts', href: '/service-accounts', icon: Key },
+  { title: 'Certificates', href: '/certificates', icon: ShieldCheck, feature: 'certExpiryTracker' },
+  { title: 'Service Accounts', href: '/service-accounts', icon: Key, feature: 'serviceAccountTracker' },
 ]
 
 const reportingNav: NavItem[] = [
@@ -83,8 +86,9 @@ const reportingNav: NavItem[] = [
     title: 'Reports',
     href: '/reports',
     icon: FileBarChart,
+    feature: 'reportsExport',
     children: [
-      { title: 'Installed Software', href: '/reports/software', icon: Package },
+      { title: 'Installed Software', href: '/reports/software', icon: Package, feature: 'reportsExport' },
     ],
   },
 ]
@@ -113,7 +117,21 @@ const adminNav: NavItem[] = [
   },
 ]
 
-function CollapsibleNavItem({ item }: { item: NavItem & { children: NavChild[] } }) {
+function ProBadge() {
+  return (
+    <span className="ml-auto rounded-sm border border-sidebar-border/70 px-1 py-0 text-[9px] font-semibold uppercase tracking-wide text-sidebar-foreground/60">
+      Pro
+    </span>
+  )
+}
+
+function CollapsibleNavItem({
+  item,
+  tier,
+}: {
+  item: NavItem & { children: NavChild[] }
+  tier: LicenceTier
+}) {
   const pathname = usePathname()
 
   // Auto-open if any child (or the parent itself) is active
@@ -127,6 +145,7 @@ function CollapsibleNavItem({ item }: { item: NavItem & { children: NavChild[] }
   // For /hosts specifically: active when on /hosts exactly or /hosts/groups/* but NOT /hosts/[id]
   // The parent highlight just needs to know if we're somewhere in the subtree
   const defaultOpen = isParentActive || isAnyChildActive
+  const parentLocked = item.feature ? !hasFeature(tier, item.feature) : false
 
   return (
     <CollapsiblePrimitive.Root defaultOpen={defaultOpen}>
@@ -145,9 +164,11 @@ function CollapsibleNavItem({ item }: { item: NavItem & { children: NavChild[] }
               )}
             />
             <span>{item.title}</span>
+            {parentLocked ? <ProBadge /> : null}
             <ChevronRight
               className={cn(
-                'ml-auto size-3 text-sidebar-foreground/50 transition-transform duration-200',
+                'size-3 text-sidebar-foreground/50 transition-transform duration-200',
+                parentLocked ? 'ml-1' : 'ml-auto',
                 defaultOpen && 'rotate-90'
               )}
             />
@@ -162,6 +183,7 @@ function CollapsibleNavItem({ item }: { item: NavItem & { children: NavChild[] }
                 child.href === '/hosts' || child.href === '/settings'
                   ? pathname === child.href
                   : pathname.startsWith(child.href)
+              const childLocked = child.feature ? !hasFeature(tier, child.feature) : false
               return (
                 <SidebarMenuSubItem key={child.href}>
                   <SidebarMenuSubButton asChild isActive={isActive}>
@@ -173,6 +195,7 @@ function CollapsibleNavItem({ item }: { item: NavItem & { children: NavChild[] }
                         )}
                       />
                       <span>{child.title}</span>
+                      {childLocked ? <ProBadge /> : null}
                     </Link>
                   </SidebarMenuSubButton>
                 </SidebarMenuSubItem>
@@ -185,25 +208,33 @@ function CollapsibleNavItem({ item }: { item: NavItem & { children: NavChild[] }
   )
 }
 
-function NavGroupItems({ items }: { items: NavItem[] }) {
+function NavGroupItems({ items, tier }: { items: NavItem[]; tier: LicenceTier }) {
   const pathname = usePathname()
   return (
     <>
       {items.map((item) => {
         if (item.children && item.children.length > 0) {
-          return <CollapsibleNavItem key={item.href} item={item as NavItem & { children: NavChild[] }} />
+          return (
+            <CollapsibleNavItem
+              key={item.href}
+              item={item as NavItem & { children: NavChild[] }}
+              tier={tier}
+            />
+          )
         }
 
         const isActive =
           item.href === '/dashboard'
             ? pathname === '/dashboard'
             : pathname.startsWith(item.href)
+        const locked = item.feature ? !hasFeature(tier, item.feature) : false
         return (
           <SidebarMenuItem key={item.href}>
             <SidebarMenuButton asChild isActive={isActive}>
               <Link href={item.href}>
                 <item.icon className={cn('size-4', isActive ? 'text-sidebar-primary' : 'text-sidebar-foreground/70')} />
                 <span>{item.title}</span>
+                {locked ? <ProBadge /> : null}
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
@@ -213,20 +244,34 @@ function NavGroupItems({ items }: { items: NavItem[] }) {
   )
 }
 
-function NavGroup({ label, items }: { label: string; items: NavItem[] }) {
+function NavGroup({
+  label,
+  items,
+  tier,
+}: {
+  label: string
+  items: NavItem[]
+  tier: LicenceTier
+}) {
   return (
     <SidebarGroup>
       <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarGroupContent>
         <SidebarMenu>
-          <NavGroupItems items={items} />
+          <NavGroupItems items={items} tier={tier} />
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>
   )
 }
 
-export function AppSidebar({ orgId }: { orgId: string }) {
+const TIER_LABEL: Record<LicenceTier, string> = {
+  community: 'Community Edition',
+  pro: 'Pro Edition',
+  enterprise: 'Enterprise Edition',
+}
+
+export function AppSidebar({ orgId, tier }: { orgId: string; tier: LicenceTier }) {
   return (
     <Sidebar>
       <SidebarHeader className="border-b border-sidebar-border px-4 py-3">
@@ -238,24 +283,24 @@ export function AppSidebar({ orgId }: { orgId: string }) {
         </div>
       </SidebarHeader>
       <SidebarContent>
-        <NavGroup label="Monitoring" items={primaryNav} />
-        <NavGroup label="Reporting" items={reportingNav} />
+        <NavGroup label="Monitoring" items={primaryNav} tier={tier} />
+        <NavGroup label="Reporting" items={reportingNav} tier={tier} />
         <SidebarGroup>
           <SidebarGroupLabel>Tooling</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <NavGroupItems items={toolingNav} />
+              <NavGroupItems items={toolingNav} tier={tier} />
               <SidebarMenuItem>
                 <TerminalPanelTrigger orgId={orgId} />
               </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-        <NavGroup label="Administration" items={adminNav} />
+        <NavGroup label="Administration" items={adminNav} tier={tier} />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border p-2">
         <p className="text-xs text-muted-foreground px-2 py-1">
-          Community Edition <span className="font-mono">{WEB_VERSION}</span>
+          {TIER_LABEL[tier]} <span className="font-mono">{WEB_VERSION}</span>
         </p>
       </SidebarFooter>
     </Sidebar>

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -6,6 +6,7 @@ import { certificates, certificateEvents } from '@/lib/db/schema'
 import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm'
 import type { Certificate, CertificateEvent, CertificateStatus, CertificateDetails } from '@/lib/db/schema'
 import { getRequiredSession } from '@/lib/auth/session'
+import { requireFeature } from '@/lib/actions/licence-guard'
 import { computeExpiryStatus } from '@/lib/certificates/expiry'
 import {
   fetchCertificateFromUrl,
@@ -37,6 +38,7 @@ export async function getCertificates(
   orgId: string,
   filters: CertificateListFilters = {},
 ): Promise<Certificate[]> {
+  await requireFeature(orgId, 'certExpiryTracker')
   const {
     status,
     host,
@@ -74,6 +76,7 @@ export async function getCertificate(
   orgId: string,
   certId: string,
 ): Promise<{ certificate: Certificate; events: CertificateEvent[] } | null> {
+  await requireFeature(orgId, 'certExpiryTracker')
   const certificate = await db.query.certificates.findFirst({
     where: and(
       eq(certificates.id, certId),
@@ -95,6 +98,7 @@ export async function getCertificate(
 }
 
 export async function getCertificateCounts(orgId: string): Promise<CertificateCounts> {
+  await requireFeature(orgId, 'certExpiryTracker')
   const rows = await db
     .select({
       status: certificates.status,
@@ -119,6 +123,7 @@ export async function deleteCertificate(
   orgId: string,
   certId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireFeature(orgId, 'certExpiryTracker')
   const existing = await db.query.certificates.findFirst({
     where: and(
       eq(certificates.id, certId),
@@ -205,6 +210,7 @@ export async function trackCertificateFromUrl(
   orgId: string,
   input: unknown,
 ): Promise<TrackCertificateResult> {
+  await requireFeature(orgId, 'certExpiryTracker')
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) {
     return { error: 'Organisation mismatch' }
@@ -288,6 +294,7 @@ export async function trackCertificateFromUpload(
   orgId: string,
   input: unknown,
 ): Promise<TrackCertificateResult> {
+  await requireFeature(orgId, 'certExpiryTracker')
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) {
     return { error: 'Organisation mismatch' }

--- a/apps/web/lib/actions/domain-accounts.ts
+++ b/apps/web/lib/actions/domain-accounts.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { domainAccounts } from '@/lib/db/schema'
 import { eq, and, asc, desc, sql } from 'drizzle-orm'
 import type { DomainAccount, DomainAccountStatus } from '@/lib/db/schema'
+import { requireFeature } from '@/lib/actions/licence-guard'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -47,6 +48,7 @@ export async function getDomainAccounts(
   orgId: string,
   filters: DomainAccountListFilters = {},
 ): Promise<DomainAccount[]> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const {
     status,
     search,
@@ -85,6 +87,7 @@ export async function getDomainAccount(
   orgId: string,
   accountId: string,
 ): Promise<DomainAccount | null> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const result = await db.query.domainAccounts.findFirst({
     where: and(
       eq(domainAccounts.id, accountId),
@@ -97,6 +100,7 @@ export async function getDomainAccount(
 export async function getDomainAccountCounts(
   orgId: string,
 ): Promise<DomainAccountCounts> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const statusRows = await db
     .select({
       status: domainAccounts.status,
@@ -131,6 +135,7 @@ export async function createDomainAccount(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const parsed = createDomainAccountSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -167,6 +172,7 @@ export async function updateDomainAccount(
   accountId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const parsed = updateDomainAccountSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -202,6 +208,7 @@ export async function deleteDomainAccount(
   orgId: string,
   accountId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const existing = await db.query.domainAccounts.findFirst({
     where: and(
       eq(domainAccounts.id, accountId),

--- a/apps/web/lib/actions/service-accounts.ts
+++ b/apps/web/lib/actions/service-accounts.ts
@@ -11,6 +11,7 @@ import type {
   ServiceAccountType,
 } from '@/lib/db/schema'
 import type { Host } from '@/lib/db/schema'
+import { requireFeature } from '@/lib/actions/licence-guard'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -45,6 +46,7 @@ export async function getServiceAccounts(
   orgId: string,
   filters: ServiceAccountListFilters = {},
 ): Promise<ServiceAccountWithHost[]> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const {
     accountType,
     status,
@@ -132,6 +134,7 @@ export async function getServiceAccount(
   events: IdentityEvent[]
   host: Host | null
 } | null> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const account = await db.query.serviceAccounts.findFirst({
     where: and(
       eq(serviceAccounts.id, accountId),
@@ -171,6 +174,7 @@ export async function getServiceAccount(
 export async function getServiceAccountCounts(
   orgId: string,
 ): Promise<ServiceAccountCounts> {
+  await requireFeature(orgId, 'serviceAccountTracker')
   const [typeRows, statusRows] = await Promise.all([
     db
       .select({
@@ -218,6 +222,7 @@ export async function getSshKeysByFingerprint(
   orgId: string,
   fingerprint: string,
 ): Promise<(SshKey & { hostHostname?: string })[]> {
+  await requireFeature(orgId, 'sshKeyInventory')
   const keys = await db.query.sshKeys.findMany({
     where: and(
       eq(sshKeys.organisationId, orgId),

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -21,6 +21,7 @@ import type {
   SoftwareInventorySettings,
 } from '@/lib/db/schema'
 import { getRequiredSession } from '@/lib/auth/session'
+import { requireFeature } from '@/lib/actions/licence-guard'
 import { escapeLikePattern } from '@/lib/utils'
 import { compareVersions } from '@/lib/version-compare'
 
@@ -54,6 +55,7 @@ export async function updateSoftwareInventorySettings(
   orgId: string,
   settings: SoftwareInventorySettings,
 ): Promise<{ success: true } | { error: string }> {
+  await requireFeature(orgId, 'reportsScheduled')
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -235,6 +237,7 @@ export async function searchPackageNames(
   orgId: string,
   q: string,
 ): Promise<PackageNameSuggestion[]> {
+  await requireFeature(orgId, 'reportsExport')
   if (!q || q.length < 2 || q.length > 100) return []
 
   const escaped = `%${escapeLikePattern(q)}%`
@@ -297,6 +300,7 @@ export async function getSoftwareReport(
   orgId: string,
   filters: SoftwareReportFilters = {},
 ): Promise<SoftwareReportResult> {
+  await requireFeature(orgId, 'reportsExport')
   const page = filters.page ?? 1
   const pageSize = Math.min(filters.pageSize ?? 50, 200)
   const offset = (page - 1) * pageSize
@@ -430,6 +434,7 @@ export async function getNewPackages(
   orgId: string,
   windowDays: 7 | 30 = 7,
 ): Promise<NewPackageRow[]> {
+  await requireFeature(orgId, 'reportsExport')
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - windowDays)
 
@@ -481,6 +486,7 @@ export interface DriftRow {
 }
 
 export async function getPackageDrift(orgId: string): Promise<DriftRow[]> {
+  await requireFeature(orgId, 'reportsExport')
   const rows = await db
     .select({
       groupId: hostGroupMembers.groupId,
@@ -570,6 +576,7 @@ export async function getPackageDetails(
   packageName: string,
   osFamily?: string,
 ): Promise<PackageDetailsResult> {
+  await requireFeature(orgId, 'reportsExport')
   const packages = await db
     .select({
       hostId: softwarePackages.hostId,
@@ -642,6 +649,7 @@ export async function getPackageVersions(
   orgId: string,
   packageName: string,
 ): Promise<string[]> {
+  await requireFeature(orgId, 'reportsExport')
   const rows = await db
     .select({ version: softwarePackages.version })
     .from(softwarePackages)
@@ -734,6 +742,7 @@ const saveReportSchema = z.object({
 })
 
 export async function listSavedReports(orgId: string): Promise<SavedSoftwareReport[]> {
+  await requireFeature(orgId, 'reportsExport')
   const session = await getRequiredSession()
   return db.query.savedSoftwareReports.findMany({
     where: and(
@@ -750,6 +759,7 @@ export async function saveSoftwareReport(
   name: string,
   filters: SoftwareReportFilters,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireFeature(orgId, 'reportsExport')
   const session = await getRequiredSession()
   const parsed = saveReportSchema.safeParse({ name, filters })
   if (!parsed.success) {
@@ -777,6 +787,7 @@ export async function deleteSavedReport(
   orgId: string,
   reportId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireFeature(orgId, 'reportsExport')
   const session = await getRequiredSession()
   try {
     await db


### PR DESCRIPTION
## Summary
- Gate certificates, service accounts, and reports server actions with `requireFeature()` — community tier gets `LicenceRequiredError` (402 at API routes, upgrade page in UI)
- Add `LockedFeature` full-page upgrade screen and render it on all five gated dashboard pages
- Wire licence tier into `AppSidebar` — locked entries get a "Pro" badge; footer now shows actual tier (community/pro/enterprise)
- SSL Certificate Checker tool stays ungated (stateless one-shot utility)
- Update `apps/docs/docs/licensing.md` to reflect the now-enforced routes

## Test plan
- [ ] Community tier: visiting `/certificates`, `/certificates/[id]`, `/service-accounts`, `/service-accounts/[id]`, `/reports/software` renders the upgrade screen
- [ ] Community tier: sidebar entries for gated features show a "Pro" badge; links remain clickable
- [ ] Community tier: calling `/api/certificates`, `/api/service-accounts`, `/api/domain-accounts` (and their `/counts`) returns HTTP 402
- [ ] Pro tier: all gated routes and actions succeed; badges disappear from sidebar
- [ ] SSL Certificate Checker (`/certificate-checker`) still accessible on community tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)