### PR TITLE
refactor(licence): drop LICENCE_PUBLIC_KEY override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,18 +20,6 @@ AGENT_DOWNLOAD_BASE_URL=http://localhost:3000
 # generate one for you on first run if you leave this empty.
 BETTER_AUTH_SECRET=
 
-# Licence verification: the public key for verifying licences purchased from
-# infrawatch.io is baked into the web image — you do not need to set anything
-# here for the standard workflow.
-#
-# Override only if you are an enterprise running your own licence issuer (your
-# own PKI). Set LICENCE_PUBLIC_KEY (British spelling — note!) to the multi-line
-# PEM content of your public key:
-#
-#   LICENCE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
-#   MIIBIj...
-#   -----END PUBLIC KEY-----"
-
 # === Terminal ===
 # WebSocket URL of the ingest service for browser terminal connections.
 # Must be reachable from the user's browser (not just the server).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,10 +69,9 @@ Severity key: **C**ritical / **H**igh / **M**edium / **L**ow / **I**nfo.
   - Agent downloads and `exec`s a binary from a server URL without signature/hash verification. A compromised or MITM'd server pushes arbitrary code to every host as root.
   - Fix direction: sign release binaries; embed a pinned public key in the agent; verify signature + expected version before `exec`. Consider TUF or cosign for release flow.
 
-- [ ] **[C-11] Hardcoded development public key used to validate production licence JWTs**
-  - Location: `apps/web/lib/licence.ts:~5-13`
-  - The dev RSA public key is baked into source. Anyone with the matching dev private key (which very likely exists under `deploy/` or has been shared) can forge `tier=enterprise` JWTs for any org id.
-  - Fix direction: load the production public key from an env var (e.g., `LICENCE_PUBLIC_KEY`); fail to boot if missing or equal to the dev key.
+- [x] **[C-11] Hardcoded development public key used to validate production licence JWTs**
+  - Location: `apps/web/lib/licence.ts`
+  - Resolved: the production public key (`PROD_PUBLIC_KEY_PEM`) is now baked into the web image and used whenever `NODE_ENV=production`. The dev key is only used in non-production. Customers verify infrawatch.io-issued licences against the embedded prod key with no configuration.
 
 - [ ] **[C-12] Raw SQL interpolation in `updateMetricRetention`**
   - Location: `apps/web/lib/actions/settings.ts:~80, ~90`

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -12,23 +12,14 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `BETTER_AUTH_SECRET` | ✓ | — | Secret key for signing sessions (min 32 chars, keep private) |
 | `BETTER_AUTH_URL` | ✓ | — | Public URL of the web app (e.g. `https://ct-ops.corp.example.com`) |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | — | Same as `BETTER_AUTH_URL` | Comma-separated list of allowed origins for CORS |
-| `LICENCE_PUBLIC_KEY` | ✓ (prod) | dev key | RSA public key PEM for validating licence JWTs. **Required in production** — the server refuses to start without it. See below. |
 | `NEXT_PUBLIC_APP_URL` | — | — | Exposed to the browser — used for constructing absolute links |
 | `NODE_ENV` | — | `development` | Set to `production` in production |
 | `AGENT_DIST_DIR` | — | `/var/lib/ct-ops/agent-dist` | Directory where compiled agent binaries are stored for download |
 | `INGEST_WS_URL` | — | `ws://localhost:8080` | WebSocket URL of the ingest service (for real-time agent status) |
 
-### Licence public key
+### Licence verification
 
-CT-Ops validates licence JWTs using an RSA public key. In development this falls back to a built-in dev key. In **production** you must supply your own:
-
-```bash
-# Generate a key pair (keep the private key safe — it signs licence tokens)
-openssl genrsa -out licence-private.pem 2048
-openssl rsa -in licence-private.pem -pubout -out licence-public.pem
-```
-
-Set `LICENCE_PUBLIC_KEY` to the contents of `licence-public.pem`. The server will refuse to start in production if the variable is absent or still set to the development key.
+CT-Ops validates licence JWTs using an RSA public key. The production public key for verifying licences purchased from infrawatch.io is **baked into the web image** — there is nothing to configure. In development the server uses a separate built-in dev key, used only when `NODE_ENV !== 'production'`.
 
 ### Example `.env.local` (development)
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -25,17 +25,6 @@ BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
 # LDAP_BASE_DN=dc=example,dc=com
 # LDAP_USER_SEARCH_FILTER=(uid={{username}})
 
-# --- Licensing ---
-# [SECURITY-CRITICAL] RSA public key (PEM) used to validate licence JWTs.
-# Required in production — the server refuses to start without it.
-# Generate your key pair with:
-#   openssl genrsa -out licence-private.pem 2048
-#   openssl rsa -in licence-private.pem -pubout -out licence-public.pem
-# Then set this variable to the contents of licence-public.pem (inline, with \n for newlines,
-# or use a Docker secret / secrets manager to inject the multi-line PEM value).
-# Never leave this unset or set to the development key in production.
-# LICENCE_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
-
 # --- Agent ---
 # Public-facing URL of this Infrawatch instance.
 # Used to build agent enrolment install commands and agent self-update URLs.

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -3,7 +3,7 @@
  *
  * Pre-warms the agent binary cache so every platform binary is available
  * immediately, even on a fresh server or after a new release ships.
- * Also performs fail-fast validation of required environment variables so
+ * Also performs fail-fast validation of required auth env vars so
  * misconfigurations surface at boot rather than at first use.
  */
 export async function register() {
@@ -13,11 +13,6 @@ export async function register() {
   // `next build` sets NODE_ENV=production but secrets are not available at
   // build time. Skip runtime-only checks during the build phase.
   if (process.env.NEXT_PHASE === 'phase-production-build') return
-
-  // Validate licence public key configuration — throws in production if missing
-  // or set to the development key, preventing forged licence acceptance.
-  const { resolveLicencePublicKeyPem } = await import('./lib/licence')
-  resolveLicencePublicKeyPem()
 
   // Validate critical auth env vars in production.
   // Better Auth accepts an empty secret and falls back silently, which would

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -4,9 +4,7 @@ import type { Feature, LicenceTier } from './features'
 // Production public key (RS256) — used to verify licence JWTs issued by the
 // official infrawatch.io licence-purchase service. The matching private key
 // lives only on the licence-purchase server (deploy/scripts/licence-prod-private.pem
-// during MVP, KMS / Vault Transit before customer launch). Customers running
-// `./start.sh` need no licence configuration — this baked-in key Just Works
-// for any licence purchased from infrawatch.io.
+// during MVP, KMS / Vault Transit before customer launch).
 //
 // Rotating this key is a breaking change requiring every customer to upgrade
 // the binary. Treat it as a release-signing key — back up the private half in
@@ -35,38 +33,10 @@ YvAIzi0rDcPBMRFMGm6M7n6lwN/XCPgdXEAzI2z+/PiBAK3suh3jyaxtD0D4FHdt
 EQIDAQAB
 -----END PUBLIC KEY-----`
 
-/**
- * Returns the RSA public key PEM to use for licence JWT verification.
- *
- * Resolution order:
- *   1. LICENCE_PUBLIC_KEY env var (override — for enterprise customers who
- *      issue licences against their own PKI rather than infrawatch.io)
- *   2. PROD_PUBLIC_KEY_PEM (default in production — verifies licences
- *      purchased from infrawatch.io)
- *   3. DEV_PUBLIC_KEY_PEM (only when NODE_ENV !== 'production')
- *
- * Throws if the env var override equals the embedded dev key — a guardrail
- * against pasting the dev key into a production config and silently accepting
- * forged licences.
- */
 export function resolveLicencePublicKeyPem(): string {
-  const envKey = process.env.LICENCE_PUBLIC_KEY?.trim()
-
-  if (envKey) {
-    if (envKey === DEV_PUBLIC_KEY_PEM.trim()) {
-      throw new Error(
-        'LICENCE_PUBLIC_KEY is set to the development key. ' +
-          'Either unset it (to use the embedded production key) or set it to ' +
-          'your enterprise self-issued public key PEM.',
-      )
-    }
-    return envKey
-  }
-
   if (process.env.NODE_ENV === 'production') {
     return PROD_PUBLIC_KEY_PEM.trim()
   }
-
   return DEV_PUBLIC_KEY_PEM.trim()
 }
 

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -37,10 +37,6 @@ services:
       AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
       INGEST_WS_URL: ${INGEST_WS_URL:-ws://localhost:8080}
       INFRAWATCH_LOADTEST_ADMIN_KEY: ${INFRAWATCH_LOADTEST_ADMIN_KEY:-}
-      # Optional override for licence JWT verification. The web image already
-      # includes the official infrawatch.io public key baked in; only set this
-      # if you are an enterprise issuing licences against your own PKI.
-      LICENCE_PUBLIC_KEY: ${LICENCE_PUBLIC_KEY:-}
     volumes:
       - agent_dist:/var/lib/infrawatch/agent-dist
 


### PR DESCRIPTION
## Summary
- Remove the `LICENCE_PUBLIC_KEY` env override from code, env templates, docker-compose, and docs
- Production now resolves to the baked-in `PROD_PUBLIC_KEY_PEM`; dev (`NODE_ENV !== 'production'`) uses `DEV_PUBLIC_KEY_PEM`. No third path
- Mark SECURITY.md **C-11** as resolved (baked-in prod key replaces the dev-key-in-prod risk)
- Drop the now-pointless `resolveLicencePublicKeyPem()` call from `instrumentation.ts`

## Why
All licences are issued by the infrawatch.io licence-purchase service. We are not supporting customer self-issuance / OEM-relabel / bring-your-own-PKI use cases. Keeping the override path created a documentation and support burden for zero real benefit, and presented an attack surface (operators pasting the wrong key).

## Test plan
- [ ] `pnpm type-check` in `apps/web` passes (verified locally)
- [ ] CI green
- [ ] Web container boots in production with no licence env vars set, using the baked-in prod key

🤖 Generated with [Claude Code](https://claude.com/claude-code)