### PR TITLE
refactor(licence-purchase): flat per-tier pricing, drop seats model

### DIFF
--- a/apps/licence-purchase/PROGRESS.md
+++ b/apps/licence-purchase/PROGRESS.md
@@ -28,7 +28,7 @@ Related references:
 - [x] Better Auth instance (email/password + TOTP) wired at `/api/auth/[...all]`.
 - [x] Landing page, pricing page (driven by `lib/tiers.ts`, monthly/annual toggle), register, login, forgot-password.
 - [x] Authenticated `/dashboard`, `/licences/[id]`, `/invoices`, `/account` pages.
-- [x] Checkout flow scaffold: `/checkout/[tier]` collects interval + payment method + seat count, Server Action calls the Stripe stub, redirects to `/checkout/success` (copy-to-clipboard) or `/checkout/cancelled`.
+- [x] Checkout flow: `/checkout/[tier]` collects interval + payment method (flat per-tier pricing, no seat limits), Server Action redirects to Stripe Checkout / hosted invoice / `/checkout/cancelled`.
 - [x] Stripe webhook endpoint at `/api/webhooks/stripe` — verifies signature, persists raw event, calls stubbed handler.
 - [x] Licence download endpoint at `/api/licences/[id]/download` streams the `.jwt` with ownership check.
 - [x] shadcn primitives: button, card, input, label, badge, separator, switch.
@@ -99,7 +99,7 @@ All templates exist as stubs in `lib/email/templates/`. Each needs an HTML + tex
 ## Phase 7 — Open questions to resolve
 
 - [ ] **Pricing amounts** — the numbers in `lib/tiers.ts` are placeholders. Confirm final monthly / annual figures and annual-discount percentage.
-- [ ] **Seat model** — is `maxHosts` a tier property, a per-purchase add-on, or a usage-based billing meter? Current schema has it nullable on `licence` and `purchase.seatCount`.
+- [x] **Seat model decided**: flat per-tier pricing, unlimited hosts/users at every tier. Customers pay for features (SSO, audit log, compliance packs), not scale. `licence.maxHosts` and `purchase.seatCount` have been dropped from the schema.
 - [ ] **Renewal JWT strategy** — new JWT per period vs. mutate `exp` on existing. Recommendation: new JWT, so revocation-by-expiry still works for air-gapped installs.
 - [ ] **BACS mandate UX** — Stripe `bacs_debit` requires a 3-business-day settlement before the first charge confirms. Policy: issue the licence immediately on subscription activation, or wait for first payment? Current plan: issue on first `invoice.paid` regardless of method.
 - [ ] **Refund policy** — define before the first real customer.

--- a/apps/licence-purchase/app/(dashboard)/licences/[id]/page.tsx
+++ b/apps/licence-purchase/app/(dashboard)/licences/[id]/page.tsx
@@ -63,12 +63,6 @@ export default async function LicencePage({ params }: { params: Promise<{ id: st
               <div className="text-xs uppercase text-muted-foreground">Expires</div>
               <div className="text-foreground">{licence.expiresAt.toLocaleString()}</div>
             </div>
-            {licence.maxHosts ? (
-              <div>
-                <div className="text-xs uppercase text-muted-foreground">Host cap</div>
-                <div className="text-foreground">{licence.maxHosts}</div>
-              </div>
-            ) : null}
             <div>
               <div className="text-xs uppercase text-muted-foreground">Features</div>
               <div className="text-foreground">{licence.features.length} unlocked</div>

--- a/apps/licence-purchase/app/checkout/[tier]/checkout-form.tsx
+++ b/apps/licence-purchase/app/checkout/[tier]/checkout-form.tsx
@@ -2,10 +2,9 @@
 
 import { useState, useTransition } from 'react'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { startCheckout } from '@/lib/actions/checkout'
-import type { BillingInterval, PaidTierId } from '@/lib/tiers'
+import type { BillingInterval, PaidTierId, TierDefinition } from '@/lib/tiers'
 
 type PaymentMethod = 'card' | 'bacs_debit' | 'invoice'
 
@@ -23,11 +22,17 @@ const PAYMENT_METHODS: { id: PaymentMethod; label: string; hint: string }[] = [
   },
 ]
 
-export function CheckoutForm({
+function formatGbp(amount: number): string {
+  return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 }).format(amount)
+}
+
+export function CheckoutPanels({
   tier,
+  tierDef,
   initialInterval,
 }: {
   tier: PaidTierId
+  tierDef: TierDefinition
   initialInterval: BillingInterval
 }) {
   const [pending, start] = useTransition()
@@ -35,12 +40,14 @@ export function CheckoutForm({
   const [interval, setInterval] = useState<BillingInterval>(initialInterval)
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('card')
 
-  function onSubmit(data: FormData) {
+  const perMonth = tierDef.displayPrice[interval] ?? 0
+  const annualisedTotal = interval === 'year' ? perMonth * 12 : perMonth
+
+  function onSubmit() {
     setError(null)
-    const seatCount = Number(data.get('seatCount') ?? '') || undefined
     start(async () => {
       try {
-        await startCheckout({ tier, interval, paymentMethod, seatCount })
+        await startCheckout({ tier, interval, paymentMethod })
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unable to start checkout')
       }
@@ -48,79 +55,112 @@ export function CheckoutForm({
   }
 
   return (
-    <form action={onSubmit} className="grid gap-5">
-      <fieldset className="grid gap-2">
-        <legend className="mb-1 text-sm font-medium text-foreground">Billing interval</legend>
-        <div className="grid grid-cols-2 gap-2">
-          {(['month', 'year'] as BillingInterval[]).map((i) => (
-            <label
-              key={i}
-              className={`flex cursor-pointer items-start gap-2 rounded-lg border p-3 text-sm ${
-                interval === i ? 'border-primary bg-primary/5' : ''
-              }`}
-            >
-              <input
-                type="radio"
-                name="interval"
-                value={i}
-                checked={interval === i}
-                onChange={() => setInterval(i)}
-                className="mt-0.5"
-              />
-              <div>
-                <div className="font-medium capitalize text-foreground">{i === 'year' ? 'Annual (save 20%)' : 'Monthly'}</div>
-                <div className="text-xs text-muted-foreground">
-                  {i === 'year' ? 'Billed once per year.' : 'Billed monthly.'}
-                </div>
+    <div className="grid gap-6 md:grid-cols-[1fr_320px]">
+      <Card>
+        <CardHeader>
+          <CardTitle className="capitalize">Buy {tierDef.name}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={onSubmit} className="grid gap-5">
+            <fieldset className="grid gap-2">
+              <legend className="mb-1 text-sm font-medium text-foreground">Billing interval</legend>
+              <div className="grid grid-cols-2 gap-2">
+                {(['month', 'year'] as BillingInterval[]).map((i) => (
+                  <label
+                    key={i}
+                    className={`flex cursor-pointer items-start gap-2 rounded-lg border p-3 text-sm ${
+                      interval === i ? 'border-primary bg-primary/5' : ''
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="interval"
+                      value={i}
+                      checked={interval === i}
+                      onChange={() => setInterval(i)}
+                      className="mt-0.5"
+                    />
+                    <div>
+                      <div className="font-medium capitalize text-foreground">
+                        {i === 'year' ? 'Annual (save 20%)' : 'Monthly'}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {i === 'year' ? 'Billed once per year.' : 'Billed monthly.'}
+                      </div>
+                    </div>
+                  </label>
+                ))}
               </div>
-            </label>
-          ))}
-        </div>
-      </fieldset>
+            </fieldset>
 
-      <fieldset className="grid gap-2">
-        <legend className="mb-1 text-sm font-medium text-foreground">Payment method</legend>
-        <div className="grid gap-2">
-          {PAYMENT_METHODS.map((m) => (
-            <label
-              key={m.id}
-              className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 text-sm ${
-                paymentMethod === m.id ? 'border-primary bg-primary/5' : ''
-              }`}
-            >
-              <input
-                type="radio"
-                name="paymentMethod"
-                value={m.id}
-                checked={paymentMethod === m.id}
-                onChange={() => setPaymentMethod(m.id)}
-                className="mt-0.5"
-              />
-              <div>
-                <div className="font-medium text-foreground">{m.label}</div>
-                <div className="text-xs text-muted-foreground">{m.hint}</div>
+            <fieldset className="grid gap-2">
+              <legend className="mb-1 text-sm font-medium text-foreground">Payment method</legend>
+              <div className="grid gap-2">
+                {PAYMENT_METHODS.map((m) => (
+                  <label
+                    key={m.id}
+                    className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 text-sm ${
+                      paymentMethod === m.id ? 'border-primary bg-primary/5' : ''
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="paymentMethod"
+                      value={m.id}
+                      checked={paymentMethod === m.id}
+                      onChange={() => setPaymentMethod(m.id)}
+                      className="mt-0.5"
+                    />
+                    <div>
+                      <div className="font-medium text-foreground">{m.label}</div>
+                      <div className="text-xs text-muted-foreground">{m.hint}</div>
+                    </div>
+                  </label>
+                ))}
               </div>
-            </label>
-          ))}
-        </div>
-      </fieldset>
+            </fieldset>
 
-      <div className="grid gap-1.5">
-        <Label htmlFor="seatCount">Hosts (seats)</Label>
-        <Input id="seatCount" name="seatCount" type="number" min={1} defaultValue={10} />
-        <p className="text-xs text-muted-foreground">
-          You can change your seat count later. Billed per host per month.
-        </p>
-      </div>
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            <Button type="submit" disabled={pending} size="lg">
+              {pending ? 'Redirecting to checkout…' : 'Continue to secure checkout'}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              You&apos;ll be redirected to Stripe to enter payment details. We never see your card number.
+            </p>
+          </form>
+        </CardContent>
+      </Card>
 
-      <Button type="submit" disabled={pending} size="lg">
-        {pending ? 'Redirecting to checkout…' : 'Continue to secure checkout'}
-      </Button>
-      <p className="text-xs text-muted-foreground">
-        You&apos;ll be redirected to Stripe to enter payment details. We never see your card number.
-      </p>
-    </form>
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle className="text-base">Order summary</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span>Tier</span>
+            <span className="font-medium capitalize">{tierDef.name}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Billing</span>
+            <span className="font-medium">
+              {interval === 'year' ? 'Annual (save 20%)' : 'Monthly'}
+            </span>
+          </div>
+          <div className="flex items-baseline justify-between pt-2">
+            <span className="text-muted-foreground">Price</span>
+            <span className="text-xl font-semibold">{formatGbp(perMonth)}<span className="text-sm font-normal text-muted-foreground"> / month</span></span>
+          </div>
+          {interval === 'year' ? (
+            <p className="text-right text-xs text-muted-foreground">
+              Billed annually at {formatGbp(annualisedTotal)}
+            </p>
+          ) : null}
+          <p className="mt-3 text-xs text-muted-foreground">
+            Final pricing and VAT will be confirmed on the Stripe checkout page.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
   )
 }

--- a/apps/licence-purchase/app/checkout/[tier]/page.tsx
+++ b/apps/licence-purchase/app/checkout/[tier]/page.tsx
@@ -9,7 +9,7 @@ import { getTier } from '@/lib/tiers'
 import { getRequiredSession } from '@/lib/auth/session'
 import { db } from '@/lib/db'
 import { contacts } from '@/lib/db/schema'
-import { CheckoutForm } from './checkout-form'
+import { CheckoutPanels } from './checkout-form'
 import type { BillingInterval, PaidTierId } from '@/lib/tiers'
 
 export const metadata = { title: 'Checkout' }
@@ -46,54 +46,29 @@ export default async function CheckoutPage({
     <div className="flex min-h-screen flex-col">
       <Nav isAuthenticated />
       <main className="flex-1">
-        <div className="mx-auto grid max-w-4xl gap-6 px-4 py-12 md:grid-cols-[1fr_320px]">
-          <Card>
-            <CardHeader>
-              <CardTitle className="capitalize">Buy {tierDef.name}</CardTitle>
-              <CardDescription>
-                You&apos;re buying as <strong>{user.email}</strong>.{' '}
-                {!user.organisationId ? 'You\u2019ll be asked for company details next.' : null}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {!technical ? (
-                <div className="space-y-3">
-                  <p className="text-sm text-foreground">
-                    Please add a <strong>technical contact</strong> before checkout. This is the
-                    email that will receive the signed licence key.
-                  </p>
-                  <Button asChild>
-                    <Link href="/account">Add technical contact</Link>
-                  </Button>
-                </div>
-              ) : (
-                <CheckoutForm tier={tier} initialInterval={initialInterval} />
-              )}
-            </CardContent>
-          </Card>
+        <div className="mx-auto max-w-4xl px-4 py-12">
+          <p className="mb-6 text-sm text-muted-foreground">
+            You&apos;re buying as <strong className="text-foreground">{user.email}</strong>.{' '}
+            {!user.organisationId ? 'You\u2019ll be asked for company details next.' : null}
+          </p>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Order summary</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span>Tier</span>
-                <span className="font-medium capitalize">{tierDef.name}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Monthly price (from)</span>
-                <span className="font-medium">£{tierDef.displayPrice.month} / host</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Annual price (from)</span>
-                <span className="font-medium">£{tierDef.displayPrice.year} / host / month</span>
-              </div>
-              <p className="mt-3 text-xs text-muted-foreground">
-                Final pricing and VAT will be confirmed on the Stripe checkout page.
-              </p>
-            </CardContent>
-          </Card>
+          {!technical ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Add a technical contact first</CardTitle>
+                <CardDescription>
+                  This is the email that will receive the signed licence key after payment.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild>
+                  <Link href="/account">Add technical contact</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            <CheckoutPanels tier={tier} tierDef={tierDef} initialInterval={initialInterval} />
+          )}
         </div>
       </main>
       <Footer />

--- a/apps/licence-purchase/components/licence/licence-card.tsx
+++ b/apps/licence-purchase/components/licence/licence-card.tsx
@@ -31,9 +31,6 @@ export function LicenceCard({ licence }: { licence: Licence }) {
         <div className="text-xs text-muted-foreground">
           Licence ID: <span className="font-mono text-foreground">{licence.jti}</span>
         </div>
-        {licence.maxHosts ? (
-          <div className="mt-1 text-xs text-muted-foreground">Host cap: {licence.maxHosts}</div>
-        ) : null}
         <div className="mt-4 flex gap-2">
           <Button asChild size="sm">
             <Link href={`/licences/${licence.id}`}>View &amp; download</Link>

--- a/apps/licence-purchase/components/pricing/tier-card.tsx
+++ b/apps/licence-purchase/components/pricing/tier-card.tsx
@@ -39,7 +39,7 @@ export function TierCard({
               <div className="flex items-baseline gap-1">
                 <span className="text-3xl font-semibold tracking-tight text-foreground">£{price}</span>
                 <span className="text-sm text-muted-foreground">
-                  {perMonth ? '/ host / month' : ''}
+                  {perMonth ? '/ month' : ''}
                 </span>
               </div>
               {interval === 'year' ? (

--- a/apps/licence-purchase/lib/actions/checkout.ts
+++ b/apps/licence-purchase/lib/actions/checkout.ts
@@ -10,7 +10,6 @@ const schema = z.object({
   tier: z.enum(['pro', 'enterprise']),
   interval: z.enum(['month', 'year']),
   paymentMethod: z.enum(['card', 'bacs_debit', 'invoice']),
-  seatCount: z.coerce.number().int().min(1).max(10_000).optional(),
 })
 
 export async function startCheckout(input: unknown): Promise<void> {
@@ -27,7 +26,6 @@ export async function startCheckout(input: unknown): Promise<void> {
     organisationId: user.organisationId,
     customerEmail: user.email,
     customerName: user.name,
-    seatCount: parsed.seatCount,
     successUrl: `${env.appUrl}/checkout/success?tier=${parsed.tier}`,
     cancelUrl: `${env.appUrl}/checkout/cancelled`,
   })

--- a/apps/licence-purchase/lib/db/migrations/0000_bored_gorgon.sql
+++ b/apps/licence-purchase/lib/db/migrations/0000_bored_gorgon.sql
@@ -1,0 +1,163 @@
+CREATE TABLE "organisation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"address_line_1" text,
+	"address_line_2" text,
+	"city" text,
+	"region" text,
+	"postal_code" text,
+	"country" text,
+	"vat_number" text,
+	"stripe_customer_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"metadata" jsonb,
+	CONSTRAINT "organisation_stripe_customer_id_unique" UNIQUE("stripe_customer_id")
+);
+--> statement-breakpoint
+CREATE TABLE "account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp with time zone,
+	"refresh_token_expires_at" timestamp with time zone,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "totp_credential" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"secret" text NOT NULL,
+	"backup_codes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"organisation_id" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"two_factor_enabled" boolean DEFAULT false NOT NULL,
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "contact" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organisation_id" text NOT NULL,
+	"role" text NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"phone" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "invoice" (
+	"id" text PRIMARY KEY NOT NULL,
+	"purchase_id" text NOT NULL,
+	"stripe_invoice_id" text NOT NULL,
+	"number" text,
+	"amount_due" integer NOT NULL,
+	"amount_paid" integer DEFAULT 0 NOT NULL,
+	"currency" text NOT NULL,
+	"status" text NOT NULL,
+	"hosted_invoice_url" text,
+	"pdf_url" text,
+	"issued_at" timestamp with time zone,
+	"paid_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "invoice_stripe_invoice_id_unique" UNIQUE("stripe_invoice_id")
+);
+--> statement-breakpoint
+CREATE TABLE "purchase" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organisation_id" text NOT NULL,
+	"stripe_customer_id" text NOT NULL,
+	"stripe_subscription_id" text,
+	"tier" text NOT NULL,
+	"interval" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"payment_method" text NOT NULL,
+	"current_period_start" timestamp with time zone,
+	"current_period_end" timestamp with time zone,
+	"cancel_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb,
+	CONSTRAINT "purchase_stripe_subscription_id_unique" UNIQUE("stripe_subscription_id")
+);
+--> statement-breakpoint
+CREATE TABLE "licence" (
+	"id" text PRIMARY KEY NOT NULL,
+	"jti" text NOT NULL,
+	"organisation_id" text NOT NULL,
+	"purchase_id" text,
+	"tier" text NOT NULL,
+	"features" jsonb NOT NULL,
+	"signed_jwt" text NOT NULL,
+	"issued_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"revoked_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "licence_jti_unique" UNIQUE("jti")
+);
+--> statement-breakpoint
+CREATE TABLE "stripe_webhook_event" (
+	"id" text PRIMARY KEY NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"processed" boolean DEFAULT false NOT NULL,
+	"processing_error" text,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"processed_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "totp_credential" ADD CONSTRAINT "totp_credential_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_organisation_id_organisation_id_fk" FOREIGN KEY ("organisation_id") REFERENCES "public"."organisation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "contact" ADD CONSTRAINT "contact_organisation_id_organisation_id_fk" FOREIGN KEY ("organisation_id") REFERENCES "public"."organisation"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invoice" ADD CONSTRAINT "invoice_purchase_id_purchase_id_fk" FOREIGN KEY ("purchase_id") REFERENCES "public"."purchase"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "purchase" ADD CONSTRAINT "purchase_organisation_id_organisation_id_fk" FOREIGN KEY ("organisation_id") REFERENCES "public"."organisation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "licence" ADD CONSTRAINT "licence_organisation_id_organisation_id_fk" FOREIGN KEY ("organisation_id") REFERENCES "public"."organisation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "licence" ADD CONSTRAINT "licence_purchase_id_purchase_id_fk" FOREIGN KEY ("purchase_id") REFERENCES "public"."purchase"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "contact_org_role_unique" ON "contact" USING btree ("organisation_id","role");

--- a/apps/licence-purchase/lib/db/migrations/meta/0000_snapshot.json
+++ b/apps/licence-purchase/lib/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,1069 @@
+{
+  "id": "07a941a4-55da-4a1b-b4be-a4a1a7793f21",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organisation": {
+      "name": "organisation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organisation_stripe_customer_id_unique": {
+          "name": "organisation_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totp_credential": {
+      "name": "totp_credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "totp_credential_user_id_user_id_fk": {
+          "name": "totp_credential_user_id_user_id_fk",
+          "tableFrom": "totp_credential",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organisation_id_organisation_id_fk": {
+          "name": "user_organisation_id_organisation_id_fk",
+          "tableFrom": "user",
+          "tableTo": "organisation",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact": {
+      "name": "contact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_org_role_unique": {
+          "name": "contact_org_role_unique",
+          "columns": [
+            {
+              "expression": "organisation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_organisation_id_organisation_id_fk": {
+          "name": "contact_organisation_id_organisation_id_fk",
+          "tableFrom": "contact",
+          "tableTo": "organisation",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice": {
+      "name": "invoice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_due": {
+          "name": "amount_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_purchase_id_purchase_id_fk": {
+          "name": "invoice_purchase_id_purchase_id_fk",
+          "tableFrom": "invoice",
+          "tableTo": "purchase",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_stripe_invoice_id_unique": {
+          "name": "invoice_stripe_invoice_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_invoice_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase": {
+      "name": "purchase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_organisation_id_organisation_id_fk": {
+          "name": "purchase_organisation_id_organisation_id_fk",
+          "tableFrom": "purchase",
+          "tableTo": "organisation",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "purchase_stripe_subscription_id_unique": {
+          "name": "purchase_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.licence": {
+      "name": "licence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_jwt": {
+          "name": "signed_jwt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "licence_organisation_id_organisation_id_fk": {
+          "name": "licence_organisation_id_organisation_id_fk",
+          "tableFrom": "licence",
+          "tableTo": "organisation",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "licence_purchase_id_purchase_id_fk": {
+          "name": "licence_purchase_id_purchase_id_fk",
+          "tableFrom": "licence",
+          "tableTo": "purchase",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "licence_jti_unique": {
+          "name": "licence_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_event": {
+      "name": "stripe_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processing_error": {
+          "name": "processing_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/licence-purchase/lib/db/migrations/meta/_journal.json
+++ b/apps/licence-purchase/lib/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776599855967,
+      "tag": "0000_bored_gorgon",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/licence-purchase/lib/db/schema/licences.ts
+++ b/apps/licence-purchase/lib/db/schema/licences.ts
@@ -1,11 +1,11 @@
-import { pgTable, text, timestamp, integer, jsonb } from 'drizzle-orm/pg-core'
+import { pgTable, text, timestamp, jsonb } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
 import { organisations } from './organisations'
 import { purchases } from './purchases'
 
 // A licence record. The signed JWT lives in `signedJwt`.
-// The jti, tier, features, maxHosts and expiresAt columns mirror the JWT claims
-// so we can query them without re-parsing the token.
+// The jti, tier, features and expiresAt columns mirror the JWT claims so we
+// can query them without re-parsing the token.
 export const licences = pgTable('licence', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
   jti: text('jti').notNull().unique(),
@@ -15,7 +15,6 @@ export const licences = pgTable('licence', {
   purchaseId: text('purchase_id').references(() => purchases.id),
   tier: text('tier').notNull(), // 'pro' | 'enterprise'
   features: jsonb('features').notNull().$type<string[]>(),
-  maxHosts: integer('max_hosts'),
   signedJwt: text('signed_jwt').notNull(),
   issuedAt: timestamp('issued_at', { withTimezone: true }).notNull().defaultNow(),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),

--- a/apps/licence-purchase/lib/db/schema/purchases.ts
+++ b/apps/licence-purchase/lib/db/schema/purchases.ts
@@ -12,7 +12,6 @@ export const purchases = pgTable('purchase', {
   stripeSubscriptionId: text('stripe_subscription_id').unique(),
   tier: text('tier').notNull(), // 'pro' | 'enterprise'
   interval: text('interval').notNull(), // 'month' | 'year'
-  seatCount: integer('seat_count'), // null = unlimited within tier limits
   status: text('status').notNull().default('pending'),
   // status values: 'pending' | 'active' | 'past_due' | 'canceled' | 'incomplete' | 'incomplete_expired'
   paymentMethod: text('payment_method').notNull(), // 'card' | 'bacs_debit' | 'invoice'

--- a/apps/licence-purchase/lib/licence/issue.ts
+++ b/apps/licence-purchase/lib/licence/issue.ts
@@ -59,14 +59,12 @@ export async function issueLicence(input: IssueLicenceInput): Promise<Licence> {
 
   const jti = createId()
   const features = featureKeysForTier(purchase.tier)
-  const maxHosts = purchase.seatCount ?? undefined
 
   const signed = await signLicence({
     organisationId: organisation.id,
     customer: { name: organisation.name, email: technicalContact.email },
     tier: purchase.tier,
     features,
-    ...(maxHosts !== undefined ? { maxHosts } : {}),
     jti,
     issuedAt,
     expiresAt,
@@ -80,7 +78,6 @@ export async function issueLicence(input: IssueLicenceInput): Promise<Licence> {
       purchaseId: purchase.id,
       tier: purchase.tier,
       features,
-      ...(maxHosts !== undefined ? { maxHosts } : {}),
       signedJwt: signed.jwt,
       issuedAt,
       expiresAt,

--- a/apps/licence-purchase/lib/licence/sign.ts
+++ b/apps/licence-purchase/lib/licence/sign.ts
@@ -8,7 +8,6 @@ export type SignLicenceInput = {
   customer: { name: string; email: string }
   tier: PaidTierId
   features: string[]
-  maxHosts?: number
   jti: string
   issuedAt: Date
   expiresAt: Date
@@ -51,9 +50,6 @@ export async function signLicence(input: SignLicenceInput): Promise<SignedLicenc
     tier: input.tier,
     features: input.features,
     customer: input.customer,
-  }
-  if (input.maxHosts !== undefined) {
-    claims['maxHosts'] = input.maxHosts
   }
 
   const iat = Math.floor(input.issuedAt.getTime() / 1000)

--- a/apps/licence-purchase/lib/stripe/create-checkout-session.ts
+++ b/apps/licence-purchase/lib/stripe/create-checkout-session.ts
@@ -13,7 +13,6 @@ export type CreateCheckoutSessionInput = {
   organisationId: string
   customerEmail: string
   customerName?: string | null
-  seatCount?: number
   successUrl: string
   cancelUrl: string
 }
@@ -36,7 +35,6 @@ export async function createCheckoutSession(
   input: CreateCheckoutSessionInput,
 ): Promise<CreateCheckoutSessionResult> {
   const priceId = resolvePriceId(input.tier, input.interval)
-  const quantity = input.seatCount ?? 1
 
   const customerId = await ensureStripeCustomer({
     organisationId: input.organisationId,
@@ -48,14 +46,13 @@ export async function createCheckoutSession(
     organisationId: input.organisationId,
     tier: input.tier,
     interval: input.interval,
-    seatCount: String(quantity),
     paymentMethod: input.paymentMethod,
   }
 
   if (input.paymentMethod === 'invoice') {
     const subscription = await stripe().subscriptions.create({
       customer: customerId,
-      items: [{ price: priceId, quantity }],
+      items: [{ price: priceId, quantity: 1 }],
       collection_method: 'send_invoice',
       days_until_due: env.stripeInvoiceCollectionDays,
       metadata,
@@ -79,7 +76,7 @@ export async function createCheckoutSession(
   const session = await stripe().checkout.sessions.create({
     mode: 'subscription',
     payment_method_types: [input.paymentMethod],
-    line_items: [{ price: priceId, quantity }],
+    line_items: [{ price: priceId, quantity: 1 }],
     customer: customerId,
     success_url: input.successUrl,
     cancel_url: input.cancelUrl,

--- a/apps/licence-purchase/lib/stripe/handle-webhook.ts
+++ b/apps/licence-purchase/lib/stripe/handle-webhook.ts
@@ -67,7 +67,6 @@ async function onSubscriptionUpserted(subscription: Stripe.Subscription): Promis
     : subscription.customer.id
 
   const item = subscription.items.data[0]
-  const seatCount = item?.quantity ?? null
   const currentPeriodStart = toDate(item?.current_period_start ?? null)
   const currentPeriodEnd = toDate(item?.current_period_end ?? null)
   const cancelAt = toDate(subscription.cancel_at ?? null)
@@ -81,7 +80,6 @@ async function onSubscriptionUpserted(subscription: Stripe.Subscription): Promis
       .update(purchases)
       .set({
         status: subscription.status,
-        ...(seatCount !== null ? { seatCount } : {}),
         ...(currentPeriodStart ? { currentPeriodStart } : {}),
         ...(currentPeriodEnd ? { currentPeriodEnd } : {}),
         cancelAt,
@@ -97,7 +95,6 @@ async function onSubscriptionUpserted(subscription: Stripe.Subscription): Promis
     stripeSubscriptionId: subscription.id,
     tier,
     interval,
-    seatCount,
     status: subscription.status,
     paymentMethod,
     currentPeriodStart,


### PR DESCRIPTION
## Summary
Community already has unlimited hosts — per-seat pricing on Pro / Enterprise created a downgrade incentive with no feature benefit and was also the cause of the £27,000 vs £2,700 discrepancy in Stripe checkout (quantity × price).

- Customers now pay a flat per-tier price; no seat count input at checkout.
- Stripe line items use `quantity: 1`, so the tier price is the total.
- `purchase.seatCount` and `licence.maxHosts` dropped from the schema.
- Pricing page and order summary no longer say "/ host".

## Also fixes the reactive order summary
The summary on `/checkout/[tier]` was a server-rendered sibling of the client form, so it never updated when you changed the billing interval. Moved it into the same client component (`CheckoutPanels`) and it now shows the selected interval's price only, with annual totals called out below.

## Migration
First Drizzle migration for this app is committed at `lib/db/migrations/0000_bored_gorgon.sql` (baseline, representing the post-change schema). Anyone starting fresh can `pnpm run db:migrate`.

**For existing dev databases** (set up via `db:push` earlier): either drop + recreate the `licence_purchase` database and re-migrate, or manually:
```sql
ALTER TABLE purchase DROP COLUMN seat_count;
ALTER TABLE licence DROP COLUMN max_hosts;
```

## Test plan
- [ ] `pnpm run db:migrate` applies cleanly on a fresh DB
- [ ] `/pricing` no longer shows "/ host"
- [ ] `/checkout/pro` — flip monthly ↔ annual and watch the order summary update in place
- [ ] Buy Pro monthly with Stripe test card `4242 4242 4242 4242` and confirm the Stripe checkout total matches the dashboard price (no quantity multiplication)
- [ ] Issued licence JWT no longer contains a `maxHosts` claim (decode it to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)