### PR TITLE
fix: prefix timescaledb image with docker.io and drop --pull always for podman-compose compat

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@
 
 services:
   db:
-    image: timescale/timescaledb:latest-pg16
+    image: docker.io/timescale/timescaledb:latest-pg16
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: timescale/timescaledb:latest-pg16
+    image: docker.io/timescale/timescaledb:latest-pg16
     restart: unless-stopped
     environment:
       POSTGRES_USER: infrawatch

--- a/start.sh
+++ b/start.sh
@@ -163,7 +163,7 @@ if ! $LOCAL; then
   # command manually.
   "${COMPOSE[@]}" -f docker-compose.single.yml pull db web ingest
   "${COMPOSE[@]}" -f docker-compose.single.yml down
-  "${COMPOSE[@]}" -f docker-compose.single.yml up -d --pull always
+  "${COMPOSE[@]}" -f docker-compose.single.yml up -d
 
   # Database migrations are applied automatically by the web container on
   # startup (its CMD runs `node migrate.js && node server.js`), and the


### PR DESCRIPTION
## Summary

Two `podman-compose` incompatibilities found during live testing on RHEL with Podman 5.6.0:

- **`timescale/timescaledb:latest-pg16`** had no registry prefix — Podman prompts interactively to choose a registry (RHEL, RedHat, docker.io…) instead of defaulting to `docker.io` like Docker does. The user picked `registry.access.redhat.com` which doesn't host the image and the pull failed. Prefixing with `docker.io/` makes the source unambiguous on all runtimes. Fixed in both `docker-compose.single.yml` and `docker-compose.dev.yml`.

- **`up -d --pull always`** — `podman-compose` treats `always` as a service name rather than a flag argument (`WARNING:podman_compose:missing services [always]`), causing the `up` to fail. The explicit `pull` step immediately before `up` in `start.sh` already guarantees fresh images, so `--pull always` is redundant and has been removed.

## Test plan

- [ ] On a Podman host: `./start.sh` no longer prompts for a registry and no longer errors on `--pull always`
- [ ] On a Docker host: `docker.io/` prefix is silently accepted — no regression
- [ ] `bash -n start.sh` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)