### PR TITLE
feat(licence-purchase): fetch pricing live from Stripe

### DIFF
--- a/apps/licence-purchase/app/checkout/[tier]/checkout-form.tsx
+++ b/apps/licence-purchase/app/checkout/[tier]/checkout-form.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { startCheckout } from '@/lib/actions/checkout'
 import type { BillingInterval, PaidTierId, TierDefinition } from '@/lib/tiers'
+import type { TierStripePrices } from '@/lib/stripe/prices'
 
 type PaymentMethod = 'card' | 'bacs_debit' | 'invoice'
 
@@ -22,26 +23,37 @@ const PAYMENT_METHODS: { id: PaymentMethod; label: string; hint: string }[] = [
   },
 ]
 
-function formatGbp(amount: number): string {
-  return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 }).format(amount)
+function formatMoney(unitAmount: number, currency: string): string {
+  return new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: currency.toUpperCase(),
+    maximumFractionDigits: unitAmount % 100 === 0 ? 0 : 2,
+  }).format(unitAmount / 100)
 }
 
 export function CheckoutPanels({
   tier,
   tierDef,
   initialInterval,
+  stripePrices,
 }: {
   tier: PaidTierId
   tierDef: TierDefinition
   initialInterval: BillingInterval
+  stripePrices: TierStripePrices
 }) {
   const [pending, start] = useTransition()
   const [error, setError] = useState<string | null>(null)
   const [interval, setInterval] = useState<BillingInterval>(initialInterval)
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>('card')
 
-  const perMonth = tierDef.displayPrice[interval] ?? 0
-  const annualisedTotal = interval === 'year' ? perMonth * 12 : perMonth
+  const activePrice = stripePrices[interval]
+  const displayPrice = activePrice
+    ? formatMoney(activePrice.unitAmount, activePrice.currency)
+    : tierDef.displayPrice[interval] !== null
+      ? `£${tierDef.displayPrice[interval]}`
+      : null
+  const intervalSuffix = interval === 'year' ? '/ year' : '/ month'
 
   function onSubmit() {
     setError(null)
@@ -149,15 +161,17 @@ export function CheckoutPanels({
           </div>
           <div className="flex items-baseline justify-between pt-2">
             <span className="text-muted-foreground">Price</span>
-            <span className="text-xl font-semibold">{formatGbp(perMonth)}<span className="text-sm font-normal text-muted-foreground"> / month</span></span>
+            {displayPrice ? (
+              <span className="text-xl font-semibold">
+                {displayPrice}
+                <span className="text-sm font-normal text-muted-foreground"> {intervalSuffix}</span>
+              </span>
+            ) : (
+              <span className="text-sm text-muted-foreground">Price unavailable</span>
+            )}
           </div>
-          {interval === 'year' ? (
-            <p className="text-right text-xs text-muted-foreground">
-              Billed annually at {formatGbp(annualisedTotal)}
-            </p>
-          ) : null}
           <p className="mt-3 text-xs text-muted-foreground">
-            Final pricing and VAT will be confirmed on the Stripe checkout page.
+            VAT will be confirmed on the Stripe checkout page.
           </p>
         </CardContent>
       </Card>

--- a/apps/licence-purchase/app/checkout/[tier]/page.tsx
+++ b/apps/licence-purchase/app/checkout/[tier]/page.tsx
@@ -9,6 +9,7 @@ import { getTier } from '@/lib/tiers'
 import { getRequiredSession } from '@/lib/auth/session'
 import { db } from '@/lib/db'
 import { contacts } from '@/lib/db/schema'
+import { getTierStripePrices } from '@/lib/stripe/prices'
 import { CheckoutPanels } from './checkout-form'
 import type { BillingInterval, PaidTierId } from '@/lib/tiers'
 
@@ -33,14 +34,17 @@ export default async function CheckoutPage({
   const initialInterval: BillingInterval = interval === 'year' ? 'year' : 'month'
   const tierDef = getTier(tier)
 
-  const technical = user.organisationId
-    ? await db.query.contacts.findFirst({
-        where: and(
-          eq(contacts.organisationId, user.organisationId),
-          eq(contacts.role, 'technical'),
-        ),
-      })
-    : null
+  const [technical, stripePrices] = await Promise.all([
+    user.organisationId
+      ? db.query.contacts.findFirst({
+          where: and(
+            eq(contacts.organisationId, user.organisationId),
+            eq(contacts.role, 'technical'),
+          ),
+        })
+      : Promise.resolve(null),
+    getTierStripePrices(tier),
+  ])
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -67,7 +71,12 @@ export default async function CheckoutPage({
               </CardContent>
             </Card>
           ) : (
-            <CheckoutPanels tier={tier} tierDef={tierDef} initialInterval={initialInterval} />
+            <CheckoutPanels
+              tier={tier}
+              tierDef={tierDef}
+              initialInterval={initialInterval}
+              stripePrices={stripePrices}
+            />
           )}
         </div>
       </main>

--- a/apps/licence-purchase/app/pricing/page.tsx
+++ b/apps/licence-purchase/app/pricing/page.tsx
@@ -3,11 +3,22 @@ import { Footer } from '@/components/shared/footer'
 import { PricingClient } from './pricing-client'
 import { TIERS } from '@/lib/tiers'
 import { getOptionalSession } from '@/lib/auth/session'
+import { getTierStripePrices, type TierStripePrices } from '@/lib/stripe/prices'
 
 export const metadata = { title: 'Pricing' }
 
 export default async function PricingPage() {
-  const session = await getOptionalSession()
+  const [session, proPrices, enterprisePrices] = await Promise.all([
+    getOptionalSession(),
+    getTierStripePrices('pro'),
+    getTierStripePrices('enterprise'),
+  ])
+
+  const stripePrices: Record<'pro' | 'enterprise', TierStripePrices> = {
+    pro: proPrices,
+    enterprise: enterprisePrices,
+  }
+
   return (
     <div className="flex min-h-screen flex-col">
       <Nav isAuthenticated={!!session} />
@@ -22,7 +33,7 @@ export default async function PricingPage() {
             </p>
           </div>
 
-          <PricingClient tiers={TIERS} />
+          <PricingClient tiers={TIERS} stripePrices={stripePrices} />
         </div>
       </main>
       <Footer />

--- a/apps/licence-purchase/app/pricing/pricing-client.tsx
+++ b/apps/licence-purchase/app/pricing/pricing-client.tsx
@@ -4,9 +4,23 @@ import { useState } from 'react'
 import { BillingToggle } from '@/components/pricing/billing-toggle'
 import { TierCard } from '@/components/pricing/tier-card'
 import type { BillingInterval, TierDefinition } from '@/lib/tiers'
+import type { TierStripePrices } from '@/lib/stripe/prices'
 
-export function PricingClient({ tiers }: { tiers: TierDefinition[] }) {
+export function PricingClient({
+  tiers,
+  stripePrices,
+}: {
+  tiers: TierDefinition[]
+  stripePrices: Record<'pro' | 'enterprise', TierStripePrices>
+}) {
   const [interval, setInterval] = useState<BillingInterval>('month')
+
+  function stripePriceFor(tierId: string) {
+    if (tierId === 'pro' || tierId === 'enterprise') {
+      return stripePrices[tierId][interval]
+    }
+    return null
+  }
 
   return (
     <>
@@ -16,7 +30,12 @@ export function PricingClient({ tiers }: { tiers: TierDefinition[] }) {
 
       <div className="mt-10 grid gap-6 md:grid-cols-3">
         {tiers.map((tier) => (
-          <TierCard key={tier.id} tier={tier} interval={interval} />
+          <TierCard
+            key={tier.id}
+            tier={tier}
+            interval={interval}
+            stripePrice={stripePriceFor(tier.id)}
+          />
         ))}
       </div>
 

--- a/apps/licence-purchase/components/pricing/tier-card.tsx
+++ b/apps/licence-purchase/components/pricing/tier-card.tsx
@@ -4,17 +4,39 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Check } from 'lucide-react'
 import type { BillingInterval, TierDefinition } from '@/lib/tiers'
+import type { StripePriceInfo } from '@/lib/stripe/prices'
 import { cn } from '@/lib/utils'
+
+function formatMoney(unitAmount: number, currency: string): string {
+  return new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: currency.toUpperCase(),
+    maximumFractionDigits: unitAmount % 100 === 0 ? 0 : 2,
+  }).format(unitAmount / 100)
+}
 
 export function TierCard({
   tier,
   interval,
+  stripePrice,
 }: {
   tier: TierDefinition
   interval: BillingInterval
+  stripePrice?: StripePriceInfo | null
 }) {
-  const price = tier.displayPrice[interval]
-  const perMonth = price !== null && price > 0
+  const fallback = tier.displayPrice[interval]
+
+  let priceLabel: string | null = null
+  if (stripePrice) {
+    priceLabel = formatMoney(stripePrice.unitAmount, stripePrice.currency)
+  } else if (fallback === 0) {
+    priceLabel = 'Free'
+  } else if (fallback !== null) {
+    priceLabel = `£${fallback}`
+  }
+
+  const intervalSuffix = interval === 'year' ? '/ year' : '/ month'
+  const isPaid = priceLabel !== null && priceLabel !== 'Free'
 
   return (
     <Card
@@ -32,18 +54,13 @@ export function TierCard({
       </CardHeader>
       <CardContent className="flex h-full flex-col gap-6">
         <div>
-          {price === 0 ? (
+          {priceLabel === 'Free' ? (
             <div className="text-3xl font-semibold tracking-tight text-foreground">Free</div>
-          ) : price !== null ? (
-            <div>
-              <div className="flex items-baseline gap-1">
-                <span className="text-3xl font-semibold tracking-tight text-foreground">£{price}</span>
-                <span className="text-sm text-muted-foreground">
-                  {perMonth ? '/ month' : ''}
-                </span>
-              </div>
-              {interval === 'year' ? (
-                <p className="mt-1 text-xs text-muted-foreground">Billed annually</p>
+          ) : priceLabel !== null ? (
+            <div className="flex items-baseline gap-1">
+              <span className="text-3xl font-semibold tracking-tight text-foreground">{priceLabel}</span>
+              {isPaid ? (
+                <span className="text-sm text-muted-foreground">{intervalSuffix}</span>
               ) : null}
             </div>
           ) : (

--- a/apps/licence-purchase/lib/stripe/prices.ts
+++ b/apps/licence-purchase/lib/stripe/prices.ts
@@ -1,0 +1,57 @@
+import { unstable_cache } from 'next/cache'
+import { stripe } from './client'
+import { env } from '@/lib/env'
+import type { BillingInterval, PaidTierId } from '@/lib/tiers'
+
+export type StripePriceInfo = {
+  unitAmount: number // smallest currency unit (e.g. pence)
+  currency: string // lowercase ISO 4217, e.g. 'gbp'
+  interval: BillingInterval
+}
+
+export type TierStripePrices = {
+  month: StripePriceInfo | null
+  year: StripePriceInfo | null
+}
+
+async function fetchPrice(priceId: string): Promise<StripePriceInfo | null> {
+  if (!priceId) return null
+  try {
+    const price = await stripe().prices.retrieve(priceId)
+    if (price.unit_amount === null || price.unit_amount === undefined) return null
+    const interval: BillingInterval = price.recurring?.interval === 'year' ? 'year' : 'month'
+    return {
+      unitAmount: price.unit_amount,
+      currency: price.currency,
+      interval,
+    }
+  } catch (err) {
+    console.warn('[stripe] failed to fetch price', priceId, err)
+    return null
+  }
+}
+
+// Cache for 5 minutes per price id. We don't need tight freshness — operators
+// change prices rarely, and stale pricing for a few minutes is fine.
+const fetchPriceCached = unstable_cache(
+  async (priceId: string) => fetchPrice(priceId),
+  ['stripe-price'],
+  { revalidate: 300, tags: ['stripe-prices'] },
+)
+
+export async function getTierStripePrices(tier: PaidTierId): Promise<TierStripePrices> {
+  const ids = env.stripePrices[tier]
+  const [month, year] = await Promise.all([
+    fetchPriceCached(ids.month),
+    fetchPriceCached(ids.year),
+  ])
+  return { month, year }
+}
+
+export function formatStripePrice(price: StripePriceInfo): string {
+  return new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency: price.currency.toUpperCase(),
+    maximumFractionDigits: price.unitAmount % 100 === 0 ? 0 : 2,
+  }).format(price.unitAmount / 100)
+}


### PR DESCRIPTION
## Summary
Stripe is now the source of truth for displayed prices on both `/pricing` and `/checkout/[tier]`. Prices are fetched from `stripe.prices.retrieve` server-side and cached for 5 minutes. `tiers.ts` `displayPrice` numbers remain only as a fallback if Stripe is unreachable or a price id is unset.

- New helper `lib/stripe/prices.ts` — `getTierStripePrices(tier)` fetches both intervals in parallel, cached via `unstable_cache` (5 min TTL).
- `/pricing` passes fetched prices through `PricingClient` → `TierCard`.
- `/checkout/[tier]` passes fetched prices through `CheckoutPanels` → order summary.
- Annual now shows the annual total (e.g. "£2,700 / year") instead of a per-month equivalent with "billed annually at £2,700" fine print.

## Test plan
- [ ] `/pricing` shows your Stripe prices exactly (£2,700 for Pro yearly, etc.)
- [ ] Toggle the Monthly ↔ Annual switch — tier cards update to the corresponding Stripe price
- [ ] `/checkout/pro` — flip interval and the order summary shows "£X / month" or "£Y / year" matching Stripe
- [ ] Continue to Stripe checkout — the total there matches what the app showed
- [ ] Temporarily unset a `STRIPE_PRICE_*` env var and reload — fallback to the `tiers.ts` displayPrice kicks in without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)