### PR TITLE
fix(db): make migration 0037 idempotent for domain_accounts.deleted_at

### DIFF
--- a/apps/web/lib/db/migrations/0037_friendly_iron_patriot.sql
+++ b/apps/web/lib/db/migrations/0037_friendly_iron_patriot.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "domain_accounts" ADD COLUMN "deleted_at" timestamp with time zone;
+ALTER TABLE "domain_accounts" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp with time zone;


### PR DESCRIPTION
## Summary
- Migration 0037 fails on existing deployments with `column "deleted_at" of relation "domain_accounts" already exists`, preventing the web container from starting.
- Root cause: migration 0019 dropped `deleted_at`, 0037 re-adds it — but on DBs where 0019's DROP was recorded as applied without actually running (the drift issue noted in commit b915029), the column is still present, so 0037 crashes.
- Fix: guard the `ADD COLUMN` with `IF NOT EXISTS`, matching the existing pattern already used in 0009 and 0011. Safe for both fresh installs and drifted databases.

## Test plan
- [ ] Apply migrations against a drifted DB (one where `domain_accounts.deleted_at` already exists); confirm migrations complete.
- [ ] Apply migrations against a fresh DB; confirm 0037 creates the column.
- [ ] Web container starts successfully after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)