### PR TITLE
Split host Tools into Tasks and Logs tabs

### DIFF
--- a/apps/docs/docs/features/tasks.md
+++ b/apps/docs/docs/features/tasks.md
@@ -37,6 +37,15 @@ Each script execution creates a **task run** record. The task runs page shows:
 
 Click a task run to see the full stdout/stderr output.
 
+### Manual vs automated runs on a host
+
+On the host detail page, the **Tools** section splits task history into two tabs:
+
+- **Tasks** — runs you started yourself by clicking **Run Script**, **Run Patch** or **Service**. This is the place to find scripts you previously ran on a host.
+- **Logs** — runs started automatically by Infrawatch on a schedule, such as software inventory scans. These share the same underlying execution mechanism, but are separated out so the Tasks list stays focused on your own activity.
+
+Both tabs link through to the same task monitor view, so the full raw output is available regardless of which tab the run was started from.
+
 ---
 
 ## Runbooks

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -62,6 +62,7 @@ import { HostNotificationCharts } from './host-notification-charts'
 import { SettingsTab } from './settings-tab'
 import { LocalUsersTab } from './local-users-tab'
 import { TasksTab } from './tasks-tab'
+import { LogsTab } from './logs-tab'
 import { InventoryTab } from './inventory-tab'
 import { HostTerminalLauncher } from './host-terminal-launcher'
 import { checkTerminalAccess } from '@/lib/actions/terminal'
@@ -75,7 +76,7 @@ import type { HostGroupWithCount } from '@/lib/actions/host-groups'
 import type { NetworkWithMembership, NetworkWithCount } from '@/lib/actions/networks'
 
 type ParentTabId = 'overview' | 'monitoring' | 'infrastructure' | 'inventory' | 'management' | 'tools'
-type Tab = 'overview' | 'storage' | 'network' | 'metrics' | 'checks' | 'alerts' | 'users' | 'settings' | 'groups' | 'host-networks' | 'tasks' | 'terminal' | 'packages'
+type Tab = 'overview' | 'storage' | 'network' | 'metrics' | 'checks' | 'alerts' | 'users' | 'settings' | 'groups' | 'host-networks' | 'tasks' | 'logs' | 'terminal' | 'packages'
 
 const TAB_LABELS: Record<Tab, string> = {
   overview: 'Overview',
@@ -89,6 +90,7 @@ const TAB_LABELS: Record<Tab, string> = {
   groups: 'Groups',
   'host-networks': 'Networks',
   tasks: 'Tasks',
+  logs: 'Logs',
   terminal: 'Terminal',
   packages: 'Packages',
 }
@@ -104,7 +106,7 @@ const PARENT_TABS: Array<{
   { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network'] },
   { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages'] },
   { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'host-networks', 'settings'] },
-  { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'terminal'] },
+  { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
 ]
 
 interface Props {
@@ -1131,6 +1133,11 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
       {/* Tasks Tab */}
       {activeTab === 'tasks' && (
         <TasksTab orgId={orgId} host={host} userId={currentUserId} />
+      )}
+
+      {/* Logs Tab */}
+      {activeTab === 'logs' && (
+        <LogsTab orgId={orgId} hostId={initialHost.id} />
       )}
 
       {/* Terminal Tab */}

--- a/apps/web/app/(dashboard)/hosts/[id]/logs-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/logs-tab.tsx
@@ -1,0 +1,244 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+import {
+  FileText,
+  ExternalLink,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Trash2,
+  Package,
+} from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  listAutomatedRunsForHost,
+  deleteTaskRuns,
+} from '@/lib/actions/task-runs'
+import type { TaskRunWithHosts } from '@/lib/actions/task-runs'
+import type { SoftwareInventoryTaskResult } from '@/lib/db/schema'
+
+interface Props {
+  orgId: string
+  hostId: string
+}
+
+const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed'])
+
+function isRunActive(status: string) {
+  return !TERMINAL_RUN_STATUSES.has(status)
+}
+
+function RunStatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case 'completed':
+      return (
+        <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">
+          <CheckCircle2 className="size-3 mr-1" />
+          Completed
+        </Badge>
+      )
+    case 'failed':
+      return (
+        <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">
+          <XCircle className="size-3 mr-1" />
+          Failed
+        </Badge>
+      )
+    case 'running':
+      return (
+        <Badge className="bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100">
+          <Loader2 className="size-3 mr-1 animate-spin" />
+          Running
+        </Badge>
+      )
+    default:
+      return (
+        <Badge className="bg-gray-100 text-gray-600 border-gray-200 hover:bg-gray-100">
+          <Clock className="size-3 mr-1" />
+          Pending
+        </Badge>
+      )
+  }
+}
+
+function taskTypeLabel(taskType: string): string {
+  switch (taskType) {
+    case 'software_inventory': return 'Software inventory'
+    default: return taskType.replace(/_/g, ' ')
+  }
+}
+
+function LogDetailsCell({ run, hostId }: { run: TaskRunWithHosts; hostId: string }) {
+  const thisHost = run.hosts.find((h) => h.hostId === hostId)
+
+  if (run.taskType === 'software_inventory') {
+    const result = thisHost?.result as SoftwareInventoryTaskResult | null
+    if (!result) {
+      return <span className="text-sm text-muted-foreground">—</span>
+    }
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Package className="size-3.5" />
+        <span>
+          {result.package_count.toLocaleString()} packages
+        </span>
+        <span className="text-xs">·</span>
+        <span className="font-mono text-xs">{result.source}</span>
+      </div>
+    )
+  }
+
+  return <span className="text-sm text-muted-foreground">—</span>
+}
+
+export function LogsTab({ orgId, hostId }: Props) {
+  const queryClient = useQueryClient()
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+
+  const { data: runs = [] } = useQuery({
+    queryKey: ['automated-runs-host', orgId, hostId],
+    queryFn: () => listAutomatedRunsForHost(orgId, hostId),
+    refetchInterval: (query) => {
+      const rows = query.state.data ?? []
+      return rows.some((r) => isRunActive(r.status)) ? 5_000 : 30_000
+    },
+  })
+
+  const { mutate: doDelete, isPending: isDeleting } = useMutation({
+    mutationFn: () => deleteTaskRuns(orgId, [...selectedIds]),
+    onSuccess: () => {
+      setSelectedIds(new Set())
+      queryClient.invalidateQueries({ queryKey: ['automated-runs-host', orgId, hostId] })
+    },
+  })
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (selectedIds.size === runs.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(runs.map((r) => r.id)))
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-semibold text-foreground">Automated Logs</h3>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Runs started automatically by the system — e.g. periodic software inventory scans.
+        </p>
+      </div>
+
+      {selectedIds.size > 0 && (
+        <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2">
+          <span className="text-sm text-muted-foreground">
+            {selectedIds.size} selected
+          </span>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => doDelete()}
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+            ) : (
+              <Trash2 className="size-3.5 mr-1.5" />
+            )}
+            Delete {selectedIds.size}
+          </Button>
+        </div>
+      )}
+
+      {runs.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-10 text-center">
+          <FileText className="size-7 mx-auto text-muted-foreground mb-3" />
+          <p className="text-sm font-medium text-foreground">No automated runs yet</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Automated runs will appear here after the system schedules its next scan.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10">
+                  <Checkbox
+                    checked={runs.length > 0 && selectedIds.size === runs.length}
+                    onCheckedChange={toggleSelectAll}
+                    aria-label="Select all"
+                  />
+                </TableHead>
+                <TableHead>Task</TableHead>
+                <TableHead>Details</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Started</TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {runs.map((run) => (
+                <TableRow key={run.id} data-state={selectedIds.has(run.id) ? 'selected' : undefined}>
+                  <TableCell>
+                    <Checkbox
+                      checked={selectedIds.has(run.id)}
+                      onCheckedChange={() => toggleSelect(run.id)}
+                      aria-label={`Select run ${run.id}`}
+                    />
+                  </TableCell>
+                  <TableCell className="font-medium">
+                    {taskTypeLabel(run.taskType)}
+                  </TableCell>
+                  <TableCell>
+                    <LogDetailsCell run={run} hostId={hostId} />
+                  </TableCell>
+                  <TableCell>
+                    <RunStatusBadge status={run.status} />
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {run.startedAt
+                      ? formatDistanceToNow(new Date(run.startedAt), { addSuffix: true })
+                      : formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}
+                  </TableCell>
+                  <TableCell>
+                    <Link href={`/tasks/${run.id}`}>
+                      <Button variant="ghost" size="sm" className="h-7 px-2 text-xs gap-1">
+                        {isRunActive(run.status) ? 'View live' : 'View'}
+                        <ExternalLink className="size-3" />
+                      </Button>
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -7,7 +7,7 @@ import {
   hosts,
   hostGroupMembers,
 } from '@/lib/db/schema'
-import { eq, and, isNull, desc, inArray, or } from 'drizzle-orm'
+import { eq, and, isNull, isNotNull, desc, inArray, or } from 'drizzle-orm'
 import type {
   TaskRun,
   TaskRunHost,
@@ -138,7 +138,9 @@ export async function getTaskRun(
 }
 
 /**
- * Returns the most recent task runs that include a given host (any status).
+ * Returns the most recent user-triggered task runs that include a given host.
+ * Automated runs created by the system sweeper (triggered_by IS NULL) are
+ * excluded — those surface under the host's Logs tab instead.
  * Optionally filtered by task_type.
  */
 export async function listTaskRunsForHost(
@@ -165,6 +167,45 @@ export async function listTaskRunsForHost(
       inArray(taskRuns.id, runIds),
       eq(taskRuns.organisationId, orgId),
       isNull(taskRuns.deletedAt),
+      isNotNull(taskRuns.triggeredBy),
+      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
+    ),
+    orderBy: [desc(taskRuns.createdAt)],
+    limit: 50,
+  })
+
+  return Promise.all(runs.map((run) => getTaskRun(orgId, run.id).then((r) => r!)))
+}
+
+/**
+ * Returns the most recent automated (system-triggered) task runs for a host.
+ * These are runs created by the ingest sweepers — e.g. software inventory
+ * scans — and have triggered_by IS NULL. Rendered under the host's Logs tab.
+ */
+export async function listAutomatedRunsForHost(
+  orgId: string,
+  hostId: string,
+  taskType?: string,
+): Promise<TaskRunWithHosts[]> {
+  const hostRunRows = await db.query.taskRunHosts.findMany({
+    where: and(
+      eq(taskRunHosts.hostId, hostId),
+      eq(taskRunHosts.organisationId, orgId),
+      isNull(taskRunHosts.deletedAt),
+    ),
+    columns: { taskRunId: true },
+  })
+
+  if (hostRunRows.length === 0) return []
+
+  const runIds = [...new Set(hostRunRows.map((r) => r.taskRunId))]
+
+  const runs = await db.query.taskRuns.findMany({
+    where: and(
+      inArray(taskRuns.id, runIds),
+      eq(taskRuns.organisationId, orgId),
+      isNull(taskRuns.deletedAt),
+      isNull(taskRuns.triggeredBy),
       ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
     ),
     orderBy: [desc(taskRuns.createdAt)],


### PR DESCRIPTION
## Summary
- Host detail page **Tools → Tasks** no longer includes automated `software_inventory` runs — it now shows only runs the user started (Run Script / Run Patch / Service).
- Added a new **Tools → Logs** sub-tab that lists automated, system-triggered runs (currently software inventory scans) with the same status / view affordances, linking through to the existing task monitor for the full raw output.
- `listTaskRunsForHost` filters on `triggeredBy IS NOT NULL`; new `listAutomatedRunsForHost` mirrors it for `triggeredBy IS NULL`.
- Updated `apps/docs/docs/features/tasks.md` with a section describing the split.

## Test plan
- [ ] Navigate to a host with prior software_inventory sweeps — confirm they no longer appear under Tools → Tasks
- [ ] Confirm those runs now appear under the new Tools → Logs sub-tab, showing package count + source
- [ ] Click **Run Script** / **Run Patch** on a Linux host and confirm the new run shows under Tasks (not Logs)
- [ ] Click **View** on a Logs row and verify it opens the existing task monitor with full stdout
- [ ] Delete selection works on both Tasks and Logs tabs independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)