### PR TITLE
fix(licence): align issuer/audience between sign and verify

### DIFF
--- a/apps/licence-purchase/.env.example
+++ b/apps/licence-purchase/.env.example
@@ -49,8 +49,8 @@ LICENCE_SIGNING_PRIVATE_KEY_PEM=
 LICENCE_SIGNING_PRIVATE_KEY_PATH=../../deploy/scripts/licence-dev-private.pem
 
 # These two must match apps/web/lib/licence.ts exactly.
-LICENCE_ISSUER=infrawatch-licensing
-LICENCE_AUDIENCE=infrawatch
+LICENCE_ISSUER=licence.infrawatch.io
+LICENCE_AUDIENCE=install.infrawatch.io
 
 # Default term lengths for issued licences. Buffer days are added so a late
 # payment retry doesn't instantly revoke a just-issued key.

--- a/apps/licence-purchase/lib/env.ts
+++ b/apps/licence-purchase/lib/env.ts
@@ -79,10 +79,10 @@ export const env = {
     return optional('LICENCE_SIGNING_PRIVATE_KEY_PATH')
   },
   get licenceIssuer() {
-    return optional('LICENCE_ISSUER') ?? 'infrawatch-licensing'
+    return optional('LICENCE_ISSUER') ?? 'licence.infrawatch.io'
   },
   get licenceAudience() {
-    return optional('LICENCE_AUDIENCE') ?? 'infrawatch'
+    return optional('LICENCE_AUDIENCE') ?? 'install.infrawatch.io'
   },
   get licenceMonthlyDays() {
     return optionalInt('LICENCE_MONTHLY_DAYS', 35)

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -40,8 +40,8 @@ export function resolveLicencePublicKeyPem(): string {
   return DEV_PUBLIC_KEY_PEM.trim()
 }
 
-const LICENCE_ISSUER = 'infrawatch-licensing'
-const LICENCE_AUDIENCE = 'infrawatch'
+const LICENCE_ISSUER = 'licence.infrawatch.io'
+const LICENCE_AUDIENCE = 'install.infrawatch.io'
 
 export type PaidTier = Exclude<LicenceTier, 'community'>
 


### PR DESCRIPTION
## Summary
- Licence JWTs were signed with \`iss=licence.infrawatch.io\` / \`aud=install.infrawatch.io\` but apps/web hard-coded the older placeholder values \`infrawatch-licensing\` / \`infrawatch\`. Every issued key failed verification with "Licence key issuer is invalid".
- Update the validator and the licence-purchase defaults/example to the domain-style values so newly-issued keys validate without any extra configuration.

## Test plan
- [ ] Pull main, restart apps/web (and apps/licence-purchase if running)
- [ ] Issue a fresh sandbox licence, paste it into Settings → Licence → Licence key in apps/web
- [ ] Confirm it validates and the tier switches from Community to Pro/Enterprise

🤖 Generated with [Claude Code](https://claude.com/claude-code)