### PR TITLE
fix: detect Podman-present-but-no-compose-provider and give actionable error

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -30,12 +30,18 @@ elif command -v podman >/dev/null 2>&1 && podman compose --help >/dev/null 2>&1;
   COMPOSE=(podman compose)
 elif command -v podman-compose >/dev/null 2>&1; then
   COMPOSE=(podman-compose)
+elif command -v podman >/dev/null 2>&1; then
+  echo "ERROR: Podman is installed but no compose provider was found." >&2
+  echo "Install podman-compose, then re-run:" >&2
+  echo "  sudo dnf install podman-compose   # RHEL / Rocky / Alma / Fedora" >&2
+  echo "  sudo apt install podman-compose   # Debian / Ubuntu" >&2
+  echo "  pip3 install podman-compose       # any distro (via pip)" >&2
+  exit 1
 else
   echo "ERROR: no supported container runtime found." >&2
   echo "Install one of the following and re-run:" >&2
   echo "  - Docker with the compose plugin ('docker compose')" >&2
-  echo "  - Podman 4.x+ ('podman compose')" >&2
-  echo "  - podman-compose (standalone)" >&2
+  echo "  - Podman + podman-compose" >&2
   exit 1
 fi
 echo "Using container runtime: ${COMPOSE[*]}"


### PR DESCRIPTION
## Summary

- Adds a fourth detection branch in `start.sh`: when Podman is installed but no compose provider (`podman compose` subcommand or `podman-compose` binary) is available, print a clear, distro-specific error with install instructions instead of the generic "no supported container runtime found" message
- Reproduces the real failure mode: Podman 5.6.0 installed, `podman-compose` not yet installed → now shows `sudo dnf install podman-compose` etc.

## Test plan

- [ ] On a Podman-only host with no `podman-compose`: `./start.sh` should print the new targeted error with `dnf`/`apt`/`pip3` options
- [ ] After `sudo dnf install podman-compose`: `./start.sh` detects `podman-compose` binary and proceeds normally
- [ ] On a Docker host: no change — still resolves to `docker compose`
- [ ] `bash -n start.sh` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)