### PR TITLE
feat: paginate, filter, sort hosts page and add fleet overview

### DIFF
--- a/apps/docs/docs/features/hosts.md
+++ b/apps/docs/docs/features/hosts.md
@@ -18,17 +18,49 @@ Status is derived in real time from the ingest heartbeat stream — there is no 
 
 ---
 
+## Fleet Overview
+
+At the top of the Hosts page you will see a set of summary cards that give a quick read of the state of the fleet before you dig into the table:
+
+- **Total hosts** registered
+- **Online** and **Offline** counts (with the online card showing the percentage of the fleet)
+- **Firing alerts** — the number of distinct hosts with at least one alert currently firing
+- **Stale** — hosts that have not reported a heartbeat in the last 15 minutes (any online heartbeat should arrive well inside that window, so any count here usually means something is wrong)
+- **Pending approval** — agents waiting for an admin to approve them
+
+Below the summary are two further panels:
+
+- **Resource hotspots** — a count of hosts currently at or above **80%** CPU, memory, or disk utilisation. Useful for catching capacity pressure on a busy day before alerts fire.
+- **Operating systems** — a breakdown of the fleet by OS, with a bar showing each OS's share. Clicking an OS name filters the host list to that OS.
+
+All of the summary numbers are computed server-side and refresh every 30 seconds, so they stay current without needing a page reload.
+
+---
+
 ## Host List
 
 The hosts table shows:
 - Hostname
-- IP address
 - OS / platform
+- IP addresses
+- Current CPU / memory / disk percentages (values at or above 80% are highlighted in red)
 - Last seen timestamp
-- Current CPU / memory / disk percentages
+- Count of active alerts for the host
 - Status badge
 
 Clicking a hostname opens the host detail page.
+
+### Paging, search, sort and filter
+
+The host list is **paged on the server** so that very large fleets load quickly. A fleet of several thousand hosts only ships the current page to the browser, not the whole inventory.
+
+- **Page size** — choose 25, 50 (default), 100 or 200 hosts per page.
+- **Search** — free-text search over hostname, display name, and IP addresses. The input is debounced, so the query only fires when you stop typing.
+- **Status filter** — restrict to Online, Offline, or Unknown.
+- **OS filter** — restrict to any operating system currently present in the inventory. Also wired up to the OS bars in the fleet overview — click a bar to apply the filter.
+- **Sorting** — click any sortable column header (hostname, OS, CPU, memory, disk, last seen, status) to sort ascending; click again to flip to descending. Only one column is sorted at a time. `NULL` values are always pushed to the end so that empty metrics never hide real data.
+
+Page, sort, and filter state all reset sensibly as you adjust them — changing a filter always returns you to the first page of results, and there is a **Clear filters** button to reset everything to the default view.
 
 ---
 
@@ -101,16 +133,6 @@ The host detail page (`/hosts/[id]`) provides a full view of a single host:
 ### Services tab
 - Systemd services on this host
 - Start / stop / restart controls via the agent
-
----
-
-## Filtering and Search
-
-The host list supports filtering by:
-- Status (Online / Offline / Pending)
-- Host group membership
-- OS type
-- Free-text search on hostname
 
 ---
 

--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -1,11 +1,30 @@
 'use client'
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useState, useMemo, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
-import { CheckCircle, Clock, WifiOff, XCircle, Server, AlertTriangle } from 'lucide-react'
+import {
+  CheckCircle,
+  Clock,
+  WifiOff,
+  XCircle,
+  Server,
+  AlertTriangle,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  Search,
+  BellRing,
+  Cpu,
+  MemoryStick,
+  HardDrive,
+  TimerOff,
+  X,
+} from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import {
   Table,
@@ -16,22 +35,44 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import {
-  listHosts,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  listHostsPaginated,
   listPendingAgents,
+  listDistinctHostOses,
+  getHostInventoryStats,
   approveAgent,
   rejectAgent,
 } from '@/lib/actions/agents'
-import type { HostWithAgent } from '@/lib/actions/agents'
+import type {
+  HostListResult,
+  HostInventoryStats,
+  HostSortField,
+  HostSortDir,
+} from '@/lib/actions/agents'
 import type { Agent } from '@/lib/db/schema'
+import { HOST_HIGH_USAGE_THRESHOLD, HOST_STALE_MINUTES } from '@/lib/db/schema/hosts'
 import { getActiveAlertCountsForHosts } from '@/lib/actions/alerts'
+
+type StatusFilter = 'all' | 'online' | 'offline' | 'unknown'
 
 interface HostsClientProps {
   orgId: string
   currentUserId: string
   currentUserRole: string
-  initialHosts: HostWithAgent[]
+  initialHostPage: HostListResult
+  initialStats: HostInventoryStats
+  initialOsOptions: string[]
   initialPendingAgents: Agent[]
 }
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const
+const DEFAULT_PAGE_SIZE = 50
 
 function StatusBadge({ status }: { status: string }) {
   switch (status) {
@@ -83,35 +124,166 @@ function formatPercent(value: number | null): string {
   return `${value.toFixed(1)}%`
 }
 
+function usageClass(value: number | null): string {
+  if (value === null || value === undefined) return 'text-muted-foreground'
+  if (value >= HOST_HIGH_USAGE_THRESHOLD) return 'text-red-600 font-medium'
+  if (value >= 60) return 'text-amber-600'
+  return ''
+}
+
+interface StatCardProps {
+  label: string
+  value: number | string
+  hint?: string
+  icon?: React.ReactNode
+  tone?: 'default' | 'positive' | 'negative' | 'warning'
+}
+
+function StatCard({ label, value, hint, icon, tone = 'default' }: StatCardProps) {
+  const toneClass =
+    tone === 'positive'
+      ? 'text-green-700'
+      : tone === 'negative'
+        ? 'text-red-700'
+        : tone === 'warning'
+          ? 'text-amber-700'
+          : 'text-foreground'
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+          {icon && <div className="text-muted-foreground">{icon}</div>}
+        </div>
+        <div className={`mt-2 text-2xl font-semibold ${toneClass}`}>{value}</div>
+        {hint && <div className="text-xs text-muted-foreground mt-1">{hint}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+
+interface SortableHeaderProps {
+  field: HostSortField
+  current: HostSortField
+  dir: HostSortDir
+  onSort: (field: HostSortField) => void
+  children: React.ReactNode
+  align?: 'left' | 'right'
+}
+
+function SortableHeader({
+  field,
+  current,
+  dir,
+  onSort,
+  children,
+  align = 'left',
+}: SortableHeaderProps) {
+  const isActive = current === field
+  const Icon = isActive ? (dir === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown
+  return (
+    <TableHead className={align === 'right' ? 'text-right' : undefined}>
+      <button
+        type="button"
+        onClick={() => onSort(field)}
+        className={`inline-flex items-center gap-1 hover:text-foreground transition-colors ${
+          isActive ? 'text-foreground' : 'text-muted-foreground'
+        }`}
+      >
+        <span>{children}</span>
+        <Icon className="size-3" />
+      </button>
+    </TableHead>
+  )
+}
+
 export function HostsClient({
   orgId,
   currentUserId,
   currentUserRole,
-  initialHosts,
+  initialHostPage,
+  initialStats,
+  initialOsOptions,
   initialPendingAgents,
 }: HostsClientProps) {
   const queryClient = useQueryClient()
   const isAdmin = currentUserRole === 'super_admin' || currentUserRole === 'org_admin'
 
-  const { data: hostsData } = useQuery({
-    queryKey: ['hosts', orgId],
-    queryFn: () => listHosts(orgId),
-    initialData: initialHosts,
+  // ─── Filter / sort / page state ────────────────────────────────────────────
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [status, setStatus] = useState<StatusFilter>('all')
+  const [os, setOs] = useState<string>('all')
+  const [sortBy, setSortBy] = useState<HostSortField>('hostname')
+  const [sortDir, setSortDir] = useState<HostSortDir>('asc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE)
+
+  // Debounce the search input so typing into the box does not spam the server.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearch(searchInput.trim())
+      setPage(0)
+    }, 250)
+    return () => clearTimeout(timer)
+  }, [searchInput])
+
+  // Any filter change resets to the first page.
+  useEffect(() => {
+    setPage(0)
+  }, [status, os, pageSize])
+
+  const queryParams = useMemo(
+    () => ({
+      search: search || undefined,
+      status: status !== 'all' ? status : undefined,
+      os: os !== 'all' ? os : undefined,
+      sortBy,
+      sortDir,
+      limit: pageSize,
+      offset: page * pageSize,
+    }),
+    [search, status, os, sortBy, sortDir, pageSize, page],
+  )
+
+  const filtersAreDefault =
+    !search && status === 'all' && os === 'all' && sortBy === 'hostname' && sortDir === 'asc' && page === 0
+
+  const { data: hostsPage = initialHostPage } = useQuery({
+    queryKey: ['hosts', 'page', orgId, queryParams],
+    queryFn: () => listHostsPaginated(orgId, queryParams),
+    initialData: filtersAreDefault && pageSize === DEFAULT_PAGE_SIZE ? initialHostPage : undefined,
+    placeholderData: keepPreviousData,
     refetchInterval: 30_000,
   })
 
+  const { data: stats = initialStats } = useQuery({
+    queryKey: ['hosts', 'stats', orgId],
+    queryFn: () => getHostInventoryStats(orgId),
+    initialData: initialStats,
+    refetchInterval: 30_000,
+  })
+
+  const { data: osOptions = initialOsOptions } = useQuery({
+    queryKey: ['hosts', 'os-options', orgId],
+    queryFn: () => listDistinctHostOses(orgId),
+    initialData: initialOsOptions,
+    refetchInterval: 60_000,
+  })
+
+  const hostRows = hostsPage.hosts
   const { data: alertCounts = {} } = useQuery({
-    queryKey: ['alert-counts', orgId],
+    queryKey: ['alert-counts', orgId, hostRows.map((h) => h.id)],
     queryFn: async () => {
-      const ids = (hostsData ?? []).map((h) => h.id)
+      const ids = hostRows.map((h) => h.id)
       if (ids.length === 0) return {}
       return getActiveAlertCountsForHosts(orgId, ids)
     },
-    enabled: (hostsData?.length ?? 0) > 0,
+    enabled: hostRows.length > 0,
     refetchInterval: 30_000,
   })
 
-  const { data: pendingAgents } = useQuery({
+  const { data: pendingAgents = initialPendingAgents } = useQuery({
     queryKey: ['agents', 'pending', orgId],
     queryFn: () => listPendingAgents(orgId),
     initialData: initialPendingAgents,
@@ -123,7 +295,8 @@ export function HostsClient({
       approveAgent(orgId, agentId, currentUserId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', 'pending', orgId] })
-      queryClient.invalidateQueries({ queryKey: ['hosts', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['hosts', 'page', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['hosts', 'stats', orgId] })
     },
   })
 
@@ -132,16 +305,178 @@ export function HostsClient({
       rejectAgent(orgId, agentId, currentUserId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', 'pending', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['hosts', 'stats', orgId] })
     },
   })
+
+  function handleSort(field: HostSortField) {
+    if (sortBy === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortBy(field)
+      setSortDir(field === 'hostname' || field === 'os' ? 'asc' : 'desc')
+    }
+    setPage(0)
+  }
+
+  function resetFilters() {
+    setSearchInput('')
+    setSearch('')
+    setStatus('all')
+    setOs('all')
+    setSortBy('hostname')
+    setSortDir('asc')
+    setPage(0)
+  }
+
+  const total = hostsPage.total
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+  const rangeFrom = total === 0 ? 0 : page * pageSize + 1
+  const rangeTo = Math.min((page + 1) * pageSize, total)
+
+  const hasActiveFilters = search !== '' || status !== 'all' || os !== 'all'
+  const topOsBreakdown = stats.osBreakdown.slice(0, 4)
+  const extraOsCount = stats.osBreakdown.length - topOsBreakdown.length
+  const extraOsSum = stats.osBreakdown
+    .slice(topOsBreakdown.length)
+    .reduce((acc, row) => acc + row.count, 0)
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold text-foreground">Hosts</h1>
         <p className="text-muted-foreground mt-1">
-          {hostsData.length} host{hostsData.length !== 1 ? 's' : ''} registered
+          {stats.total.toLocaleString()} host{stats.total !== 1 ? 's' : ''} registered
         </p>
+      </div>
+
+      {/* ─── Summary stats ─────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <StatCard
+          label="Total hosts"
+          value={stats.total.toLocaleString()}
+          icon={<Server className="size-4" />}
+        />
+        <StatCard
+          label="Online"
+          value={stats.online.toLocaleString()}
+          tone={stats.online > 0 ? 'positive' : 'default'}
+          icon={<CheckCircle className="size-4" />}
+          hint={stats.total > 0 ? `${Math.round((stats.online / stats.total) * 100)}% of fleet` : undefined}
+        />
+        <StatCard
+          label="Offline"
+          value={stats.offline.toLocaleString()}
+          tone={stats.offline > 0 ? 'negative' : 'default'}
+          icon={<WifiOff className="size-4" />}
+        />
+        <StatCard
+          label="Firing alerts"
+          value={stats.hostsWithFiringAlerts.toLocaleString()}
+          tone={stats.hostsWithFiringAlerts > 0 ? 'negative' : 'default'}
+          icon={<BellRing className="size-4" />}
+          hint={stats.hostsWithFiringAlerts > 0 ? 'hosts with active alerts' : undefined}
+        />
+        <StatCard
+          label={`Stale (> ${HOST_STALE_MINUTES}m)`}
+          value={stats.staleHosts.toLocaleString()}
+          tone={stats.staleHosts > 0 ? 'warning' : 'default'}
+          icon={<TimerOff className="size-4" />}
+          hint="no recent heartbeat"
+        />
+        <StatCard
+          label="Pending approval"
+          value={stats.pending.toLocaleString()}
+          tone={stats.pending > 0 ? 'warning' : 'default'}
+          icon={<Clock className="size-4" />}
+        />
+      </div>
+
+      {/* ─── Resource hotspots + OS breakdown ──────────────────────────────── */}
+      <div className="grid gap-3 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm">Resource hotspots</CardTitle>
+            <CardDescription>
+              Hosts at or above {HOST_HIGH_USAGE_THRESHOLD}% utilisation right now
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="flex items-center gap-3 p-3 rounded-md border">
+                <Cpu className="size-5 text-amber-600" />
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">CPU</div>
+                  <div className="text-xl font-semibold">{stats.highCpu}</div>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 p-3 rounded-md border">
+                <MemoryStick className="size-5 text-amber-600" />
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Memory</div>
+                  <div className="text-xl font-semibold">{stats.highMemory}</div>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 p-3 rounded-md border">
+                <HardDrive className="size-5 text-amber-600" />
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Disk</div>
+                  <div className="text-xl font-semibold">{stats.highDisk}</div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm">Operating systems</CardTitle>
+            <CardDescription>
+              {stats.osBreakdown.length === 0
+                ? 'No host data yet'
+                : `${stats.osBreakdown.length} distinct OS${stats.osBreakdown.length !== 1 ? "es" : ''} in inventory`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {stats.osBreakdown.length === 0 ? (
+              <div className="text-sm text-muted-foreground">—</div>
+            ) : (
+              <ul className="space-y-2">
+                {topOsBreakdown.map((row) => {
+                  const pct = stats.total > 0 ? Math.round((row.count / stats.total) * 100) : 0
+                  return (
+                    <li key={row.os} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <button
+                          type="button"
+                          onClick={() => setOs(row.os === 'Unknown' ? 'all' : row.os)}
+                          className="text-left hover:underline underline-offset-2"
+                          title="Filter list by this OS"
+                        >
+                          {row.os}
+                        </button>
+                        <span className="text-muted-foreground tabular-nums">
+                          {row.count.toLocaleString()} <span className="text-xs">({pct}%)</span>
+                        </span>
+                      </div>
+                      <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full bg-primary"
+                          style={{ width: `${Math.max(pct, 2)}%` }}
+                        />
+                      </div>
+                    </li>
+                  )
+                })}
+                {extraOsCount > 0 && (
+                  <li className="text-xs text-muted-foreground pt-1">
+                    + {extraOsCount} other OS{extraOsCount !== 1 ? 'es' : ''} ({extraOsSum.toLocaleString()} hosts)
+                  </li>
+                )}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
       </div>
 
       {isAdmin && pendingAgents.length > 0 && (
@@ -214,80 +549,226 @@ export function HostsClient({
             <Server className="size-4 text-muted-foreground" />
             Host Inventory
           </CardTitle>
+          <CardDescription>
+            Search, filter and sort across the fleet. Showing paged results from the server.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          {hostsData.length === 0 ? (
+          {/* ─── Filter bar ────────────────────────────────────────────────── */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            <div className="relative flex-1 min-w-[220px] max-w-md">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+              <Input
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Search hostname, display name or IP…"
+                className="pl-9"
+              />
+            </div>
+            <Select value={status} onValueChange={(v) => setStatus(v as StatusFilter)}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                <SelectItem value="online">Online</SelectItem>
+                <SelectItem value="offline">Offline</SelectItem>
+                <SelectItem value="unknown">Unknown</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={os} onValueChange={setOs}>
+              <SelectTrigger className="w-44">
+                <SelectValue placeholder="OS" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All operating systems</SelectItem>
+                {osOptions.map((opt) => (
+                  <SelectItem key={opt} value={opt}>
+                    {opt}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={String(pageSize)}
+              onValueChange={(v) => setPageSize(Number(v))}
+            >
+              <SelectTrigger className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PAGE_SIZE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt} value={String(opt)}>
+                    {opt} / page
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {hasActiveFilters && (
+              <Button variant="ghost" size="sm" onClick={resetFilters} className="gap-1">
+                <X className="size-3.5" />
+                Clear filters
+              </Button>
+            )}
+          </div>
+
+          {/* ─── Table ─────────────────────────────────────────────────────── */}
+          {total === 0 ? (
             <div className="text-center py-12">
               <Server className="size-10 mx-auto text-muted-foreground/40 mb-3" />
-              <p className="text-muted-foreground font-medium">No hosts registered yet</p>
-              <p className="text-sm text-muted-foreground mt-1">
-                Deploy an agent to start monitoring your infrastructure.
-              </p>
-              {isAdmin && (
-                <p className="text-sm text-muted-foreground mt-2">
-                  Create an enrolment token in{' '}
-                  <a href="/settings/agents" className="text-primary underline underline-offset-2">
-                    Settings → Agents
-                  </a>{' '}
-                  to get started.
-                </p>
+              {hasActiveFilters ? (
+                <>
+                  <p className="text-muted-foreground font-medium">No hosts match your filters</p>
+                  <Button variant="link" onClick={resetFilters} className="mt-1">
+                    Clear filters
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <p className="text-muted-foreground font-medium">No hosts registered yet</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Deploy an agent to start monitoring your infrastructure.
+                  </p>
+                  {isAdmin && (
+                    <p className="text-sm text-muted-foreground mt-2">
+                      Create an enrolment token in{' '}
+                      <a
+                        href="/settings/agents"
+                        className="text-primary underline underline-offset-2"
+                      >
+                        Settings → Agents
+                      </a>{' '}
+                      to get started.
+                    </p>
+                  )}
+                </>
               )}
             </div>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Hostname</TableHead>
-                  <TableHead>OS</TableHead>
-                  <TableHead>IP Addresses</TableHead>
-                  <TableHead>CPU</TableHead>
-                  <TableHead>Memory</TableHead>
-                  <TableHead>Last Seen</TableHead>
-                  <TableHead>Alerts</TableHead>
-                  <TableHead>Status</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {hostsData.map((host) => (
-                  <TableRow key={host.id}>
-                    <TableCell className="font-medium">
-                      <Link
-                        href={`/hosts/${host.id}`}
-                        className="hover:underline text-foreground"
-                      >
-                        {host.displayName ?? host.hostname}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm">
-                      {host.os ?? '—'}
-                      {host.arch && (
-                        <span className="text-muted-foreground/60"> ({host.arch})</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {(host.ipAddresses ?? []).slice(0, 2).join(', ') || '—'}
-                    </TableCell>
-                    <TableCell className="text-sm">{formatPercent(host.cpuPercent)}</TableCell>
-                    <TableCell className="text-sm">{formatPercent(host.memoryPercent)}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {formatHeartbeat(host.lastSeenAt)}
-                    </TableCell>
-                    <TableCell>
-                      {(alertCounts[host.id] ?? 0) > 0 ? (
-                        <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">
-                          {alertCounts[host.id]}
-                        </Badge>
-                      ) : (
-                        <span className="text-muted-foreground text-sm">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <StatusBadge status={host.status} />
-                    </TableCell>
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <SortableHeader field="hostname" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      Hostname
+                    </SortableHeader>
+                    <SortableHeader field="os" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      OS
+                    </SortableHeader>
+                    <TableHead>IP Addresses</TableHead>
+                    <SortableHeader field="cpuPercent" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      CPU
+                    </SortableHeader>
+                    <SortableHeader field="memoryPercent" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      Memory
+                    </SortableHeader>
+                    <SortableHeader field="diskPercent" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      Disk
+                    </SortableHeader>
+                    <SortableHeader field="lastSeenAt" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      Last Seen
+                    </SortableHeader>
+                    <TableHead>Alerts</TableHead>
+                    <SortableHeader field="status" current={sortBy} dir={sortDir} onSort={handleSort}>
+                      Status
+                    </SortableHeader>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {hostRows.map((host) => (
+                    <TableRow key={host.id}>
+                      <TableCell className="font-medium">
+                        <Link
+                          href={`/hosts/${host.id}`}
+                          className="hover:underline text-foreground"
+                        >
+                          {host.displayName ?? host.hostname}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm">
+                        {host.os ?? '—'}
+                        {host.arch && (
+                          <span className="text-muted-foreground/60"> ({host.arch})</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {(host.ipAddresses ?? []).slice(0, 2).join(', ') || '—'}
+                      </TableCell>
+                      <TableCell className={`text-sm ${usageClass(host.cpuPercent)}`}>
+                        {formatPercent(host.cpuPercent)}
+                      </TableCell>
+                      <TableCell className={`text-sm ${usageClass(host.memoryPercent)}`}>
+                        {formatPercent(host.memoryPercent)}
+                      </TableCell>
+                      <TableCell className={`text-sm ${usageClass(host.diskPercent)}`}>
+                        {formatPercent(host.diskPercent)}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {formatHeartbeat(host.lastSeenAt)}
+                      </TableCell>
+                      <TableCell>
+                        {(alertCounts[host.id] ?? 0) > 0 ? (
+                          <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">
+                            {alertCounts[host.id]}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground text-sm">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <StatusBadge status={host.status} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              {/* ─── Pagination footer ───────────────────────────────────── */}
+              <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mt-4">
+                <div className="text-sm text-muted-foreground">
+                  Showing <span className="tabular-nums font-medium text-foreground">{rangeFrom.toLocaleString()}</span>–
+                  <span className="tabular-nums font-medium text-foreground">{rangeTo.toLocaleString()}</span>{' '}
+                  of <span className="tabular-nums font-medium text-foreground">{total.toLocaleString()}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage(0)}
+                    disabled={page === 0}
+                  >
+                    First
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0}
+                  >
+                    Previous
+                  </Button>
+                  <span className="text-sm text-muted-foreground px-2 tabular-nums">
+                    Page {page + 1} of {pageCount}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                    disabled={page + 1 >= pageCount}
+                  >
+                    Next
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage(pageCount - 1)}
+                    disabled={page + 1 >= pageCount}
+                  >
+                    Last
+                  </Button>
+                </div>
+              </div>
+            </>
           )}
         </CardContent>
       </Card>

--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -220,18 +220,39 @@ export function HostsClient({
   const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE)
 
   // Debounce the search input so typing into the box does not spam the server.
+  // Timer lives in a ref so the setState pair (setSearch + setPage) runs from an
+  // event callback path rather than from inside an effect — the lint rule
+  // `react-hooks/set-state-in-effect` blocks the effect variant.
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearch(searchInput.trim())
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+    }
+  }, [])
+
+  function handleSearchChange(value: string) {
+    setSearchInput(value)
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+    searchTimerRef.current = setTimeout(() => {
+      setSearch(value.trim())
       setPage(0)
     }, 250)
-    return () => clearTimeout(timer)
-  }, [searchInput])
+  }
 
-  // Any filter change resets to the first page.
-  useEffect(() => {
+  // Any filter change resets to the first page — done inline in the handler to
+  // keep the state transition out of an effect.
+  function handleStatusChange(value: StatusFilter) {
+    setStatus(value)
     setPage(0)
-  }, [status, os, pageSize])
+  }
+  function handleOsChange(value: string) {
+    setOs(value)
+    setPage(0)
+  }
+  function handlePageSizeChange(value: number) {
+    setPageSize(value)
+    setPage(0)
+  }
 
   const queryParams = useMemo(
     () => ({
@@ -449,7 +470,7 @@ export function HostsClient({
                       <div className="flex items-center justify-between text-sm">
                         <button
                           type="button"
-                          onClick={() => setOs(row.os === 'Unknown' ? 'all' : row.os)}
+                          onClick={() => handleOsChange(row.os === 'Unknown' ? 'all' : row.os)}
                           className="text-left hover:underline underline-offset-2"
                           title="Filter list by this OS"
                         >
@@ -560,12 +581,12 @@ export function HostsClient({
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
               <Input
                 value={searchInput}
-                onChange={(e) => setSearchInput(e.target.value)}
+                onChange={(e) => handleSearchChange(e.target.value)}
                 placeholder="Search hostname, display name or IP…"
                 className="pl-9"
               />
             </div>
-            <Select value={status} onValueChange={(v) => setStatus(v as StatusFilter)}>
+            <Select value={status} onValueChange={(v) => handleStatusChange(v as StatusFilter)}>
               <SelectTrigger className="w-40">
                 <SelectValue placeholder="Status" />
               </SelectTrigger>
@@ -576,7 +597,7 @@ export function HostsClient({
                 <SelectItem value="unknown">Unknown</SelectItem>
               </SelectContent>
             </Select>
-            <Select value={os} onValueChange={setOs}>
+            <Select value={os} onValueChange={handleOsChange}>
               <SelectTrigger className="w-44">
                 <SelectValue placeholder="OS" />
               </SelectTrigger>
@@ -591,7 +612,7 @@ export function HostsClient({
             </Select>
             <Select
               value={String(pageSize)}
-              onValueChange={(v) => setPageSize(Number(v))}
+              onValueChange={(v) => handlePageSizeChange(Number(v))}
             >
               <SelectTrigger className="w-32">
                 <SelectValue />

--- a/apps/web/app/(dashboard)/hosts/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
-import { listHosts, listPendingAgents } from '@/lib/actions/agents'
+import {
+  listHostsPaginated,
+  listPendingAgents,
+  listDistinctHostOses,
+  getHostInventoryStats,
+} from '@/lib/actions/agents'
 import { HostsClient } from './hosts-client'
 
 export const metadata: Metadata = {
@@ -11,9 +16,11 @@ export default async function HostsPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
 
-  const [hostsWithAgents, pendingAgents] = await Promise.all([
-    listHosts(orgId),
+  const [hostPage, pendingAgents, stats, osOptions] = await Promise.all([
+    listHostsPaginated(orgId, { limit: 50, offset: 0, sortBy: 'hostname', sortDir: 'asc' }),
     listPendingAgents(orgId),
+    getHostInventoryStats(orgId),
+    listDistinctHostOses(orgId),
   ])
 
   return (
@@ -21,7 +28,9 @@ export default async function HostsPage() {
       orgId={orgId}
       currentUserId={session.user.id}
       currentUserRole={session.user.role}
-      initialHosts={hostsWithAgents}
+      initialHostPage={hostPage}
+      initialStats={stats}
+      initialOsOptions={osOptions}
       initialPendingAgents={pendingAgents}
     />
   )

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -28,9 +28,11 @@ import {
   softwarePackages,
   softwareScans,
 } from '@/lib/db/schema'
-import { eq, and, isNull, gt, gte, lte, asc, sql, inArray } from 'drizzle-orm'
+import { eq, and, isNull, gt, gte, lte, asc, desc, sql, inArray, ilike, or, count } from 'drizzle-orm'
 import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
+import { HOST_HIGH_USAGE_THRESHOLD, HOST_STALE_MINUTES } from '@/lib/db/schema/hosts'
 import { applyGlobalDefaultsToHost } from '@/lib/actions/alerts'
+import { escapeLikePattern } from '@/lib/utils'
 import { getOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
 import { triggerAgentUninstall, getTaskRun } from '@/lib/actions/task-runs'
 import { assignTagsToResource, getOrgDefaultTags, mergeTagLayers } from '@/lib/actions/tags'
@@ -237,6 +239,209 @@ export async function listHosts(orgId: string): Promise<HostWithAgent[]> {
     ...row.hosts,
     agent: row.agents ?? null,
   }))
+}
+
+// ─── Paginated host inventory + stats (hosts page) ───────────────────────────
+//
+// listHosts above returns every host in one shot. It is used by features that
+// genuinely need the whole set (network graph, terminal host picker, bulk-tag,
+// group membership). The main /hosts page instead uses the paginated variant
+// below so that a tenant with thousands of hosts does not ship every row to
+// the browser on first paint.
+
+export type HostSortField =
+  | 'hostname'
+  | 'os'
+  | 'status'
+  | 'cpuPercent'
+  | 'memoryPercent'
+  | 'diskPercent'
+  | 'lastSeenAt'
+
+export type HostSortDir = 'asc' | 'desc'
+
+export interface HostListParams {
+  search?: string
+  status?: 'online' | 'offline' | 'unknown'
+  os?: string
+  sortBy?: HostSortField
+  sortDir?: HostSortDir
+  limit?: number
+  offset?: number
+}
+
+export interface HostListResult {
+  hosts: HostWithAgent[]
+  total: number
+}
+
+const HOST_PAGE_MAX = 200
+
+export async function listHostsPaginated(
+  orgId: string,
+  params: HostListParams = {},
+): Promise<HostListResult> {
+  const limit = Math.max(1, Math.min(params.limit ?? 50, HOST_PAGE_MAX))
+  const offset = Math.max(0, params.offset ?? 0)
+  const sortBy: HostSortField = params.sortBy ?? 'hostname'
+  const sortDir: HostSortDir = params.sortDir ?? 'asc'
+
+  const conditions = [eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)]
+
+  if (params.status) {
+    conditions.push(eq(hosts.status, params.status))
+  }
+  if (params.os) {
+    conditions.push(eq(hosts.os, params.os))
+  }
+  if (params.search && params.search.trim().length > 0) {
+    const pattern = `%${escapeLikePattern(params.search.trim())}%`
+    // Cast the ip_addresses jsonb column to text so an ILIKE pattern still
+    // matches substrings inside the serialised array.
+    const searchClause = or(
+      ilike(hosts.hostname, pattern),
+      ilike(hosts.displayName, pattern),
+      sql`${hosts.ipAddresses}::text ILIKE ${pattern}`,
+    )
+    if (searchClause) conditions.push(searchClause)
+  }
+
+  const columnMap = {
+    hostname: hosts.hostname,
+    os: hosts.os,
+    status: hosts.status,
+    cpuPercent: hosts.cpuPercent,
+    memoryPercent: hosts.memoryPercent,
+    diskPercent: hosts.diskPercent,
+    lastSeenAt: hosts.lastSeenAt,
+  } as const
+  const sortColumn = columnMap[sortBy]
+
+  // Push NULLs to the end regardless of direction — otherwise a DESC sort on a
+  // mostly-empty column (e.g. diskPercent before first scrape) surfaces a wall
+  // of "—" before any real data.
+  const orderExpr =
+    sortDir === 'desc'
+      ? sql`${sortColumn} DESC NULLS LAST`
+      : sql`${sortColumn} ASC NULLS LAST`
+
+  const whereExpr = and(...conditions)
+
+  const [rows, totalRow] = await Promise.all([
+    db
+      .select()
+      .from(hosts)
+      .leftJoin(agents, eq(hosts.agentId, agents.id))
+      .where(whereExpr)
+      .orderBy(orderExpr, asc(hosts.hostname))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ c: count() })
+      .from(hosts)
+      .where(whereExpr),
+  ])
+
+  return {
+    hosts: rows.map((row) => ({
+      ...row.hosts,
+      agent: row.agents ?? null,
+    })),
+    total: Number(totalRow[0]?.c ?? 0),
+  }
+}
+
+export interface HostInventoryStats {
+  total: number
+  online: number
+  offline: number
+  unknown: number
+  pending: number
+  staleHosts: number
+  highCpu: number
+  highMemory: number
+  highDisk: number
+  hostsWithFiringAlerts: number
+  osBreakdown: Array<{ os: string; count: number }>
+}
+
+export async function getHostInventoryStats(orgId: string): Promise<HostInventoryStats> {
+  const baseWhere = and(eq(hosts.organisationId, orgId), isNull(hosts.deletedAt))
+  const threshold = HOST_HIGH_USAGE_THRESHOLD
+  const staleCutoff = new Date(Date.now() - HOST_STALE_MINUTES * 60 * 1000)
+
+  const [summary, osRows, pendingRow, alertHostRow] = await Promise.all([
+    db
+      .select({
+        total: count(),
+        online: sql<number>`cast(count(*) filter (where ${hosts.status} = 'online') as int)`,
+        offline: sql<number>`cast(count(*) filter (where ${hosts.status} = 'offline') as int)`,
+        unknown: sql<number>`cast(count(*) filter (where ${hosts.status} NOT IN ('online','offline')) as int)`,
+        highCpu: sql<number>`cast(count(*) filter (where ${hosts.cpuPercent} >= ${threshold}) as int)`,
+        highMemory: sql<number>`cast(count(*) filter (where ${hosts.memoryPercent} >= ${threshold}) as int)`,
+        highDisk: sql<number>`cast(count(*) filter (where ${hosts.diskPercent} >= ${threshold}) as int)`,
+        stale: sql<number>`cast(count(*) filter (where ${hosts.lastSeenAt} IS NULL OR ${hosts.lastSeenAt} < ${staleCutoff.toISOString()}) as int)`,
+      })
+      .from(hosts)
+      .where(baseWhere),
+    db
+      .select({
+        os: hosts.os,
+        c: count(),
+      })
+      .from(hosts)
+      .where(baseWhere)
+      .groupBy(hosts.os)
+      .orderBy(desc(count())),
+    db
+      .select({ c: count() })
+      .from(agents)
+      .where(
+        and(
+          eq(agents.organisationId, orgId),
+          eq(agents.status, 'pending'),
+          isNull(agents.deletedAt),
+        ),
+      ),
+    db
+      .select({
+        c: sql<number>`cast(count(distinct ${alertInstances.hostId}) as int)`,
+      })
+      .from(alertInstances)
+      .where(
+        and(
+          eq(alertInstances.organisationId, orgId),
+          eq(alertInstances.status, 'firing'),
+        ),
+      ),
+  ])
+
+  const row = summary[0]
+  return {
+    total: Number(row?.total ?? 0),
+    online: Number(row?.online ?? 0),
+    offline: Number(row?.offline ?? 0),
+    unknown: Number(row?.unknown ?? 0),
+    pending: Number(pendingRow[0]?.c ?? 0),
+    staleHosts: Number(row?.stale ?? 0),
+    highCpu: Number(row?.highCpu ?? 0),
+    highMemory: Number(row?.highMemory ?? 0),
+    highDisk: Number(row?.highDisk ?? 0),
+    hostsWithFiringAlerts: Number(alertHostRow[0]?.c ?? 0),
+    osBreakdown: osRows.map((r) => ({
+      os: r.os ?? 'Unknown',
+      count: Number(r.c),
+    })),
+  }
+}
+
+export async function listDistinctHostOses(orgId: string): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ os: hosts.os })
+    .from(hosts)
+    .where(and(eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)))
+    .orderBy(asc(hosts.os))
+  return rows.map((r) => r.os).filter((v): v is string => v !== null && v !== '')
 }
 
 export async function createEnrolmentToken(

--- a/apps/web/lib/db/schema/hosts.ts
+++ b/apps/web/lib/db/schema/hosts.ts
@@ -38,6 +38,12 @@ export const DEFAULT_COLLECTION_SETTINGS: HostCollectionSettings = {
   localUsers: false,
 }
 
+// Operational thresholds shared between host stats queries (server) and the
+// host inventory UI (client). Bumping these means the "hot" resource cards and
+// the SQL filter that counts them stay in agreement.
+export const HOST_HIGH_USAGE_THRESHOLD = 80
+export const HOST_STALE_MINUTES = 15
+
 export interface HostMetadata {
   disks: DiskInfo[]
   network_interfaces: NetworkInterface[]


### PR DESCRIPTION
## Summary
- Replace the full-fleet hosts page load with a server-side paged, searchable, sortable, filterable list — a 2000-host load test was shipping every row to the browser on first paint.
- Add a fleet overview at the top of the page: total, online, offline, firing alerts, stale (> 15m), pending approval, plus resource hotspots (CPU/mem/disk ≥ 80%) and an OS breakdown that doubles as an OS filter.
- Keep the existing `listHosts()` server action untouched so the network graph, terminal picker, group management and alerts page continue to see the whole inventory.

## Test plan
- [ ] Load the hosts page with 2000 hosts — verify first paint ships ~50 rows, not 2000
- [ ] Type in the search box — verify debounced ILIKE match on hostname, display name and IP works and resets to page 1
- [ ] Change status / OS filters — verify they reset to page 1 and narrow results correctly
- [ ] Click sortable column headers — verify toggle ascending/descending and that `NULL` metrics sort to the end in both directions
- [ ] Change page size (25 / 50 / 100 / 200) — verify pagination footer updates
- [ ] Verify the fleet overview numbers match a hand-count of a small test org
- [ ] Click an OS row in the overview — verify it applies the OS filter to the table
- [ ] Admin user: verify the pending-agent approval panel still renders and approve/reject still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)