### PR TITLE
fix(licence-purchase): resolve webhook race and auto-redirect on success

### DIFF
--- a/apps/licence-purchase/app/checkout/success/page.tsx
+++ b/apps/licence-purchase/app/checkout/success/page.tsx
@@ -1,32 +1,30 @@
-import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { and, desc, eq, gte, isNull } from 'drizzle-orm'
 import { Nav } from '@/components/shared/nav'
 import { Footer } from '@/components/shared/footer'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { CopyButton } from '@/components/licence/copy-button'
-import { CheckCircle2, Clock } from 'lucide-react'
+import { AwaitLicence } from '@/components/licence/await-licence'
 import { getOptionalSession } from '@/lib/auth/session'
 import { db } from '@/lib/db'
 import { licences } from '@/lib/db/schema'
 
 export const metadata = { title: 'Purchase complete' }
 
-// Customer lands here right after Stripe Checkout returns. For card payments,
-// the webhook has usually fired by now; for BACS / invoice we ask the customer
-// to wait. The page queries the most-recent licence issued in the last hour —
-// if present we show it inline, otherwise we direct them to the dashboard.
-async function recentLicenceForUser(organisationId: string | null) {
-  if (!organisationId) return null
+// Customer lands here right after Stripe Checkout returns. If the webhook has
+// already issued the licence we redirect straight to the dashboard; otherwise
+// a client component polls until it appears and then redirects.
+async function hasRecentLicence(organisationId: string | null): Promise<boolean> {
+  if (!organisationId) return false
   const cutoff = new Date(Date.now() - 60 * 60 * 1000)
-  return db.query.licences.findFirst({
+  const row = await db.query.licences.findFirst({
     where: and(
       eq(licences.organisationId, organisationId),
       isNull(licences.revokedAt),
       gte(licences.issuedAt, cutoff),
     ),
     orderBy: [desc(licences.issuedAt)],
+    columns: { id: true },
   })
+  return !!row
 }
 
 export default async function SuccessPage({
@@ -36,72 +34,18 @@ export default async function SuccessPage({
 }) {
   const { method, tier } = await searchParams
   const session = await getOptionalSession()
-  const licence = await recentLicenceForUser(session?.user.organisationId ?? null)
+  const licenceReady = await hasRecentLicence(session?.user.organisationId ?? null)
 
-  const isInvoiceFlow = method === 'invoice'
+  if (licenceReady) {
+    redirect('/dashboard')
+  }
 
   return (
     <div className="flex min-h-screen flex-col">
       <Nav isAuthenticated={!!session} />
       <main className="flex-1">
         <div className="mx-auto max-w-2xl px-4 py-16">
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-primary/10">
-                {licence ? (
-                  <CheckCircle2 className="size-5 text-primary" aria-hidden />
-                ) : (
-                  <Clock className="size-5 text-primary" aria-hidden />
-                )}
-              </div>
-              <CardTitle>
-                {licence
-                  ? 'Purchase complete'
-                  : isInvoiceFlow
-                    ? 'Invoice issued'
-                    : 'Payment received — issuing your licence'}
-              </CardTitle>
-              <CardDescription>
-                {licence
-                  ? 'Your licence is ready. Copy it now, or download it any time from your dashboard.'
-                  : isInvoiceFlow
-                    ? 'Check your email for the invoice. Your licence will be issued as soon as payment clears.'
-                    : 'It can take a few seconds for Stripe to confirm payment. Refresh in a moment, or head to your dashboard.'}
-                {tier ? <> Tier: <strong className="capitalize">{tier}</strong>.</> : null}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {licence ? (
-                <>
-                  <div className="rounded-lg border bg-muted p-3">
-                    <div className="mb-2 flex items-center justify-between">
-                      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        Licence key
-                      </span>
-                      <CopyButton value={licence.signedJwt} />
-                    </div>
-                    <pre className="overflow-x-auto text-xs text-foreground whitespace-pre-wrap break-all">
-                      {licence.signedJwt}
-                    </pre>
-                  </div>
-
-                  <p className="text-sm text-muted-foreground">
-                    Paste this key into <strong>Settings → Licence → Licence key</strong> on your Infrawatch server.
-                    It is also safe to transfer over air-gap to a disconnected host.
-                  </p>
-                </>
-              ) : null}
-
-              <div className="flex flex-wrap gap-2">
-                <Button asChild>
-                  <Link href="/dashboard">Go to dashboard</Link>
-                </Button>
-                <Button asChild variant="outline">
-                  <Link href="/invoices">View invoices</Link>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
+          <AwaitLicence tier={tier} isInvoiceFlow={method === 'invoice'} />
         </div>
       </main>
       <Footer />

--- a/apps/licence-purchase/components/licence/await-licence.tsx
+++ b/apps/licence-purchase/components/licence/await-licence.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Clock, Loader2 } from 'lucide-react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
+import { getRecentLicenceIdForCurrentUser } from '@/lib/actions/licences'
+
+type Props = {
+  tier?: string
+  isInvoiceFlow: boolean
+}
+
+// Polls for the licence that Stripe's webhook will create once payment clears.
+// As soon as a licence appears, we hard-navigate to /dashboard so the user
+// sees it in their list without having to click anything.
+export function AwaitLicence({ tier, isInvoiceFlow }: Props) {
+  const router = useRouter()
+  const [elapsed, setElapsed] = useState(0)
+  const redirected = useRef(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function poll() {
+      if (cancelled) return
+      try {
+        const id = await getRecentLicenceIdForCurrentUser()
+        if (id && !redirected.current) {
+          redirected.current = true
+          router.replace('/dashboard')
+          return
+        }
+      } catch {
+        // transient — keep polling
+      }
+      if (!cancelled) {
+        setElapsed((n) => n + 1)
+        timer = setTimeout(poll, 2000)
+      }
+    }
+
+    let timer = setTimeout(poll, 1000)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [router])
+
+  // After ~20 polling cycles (~40s) for invoice flow, stop promising imminent
+  // redirect — invoice payment can take days to clear.
+  const longWait = elapsed > 20
+
+  return (
+    <Card>
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-primary/10">
+          {isInvoiceFlow ? (
+            <Clock className="size-5 text-primary" aria-hidden />
+          ) : (
+            <Loader2 className="size-5 text-primary animate-spin" aria-hidden />
+          )}
+        </div>
+        <CardTitle>
+          {isInvoiceFlow ? 'Invoice issued' : 'Processing your payment'}
+        </CardTitle>
+        <CardDescription>
+          {isInvoiceFlow
+            ? 'Check your email for the invoice. Your licence will be issued as soon as payment clears — this page will update automatically.'
+            : longWait
+              ? 'Still waiting for Stripe to confirm. You can leave this page — your licence will be emailed as soon as it is ready.'
+              : 'Waiting for Stripe to confirm your payment. You will be taken to your licences as soon as it is ready.'}
+          {tier ? <> Tier: <strong className="capitalize">{tier}</strong>.</> : null}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2 justify-center">
+        <Button asChild variant="outline">
+          <Link href="/dashboard">Go to dashboard now</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/licence-purchase/lib/actions/licences.ts
+++ b/apps/licence-purchase/lib/actions/licences.ts
@@ -1,9 +1,9 @@
 'use server'
 
-import { and, eq, isNull, desc } from 'drizzle-orm'
+import { and, eq, gte, isNull, desc } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { licences } from '@/lib/db/schema'
-import { getRequiredSession } from '@/lib/auth/session'
+import { getOptionalSession, getRequiredSession } from '@/lib/auth/session'
 import type { Licence } from '@/lib/db/schema'
 
 export async function listLicencesForOrganisation(): Promise<Licence[]> {
@@ -22,4 +22,24 @@ export async function getLicenceById(id: string): Promise<Licence | null> {
     where: and(eq(licences.id, id), eq(licences.organisationId, user.organisationId)),
   })
   return result ?? null
+}
+
+// Polled by the checkout-success client while the Stripe webhook finishes its
+// round-trip. Returns the id of the most-recent licence issued in the last
+// hour — enough for the UI to know the purchase completed and redirect.
+export async function getRecentLicenceIdForCurrentUser(): Promise<string | null> {
+  const session = await getOptionalSession()
+  const organisationId = session?.user.organisationId
+  if (!organisationId) return null
+  const cutoff = new Date(Date.now() - 60 * 60 * 1000)
+  const result = await db.query.licences.findFirst({
+    where: and(
+      eq(licences.organisationId, organisationId),
+      isNull(licences.revokedAt),
+      gte(licences.issuedAt, cutoff),
+    ),
+    orderBy: [desc(licences.issuedAt)],
+    columns: { id: true },
+  })
+  return result?.id ?? null
 }

--- a/apps/licence-purchase/lib/stripe/handle-webhook.ts
+++ b/apps/licence-purchase/lib/stripe/handle-webhook.ts
@@ -8,6 +8,7 @@ import { licences } from '@/lib/db/schema'
 import { sendEmail } from '@/lib/email/client'
 import { receiptEmail } from '@/lib/email/templates/receipt'
 import { paymentFailedEmail } from '@/lib/email/templates/payment-failed'
+import { stripe } from '@/lib/stripe/client'
 import { env } from '@/lib/env'
 
 // Dispatches a Stripe webhook event to the appropriate handler. Each handler
@@ -117,15 +118,22 @@ async function onInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   const subscriptionId = getInvoiceSubscriptionId(invoice)
   if (!subscriptionId) return
 
-  const purchase = await db.query.purchases.findFirst({
+  // Stripe commonly delivers invoice.paid before customer.subscription.created.
+  // If the purchase row is missing, fetch the subscription directly and create
+  // it inline so we're order-independent.
+  let purchase = await db.query.purchases.findFirst({
     where: eq(purchases.stripeSubscriptionId, subscriptionId),
   })
   if (!purchase) {
-    // Subscription event hasn't arrived yet; Stripe will retry delivery so we
-    // throw and let the webhook route capture the error for replay.
-    throw new Error(
-      `invoice.paid for subscription ${subscriptionId} arrived before the purchase row existed`,
-    )
+    const subscription = await stripe().subscriptions.retrieve(subscriptionId)
+    await onSubscriptionUpserted(subscription)
+    purchase = await db.query.purchases.findFirst({
+      where: eq(purchases.stripeSubscriptionId, subscriptionId),
+    })
+  }
+  if (!purchase) {
+    // Metadata missing — nothing we can do with this invoice.
+    return
   }
 
   const invoiceRow = await upsertInvoice(invoice, purchase.id)


### PR DESCRIPTION
## Summary
- Fix Stripe webhook race: `invoice.paid` often arrives before `customer.subscription.created`, so the handler threw before the purchase row existed and no licence was ever issued. `onInvoicePaid` now fetches the subscription from Stripe and upserts the purchase inline when the row is missing, making the flow order-independent.
- Auto-redirect on `/checkout/success`: the page now polls for the licence every 2s via a new `AwaitLicence` client component and `getRecentLicenceIdForCurrentUser` server action. As soon as the webhook mints the licence, the user is taken straight to `/dashboard` — no manual refresh.

## Test plan
- [ ] Run `stripe listen --forward-to localhost:3001/api/webhooks/stripe` in a sandbox
- [ ] Complete a card checkout; confirm the success page shows "Processing your payment" then auto-redirects to `/dashboard` with the licence visible
- [ ] Confirm `invoice.paid` → `customer.subscription.created` order no longer blocks licence issuance
- [ ] Complete an invoice/BACS flow; confirm the "Invoice issued" copy shows and the page updates once payment clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)