### PR TITLE
fix: add rootless Podman pre-flight check for missing systemd user session

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -46,6 +46,28 @@ else
 fi
 echo "Using container runtime: ${COMPOSE[*]}"
 
+# ---- Rootless Podman pre-flight: verify systemd user session ----
+# Rootless Podman networking (netavark + aardvark-dns) requires a D-Bus user
+# socket. Without it, containers start but immediately fail with a cryptic
+# "aardvark-dns failed to start" error. Catch the condition early.
+if [ "${COMPOSE[0]}" != "docker" ] && [ "$(id -u)" != "0" ]; then
+  EXPECTED_RUN_DIR="/run/user/$(id -u)"
+  if [ "${XDG_RUNTIME_DIR:-}" != "$EXPECTED_RUN_DIR" ] || [ ! -S "${XDG_RUNTIME_DIR}/bus" ]; then
+    echo "" >&2
+    echo "ERROR: Rootless Podman requires a systemd user session, but none was found." >&2
+    echo "Run this once on the server (as root), then reconnect your SSH session:" >&2
+    echo "" >&2
+    echo "  sudo loginctl enable-linger $(id -u)" >&2
+    echo "" >&2
+    echo "After reconnecting, verify with:" >&2
+    echo "  echo \$XDG_RUNTIME_DIR    # should print $EXPECTED_RUN_DIR" >&2
+    echo "  ls $EXPECTED_RUN_DIR/bus  # should exist" >&2
+    echo "" >&2
+    echo "Alternatively, run as root: sudo ./start.sh" >&2
+    exit 1
+  fi
+fi
+
 LOCAL=false
 DB_ONLY=false
 DOWN=false


### PR DESCRIPTION
## Summary

Rootless Podman networking (netavark + aardvark-dns) requires a D-Bus user socket at `/run/user/<uid>/bus`. On SSH sessions where `loginctl enable-linger` has not been configured, that socket doesn't exist — containers start but immediately fail with the unhelpful error:

```
aardvark-dns failed to start: Failed to connect to user scope bus via local transport: No such file or directory
```

This adds a pre-flight check in `start.sh` that detects the condition before any container work begins and prints exact remediation steps. Docker users are unaffected (the check is skipped entirely when `docker` is the runtime or the user is root).

**Confirmed fix on RHEL / Podman 5.6.0:**
```bash
sudo loginctl enable-linger <uid>
# disconnect and reconnect SSH
./start.sh   # now passes the check and proceeds
```

## Test plan

- [ ] On a rootless Podman host with no linger / no SSH session: `./start.sh` exits 1 with the new error message before attempting to start any containers
- [ ] After `sudo loginctl enable-linger <uid>` and SSH reconnect: check is satisfied, stack starts
- [ ] On a Docker host: check block is skipped entirely — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)