### PR TITLE
fix(security): C-11 hardcoded dev licence key + C-12 sql.raw in metric retention

### DIFF
--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -12,10 +12,23 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `BETTER_AUTH_SECRET` | ✓ | — | Secret key for signing sessions (min 32 chars, keep private) |
 | `BETTER_AUTH_URL` | ✓ | — | Public URL of the web app (e.g. `https://ct-ops.corp.example.com`) |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | — | Same as `BETTER_AUTH_URL` | Comma-separated list of allowed origins for CORS |
+| `LICENCE_PUBLIC_KEY` | ✓ (prod) | dev key | RSA public key PEM for validating licence JWTs. **Required in production** — the server refuses to start without it. See below. |
 | `NEXT_PUBLIC_APP_URL` | — | — | Exposed to the browser — used for constructing absolute links |
 | `NODE_ENV` | — | `development` | Set to `production` in production |
 | `AGENT_DIST_DIR` | — | `/var/lib/ct-ops/agent-dist` | Directory where compiled agent binaries are stored for download |
 | `INGEST_WS_URL` | — | `ws://localhost:8080` | WebSocket URL of the ingest service (for real-time agent status) |
+
+### Licence public key
+
+CT-Ops validates licence JWTs using an RSA public key. In development this falls back to a built-in dev key. In **production** you must supply your own:
+
+```bash
+# Generate a key pair (keep the private key safe — it signs licence tokens)
+openssl genrsa -out licence-private.pem 2048
+openssl rsa -in licence-private.pem -pubout -out licence-public.pem
+```
+
+Set `LICENCE_PUBLIC_KEY` to the contents of `licence-public.pem`. The server will refuse to start in production if the variable is absent or still set to the development key.
 
 ### Example `.env.local` (development)
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -25,6 +25,17 @@ BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
 # LDAP_BASE_DN=dc=example,dc=com
 # LDAP_USER_SEARCH_FILTER=(uid={{username}})
 
+# --- Licensing ---
+# [SECURITY-CRITICAL] RSA public key (PEM) used to validate licence JWTs.
+# Required in production — the server refuses to start without it.
+# Generate your key pair with:
+#   openssl genrsa -out licence-private.pem 2048
+#   openssl rsa -in licence-private.pem -pubout -out licence-public.pem
+# Then set this variable to the contents of licence-public.pem (inline, with \n for newlines,
+# or use a Docker secret / secrets manager to inject the multi-line PEM value).
+# Never leave this unset or set to the development key in production.
+# LICENCE_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
+
 # --- Agent ---
 # Public-facing URL of this Infrawatch instance.
 # Used to build agent enrolment install commands and agent self-update URLs.

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -3,10 +3,17 @@
  *
  * Pre-warms the agent binary cache so every platform binary is available
  * immediately, even on a fresh server or after a new release ships.
+ * Also performs fail-fast validation of required environment variables so
+ * misconfigurations surface at boot rather than at first use.
  */
 export async function register() {
   // Only run in the Node.js runtime (not Edge), and only on the server.
   if (process.env.NEXT_RUNTIME !== 'nodejs') return
+
+  // Validate licence public key configuration — throws in production if missing
+  // or set to the development key, preventing forged licence acceptance.
+  const { resolveLicencePublicKeyPem } = await import('./lib/licence')
+  resolveLicencePublicKeyPem()
 
   const { prewarmAgentCache } = await import('./lib/agent/cache-prewarm')
   await prewarmAgentCache()

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -73,34 +73,24 @@ export async function updateMetricRetention(
       .where(eq(organisations.id, orgId))
 
     // Update TimescaleDB retention policies for both metric hypertables.
-    // Wrapped in a DO block so this silently degrades on plain PostgreSQL.
-    // Each policy call is in its own sub-block so one failure doesn't abort the other.
-    const days = parsed.data.days
-    await db.execute(sql`
-      DO $$
-      BEGIN
-        BEGIN
-          PERFORM drop_retention_policy('host_metrics', if_exists => true);
-        EXCEPTION WHEN OTHERS THEN
-          NULL;
-        END;
-        BEGIN
-          PERFORM add_retention_policy('host_metrics', INTERVAL '${sql.raw(String(days))} days', if_not_exists => true);
-        EXCEPTION WHEN OTHERS THEN
-          NULL;
-        END;
-        BEGIN
-          PERFORM drop_retention_policy('check_results', if_exists => true);
-        EXCEPTION WHEN OTHERS THEN
-          NULL;
-        END;
-        BEGIN
-          PERFORM add_retention_policy('check_results', INTERVAL '${sql.raw(String(days))} days', if_not_exists => true);
-        EXCEPTION WHEN OTHERS THEN
-          NULL;
-        END;
-      END $$;
-    `)
+    // Each statement is wrapped in its own try/catch so failures silently degrade
+    // on plain PostgreSQL (where these functions do not exist).
+    // make_interval(days => N) uses a proper query parameter — no sql.raw required.
+    const d = parsed.data.days
+    for (const table of ['host_metrics', 'check_results']) {
+      try {
+        await db.execute(sql`SELECT drop_retention_policy(${table}, if_exists => true)`)
+      } catch {
+        // TimescaleDB not available
+      }
+      try {
+        await db.execute(
+          sql`SELECT add_retention_policy(${table}, make_interval(days => ${d}), if_not_exists => true)`,
+        )
+      } catch {
+        // TimescaleDB not available
+      }
+    }
 
     return { success: true }
   } catch (err) {

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -1,8 +1,9 @@
 import { importSPKI, jwtVerify } from 'jose'
 import type { Feature, LicenceTier } from './features'
 
-// Dev public key (RS256) — replace with your production signing key before release.
-// The matching private key is in deploy/scripts/licence-dev-private.pem (never commit).
+// Dev-only public key (RS256) — used in development when LICENCE_PUBLIC_KEY is not set.
+// In production, set LICENCE_PUBLIC_KEY to your RSA public key PEM.
+// The matching private key lives in deploy/scripts/licence-dev-private.pem (never commit).
 const DEV_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Wep87Fxy2SUYnx8MLx2
 oVWA94ygeDMKfRQWm16Vdvc+fzpTQettcbMQN6AMe/SzFk0oipzs2wB//9DyoFhK
@@ -12,6 +13,40 @@ OcVgn3vrZ0RfExrMhelwZvgDoutHol9KhoqCQkSLxaL2eMC9NzYtCuESLCYOEiIS
 q6YFpCA6PtWXuwKYMfj9egw/d2KePf5YiBEBZJzLu1L57Fouf1fVWc7hr32BrL9N
 wQIDAQAB
 -----END PUBLIC KEY-----`
+
+/**
+ * Returns the RSA public key PEM to use for licence JWT verification.
+ *
+ * Resolution order:
+ *   1. LICENCE_PUBLIC_KEY env var (always preferred)
+ *   2. Dev key — only allowed when NODE_ENV !== 'production'
+ *
+ * Throws at startup in production if the env var is absent or still set to
+ * the development key, so misconfigured deployments fail fast rather than
+ * silently accepting forged licences.
+ */
+export function resolveLicencePublicKeyPem(): string {
+  const envKey = process.env.LICENCE_PUBLIC_KEY?.trim()
+
+  if (envKey) {
+    if (process.env.NODE_ENV === 'production' && envKey === DEV_PUBLIC_KEY_PEM.trim()) {
+      throw new Error(
+        'LICENCE_PUBLIC_KEY is set to the development key. ' +
+          'Set it to your production RSA public key PEM before deploying.',
+      )
+    }
+    return envKey
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'LICENCE_PUBLIC_KEY environment variable is required in production. ' +
+        'Set it to your RSA public key PEM (see docs/getting-started/configuration.md).',
+    )
+  }
+
+  return DEV_PUBLIC_KEY_PEM.trim()
+}
 
 const LICENCE_ISSUER = 'infrawatch-licensing'
 const LICENCE_AUDIENCE = 'infrawatch'
@@ -57,7 +92,7 @@ function isCustomer(v: unknown): v is LicenceCustomer {
 
 export async function validateLicenceKey(key: string): Promise<LicenceValidationResult> {
   try {
-    const publicKey = await importSPKI(DEV_PUBLIC_KEY_PEM.trim(), 'RS256')
+    const publicKey = await importSPKI(resolveLicencePublicKeyPem(), 'RS256')
     const { payload } = await jwtVerify(key, publicKey, {
       algorithms: ['RS256'],
       issuer: LICENCE_ISSUER,


### PR DESCRIPTION
## Summary

- **C-11 (#283)** — Hardcoded development RSA public key used to validate production licence JWTs. Anyone with the matching dev private key could forge `tier=enterprise` JWTs for any org. Fixes by loading `LICENCE_PUBLIC_KEY` from env; throws at boot in production if absent or set to the dev key.
- **C-12 (#284)** — `sql.raw(String(days))` in `updateMetricRetention` bypassed Drizzle's parameterisation for a TimescaleDB `INTERVAL` argument. Replaced with individual `try/catch` SQL calls using `make_interval(days => $1)` so the value is always a proper query parameter.

## Changes

### C-11 — Licence public key from environment
- `apps/web/lib/licence.ts` — add `resolveLicencePublicKeyPem()`: reads `LICENCE_PUBLIC_KEY` env var; in production throws if absent or equal to the dev key; in development falls back to embedded dev key
- `apps/web/instrumentation.ts` — call `resolveLicencePublicKeyPem()` at server boot so misconfiguration surfaces immediately
- `apps/web/.env.example` — document `LICENCE_PUBLIC_KEY` with security comment and generation instructions
- `apps/docs/docs/getting-started/configuration.md` — add `LICENCE_PUBLIC_KEY` to the env var table and add a dedicated section with key-generation steps

### C-12 — Parameterised TimescaleDB retention policy
- `apps/web/lib/actions/settings.ts` — replace `DO $$` block with individual `db.execute()` calls; use `make_interval(days => ${d})` for safe parameterisation; each call wrapped in `try/catch` to silently degrade on plain PostgreSQL

## Test plan

- [ ] In development (no `LICENCE_PUBLIC_KEY` set): server starts normally; licence validation uses dev key
- [ ] With `LICENCE_PUBLIC_KEY` set to a valid PEM: licence validation uses the env key
- [ ] In production with `LICENCE_PUBLIC_KEY` unset: server throws at boot with a clear message
- [ ] In production with `LICENCE_PUBLIC_KEY` set to the dev key: server throws at boot
- [ ] `updateMetricRetention` called with a valid integer: org record updated; TimescaleDB policies updated (or silently skipped on plain Postgres)
- [ ] `updateMetricRetention` called with a non-integer: Zod rejects before any DB call

https://claude.ai/code/session_01Whzjhm8vnuXGaaxjALWq2u