### PR TITLE
revert: remove all Podman support, Docker only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROTO_OUT := proto/gen/go
 
 # Persistent host-directory caches for Go builds.
 # Using host dirs (owned by the current user) avoids permission errors when
-# the container runs with --user $(id -u):$(id -g) and a root-owned named volume.
+# Docker runs with --user $(id -u):$(id -g) and a root-owned named volume.
 GO_CACHE_DIR := $(HOME)/.cache/infrawatch/go-build
 GO_MOD_DIR   := $(HOME)/.cache/infrawatch/go-mod
 
@@ -14,17 +14,6 @@ GO_MOD_DIR   := $(HOME)/.cache/infrawatch/go-mod
 # running this Makefile (e.g. darwin/arm64 on Apple Silicon).
 HOST_OS   := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 HOST_ARCH := $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-
-# Detect container runtime. Override with CONTAINER_RUNTIME=podman if both are
-# installed and you want the non-default.
-CONTAINER_RUNTIME ?= $(shell \
-	if command -v docker >/dev/null 2>&1; then echo docker; \
-	elif command -v podman >/dev/null 2>&1; then echo podman; \
-	else echo MISSING; fi)
-
-ifeq ($(CONTAINER_RUNTIME),MISSING)
-$(error No container runtime found. Install docker or podman and retry.)
-endif
 
 GO_CACHE_ARGS := \
 	-e GOCACHE=/go-cache \
@@ -52,7 +41,7 @@ go-build: agent ingest
 agent:
 	@echo "Building agent binaries for all platforms..."
 	@mkdir -p $(AGENT_DIST_DIR) $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	$(CONTAINER_RUNTIME) run --rm \
+	docker run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -71,7 +60,7 @@ agent:
 ingest:
 	@echo "Building ingest service..."
 	@mkdir -p dist $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	$(CONTAINER_RUNTIME) run --rm \
+	docker run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -88,7 +77,7 @@ ingest:
 loadtest:
 	@echo "Building infrawatch-loadtest for $(HOST_OS)/$(HOST_ARCH)..."
 	@mkdir -p dist $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	$(CONTAINER_RUNTIME) run --rm \
+	docker run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -102,7 +91,7 @@ loadtest:
 
 go-test:
 	@mkdir -p $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	$(CONTAINER_RUNTIME) run --rm \
+	docker run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -113,7 +102,7 @@ go-test:
 # Download all Go dependencies.
 go-deps:
 	@mkdir -p $(GO_CACHE_DIR) $(GO_MOD_DIR)
-	$(CONTAINER_RUNTIME) run --rm \
+	docker run --rm \
 		-v "$(CURDIR):/src" \
 		-w /src \
 		--user "$(shell id -u):$(shell id -g)" \
@@ -121,10 +110,10 @@ go-deps:
 		golang:1.25 \
 		sh -c "go work sync && cd proto/gen/go && go mod tidy && cd /src/agent && go mod tidy && cd /src/apps/ingest && go mod tidy"
 
-# Generate dev TLS certificates for local development (requires a container runtime).
+# Generate dev TLS certificates for local development (requires Docker).
 dev-tls:
 	@mkdir -p deploy/dev-tls
-	$(CONTAINER_RUNTIME) run --rm \
+	docker run --rm \
 		-v "$(CURDIR)/deploy/dev-tls:/out" \
 		alpine/openssl req -x509 \
 		-newkey rsa:4096 \

--- a/apps/docs/docs/deployment/air-gap.md
+++ b/apps/docs/docs/deployment/air-gap.md
@@ -55,7 +55,7 @@ Or use a USB drive, secure FTP, or any other approved transfer mechanism.
 ```bash
 cd /opt/infrawatch
 tar -xzf infrawatch-bundle-*.tar.gz
-docker load < images.tar   # Podman: podman load -i images.tar
+docker load < images.tar
 ```
 
 ---
@@ -125,8 +125,7 @@ INFRAWATCH_VERSION=v0.4.0 bash deploy/scripts/airgap-bundle.sh
 # Transfer the new tarball
 scp infrawatch-bundle-v0.4.0.tar.gz ops@server:/opt/infrawatch/
 
-# On the target server (substitute `podman load -i images.tar` and
-# `podman compose` / `podman-compose` on Podman hosts)
+# On the target server
 docker load < images.tar
 docker compose -f docker-compose.single.yml pull   # no-op: images already loaded
 docker compose -f docker-compose.single.yml up -d  # restarts with new images

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -13,11 +13,9 @@ There are two ways to run Infrawatch:
 
 | Tool | Version | Notes |
 |---|---|---|
-| Docker + Docker Compose **or** Podman + `podman compose` / `podman-compose` | Docker v2.x / Podman 4.x+ | Runs the full stack and all build steps |
+| Docker + Docker Compose | v2.x | Runs the full stack and all build steps |
 
 That's it. No local Go, Node.js, or pnpm required.
-
-**Running on Podman:** Infrawatch also works on hosts that use Podman instead of Docker (common on RHEL, Rocky, Alma, Fedora). `install.sh`, `start.sh`, and the `Makefile` auto-detect which runtime is available. Wherever this guide shows a `docker compose …` command, substitute `podman compose …` (Podman 4.x+) or `podman-compose …` (the standalone provider).
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@
 
 services:
   db:
-    image: docker.io/timescale/timescaledb:latest-pg16
+    image: timescale/timescaledb:latest-pg16
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: docker.io/timescale/timescaledb:latest-pg16
+    image: timescale/timescaledb:latest-pg16
     restart: unless-stopped
     environment:
       POSTGRES_USER: infrawatch

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,11 +13,9 @@ There are two ways to run Infrawatch:
 
 | Tool | Version | Why |
 |---|---|---|
-| Docker + Docker Compose **or** Podman + `podman compose` / `podman-compose` | Docker v2.x / Podman 4.x+ | Runs the full stack and all build steps |
+| Docker + Docker Compose | v2.x | Runs the full stack and all build steps |
 
 That's it. No local Go, Node.js, or pnpm required.
-
-**Running on Podman:** Infrawatch also works on hosts that use Podman instead of Docker (common on RHEL, Rocky, Alma, Fedora). `install.sh`, `start.sh`, and the `Makefile` auto-detect which runtime is available. Wherever this guide shows a `docker compose …` command, substitute `podman compose …` (Podman 4.x+) or `podman-compose …` (the standalone provider).
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ REPO_NAME="infrawatch"
 
 if [ "$(id -u)" = "0" ]; then
   echo "ERROR: do not run this installer as root." >&2
-  echo "Run it as the user that will operate Infrawatch (must be able to run containers — in the 'docker' group for Docker, or a user with rootless Podman configured)." >&2
+  echo "Run it as the user that will operate Infrawatch (must be in the docker group)." >&2
   exit 1
 fi
 
@@ -26,11 +26,7 @@ need() {
     exit 1
   fi
 }
-if ! command -v docker >/dev/null 2>&1 && ! command -v podman >/dev/null 2>&1; then
-  echo "ERROR: neither 'docker' nor 'podman' found in PATH" >&2
-  echo "Install Docker (with the compose plugin) or Podman 4.x+ and re-run." >&2
-  exit 1
-fi
+need docker
 need curl
 need unzip
 need openssl

--- a/start.sh
+++ b/start.sh
@@ -21,53 +21,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# ---- Detect container runtime (Docker or Podman) ----
-# Resolves a COMPOSE array used for every compose invocation below.
-# Preference order: docker compose > podman compose > podman-compose.
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-  COMPOSE=(docker compose)
-elif command -v podman >/dev/null 2>&1 && podman compose --help >/dev/null 2>&1; then
-  COMPOSE=(podman compose)
-elif command -v podman-compose >/dev/null 2>&1; then
-  COMPOSE=(podman-compose)
-elif command -v podman >/dev/null 2>&1; then
-  echo "ERROR: Podman is installed but no compose provider was found." >&2
-  echo "Install podman-compose, then re-run:" >&2
-  echo "  sudo dnf install podman-compose   # RHEL / Rocky / Alma / Fedora" >&2
-  echo "  sudo apt install podman-compose   # Debian / Ubuntu" >&2
-  echo "  pip3 install podman-compose       # any distro (via pip)" >&2
-  exit 1
-else
-  echo "ERROR: no supported container runtime found." >&2
-  echo "Install one of the following and re-run:" >&2
-  echo "  - Docker with the compose plugin ('docker compose')" >&2
-  echo "  - Podman + podman-compose" >&2
-  exit 1
-fi
-echo "Using container runtime: ${COMPOSE[*]}"
-
-# ---- Rootless Podman pre-flight: verify systemd user session ----
-# Rootless Podman networking (netavark + aardvark-dns) requires a D-Bus user
-# socket. Without it, containers start but immediately fail with a cryptic
-# "aardvark-dns failed to start" error. Catch the condition early.
-if [ "${COMPOSE[0]}" != "docker" ] && [ "$(id -u)" != "0" ]; then
-  EXPECTED_RUN_DIR="/run/user/$(id -u)"
-  if [ "${XDG_RUNTIME_DIR:-}" != "$EXPECTED_RUN_DIR" ] || [ ! -S "${XDG_RUNTIME_DIR}/bus" ]; then
-    echo "" >&2
-    echo "ERROR: Rootless Podman requires a systemd user session, but none was found." >&2
-    echo "Run this once on the server (as root), then reconnect your SSH session:" >&2
-    echo "" >&2
-    echo "  sudo loginctl enable-linger $(id -u)" >&2
-    echo "" >&2
-    echo "After reconnecting, verify with:" >&2
-    echo "  echo \$XDG_RUNTIME_DIR    # should print $EXPECTED_RUN_DIR" >&2
-    echo "  ls $EXPECTED_RUN_DIR/bus  # should exist" >&2
-    echo "" >&2
-    echo "Alternatively, run as root: sudo ./start.sh" >&2
-    exit 1
-  fi
-fi
-
 LOCAL=false
 DB_ONLY=false
 DOWN=false
@@ -86,10 +39,10 @@ done
 # ---- Handle --down ----
 if $DOWN; then
   if $LOCAL; then
-    "${COMPOSE[@]}" -f docker-compose.dev.yml down
+    docker compose -f docker-compose.dev.yml down
     echo "Dev database stopped."
   else
-    "${COMPOSE[@]}" -f docker-compose.single.yml down
+    docker compose -f docker-compose.single.yml down
     echo "Production stack stopped."
   fi
   exit 0
@@ -114,8 +67,8 @@ if [ ! -f ".env" ]; then
 fi
 
 # Load .env so values like AGENT_DOWNLOAD_BASE_URL are available both to
-# this script and (via export) to the compose variable substitution that
-# follows.
+# this script and (via export) to the docker compose variable substitution
+# that follows.
 set -a
 # shellcheck disable=SC1091
 source .env
@@ -178,14 +131,13 @@ if ! $LOCAL; then
   echo "Agent download base URL: ${AGENT_DOWNLOAD_BASE_URL}"
 
   # Always pull the latest published images from GHCR. This is the production
-  # install path — users running Infrawatch from containers do not have a source
+  # install path — users running Infrawatch from Docker do not have a source
   # checkout to build from. To run a locally-built image instead, set
   # WEB_IMAGE / INGEST_IMAGE in your environment (or .env) before invoking this
-  # script, or run the equivalent `compose -f docker-compose.single.yml build`
-  # command manually.
-  "${COMPOSE[@]}" -f docker-compose.single.yml pull db web ingest
-  "${COMPOSE[@]}" -f docker-compose.single.yml down
-  "${COMPOSE[@]}" -f docker-compose.single.yml up -d
+  # script, or run `docker compose -f docker-compose.single.yml build` manually.
+  docker compose -f docker-compose.single.yml pull db web ingest
+  docker compose -f docker-compose.single.yml down
+  docker compose -f docker-compose.single.yml up -d --pull always
 
   # Database migrations are applied automatically by the web container on
   # startup (its CMD runs `node migrate.js && node server.js`), and the
@@ -233,10 +185,10 @@ make ingest
 
 # ---- Start database ----
 echo "Starting dev database..."
-"${COMPOSE[@]}" -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml up -d
 
 echo "Waiting for database to be healthy..."
-until "${COMPOSE[@]}" -f docker-compose.dev.yml exec -T db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; do
+until docker compose -f docker-compose.dev.yml exec -T db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; do
   sleep 1
 done
 echo "Database ready."

--- a/start.sh
+++ b/start.sh
@@ -46,6 +46,28 @@ else
 fi
 echo "Using container runtime: ${COMPOSE[*]}"
 
+# ---- Rootless Podman pre-flight: verify systemd user session ----
+# Rootless Podman networking (netavark + aardvark-dns) requires a D-Bus user
+# socket. Without it, containers start but immediately fail with a cryptic
+# "aardvark-dns failed to start" error. Catch the condition early.
+if [ "${COMPOSE[0]}" != "docker" ] && [ "$(id -u)" != "0" ]; then
+  EXPECTED_RUN_DIR="/run/user/$(id -u)"
+  if [ "${XDG_RUNTIME_DIR:-}" != "$EXPECTED_RUN_DIR" ] || [ ! -S "${XDG_RUNTIME_DIR}/bus" ]; then
+    echo "" >&2
+    echo "ERROR: Rootless Podman requires a systemd user session, but none was found." >&2
+    echo "Run this once on the server (as root), then reconnect your SSH session:" >&2
+    echo "" >&2
+    echo "  sudo loginctl enable-linger $(id -u)" >&2
+    echo "" >&2
+    echo "After reconnecting, verify with:" >&2
+    echo "  echo \$XDG_RUNTIME_DIR    # should print $EXPECTED_RUN_DIR" >&2
+    echo "  ls $EXPECTED_RUN_DIR/bus  # should exist" >&2
+    echo "" >&2
+    echo "Alternatively, run as root: sudo ./start.sh" >&2
+    exit 1
+  fi
+fi
+
 LOCAL=false
 DB_ONLY=false
 DOWN=false


### PR DESCRIPTION
## Summary

Podman support was introduced across several PRs but the operational complexity (rootless session requirements, netavark/aardvark-dns issues, cgroupv2/systemd user session setup on RHEL) creates too much support burden. Reverting to Docker-only.

Changes reverted:
- **`start.sh`**: runtime detection block removed; plain `docker compose` restored, `--pull always` restored
- **`install.sh`**: `need docker` check and original error message restored
- **`Makefile`**: `CONTAINER_RUNTIME` detection removed; `docker run` restored
- **`docker-compose.single.yml` / `docker-compose.dev.yml`**: `timescale/timescaledb` image unqualified name restored (Docker handles `docker.io` default implicitly)
- **Docs**: prerequisites tables and Podman notes reverted

PR #377 (rootless Podman pre-flight check) was closed without merging before this revert was raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)