### PR TITLE
feat(web): add Cmd+K command palette scaffold

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/shared/sidebar'
 import { Topbar } from '@/components/shared/topbar'
+import { CommandPaletteProvider } from '@/components/shared/command-palette'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getEffectiveLicence } from '@/lib/actions/licence-guard'
 import { TerminalProviderWrapper, TerminalContentWrapper } from '@/components/terminal/terminal-layout-wrapper'
@@ -25,14 +26,16 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const licence = await getEffectiveLicence(orgId)
 
   return (
-    <TerminalProviderWrapper>
-      <SidebarProvider className="h-svh overflow-hidden">
-        <AppSidebar orgId={orgId} tier={licence.tier} />
-        <TerminalContentWrapper orgId={orgId}>
-          <Topbar orgId={orgId} />
-          <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>
-        </TerminalContentWrapper>
-      </SidebarProvider>
-    </TerminalProviderWrapper>
+    <CommandPaletteProvider orgId={orgId}>
+      <TerminalProviderWrapper>
+        <SidebarProvider className="h-svh overflow-hidden">
+          <AppSidebar orgId={orgId} tier={licence.tier} />
+          <TerminalContentWrapper orgId={orgId}>
+            <Topbar orgId={orgId} />
+            <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>
+          </TerminalContentWrapper>
+        </SidebarProvider>
+      </TerminalProviderWrapper>
+    </CommandPaletteProvider>
   )
 }

--- a/apps/web/components/shared/command-palette/command-palette.tsx
+++ b/apps/web/components/shared/command-palette/command-palette.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command'
+import { useNavigationItems, useHostItems } from './providers'
+import type { CommandPaletteGroup, CommandPaletteItem } from './types'
+
+const RECENTS_STORAGE_KEY = 'infrawatch.command-palette.recents'
+const MAX_RECENTS = 5
+
+interface CommandPaletteContextValue {
+  open: () => void
+  close: () => void
+  toggle: () => void
+  isOpen: boolean
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(null)
+
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext)
+  if (!ctx) {
+    throw new Error('useCommandPalette must be used inside <CommandPaletteProvider>')
+  }
+  return ctx
+}
+
+function readRecents(): string[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(RECENTS_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((x): x is string => typeof x === 'string').slice(0, MAX_RECENTS)
+  } catch {
+    return []
+  }
+}
+
+function writeRecents(ids: string[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(RECENTS_STORAGE_KEY, JSON.stringify(ids.slice(0, MAX_RECENTS)))
+  } catch {
+    // ignore quota or serialisation errors
+  }
+}
+
+interface CommandPaletteProviderProps {
+  orgId: string
+  children: React.ReactNode
+}
+
+export function CommandPaletteProvider({ orgId, children }: CommandPaletteProviderProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const isPaletteCombo =
+        event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey
+      if (isPaletteCombo) {
+        event.preventDefault()
+        setIsOpen((prev) => !prev)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  const value = useMemo<CommandPaletteContextValue>(
+    () => ({ isOpen, open, close, toggle }),
+    [isOpen, open, close, toggle],
+  )
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+      <CommandPaletteDialog orgId={orgId} isOpen={isOpen} onOpenChange={setIsOpen} />
+    </CommandPaletteContext.Provider>
+  )
+}
+
+interface CommandPaletteDialogProps {
+  orgId: string
+  isOpen: boolean
+  onOpenChange: (next: boolean) => void
+}
+
+function CommandPaletteDialog({ orgId, isOpen, onOpenChange }: CommandPaletteDialogProps) {
+  const router = useRouter()
+  const navItems = useNavigationItems()
+  const hostItems = useHostItems(orgId, isOpen)
+
+  const allItems = useMemo(() => [...navItems, ...hostItems], [navItems, hostItems])
+
+  const groups = useMemo<CommandPaletteGroup[]>(() => {
+    const groupMap = new Map<string, CommandPaletteItem[]>()
+    for (const item of allItems) {
+      const list = groupMap.get(item.group) ?? []
+      list.push(item)
+      groupMap.set(item.group, list)
+    }
+    return Array.from(groupMap.entries()).map(([heading, items]) => ({ heading, items }))
+  }, [allItems])
+
+  const recentItems = useMemo<CommandPaletteItem[]>(() => {
+    if (!isOpen) return []
+    const ids = readRecents()
+    if (ids.length === 0) return []
+    const byId = new Map(allItems.map((item) => [item.id, item]))
+    return ids
+      .map((id) => byId.get(id))
+      .filter((item): item is CommandPaletteItem => item !== undefined)
+  }, [isOpen, allItems])
+
+  const handleSelect = useCallback(
+    (item: CommandPaletteItem) => {
+      const current = readRecents()
+      const next = [item.id, ...current.filter((id) => id !== item.id)].slice(0, MAX_RECENTS)
+      writeRecents(next)
+      onOpenChange(false)
+      if (item.onSelect) {
+        item.onSelect()
+      } else if (item.href) {
+        router.push(item.href)
+      }
+    },
+    [onOpenChange, router],
+  )
+
+  return (
+    <CommandDialog open={isOpen} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Search hosts, navigate, run commands…" />
+      <CommandList>
+        <CommandEmpty>No matches.</CommandEmpty>
+        {recentItems.length > 0 && (
+          <>
+            <CommandGroup heading="Recent">
+              {recentItems.map((item) => (
+                <PaletteRow key={`recent-${item.id}`} item={item} onSelect={handleSelect} />
+              ))}
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
+        {groups.map((group) => (
+          <CommandGroup key={group.heading} heading={group.heading}>
+            {group.items.map((item) => (
+              <PaletteRow key={item.id} item={item} onSelect={handleSelect} />
+            ))}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  )
+}
+
+interface PaletteRowProps {
+  item: CommandPaletteItem
+  onSelect: (item: CommandPaletteItem) => void
+}
+
+function PaletteRow({ item, onSelect }: PaletteRowProps) {
+  const Icon = item.icon
+  const searchValue = [item.label, item.description, ...(item.keywords ?? [])]
+    .filter((x): x is string => typeof x === 'string' && x.length > 0)
+    .join(' ')
+  return (
+    <CommandItem value={searchValue} onSelect={() => onSelect(item)}>
+      {Icon ? <Icon className="size-4 text-muted-foreground" /> : null}
+      <div className="flex flex-col">
+        <span className="text-sm text-foreground">{item.label}</span>
+        {item.description ? (
+          <span className="text-xs text-muted-foreground">{item.description}</span>
+        ) : null}
+      </div>
+    </CommandItem>
+  )
+}

--- a/apps/web/components/shared/command-palette/index.ts
+++ b/apps/web/components/shared/command-palette/index.ts
@@ -1,0 +1,3 @@
+export { CommandPaletteProvider, useCommandPalette } from './command-palette'
+export { CommandPaletteTrigger } from './trigger'
+export type { CommandPaletteItem, CommandPaletteGroup } from './types'

--- a/apps/web/components/shared/command-palette/providers.tsx
+++ b/apps/web/components/shared/command-palette/providers.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  Activity,
+  BarChart3,
+  Bell,
+  BellPlus,
+  BookOpen,
+  FileBarChart,
+  FolderSearch,
+  HeartPulse,
+  Key,
+  Layers,
+  Network,
+  Package,
+  ScanSearch,
+  Server,
+  Settings,
+  ShieldCheck,
+  Users,
+} from 'lucide-react'
+import { listHosts } from '@/lib/actions/agents'
+import type { CommandPaletteItem } from './types'
+
+const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
+  { id: 'nav-dashboard', label: 'Overview', icon: BarChart3, href: '/dashboard', keywords: ['home', 'start'] },
+  { id: 'nav-hosts', label: 'Hosts', icon: Server, href: '/hosts', keywords: ['servers', 'machines'] },
+  { id: 'nav-host-groups', label: 'Host Groups', icon: Layers, href: '/hosts/groups' },
+  { id: 'nav-networks', label: 'Networks', icon: Network, href: '/hosts/networks' },
+  { id: 'nav-alerts', label: 'Checks & Alerts', icon: Bell, href: '/alerts', keywords: ['monitors', 'checks'] },
+  { id: 'nav-notifications', label: 'Notifications', icon: BellPlus, href: '/notifications' },
+  { id: 'nav-certificates', label: 'Certificates', icon: ShieldCheck, href: '/certificates', keywords: ['ssl', 'tls', 'certs'] },
+  { id: 'nav-service-accounts', label: 'Service Accounts', icon: Key, href: '/service-accounts' },
+  { id: 'nav-reports', label: 'Reports', icon: FileBarChart, href: '/reports' },
+  { id: 'nav-reports-software', label: 'Installed Software Report', icon: Package, href: '/reports/software' },
+  { id: 'nav-cert-checker', label: 'SSL Certificate Checker', icon: ScanSearch, href: '/certificate-checker' },
+  { id: 'nav-dir-lookup', label: 'Directory User Lookup', icon: FolderSearch, href: '/directory-lookup' },
+  { id: 'nav-bundlers', label: 'Air-gap Bundlers', icon: Package, href: '/bundlers' },
+  { id: 'nav-runbooks', label: 'Runbooks', icon: BookOpen, href: '/runbooks' },
+  { id: 'nav-tasks', label: 'Scheduled Tasks', icon: Activity, href: '/tasks' },
+  { id: 'nav-team', label: 'Team', icon: Users, href: '/team' },
+  { id: 'nav-settings', label: 'Settings', icon: Settings, href: '/settings' },
+  { id: 'nav-agent-enrolment', label: 'Agent Enrolment', icon: Server, href: '/settings/agents' },
+  { id: 'nav-alert-defaults', label: 'Alert Defaults', icon: BellPlus, href: '/settings/alerts' },
+  { id: 'nav-ldap', label: 'LDAP / Directory', icon: Key, href: '/settings/ldap' },
+  { id: 'nav-system-health', label: 'System Health', icon: HeartPulse, href: '/settings/system' },
+]
+
+export function useNavigationItems(): CommandPaletteItem[] {
+  return useMemo(
+    () => NAV_ITEMS.map((item) => ({ ...item, group: 'Navigation' })),
+    [],
+  )
+}
+
+export function useHostItems(orgId: string, enabled: boolean): CommandPaletteItem[] {
+  const { data } = useQuery({
+    queryKey: ['command-palette', 'hosts', orgId],
+    queryFn: () => listHosts(orgId),
+    enabled,
+    staleTime: 30_000,
+  })
+
+  return useMemo(() => {
+    if (!data) return []
+    return data.map((host) => {
+      const ips = Array.isArray(host.ipAddresses) ? host.ipAddresses : []
+      const displayName = host.displayName ?? host.hostname
+      const description = [host.hostname !== displayName ? host.hostname : null, host.os, ips[0]]
+        .filter(Boolean)
+        .join(' · ')
+      return {
+        id: `host-${host.id}`,
+        label: displayName,
+        description: description || undefined,
+        icon: Server,
+        group: 'Hosts',
+        keywords: [host.hostname, ...ips],
+        href: `/hosts/${host.id}`,
+      }
+    })
+  }, [data])
+}

--- a/apps/web/components/shared/command-palette/trigger.tsx
+++ b/apps/web/components/shared/command-palette/trigger.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useCommandPalette } from './command-palette'
+
+function subscribePlatform(): () => void {
+  return () => {}
+}
+
+function getIsMac(): boolean {
+  return /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+}
+
+function getServerIsMac(): null {
+  return null
+}
+
+export function CommandPaletteTrigger() {
+  const { open } = useCommandPalette()
+  const isMac = useSyncExternalStore(subscribePlatform, getIsMac, getServerIsMac)
+
+  const shortcutLabel = isMac === null ? '' : isMac ? '⌘K' : 'Ctrl K'
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={open}
+      className="hidden h-8 gap-2 px-2 text-muted-foreground sm:inline-flex"
+      aria-label="Open command palette"
+    >
+      <Search className="size-4" />
+      <span className="text-xs">Search</span>
+      {shortcutLabel ? (
+        <kbd className="ml-1 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+          {shortcutLabel}
+        </kbd>
+      ) : null}
+    </Button>
+  )
+}

--- a/apps/web/components/shared/command-palette/types.ts
+++ b/apps/web/components/shared/command-palette/types.ts
@@ -1,0 +1,17 @@
+import type { LucideIcon } from 'lucide-react'
+
+export interface CommandPaletteItem {
+  id: string
+  label: string
+  description?: string
+  keywords?: string[]
+  icon?: LucideIcon
+  group: string
+  href?: string
+  onSelect?: () => void
+}
+
+export interface CommandPaletteGroup {
+  heading: string
+  items: CommandPaletteItem[]
+}

--- a/apps/web/components/shared/topbar.tsx
+++ b/apps/web/components/shared/topbar.tsx
@@ -15,6 +15,7 @@ import {
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { LogOut, User } from 'lucide-react'
 import { NotificationBell } from './notification-bell'
+import { CommandPaletteTrigger } from './command-palette'
 
 function getInitials(name: string): string {
   return name
@@ -45,6 +46,7 @@ export function Topbar({ orgId }: TopbarProps) {
     <header className="flex h-14 items-center gap-3 border-b bg-background px-4">
       <SidebarTrigger />
       <div className="flex-1" />
+      <CommandPaletteTrigger />
       {userId && orgId && (
         <NotificationBell orgId={orgId} userId={userId} />
       )}


### PR DESCRIPTION
## Summary
- Add a global **Cmd/Ctrl+K** command palette mounted in the dashboard layout
- Ship with two built-in providers: **Navigation** (all sidebar entries) and **Hosts** (searchable by hostname, display name, IP)
- Surface a "Search" trigger button in the topbar with a platform-aware shortcut label (`⌘K` on macOS, `Ctrl K` elsewhere)
- localStorage-backed **Recents** group showing the last 5 selections when the palette opens
- Extensible shape: `CommandPaletteItem` + provider hooks — future features (shared host notes, alerts, certificates, etc.) add items by contributing a provider hook to `command-palette.tsx`, no shell changes required

## Why
Prerequisite for the shared host notes feature so the notes provider has a home on day one. Splitting the palette into its own PR keeps the infrastructure (keyboard shortcut, dialog, recents, provider registry) separate from the domain feature — matches the "one feature per branch" convention.

## Where it lives
```
apps/web/components/shared/command-palette/
  command-palette.tsx   # Context + dialog + Cmd+K hotkey + recents
  providers.tsx         # useNavigationItems, useHostItems
  trigger.tsx           # Topbar button
  types.ts              # CommandPaletteItem shape
  index.ts
```

Wired into `apps/web/app/(dashboard)/layout.tsx` (provider) and `apps/web/components/shared/topbar.tsx` (trigger).

## Test plan
- [ ] Load any dashboard page — `⌘K` / `Ctrl+K` opens the palette
- [ ] Topbar "Search" button opens the same palette
- [ ] Type a hostname fragment — host rows filter and clicking navigates to `/hosts/[id]`
- [ ] Type a nav target (e.g. "alerts", "certs") — navigation entry filters and navigates
- [ ] Close and reopen — previous selection appears under **Recent**
- [ ] Open across browser tabs — Recents are shared (same localStorage key)
- [ ] Verify `pnpm run lint` and `pnpm exec tsc --noEmit` are clean (both confirmed locally)

## Not in this PR
- Notes provider — lands with the shared host notes feature PRs
- Global full-text search across notes/alerts — waits for the notes data layer