### PR TITLE
chore(licence): rotate dev signing keypair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,9 @@ apps/web/data/agent-dist/infrawatch-agent-*
 # Dev ingest data — contains generated JWT private key, never commit
 deploy/dev-ingest-data/
 
+# Licence signing private key — generated locally, never commit
+deploy/scripts/licence-dev-private.pem
+deploy/scripts/licence-*-private.pem
+
 # Claude Code local config
 .claude/

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -5,13 +5,13 @@ import type { Feature, LicenceTier } from './features'
 // In production, set LICENCE_PUBLIC_KEY to your RSA public key PEM.
 // The matching private key lives in deploy/scripts/licence-dev-private.pem (never commit).
 const DEV_PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Wep87Fxy2SUYnx8MLx2
-oVWA94ygeDMKfRQWm16Vdvc+fzpTQettcbMQN6AMe/SzFk0oipzs2wB//9DyoFhK
-Aj2C2rsmuRlgFv8hcdHrfFKRw416pJTzmMNeu+Qc+shXw76lvOjnFRkEc/KKchcX
-CdPM3h3rYVbjBpZEkgbbxqRnG9wbBF4/eEtQthkEilIPYf3O+zWaUxwpMyLuykr7
-OcVgn3vrZ0RfExrMhelwZvgDoutHol9KhoqCQkSLxaL2eMC9NzYtCuESLCYOEiIS
-q6YFpCA6PtWXuwKYMfj9egw/d2KePf5YiBEBZJzLu1L57Fouf1fVWc7hr32BrL9N
-wQIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz/pW3tGLo8e//f75eVk3
+pNM/S9CPBYozjgSRDxppJQIr2JPTI4tM9jd4Of1i0/MYfighpTSilDtUGgI6Q6Z9
+8hs5aBFT/N63BanMwsAlqGHRZ/igJSWu5HhBuWR2CtKIpIqGcel32uAyGDnTjfKu
+iYswa0tn+/Q2KxX7HF6aoNAH0CH333sa88QxNCRCKvj/Byqqdma/VTp7Gj50JdSP
+YvAIzi0rDcPBMRFMGm6M7n6lwN/XCPgdXEAzI2z+/PiBAK3suh3jyaxtD0D4FHdt
+/Iyxxs/zZsceZIpjDcyVbd1JJ6Y3DumbgAPqajnMNSVkniYWG7Q37DfsYNtk6/DT
+EQIDAQAB
 -----END PUBLIC KEY-----`
 
 /**


### PR DESCRIPTION
## Summary
- Generated a fresh RSA 2048 dev signing keypair so the licence-purchase issuer can sign JWTs that the `apps/web` verifier accepts
- Embedded the matching public key in `apps/web/lib/licence.ts` (`DEV_PUBLIC_KEY_PEM`)
- Added `.gitignore` rules so the private key (`deploy/scripts/licence-dev-private.pem`) can never be committed

## Notes
- Private key is generated locally and lives at `deploy/scripts/licence-dev-private.pem` (mode 600). Each developer can regenerate with `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out deploy/scripts/licence-dev-private.pem`
- Production deployments still require `LICENCE_PUBLIC_KEY` env var — the dev key is fallback only when `NODE_ENV !== 'production'`
- Sign + verify round trip was tested locally before commit

## Test plan
- [x] Sign + verify JWT round trip succeeds with the new keypair
- [ ] CI passes (lint, typecheck, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)