### PR TITLE
feat(loadtest): widen synthetic CPU/memory to 0-100

### DIFF
--- a/agent/internal/loadtest/metrics.go
+++ b/agent/internal/loadtest/metrics.go
@@ -45,8 +45,8 @@ func NewSyntheticMetrics(agentIndex int, hostname string, jitter float64) *Synth
 	)
 
 	return &SyntheticMetrics{
-		cpuPct:       20 + float64(r.Intn(40)),
-		memPct:       30 + float64(r.Intn(40)),
+		cpuPct:       float64(r.Intn(101)),
+		memPct:       float64(r.Intn(101)),
 		diskPct:      40 + float64(r.Intn(30)),
 		uptimeSec:    int64(3600 + r.Intn(86400*7)),
 		lastTick:     time.Now(),
@@ -74,8 +74,8 @@ func (s *SyntheticMetrics) Tick() *Snapshot {
 	s.lastTick = now
 
 	step := s.jitter * 5.0
-	s.cpuPct = clamp(s.cpuPct+s.rng.NormFloat64()*step, 1, 99)
-	s.memPct = clamp(s.memPct+s.rng.NormFloat64()*step*0.6, 5, 95)
+	s.cpuPct = clamp(s.cpuPct+s.rng.NormFloat64()*step, 0, 100)
+	s.memPct = clamp(s.memPct+s.rng.NormFloat64()*step*0.6, 0, 100)
 	s.diskPct = clamp(s.diskPct+s.rng.NormFloat64()*step*0.1, 10, 98)
 
 	disks := make([]*agentv1.DiskInfo, len(s.disks))

--- a/agent/internal/loadtest/metrics_test.go
+++ b/agent/internal/loadtest/metrics_test.go
@@ -9,10 +9,10 @@ func TestSyntheticMetricsTickStaysInBounds(t *testing.T) {
 
 	for i := 0; i < 10_000; i++ {
 		snap := m.Tick()
-		if snap.CPUPercent < 1 || snap.CPUPercent > 99 {
+		if snap.CPUPercent < 0 || snap.CPUPercent > 100 {
 			t.Fatalf("cpu out of bounds after %d ticks: %f", i, snap.CPUPercent)
 		}
-		if snap.MemoryPercent < 5 || snap.MemoryPercent > 95 {
+		if snap.MemoryPercent < 0 || snap.MemoryPercent > 100 {
 			t.Fatalf("memory out of bounds after %d ticks: %f", i, snap.MemoryPercent)
 		}
 		if snap.DiskPercent < 10 || snap.DiskPercent > 98 {


### PR DESCRIPTION
## Summary
- Seed initial CPU and memory baselines uniformly across 0–100 so a virtual fleet immediately covers the full range.
- Extend random-walk clamps on CPU and memory to the full 0–100 range so drift can actually reach the extremes.
- Lets load-test runs exercise alert thresholds at 0% and 100% instead of only the middle band.

## Test plan
- [x] `go test ./internal/loadtest/... -run TestSyntheticMetrics -count=1` passes
- [x] `go build ./...` clean
- [ ] Run a short load test and confirm alerts trigger at the extremes

🤖 Generated with [Claude Code](https://claude.com/claude-code)