### PR TITLE
feat(licence-purchase): complete end-to-end buy → pay → download flow

### DIFF
--- a/apps/licence-purchase/PROGRESS.md
+++ b/apps/licence-purchase/PROGRESS.md
@@ -37,33 +37,30 @@ Related references:
 
 ## Phase 1 — Stripe wiring
 
-- [ ] Implement `lib/stripe/create-checkout-session.ts`:
-  - `card` / `bacs_debit` → `stripe.checkout.sessions.create({ mode: 'subscription', payment_method_types, line_items: [{ price, quantity: seatCount }], customer_email, success_url, cancel_url, automatic_tax: { enabled: env.stripeTaxEnabled }, subscription_data: { metadata } })`
-  - `invoice` → `stripe.subscriptions.create({ collection_method: 'send_invoice', days_until_due: env.stripeInvoiceCollectionDays, ... })` then return the hosted invoice URL.
-- [ ] Implement `lib/stripe/handle-webhook.ts` cases:
-  - `checkout.session.completed` → create / update `purchase` row, link `organisations.stripeCustomerId`.
-  - `invoice.paid` → upsert `invoice`, trigger Phase 2 licence issuance, send receipt email.
-  - `invoice.payment_failed` → mark `purchase.status = 'past_due'`, notify billing contact.
-  - `customer.subscription.updated` → reflect period / status changes.
-  - `customer.subscription.deleted` → mark `purchase.status = 'canceled'`; existing licence keeps working until `exp`.
-- [ ] Implement `lib/stripe/customer-portal.ts` via `stripe.billingPortal.sessions.create(...)` and wire it to a button on `/account`.
-- [ ] Create Stripe products + prices (Pro monthly/annual, Enterprise monthly/annual) and paste the price IDs into `.env.example` defaults.
-- [ ] Enable Stripe Tax on the account; validate VAT numbers on checkout (`stripe.tax.registrations.list`, `stripe.customers.update({ tax: { ... } })`).
-- [ ] Register webhook endpoint with Stripe (test + prod) and rotate `STRIPE_WEBHOOK_SECRET` into secret store.
+- [x] `lib/stripe/create-checkout-session.ts` — card/bacs_debit via `stripe.checkout.sessions.create`, invoice via `stripe.subscriptions.create({ collection_method: 'send_invoice' })`. Customer is pre-created once per org via `ensure-customer.ts`; both flows share the same Stripe customer id.
+- [x] `lib/stripe/handle-webhook.ts` — handles `checkout.session.completed`, `customer.subscription.created|updated|deleted`, `invoice.paid`, `invoice.payment_failed`. Idempotent: route checks `stripeWebhookEvents.processed` before dispatch, and licence issuance skips if a licence already exists for the invoice's period.
+- [x] `lib/stripe/customer-portal.ts` — wired and surfaced as a button on `/account` via `lib/actions/billing.ts` + `BillingPortalButton`.
+- [x] `issueLicence` wired into `invoice.paid` — calls on first payment and every renewal (new JWT per period).
+- [x] `/checkout/[tier]` gates on a saved technical contact — prevents a purchase that would fail at issuance time.
+- [x] `/checkout/success` queries the latest licence and shows it inline; falls back to "issuing your licence" UX if the webhook hasn't caught up.
+- [x] `/invoices` lists invoices from the local DB (populated by the `invoice.paid|payment_failed` webhook) with links to Stripe's hosted pages + PDFs.
+- [ ] **Operator task**: create Stripe products + prices (Pro monthly/annual, Enterprise monthly/annual) and paste the price IDs into `.env.local`.
+- [ ] **Operator task**: enable Stripe Tax on the account; validate VAT numbers on checkout (`stripe.tax.registrations.list`, `stripe.customers.update({ tax: { ... } })`).
+- [ ] **Operator task**: register webhook endpoint with Stripe (test + prod) and rotate `STRIPE_WEBHOOK_SECRET` into secret store. Events to forward: `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.paid`, `invoice.payment_failed`.
 
 ## Phase 2 — Licence issuance
 
-- [ ] Replace `lib/licence/sign.ts` stub with real RS256 signer — load PEM from `env.licenceSigningPem` or file path, sign with `jose.SignJWT`. Payload MUST match `apps/web/lib/licence.ts` exactly (`iss`, `aud`, `sub`, `tier`, `features`, `customer`, `maxHosts?`, `jti`, `iat`, `nbf`, `exp`).
-- [ ] Write an issuer function that: generates a fresh `jti` (cuid2), looks up tier features via `featureKeysForTier` from `lib/tiers.ts`, calls `signLicence`, persists a `licence` row, and sends the "licence ready" email to the technical contact.
-- [ ] Wire it into the `invoice.paid` webhook handler (first payment) and into a scheduled renewal job (every paid period).
-- [ ] Decide whether renewals issue a *new* JWT (cleaner revocation story) or extend the existing one. Recommended: new JWT per period, deprecate old one naturally via expiry.
+- [x] Replace `lib/licence/sign.ts` stub with real RS256 signer — loads PEM from `env.licenceSigningPem` (takes precedence) or `env.licenceSigningPath`, signs with `jose.SignJWT`. Payload matches `apps/web/lib/licence.ts` exactly (`iss`, `aud`, `sub`, `tier`, `features`, `customer`, `maxHosts?`, `jti`, `iat`, `nbf`, `exp`).
+- [x] Issuer function at `lib/licence/issue.ts` — generates fresh `jti` (cuid2), resolves features via `featureKeysForTier`, calls `signLicence`, persists a `licence` row, and sends the "licence ready" email to the technical contact. Throws cleanly if the org has no technical contact.
+- [x] Renewal strategy decided: **new JWT per period**. Every call to `issueLicence` mints a new row with a new jti; natural expiry deprecates the old one, which works for air-gapped installs.
+- [ ] Wire `issueLicence` into the `invoice.paid` webhook handler (first payment) and into a scheduled renewal job (every paid period). Deferred to Phase 1 alongside the rest of the Stripe webhook handler.
 - [ ] Document production signing-key custody (AWS KMS / HashiCorp Vault Transit / HSM). The dev PEM at `deploy/scripts/licence-dev-private.pem` is for local only.
 
 ## Phase 3 — Account UX
 
 - [ ] Wire `/account` contact forms to actually persist — server action is ready, add success toast.
 - [ ] Add company detail editing (`organisations` columns) with VAT-number validation.
-- [ ] Populate `/invoices` by calling `stripe.invoices.list({ customer })` and rendering download links.
+- [x] `/invoices` populated from the local DB (webhook-driven). If a richer live view is needed, swap to `stripe.invoices.list({ customer })`.
 - [ ] Populate dashboard with real `purchase` + `licence` joins (right now it only reads licences).
 - [ ] Enforce Better Auth email verification + require TOTP MFA on first login after purchase.
 - [ ] Password reset flow (placeholder page currently tells users to email support).

--- a/apps/licence-purchase/app/(dashboard)/account/page.tsx
+++ b/apps/licence-purchase/app/(dashboard)/account/page.tsx
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm'
 import { PageHeader } from '@/components/shared/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { ContactForm } from '@/components/account/contact-form'
+import { BillingPortalButton } from '@/components/account/billing-portal-button'
 import { getRequiredSession } from '@/lib/auth/session'
 import { db } from '@/lib/db'
 import { contacts, organisations, users } from '@/lib/db/schema'
@@ -52,13 +53,14 @@ export default async function AccountPage() {
                 : ''}
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <dl className="grid gap-2 text-sm md:grid-cols-2">
               <div><dt className="text-xs uppercase text-muted-foreground">Name</dt><dd className="text-foreground">{org?.name ?? '—'}</dd></div>
               <div><dt className="text-xs uppercase text-muted-foreground">Country</dt><dd className="text-foreground">{org?.country ?? '—'}</dd></div>
               <div><dt className="text-xs uppercase text-muted-foreground">VAT number</dt><dd className="text-foreground">{org?.vatNumber ?? '—'}</dd></div>
               <div><dt className="text-xs uppercase text-muted-foreground">Stripe customer</dt><dd className="font-mono text-xs text-foreground">{org?.stripeCustomerId ?? '—'}</dd></div>
             </dl>
+            <BillingPortalButton disabled={!org?.stripeCustomerId} />
           </CardContent>
         </Card>
       </div>

--- a/apps/licence-purchase/app/(dashboard)/invoices/page.tsx
+++ b/apps/licence-purchase/app/(dashboard)/invoices/page.tsx
@@ -1,32 +1,95 @@
+import Link from 'next/link'
 import { PageHeader } from '@/components/shared/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { listInvoicesForOrganisation } from '@/lib/actions/invoices'
 
 export const metadata = { title: 'Invoices' }
 
-export default function InvoicesPage() {
+function formatAmount(amountInSmallestUnit: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+    }).format(amountInSmallestUnit / 100)
+  } catch {
+    return `${(amountInSmallestUnit / 100).toFixed(2)} ${currency.toUpperCase()}`
+  }
+}
+
+function statusVariant(status: string): 'default' | 'secondary' | 'destructive' {
+  if (status === 'paid') return 'default'
+  if (status === 'uncollectible' || status === 'void') return 'destructive'
+  return 'secondary'
+}
+
+export default async function InvoicesPage() {
+  const rows = await listInvoicesForOrganisation()
+
   return (
     <>
       <PageHeader
         title="Invoices"
-        description="Invoices are fetched live from Stripe. See PROGRESS.md Phase 3 for implementation."
+        description="All invoices for your organisation. Click through to view or download PDFs on Stripe."
       />
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Coming soon</CardTitle>
-          <CardDescription>
-            Once Stripe is wired up, this page will list all invoices for your organisation with PDF downloads.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            For early support or manual invoice requests, email{' '}
-            <a href="mailto:support@infrawatch.io" className="text-foreground underline">
-              support@infrawatch.io
-            </a>
-            .
-          </p>
-        </CardContent>
-      </Card>
+
+      {rows.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">No invoices yet</CardTitle>
+            <CardDescription>
+              Invoices appear here once a purchase has been completed.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <div className="divide-y">
+              {rows.map((invoice) => (
+                <div key={invoice.id} className="flex items-center justify-between px-4 py-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="font-medium">{invoice.number ?? invoice.stripeInvoiceId}</span>
+                      <Badge variant={statusVariant(invoice.status)} className="capitalize">
+                        {invoice.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {invoice.issuedAt ? new Date(invoice.issuedAt).toLocaleDateString() : '—'}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <div className="text-sm font-medium">
+                      {formatAmount(invoice.amountDue, invoice.currency)}
+                    </div>
+                    {invoice.hostedInvoiceUrl ? (
+                      <Link
+                        href={invoice.hostedInvoiceUrl}
+                        className="text-xs text-foreground underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        View
+                      </Link>
+                    ) : null}
+                    {invoice.pdfUrl ? (
+                      <Link
+                        href={invoice.pdfUrl}
+                        className="text-xs text-foreground underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        PDF
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </>
   )
 }

--- a/apps/licence-purchase/app/api/webhooks/stripe/route.ts
+++ b/apps/licence-purchase/app/api/webhooks/stripe/route.ts
@@ -45,6 +45,17 @@ export async function POST(req: NextRequest): Promise<Response> {
     console.error('[stripe webhook] failed to persist event', err)
   }
 
+  // Idempotency: if this event has already been processed (Stripe retries on
+  // transient network errors), skip the handler. Event row always exists here
+  // because the insert above either created it or the onConflictDoNothing kept
+  // the existing row in place.
+  const existingEvent = await db.query.stripeWebhookEvents.findFirst({
+    where: eq(stripeWebhookEvents.id, event.id),
+  })
+  if (existingEvent?.processed) {
+    return new Response('ok', { status: 200 })
+  }
+
   try {
     await handleStripeEvent(event)
     await db

--- a/apps/licence-purchase/app/checkout/[tier]/page.tsx
+++ b/apps/licence-purchase/app/checkout/[tier]/page.tsx
@@ -1,9 +1,14 @@
+import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { and, eq } from 'drizzle-orm'
 import { Nav } from '@/components/shared/nav'
 import { Footer } from '@/components/shared/footer'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { getTier } from '@/lib/tiers'
 import { getRequiredSession } from '@/lib/auth/session'
+import { db } from '@/lib/db'
+import { contacts } from '@/lib/db/schema'
 import { CheckoutForm } from './checkout-form'
 import type { BillingInterval, PaidTierId } from '@/lib/tiers'
 
@@ -28,6 +33,15 @@ export default async function CheckoutPage({
   const initialInterval: BillingInterval = interval === 'year' ? 'year' : 'month'
   const tierDef = getTier(tier)
 
+  const technical = user.organisationId
+    ? await db.query.contacts.findFirst({
+        where: and(
+          eq(contacts.organisationId, user.organisationId),
+          eq(contacts.role, 'technical'),
+        ),
+      })
+    : null
+
   return (
     <div className="flex min-h-screen flex-col">
       <Nav isAuthenticated />
@@ -42,7 +56,19 @@ export default async function CheckoutPage({
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <CheckoutForm tier={tier} initialInterval={initialInterval} />
+              {!technical ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-foreground">
+                    Please add a <strong>technical contact</strong> before checkout. This is the
+                    email that will receive the signed licence key.
+                  </p>
+                  <Button asChild>
+                    <Link href="/account">Add technical contact</Link>
+                  </Button>
+                </div>
+              ) : (
+                <CheckoutForm tier={tier} initialInterval={initialInterval} />
+              )}
             </CardContent>
           </Card>
 

--- a/apps/licence-purchase/app/checkout/success/page.tsx
+++ b/apps/licence-purchase/app/checkout/success/page.tsx
@@ -1,61 +1,103 @@
 import Link from 'next/link'
+import { and, desc, eq, gte, isNull } from 'drizzle-orm'
 import { Nav } from '@/components/shared/nav'
 import { Footer } from '@/components/shared/footer'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { CopyButton } from '@/components/licence/copy-button'
-import { CheckCircle2 } from 'lucide-react'
+import { CheckCircle2, Clock } from 'lucide-react'
+import { getOptionalSession } from '@/lib/auth/session'
+import { db } from '@/lib/db'
+import { licences } from '@/lib/db/schema'
 
 export const metadata = { title: 'Purchase complete' }
+
+// Customer lands here right after Stripe Checkout returns. For card payments,
+// the webhook has usually fired by now; for BACS / invoice we ask the customer
+// to wait. The page queries the most-recent licence issued in the last hour —
+// if present we show it inline, otherwise we direct them to the dashboard.
+async function recentLicenceForUser(organisationId: string | null) {
+  if (!organisationId) return null
+  const cutoff = new Date(Date.now() - 60 * 60 * 1000)
+  return db.query.licences.findFirst({
+    where: and(
+      eq(licences.organisationId, organisationId),
+      isNull(licences.revokedAt),
+      gte(licences.issuedAt, cutoff),
+    ),
+    orderBy: [desc(licences.issuedAt)],
+  })
+}
 
 export default async function SuccessPage({
   searchParams,
 }: {
-  searchParams: Promise<{ stub?: string; tier?: string }>
+  searchParams: Promise<{ method?: string; tier?: string }>
 }) {
-  const { stub, tier } = await searchParams
-  const stubbedKey = 'FAKE_JWT_FOR_SCAFFOLDING'
+  const { method, tier } = await searchParams
+  const session = await getOptionalSession()
+  const licence = await recentLicenceForUser(session?.user.organisationId ?? null)
+
+  const isInvoiceFlow = method === 'invoice'
 
   return (
     <div className="flex min-h-screen flex-col">
-      <Nav isAuthenticated />
+      <Nav isAuthenticated={!!session} />
       <main className="flex-1">
         <div className="mx-auto max-w-2xl px-4 py-16">
           <Card>
             <CardHeader className="text-center">
               <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-primary/10">
-                <CheckCircle2 className="size-5 text-primary" aria-hidden />
+                {licence ? (
+                  <CheckCircle2 className="size-5 text-primary" aria-hidden />
+                ) : (
+                  <Clock className="size-5 text-primary" aria-hidden />
+                )}
               </div>
-              <CardTitle>Purchase complete</CardTitle>
+              <CardTitle>
+                {licence
+                  ? 'Purchase complete'
+                  : isInvoiceFlow
+                    ? 'Invoice issued'
+                    : 'Payment received — issuing your licence'}
+              </CardTitle>
               <CardDescription>
-                {stub
-                  ? 'This is a scaffold preview — Stripe integration is pending (see PROGRESS.md).'
-                  : 'Your licence is ready. Copy it now, or download it any time from your dashboard.'}
+                {licence
+                  ? 'Your licence is ready. Copy it now, or download it any time from your dashboard.'
+                  : isInvoiceFlow
+                    ? 'Check your email for the invoice. Your licence will be issued as soon as payment clears.'
+                    : 'It can take a few seconds for Stripe to confirm payment. Refresh in a moment, or head to your dashboard.'}
                 {tier ? <> Tier: <strong className="capitalize">{tier}</strong>.</> : null}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="rounded-lg border bg-muted p-3">
-                <div className="mb-2 flex items-center justify-between">
-                  <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    Licence key
-                  </span>
-                  <CopyButton value={stubbedKey} />
-                </div>
-                <pre className="overflow-x-auto text-xs text-foreground">{stubbedKey}</pre>
-              </div>
+              {licence ? (
+                <>
+                  <div className="rounded-lg border bg-muted p-3">
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Licence key
+                      </span>
+                      <CopyButton value={licence.signedJwt} />
+                    </div>
+                    <pre className="overflow-x-auto text-xs text-foreground whitespace-pre-wrap break-all">
+                      {licence.signedJwt}
+                    </pre>
+                  </div>
 
-              <p className="text-sm text-muted-foreground">
-                Paste this key into <strong>Settings → Licence → Licence key</strong> on your Infrawatch server.
-                It is also safe to transfer over air-gap to a disconnected host.
-              </p>
+                  <p className="text-sm text-muted-foreground">
+                    Paste this key into <strong>Settings → Licence → Licence key</strong> on your Infrawatch server.
+                    It is also safe to transfer over air-gap to a disconnected host.
+                  </p>
+                </>
+              ) : null}
 
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <Button asChild>
                   <Link href="/dashboard">Go to dashboard</Link>
                 </Button>
                 <Button asChild variant="outline">
-                  <Link href="https://docs.infrawatch.io/licensing">Installation guide</Link>
+                  <Link href="/invoices">View invoices</Link>
                 </Button>
               </div>
             </CardContent>

--- a/apps/licence-purchase/components/account/billing-portal-button.tsx
+++ b/apps/licence-purchase/components/account/billing-portal-button.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { openBillingPortal } from '@/lib/actions/billing'
+
+export function BillingPortalButton({ disabled }: { disabled?: boolean }) {
+  return (
+    <form action={openBillingPortal}>
+      <Button type="submit" variant="outline" size="sm" disabled={disabled}>
+        Manage billing in Stripe
+      </Button>
+    </form>
+  )
+}

--- a/apps/licence-purchase/lib/actions/billing.ts
+++ b/apps/licence-purchase/lib/actions/billing.ts
@@ -1,0 +1,23 @@
+'use server'
+
+import { eq } from 'drizzle-orm'
+import { redirect } from 'next/navigation'
+import { db } from '@/lib/db'
+import { organisations } from '@/lib/db/schema'
+import { getRequiredSession } from '@/lib/auth/session'
+import { createCustomerPortalSession } from '@/lib/stripe/customer-portal'
+
+export async function openBillingPortal(): Promise<void> {
+  const { user } = await getRequiredSession()
+  if (!user.organisationId) {
+    redirect('/account?reason=missing-organisation')
+  }
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, user.organisationId),
+  })
+  if (!org?.stripeCustomerId) {
+    redirect('/account?reason=no-customer')
+  }
+  const url = await createCustomerPortalSession(org.stripeCustomerId)
+  redirect(url)
+}

--- a/apps/licence-purchase/lib/actions/checkout.ts
+++ b/apps/licence-purchase/lib/actions/checkout.ts
@@ -26,8 +26,9 @@ export async function startCheckout(input: unknown): Promise<void> {
     paymentMethod: parsed.paymentMethod,
     organisationId: user.organisationId,
     customerEmail: user.email,
+    customerName: user.name,
     seatCount: parsed.seatCount,
-    successUrl: `${env.appUrl}/checkout/success`,
+    successUrl: `${env.appUrl}/checkout/success?tier=${parsed.tier}`,
     cancelUrl: `${env.appUrl}/checkout/cancelled`,
   })
 

--- a/apps/licence-purchase/lib/actions/invoices.ts
+++ b/apps/licence-purchase/lib/actions/invoices.ts
@@ -1,0 +1,21 @@
+'use server'
+
+import { desc, eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { invoices, purchases } from '@/lib/db/schema'
+import type { Invoice } from '@/lib/db/schema'
+import { getRequiredSession } from '@/lib/auth/session'
+
+export async function listInvoicesForOrganisation(): Promise<Invoice[]> {
+  const { user } = await getRequiredSession()
+  if (!user.organisationId) return []
+
+  const rows = await db
+    .select({ invoice: invoices })
+    .from(invoices)
+    .innerJoin(purchases, eq(purchases.id, invoices.purchaseId))
+    .where(eq(purchases.organisationId, user.organisationId))
+    .orderBy(desc(invoices.issuedAt))
+
+  return rows.map((r) => r.invoice)
+}

--- a/apps/licence-purchase/lib/db/index.ts
+++ b/apps/licence-purchase/lib/db/index.ts
@@ -2,11 +2,27 @@ import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import * as schema from './schema'
 
-const connectionString = process.env['DATABASE_URL']
-if (!connectionString) {
-  throw new Error('DATABASE_URL environment variable is required')
+type Db = ReturnType<typeof drizzle<typeof schema>>
+
+let _db: Db | null = null
+
+function getDb(): Db {
+  if (_db) return _db
+  const connectionString = process.env['DATABASE_URL']
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is required')
+  }
+  const client = postgres(connectionString, { prepare: false })
+  _db = drizzle(client, { schema })
+  return _db
 }
 
-const client = postgres(connectionString, { prepare: false })
-
-export const db = drizzle(client, { schema })
+// Proxy defers the client construction to first use so `next build` can import
+// modules that touch `db` without requiring DATABASE_URL at build time.
+export const db = new Proxy({} as Db, {
+  get(_target, prop, receiver) {
+    const d = getDb()
+    const value = Reflect.get(d, prop, receiver)
+    return typeof value === 'function' ? value.bind(d) : value
+  },
+})

--- a/apps/licence-purchase/lib/licence/issue.ts
+++ b/apps/licence-purchase/lib/licence/issue.ts
@@ -1,0 +1,107 @@
+import { and, eq } from 'drizzle-orm'
+import { createId } from '@paralleldrive/cuid2'
+import { db } from '@/lib/db'
+import { contacts, licences, organisations, purchases } from '@/lib/db/schema'
+import type { Licence } from '@/lib/db/schema'
+import { env } from '@/lib/env'
+import { sendEmail } from '@/lib/email/client'
+import { licenceReadyEmail } from '@/lib/email/templates/licence-ready'
+import { featureKeysForTier, type PaidTierId } from '@/lib/tiers'
+import { signLicence } from './sign'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export type IssueLicenceInput = {
+  purchaseId: string
+  issuedAt?: Date
+}
+
+function isPaidTier(tier: string): tier is PaidTierId {
+  return tier === 'pro' || tier === 'enterprise'
+}
+
+// Issues a fresh signed licence for a purchase. Called on first `invoice.paid`
+// and again on each renewal period — every call mints a new JWT with a new jti
+// so natural expiry (not mutation) drives revocation for air-gapped installs.
+export async function issueLicence(input: IssueLicenceInput): Promise<Licence> {
+  const purchase = await db.query.purchases.findFirst({
+    where: eq(purchases.id, input.purchaseId),
+  })
+  if (!purchase) {
+    throw new Error(`Purchase ${input.purchaseId} not found`)
+  }
+  if (!isPaidTier(purchase.tier)) {
+    throw new Error(`Purchase ${purchase.id} has non-paid tier: ${purchase.tier}`)
+  }
+  if (purchase.interval !== 'month' && purchase.interval !== 'year') {
+    throw new Error(`Purchase ${purchase.id} has invalid interval: ${purchase.interval}`)
+  }
+
+  const organisation = await db.query.organisations.findFirst({
+    where: eq(organisations.id, purchase.organisationId),
+  })
+  if (!organisation) {
+    throw new Error(`Organisation ${purchase.organisationId} not found`)
+  }
+
+  const technicalContact = await db.query.contacts.findFirst({
+    where: and(eq(contacts.organisationId, organisation.id), eq(contacts.role, 'technical')),
+  })
+  if (!technicalContact) {
+    throw new Error(
+      `Organisation ${organisation.id} has no technical contact — add one before issuing a licence`,
+    )
+  }
+
+  const issuedAt = input.issuedAt ?? new Date()
+  const termDays = purchase.interval === 'year' ? env.licenceYearlyDays : env.licenceMonthlyDays
+  const expiresAt = new Date(issuedAt.getTime() + termDays * DAY_MS)
+
+  const jti = createId()
+  const features = featureKeysForTier(purchase.tier)
+  const maxHosts = purchase.seatCount ?? undefined
+
+  const signed = await signLicence({
+    organisationId: organisation.id,
+    customer: { name: organisation.name, email: technicalContact.email },
+    tier: purchase.tier,
+    features,
+    ...(maxHosts !== undefined ? { maxHosts } : {}),
+    jti,
+    issuedAt,
+    expiresAt,
+  })
+
+  const [inserted] = await db
+    .insert(licences)
+    .values({
+      jti,
+      organisationId: organisation.id,
+      purchaseId: purchase.id,
+      tier: purchase.tier,
+      features,
+      ...(maxHosts !== undefined ? { maxHosts } : {}),
+      signedJwt: signed.jwt,
+      issuedAt,
+      expiresAt,
+    })
+    .returning()
+
+  if (!inserted) {
+    throw new Error('Failed to persist issued licence')
+  }
+
+  const email = licenceReadyEmail({
+    organisationName: organisation.name,
+    dashboardUrl: `${env.appUrl}/dashboard`,
+  })
+  await sendEmail({
+    to: technicalContact.email,
+    subject: email.subject,
+    html: email.html,
+    text: email.text,
+    replyTo: env.supportEmail,
+  })
+
+  return inserted
+}

--- a/apps/licence-purchase/lib/licence/sign.ts
+++ b/apps/licence-purchase/lib/licence/sign.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises'
+import { importPKCS8, SignJWT } from 'jose'
 import { env } from '@/lib/env'
 import type { PaidTierId } from '@/lib/tiers'
 
@@ -18,34 +20,58 @@ export type SignedLicence = {
   expiresAt: Date
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// STUB — wired up in Phase 2. See apps/licence-purchase/PROGRESS.md.
-//
-// Real implementation (pseudo):
-//   import { importPKCS8, SignJWT } from 'jose'
-//   const pem = env.licenceSigningPem ?? readFileSync(env.licenceSigningPath!)
-//   const key = await importPKCS8(pem, 'RS256')
-//   const jwt = await new SignJWT({ tier, features, maxHosts, customer })
-//     .setProtectedHeader({ alg: 'RS256' })
-//     .setIssuer(env.licenceIssuer)
-//     .setAudience(env.licenceAudience)
-//     .setSubject(organisationId)
-//     .setJti(jti)
-//     .setIssuedAt(issuedAt)
-//     .setNotBefore(issuedAt)
-//     .setExpirationTime(expiresAt)
-//     .sign(key)
-//
-// Payload shape must match apps/web/lib/licence.ts (LicencePayload type).
-// ─────────────────────────────────────────────────────────────────────────────
+type SigningKey = Awaited<ReturnType<typeof importPKCS8>>
+
+let cachedKey: Promise<SigningKey> | null = null
+
+async function loadSigningKey(): Promise<SigningKey> {
+  if (cachedKey) return cachedKey
+  cachedKey = (async (): Promise<SigningKey> => {
+    const inlinePem = env.licenceSigningPem
+    const pem = inlinePem ?? (env.licenceSigningPath ? await readFile(env.licenceSigningPath, 'utf8') : undefined)
+    if (!pem) {
+      throw new Error(
+        'Licence signing key is not configured: set LICENCE_SIGNING_PRIVATE_KEY_PEM or LICENCE_SIGNING_PRIVATE_KEY_PATH',
+      )
+    }
+    return importPKCS8(pem.trim(), 'RS256')
+  })()
+  try {
+    return await cachedKey
+  } catch (err) {
+    cachedKey = null
+    throw err
+  }
+}
+
 export async function signLicence(input: SignLicenceInput): Promise<SignedLicence> {
-  console.warn('[licence] signLicence is a scaffolding stub; returning a placeholder token.', {
+  const key = await loadSigningKey()
+
+  const claims: Record<string, unknown> = {
     tier: input.tier,
-    organisationId: input.organisationId,
-    issuer: env.licenceIssuer,
-  })
+    features: input.features,
+    customer: input.customer,
+  }
+  if (input.maxHosts !== undefined) {
+    claims['maxHosts'] = input.maxHosts
+  }
+
+  const iat = Math.floor(input.issuedAt.getTime() / 1000)
+  const exp = Math.floor(input.expiresAt.getTime() / 1000)
+
+  const jwt = await new SignJWT(claims)
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuer(env.licenceIssuer)
+    .setAudience(env.licenceAudience)
+    .setSubject(input.organisationId)
+    .setJti(input.jti)
+    .setIssuedAt(iat)
+    .setNotBefore(iat)
+    .setExpirationTime(exp)
+    .sign(key)
+
   return {
-    jwt: 'FAKE_JWT_FOR_SCAFFOLDING',
+    jwt,
     jti: input.jti,
     expiresAt: input.expiresAt,
   }

--- a/apps/licence-purchase/lib/stripe/create-checkout-session.ts
+++ b/apps/licence-purchase/lib/stripe/create-checkout-session.ts
@@ -1,4 +1,8 @@
+import type Stripe from 'stripe'
+import { env } from '@/lib/env'
 import type { BillingInterval, PaidTierId } from '@/lib/tiers'
+import { stripe } from './client'
+import { ensureStripeCustomer } from './ensure-customer'
 
 export type PaymentMethodChoice = 'card' | 'bacs_debit' | 'invoice'
 
@@ -8,6 +12,7 @@ export type CreateCheckoutSessionInput = {
   paymentMethod: PaymentMethodChoice
   organisationId: string
   customerEmail: string
+  customerName?: string | null
   seatCount?: number
   successUrl: string
   cancelUrl: string
@@ -18,33 +23,74 @@ export type CreateCheckoutSessionResult = {
   sessionId: string
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// STUB — wired up in Phase 1. See apps/licence-purchase/PROGRESS.md.
-//
-// Implementation plan:
-// - For paymentMethod='card' | 'bacs_debit':
-//     stripe.checkout.sessions.create({
-//       mode: 'subscription',
-//       payment_method_types: [paymentMethod],
-//       line_items: [{ price: env.stripePrices[tier][interval], quantity: seatCount ?? 1 }],
-//       customer_email, success_url, cancel_url,
-//       automatic_tax: { enabled: env.stripeTaxEnabled },
-//       subscription_data: { metadata: { organisationId, tier, interval } },
-//     })
-// - For paymentMethod='invoice':
-//     Create a Stripe subscription directly with collection_method='send_invoice',
-//     days_until_due: env.stripeInvoiceCollectionDays.
-//     Return the hosted invoice URL so the customer can pay via bank transfer.
-// ─────────────────────────────────────────────────────────────────────────────
+function resolvePriceId(tier: PaidTierId, interval: BillingInterval): string {
+  const priceId = env.stripePrices[tier][interval]
+  if (!priceId) {
+    const envVar = `STRIPE_PRICE_${tier.toUpperCase()}_${interval === 'month' ? 'MONTHLY' : 'YEARLY'}`
+    throw new Error(`Missing Stripe price id for ${tier}/${interval} — set ${envVar}`)
+  }
+  return priceId
+}
+
 export async function createCheckoutSession(
   input: CreateCheckoutSessionInput,
 ): Promise<CreateCheckoutSessionResult> {
-  console.warn(
-    '[stripe] createCheckoutSession is a scaffolding stub; returning a placeholder redirect.',
-    { tier: input.tier, interval: input.interval, paymentMethod: input.paymentMethod },
-  )
-  return {
-    url: `${input.successUrl}?stub=true&tier=${input.tier}&interval=${input.interval}`,
-    sessionId: 'cs_stub',
+  const priceId = resolvePriceId(input.tier, input.interval)
+  const quantity = input.seatCount ?? 1
+
+  const customerId = await ensureStripeCustomer({
+    organisationId: input.organisationId,
+    email: input.customerEmail,
+    name: input.customerName ?? null,
+  })
+
+  const metadata: Record<string, string> = {
+    organisationId: input.organisationId,
+    tier: input.tier,
+    interval: input.interval,
+    seatCount: String(quantity),
+    paymentMethod: input.paymentMethod,
   }
+
+  if (input.paymentMethod === 'invoice') {
+    const subscription = await stripe().subscriptions.create({
+      customer: customerId,
+      items: [{ price: priceId, quantity }],
+      collection_method: 'send_invoice',
+      days_until_due: env.stripeInvoiceCollectionDays,
+      metadata,
+      ...(env.stripeTaxEnabled ? { automatic_tax: { enabled: true } } : {}),
+    })
+
+    const latestInvoiceRef: string | Stripe.Invoice | null = subscription.latest_invoice
+    const latestInvoiceId =
+      typeof latestInvoiceRef === 'string' ? latestInvoiceRef : latestInvoiceRef?.id
+    if (!latestInvoiceId) {
+      throw new Error('Stripe did not attach an invoice to the new subscription')
+    }
+    const invoice = await stripe().invoices.retrieve(latestInvoiceId)
+    const url = invoice.hosted_invoice_url
+    if (!url) {
+      throw new Error('Stripe invoice is missing a hosted_invoice_url')
+    }
+    return { url, sessionId: subscription.id }
+  }
+
+  const session = await stripe().checkout.sessions.create({
+    mode: 'subscription',
+    payment_method_types: [input.paymentMethod],
+    line_items: [{ price: priceId, quantity }],
+    customer: customerId,
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    client_reference_id: input.organisationId,
+    metadata,
+    subscription_data: { metadata },
+    ...(env.stripeTaxEnabled ? { automatic_tax: { enabled: true } } : {}),
+  })
+
+  if (!session.url) {
+    throw new Error('Stripe did not return a Checkout URL')
+  }
+  return { url: session.url, sessionId: session.id }
 }

--- a/apps/licence-purchase/lib/stripe/customer-portal.ts
+++ b/apps/licence-purchase/lib/stripe/customer-portal.ts
@@ -1,14 +1,10 @@
-// ─────────────────────────────────────────────────────────────────────────────
-// STUB — wired up in Phase 1. See apps/licence-purchase/PROGRESS.md.
-//
-// Real implementation:
-//   const session = await stripe().billingPortal.sessions.create({
-//     customer: stripeCustomerId,
-//     return_url: `${env.appUrl}/account`,
-//   })
-//   return session.url
-// ─────────────────────────────────────────────────────────────────────────────
+import { env } from '@/lib/env'
+import { stripe } from './client'
+
 export async function createCustomerPortalSession(stripeCustomerId: string): Promise<string> {
-  console.warn('[stripe] customer portal is a stub', { stripeCustomerId })
-  return '/account?portal=stub'
+  const session = await stripe().billingPortal.sessions.create({
+    customer: stripeCustomerId,
+    return_url: `${env.appUrl}/account`,
+  })
+  return session.url
 }

--- a/apps/licence-purchase/lib/stripe/ensure-customer.ts
+++ b/apps/licence-purchase/lib/stripe/ensure-customer.ts
@@ -1,0 +1,33 @@
+import { eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { organisations } from '@/lib/db/schema'
+import { stripe } from './client'
+
+// Returns the Stripe customer id for an organisation, creating the Stripe
+// customer + persisting the id on first call. Subsequent calls are a single DB
+// read. Called from the checkout flow so both Checkout (card/BACS) and direct
+// send_invoice subscriptions share one customer per organisation.
+export async function ensureStripeCustomer(params: {
+  organisationId: string
+  email: string
+  name: string | null
+}): Promise<string> {
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, params.organisationId),
+  })
+  if (!org) throw new Error(`Organisation ${params.organisationId} not found`)
+  if (org.stripeCustomerId) return org.stripeCustomerId
+
+  const customer = await stripe().customers.create({
+    email: params.email,
+    name: params.name ?? org.name,
+    metadata: { organisationId: params.organisationId },
+  })
+
+  await db
+    .update(organisations)
+    .set({ stripeCustomerId: customer.id, updatedAt: new Date() })
+    .where(eq(organisations.id, params.organisationId))
+
+  return customer.id
+}

--- a/apps/licence-purchase/lib/stripe/handle-webhook.ts
+++ b/apps/licence-purchase/lib/stripe/handle-webhook.ts
@@ -1,18 +1,281 @@
 import type Stripe from 'stripe'
+import { and, desc, eq, gte } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { invoices, organisations, purchases, contacts } from '@/lib/db/schema'
+import type { Purchase } from '@/lib/db/schema'
+import { issueLicence } from '@/lib/licence/issue'
+import { licences } from '@/lib/db/schema'
+import { sendEmail } from '@/lib/email/client'
+import { receiptEmail } from '@/lib/email/templates/receipt'
+import { paymentFailedEmail } from '@/lib/email/templates/payment-failed'
+import { env } from '@/lib/env'
 
-// ─────────────────────────────────────────────────────────────────────────────
-// STUB — wired up in Phase 1 / Phase 2. See apps/licence-purchase/PROGRESS.md.
-//
-// Event types to handle:
-//   checkout.session.completed           → link Stripe customer / subscription to organisation
-//   invoice.paid                         → issue or renew licence (Phase 2)
-//   invoice.payment_failed               → mark purchase past_due + notify billing contact
-//   customer.subscription.updated        → reflect status/period changes
-//   customer.subscription.deleted        → mark purchase canceled
-//   customer.subscription.trial_will_end → future: trial support
-// ─────────────────────────────────────────────────────────────────────────────
+// Dispatches a Stripe webhook event to the appropriate handler. Each handler
+// is written to be idempotent so duplicate deliveries don't corrupt state.
 export async function handleStripeEvent(event: Stripe.Event): Promise<void> {
-  console.log(`[stripe webhook] received ${event.type} (${event.id})`)
-  // No-op in scaffold. The raw event is already persisted to stripe_webhook_events
-  // by the route handler, ready for replay once the real logic is implemented.
+  switch (event.type) {
+    case 'checkout.session.completed':
+      await onCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session)
+      return
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated':
+      await onSubscriptionUpserted(event.data.object as Stripe.Subscription)
+      return
+    case 'customer.subscription.deleted':
+      await onSubscriptionDeleted(event.data.object as Stripe.Subscription)
+      return
+    case 'invoice.paid':
+      await onInvoicePaid(event.data.object as Stripe.Invoice)
+      return
+    case 'invoice.payment_failed':
+      await onInvoicePaymentFailed(event.data.object as Stripe.Invoice)
+      return
+    default:
+      // Event persisted by the route — safe to ignore unhandled types.
+      return
+  }
+}
+
+// ── checkout.session.completed ────────────────────────────────────────────────
+// Fires for card / bacs_debit flows. Links the subscription to the org. The
+// actual purchase row is created/updated by customer.subscription.created|updated,
+// which always fires for both flows (including send_invoice).
+async function onCheckoutSessionCompleted(session: Stripe.Checkout.Session): Promise<void> {
+  const organisationId = session.client_reference_id ?? session.metadata?.['organisationId']
+  const customerId = typeof session.customer === 'string' ? session.customer : session.customer?.id
+  if (!organisationId || !customerId) return
+
+  await db
+    .update(organisations)
+    .set({ stripeCustomerId: customerId, updatedAt: new Date() })
+    .where(eq(organisations.id, organisationId))
+}
+
+// ── customer.subscription.created / updated ───────────────────────────────────
+// Creates the purchase row on first arrival, updates period/status on later
+// firings. Treated as one handler because Stripe sometimes collapses the two.
+async function onSubscriptionUpserted(subscription: Stripe.Subscription): Promise<void> {
+  const meta = subscription.metadata ?? {}
+  const organisationId = meta['organisationId']
+  const tier = meta['tier']
+  const interval = meta['interval']
+  const paymentMethod = meta['paymentMethod'] ?? 'card'
+  if (!organisationId || !tier || !interval) return
+
+  const customerId = typeof subscription.customer === 'string'
+    ? subscription.customer
+    : subscription.customer.id
+
+  const item = subscription.items.data[0]
+  const seatCount = item?.quantity ?? null
+  const currentPeriodStart = toDate(item?.current_period_start ?? null)
+  const currentPeriodEnd = toDate(item?.current_period_end ?? null)
+  const cancelAt = toDate(subscription.cancel_at ?? null)
+
+  const existing = await db.query.purchases.findFirst({
+    where: eq(purchases.stripeSubscriptionId, subscription.id),
+  })
+
+  if (existing) {
+    await db
+      .update(purchases)
+      .set({
+        status: subscription.status,
+        ...(seatCount !== null ? { seatCount } : {}),
+        ...(currentPeriodStart ? { currentPeriodStart } : {}),
+        ...(currentPeriodEnd ? { currentPeriodEnd } : {}),
+        cancelAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(purchases.id, existing.id))
+    return
+  }
+
+  await db.insert(purchases).values({
+    organisationId,
+    stripeCustomerId: customerId,
+    stripeSubscriptionId: subscription.id,
+    tier,
+    interval,
+    seatCount,
+    status: subscription.status,
+    paymentMethod,
+    currentPeriodStart,
+    currentPeriodEnd,
+    cancelAt,
+  })
+}
+
+async function onSubscriptionDeleted(subscription: Stripe.Subscription): Promise<void> {
+  await db
+    .update(purchases)
+    .set({ status: 'canceled', updatedAt: new Date() })
+    .where(eq(purchases.stripeSubscriptionId, subscription.id))
+}
+
+// ── invoice.paid ──────────────────────────────────────────────────────────────
+// Upserts the invoice row and issues a licence for the current period.
+// Idempotent: if a licence already exists covering this billing period, skip.
+async function onInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
+  const subscriptionId = getInvoiceSubscriptionId(invoice)
+  if (!subscriptionId) return
+
+  const purchase = await db.query.purchases.findFirst({
+    where: eq(purchases.stripeSubscriptionId, subscriptionId),
+  })
+  if (!purchase) {
+    // Subscription event hasn't arrived yet; Stripe will retry delivery so we
+    // throw and let the webhook route capture the error for replay.
+    throw new Error(
+      `invoice.paid for subscription ${subscriptionId} arrived before the purchase row existed`,
+    )
+  }
+
+  const invoiceRow = await upsertInvoice(invoice, purchase.id)
+
+  await db
+    .update(purchases)
+    .set({ status: 'active', updatedAt: new Date() })
+    .where(eq(purchases.id, purchase.id))
+
+  await maybeIssueLicenceForPeriod(purchase, invoice)
+  await sendReceipt(purchase.organisationId, invoice, invoiceRow.hostedInvoiceUrl)
+}
+
+async function onInvoicePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
+  const subscriptionId = getInvoiceSubscriptionId(invoice)
+  if (!subscriptionId) return
+
+  const purchase = await db.query.purchases.findFirst({
+    where: eq(purchases.stripeSubscriptionId, subscriptionId),
+  })
+  if (!purchase) return
+
+  await upsertInvoice(invoice, purchase.id)
+  await db
+    .update(purchases)
+    .set({ status: 'past_due', updatedAt: new Date() })
+    .where(eq(purchases.id, purchase.id))
+
+  await sendPaymentFailedNotice(purchase.organisationId, invoice)
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function toDate(unix: number | null): Date | null {
+  if (unix === null || unix === undefined) return null
+  return new Date(unix * 1000)
+}
+
+function getInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const parent = invoice.parent as { subscription_details?: { subscription?: string | Stripe.Subscription } } | null
+  const ref = parent?.subscription_details?.subscription
+  if (!ref) return null
+  return typeof ref === 'string' ? ref : ref.id
+}
+
+async function upsertInvoice(invoice: Stripe.Invoice, purchaseId: string) {
+  const values = {
+    purchaseId,
+    stripeInvoiceId: invoice.id!,
+    number: invoice.number ?? null,
+    amountDue: invoice.amount_due,
+    amountPaid: invoice.amount_paid,
+    currency: invoice.currency,
+    status: invoice.status ?? 'open',
+    hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+    pdfUrl: invoice.invoice_pdf ?? null,
+    issuedAt: toDate(invoice.created),
+    paidAt: invoice.status === 'paid' ? new Date() : null,
+  }
+
+  const existing = await db.query.invoices.findFirst({
+    where: eq(invoices.stripeInvoiceId, invoice.id!),
+  })
+
+  if (existing) {
+    await db
+      .update(invoices)
+      .set({ ...values, updatedAt: new Date() })
+      .where(eq(invoices.id, existing.id))
+    return { ...existing, ...values }
+  }
+
+  const [inserted] = await db.insert(invoices).values(values).returning()
+  if (!inserted) throw new Error(`Failed to persist invoice ${invoice.id}`)
+  return inserted
+}
+
+async function maybeIssueLicenceForPeriod(
+  purchase: Purchase,
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  const periodStart = invoice.period_start ? toDate(invoice.period_start) : null
+  const boundary = periodStart ?? purchase.currentPeriodStart ?? new Date(Date.now() - 60 * 60 * 1000)
+
+  const existing = await db.query.licences.findFirst({
+    where: and(
+      eq(licences.purchaseId, purchase.id),
+      gte(licences.issuedAt, boundary),
+    ),
+    orderBy: [desc(licences.issuedAt)],
+  })
+  if (existing) return
+
+  await issueLicence({ purchaseId: purchase.id })
+}
+
+async function sendReceipt(
+  organisationId: string,
+  invoice: Stripe.Invoice,
+  hostedInvoiceUrl: string | null,
+): Promise<void> {
+  const billing = await db.query.contacts.findFirst({
+    where: and(eq(contacts.organisationId, organisationId), eq(contacts.role, 'billing')),
+  })
+  const to = billing?.email
+  if (!to) return
+
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, organisationId),
+  })
+  const tmpl = receiptEmail({
+    organisationName: org?.name ?? 'your organisation',
+    invoiceNumber: invoice.number ?? invoice.id ?? 'n/a',
+    amount: formatAmount(invoice.amount_paid, invoice.currency),
+    invoiceUrl: hostedInvoiceUrl ?? invoice.hosted_invoice_url ?? '#',
+  })
+  await sendEmail({ to, subject: tmpl.subject, html: tmpl.html, text: tmpl.text, replyTo: env.supportEmail })
+}
+
+async function sendPaymentFailedNotice(
+  organisationId: string,
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  const billing = await db.query.contacts.findFirst({
+    where: and(eq(contacts.organisationId, organisationId), eq(contacts.role, 'billing')),
+  })
+  if (!billing?.email) return
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, organisationId),
+  })
+  const tmpl = paymentFailedEmail({
+    organisationName: org?.name ?? 'your organisation',
+    invoiceUrl: invoice.hosted_invoice_url ?? '#',
+  })
+  const to = env.opsNotificationEmail
+    ? [billing.email, env.opsNotificationEmail]
+    : billing.email
+  await sendEmail({ to, subject: tmpl.subject, html: tmpl.html, text: tmpl.text, replyTo: env.supportEmail })
+}
+
+function formatAmount(amountInSmallestUnit: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+    }).format(amountInSmallestUnit / 100)
+  } catch {
+    return `${(amountInSmallestUnit / 100).toFixed(2)} ${currency.toUpperCase()}`
+  }
 }


### PR DESCRIPTION
## Summary
- Real RS256 licence signer + issuer that match `apps/web/lib/licence.ts`; new JWT per period (air-gap friendly revocation by expiry).
- Stripe Checkout (card / BACS) and `send_invoice` subscription flows share one Stripe customer per organisation.
- Idempotent webhook handler for six events: `checkout.session.completed`, `customer.subscription.{created,updated,deleted}`, `invoice.{paid,payment_failed}`. Licence issuance skips if a licence already covers the invoice's billing period.
- UX polish: Customer Portal button, technical-contact gate on checkout, live licence on `/checkout/success`, real `/invoices` list.
- Lazy DB client init so `next build` works without `DATABASE_URL`.

## End-to-end customer flow
1. Register → placeholder org auto-created
2. `/account` → add technical contact (required before checkout)
3. `/pricing` → Buy Pro / Enterprise
4. `/checkout/[tier]` → pick interval + payment method + seats → Stripe
5. Pay in Stripe → `/checkout/success` shows the licence inline
6. `/dashboard` lists licences; click through → download `.jwt`
7. `/invoices` lists invoices with Stripe PDF links
8. `/account` → Manage billing in Stripe (Customer Portal)

## Stripe setup required before this can run
- Create products + prices for Pro/Enterprise × monthly/yearly; paste price ids into `STRIPE_PRICE_*` env vars
- Register webhook endpoint at `/api/webhooks/stripe` forwarding the six events listed above; put signing secret in `STRIPE_WEBHOOK_SECRET`
- Enable Customer Portal in Stripe Settings → Billing
- Optional: Stripe Tax + BACS Direct Debit payment method

## Test plan
- [ ] `pnpm run db:migrate && pnpm run dev` in `apps/licence-purchase`
- [ ] `stripe listen --forward-to localhost:3001/api/webhooks/stripe`
- [ ] Register, add a technical contact, buy Pro with card `4242 4242 4242 4242`
- [ ] Confirm `/checkout/success` shows the licence JWT and `/dashboard` lists it
- [ ] Download the JWT and verify it against `apps/web/lib/licence.ts` `validateLicenceKey()`
- [ ] `/invoices` shows the paid invoice with hosted + PDF links
- [ ] Trigger `stripe trigger invoice.payment_failed` and confirm purchase flips to `past_due`
- [ ] Click "Manage billing in Stripe" on `/account` and confirm the portal opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)