### PR TITLE
fix(ci): use correct package name in Deploy Docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,10 +43,10 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @infrawatch/docs --frozen-lockfile
+        run: pnpm install --filter @ct-ops/docs --frozen-lockfile
 
       - name: Build docs
-        run: pnpm --filter @infrawatch/docs build
+        run: pnpm --filter @ct-ops/docs build
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- Change `@infrawatch/docs` → `@ct-ops/docs` in `.github/workflows/deploy-docs.yml` (both `pnpm install --filter` and `pnpm --filter ... build`)

## Why
The docs package is `@ct-ops/docs` (see `apps/docs/package.json`), but the workflow still referred to the pre-rename `@infrawatch/docs`. pnpm matched no project, so `apps/docs/docs/.vuepress/dist` was never produced and the artifact upload failed with `tar: ... Cannot open: No such file or directory`. Every Deploy Docs run since the rename has failed.

Closes #406

## Test plan
- [ ] Workflow run on this PR's merge to main succeeds and deploys to GitHub Pages