### PR TITLE
[L-07] Centralise role constants in lib/auth/roles.ts

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/page.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/page.tsx
@@ -3,12 +3,11 @@ import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getLdapConfigurations } from '@/lib/actions/ldap'
 import { LdapSettingsClient } from './ldap-client'
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 export const metadata: Metadata = {
   title: 'LDAP / Directory Settings',
 }
-
-const ADMIN_ROLES = ['org_admin', 'super_admin']
 
 export default async function LdapSettingsPage() {
   const session = await getRequiredSession()

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -6,12 +6,10 @@ import { eq, and, isNull, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { getRequiredSession } from '@/lib/auth/session'
 import type { Network, Host } from '@/lib/db/schema'
+import { ADMIN_ROLES, MEMBERSHIP_ROLES } from '@/lib/auth/roles'
 
 export type NetworkWithCount = Network & { hostCount: number }
 export type NetworkWithMembership = Network & { autoAssigned: boolean }
-
-const ADMIN_ROLES = ['org_admin', 'super_admin']
-const MEMBERSHIP_ROLES = ['org_admin', 'super_admin', 'engineer']
 
 const networkSchema = z.object({
   name: z.string().min(1).max(100),

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -44,7 +44,7 @@ export async function updateOrgNotificationSettings(
 ): Promise<{ success: true } | { error: string }> {
   const session = await getRequiredSession()
 
-  if (!ADMIN_ROLES.includes(session.user.role as (typeof ADMIN_ROLES)[number])) {
+  if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to update notification settings' }
   }
 

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -6,10 +6,7 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import type { OrgMetadata, OrgNotificationSettings } from '@/lib/db/schema/organisations'
 import { getRequiredSession } from '@/lib/auth/session'
-
-const ADMIN_ROLES = ['org_admin', 'super_admin'] as const
-
-const DEFAULT_ROLES = ['super_admin', 'org_admin', 'engineer']
+import { ADMIN_ROLES, DEFAULT_NOTIFICATION_ROLES } from '@/lib/auth/roles'
 
 const updateOrgNotificationSettingsSchema = z.object({
   inAppEnabled: z.boolean(),
@@ -36,7 +33,7 @@ export async function getOrgNotificationSettings(
   const ns = meta.notificationSettings ?? {}
   return {
     inAppEnabled: ns.inAppEnabled !== false,
-    inAppRoles: ns.inAppRoles ?? DEFAULT_ROLES,
+    inAppRoles: ns.inAppRoles ?? [...DEFAULT_NOTIFICATION_ROLES],
     allowUserOptOut: ns.allowUserOptOut !== false,
   }
 }

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -8,8 +8,7 @@ import { validateLicenceKey } from '@/lib/licence'
 import { getRequiredSession } from '@/lib/auth/session'
 import { hasLicenceFeature } from '@/lib/actions/licence-guard'
 import { COMMUNITY_MAX_RETENTION_DAYS } from '@/lib/features'
-
-const ADMIN_ROLES = ['org_admin', 'super_admin']
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 const updateOrgNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -24,8 +24,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { requireFeature } from '@/lib/actions/licence-guard'
 import { escapeLikePattern } from '@/lib/utils'
 import { compareVersions } from '@/lib/version-compare'
-
-const ADMIN_ROLES = ['org_admin', 'super_admin']
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 // ── Settings ──────────────────────────────────────────────────────────────────
 

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -6,8 +6,7 @@ import { eq, and, isNull } from 'drizzle-orm'
 import { createId } from '@paralleldrive/cuid2'
 import { getRequiredSession } from '@/lib/auth/session'
 import type { OrgMetadata, HostMetadata } from '@/lib/db/schema'
-
-const ADMIN_ROLES = ['org_admin', 'super_admin']
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 export interface TerminalAccessResult {
   allowed: true

--- a/apps/web/lib/auth/note-permissions.ts
+++ b/apps/web/lib/auth/note-permissions.ts
@@ -1,7 +1,6 @@
 import type { SessionUser } from '@/lib/auth/session'
 import type { Note } from '@/lib/db/schema'
-
-const ADMIN_ROLES = ['org_admin', 'super_admin']
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 // v1 reachability is "same org". Tag-based RBAC does not yet exist in this
 // codebase — once it does, notes should inherit the same host-reachability

--- a/apps/web/lib/auth/roles.ts
+++ b/apps/web/lib/auth/roles.ts
@@ -1,8 +1,6 @@
-export const ADMIN_ROLES = ['org_admin', 'super_admin'] as const
+export type AdminRole = 'org_admin' | 'super_admin'
+export type MembershipRole = 'org_admin' | 'super_admin' | 'engineer'
 
-export const MEMBERSHIP_ROLES = ['org_admin', 'super_admin', 'engineer'] as const
-
-export const DEFAULT_NOTIFICATION_ROLES = ['super_admin', 'org_admin', 'engineer'] as const
-
-export type AdminRole = (typeof ADMIN_ROLES)[number]
-export type MembershipRole = (typeof MEMBERSHIP_ROLES)[number]
+export const ADMIN_ROLES: string[] = ['org_admin', 'super_admin']
+export const MEMBERSHIP_ROLES: string[] = ['org_admin', 'super_admin', 'engineer']
+export const DEFAULT_NOTIFICATION_ROLES: string[] = ['super_admin', 'org_admin', 'engineer']

--- a/apps/web/lib/auth/roles.ts
+++ b/apps/web/lib/auth/roles.ts
@@ -1,0 +1,8 @@
+export const ADMIN_ROLES = ['org_admin', 'super_admin'] as const
+
+export const MEMBERSHIP_ROLES = ['org_admin', 'super_admin', 'engineer'] as const
+
+export const DEFAULT_NOTIFICATION_ROLES = ['super_admin', 'org_admin', 'engineer'] as const
+
+export type AdminRole = (typeof ADMIN_ROLES)[number]
+export type MembershipRole = (typeof MEMBERSHIP_ROLES)[number]


### PR DESCRIPTION
## Summary

- Creates `apps/web/lib/auth/roles.ts` as the single source of truth for role constants
- Removes 7 duplicate `ADMIN_ROLES` definitions from `networks.ts`, `notification-settings.ts`, `terminal.ts`, `software-inventory.ts`, `settings.ts`, `note-permissions.ts`, and the LDAP settings page
- Also centralises `MEMBERSHIP_ROLES` (previously only in `networks.ts`) and `DEFAULT_NOTIFICATION_ROLES` (previously `DEFAULT_ROLES` in `notification-settings.ts`)

Closes #354

## Test plan

- [ ] Confirm no TypeScript errors (`pnpm run build` in `apps/web`)
- [ ] Verify LDAP settings page still redirects non-admins to `/settings`
- [ ] Verify network create/update/delete still enforces admin role
- [ ] Verify notification settings update still enforces admin role
- [ ] Verify terminal org/host settings still enforce admin role
- [ ] Verify software inventory schedule/scan still enforces admin role
- [ ] Verify org name / retention / licence key actions still enforce admin role

https://claude.ai/code/session_01RZ6qBYoyrUQ8qYMNpUKF82