### PR TITLE
feat(licence-purchase): add logout button to authenticated nav

### DIFF
--- a/apps/licence-purchase/components/shared/logout-button.tsx
+++ b/apps/licence-purchase/components/shared/logout-button.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+
+export function LogoutButton() {
+  const router = useRouter()
+  const [pending, start] = useTransition()
+
+  function onClick() {
+    start(async () => {
+      await fetch('/api/auth/sign-out', { method: 'POST' })
+      router.push('/login')
+      router.refresh()
+    })
+  }
+
+  return (
+    <Button variant="ghost" size="sm" onClick={onClick} disabled={pending}>
+      {pending ? 'Signing out…' : 'Sign out'}
+    </Button>
+  )
+}

--- a/apps/licence-purchase/components/shared/nav.tsx
+++ b/apps/licence-purchase/components/shared/nav.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { ShieldCheck } from 'lucide-react'
+import { LogoutButton } from '@/components/shared/logout-button'
 
 export function Nav({ isAuthenticated }: { isAuthenticated?: boolean }) {
   return (
@@ -21,9 +22,12 @@ export function Nav({ isAuthenticated }: { isAuthenticated?: boolean }) {
             Docs
           </Link>
           {isAuthenticated ? (
-            <Button asChild size="sm">
-              <Link href="/dashboard">Dashboard</Link>
-            </Button>
+            <>
+              <Button asChild size="sm">
+                <Link href="/dashboard">Dashboard</Link>
+              </Button>
+              <LogoutButton />
+            </>
           ) : (
             <>
               <Button asChild variant="ghost" size="sm">


### PR DESCRIPTION
## Summary
- Adds a `LogoutButton` client component that posts to Better Auth's `/api/auth/sign-out` endpoint, then redirects to `/login`.
- Renders the button in the shared `Nav` whenever `isAuthenticated` is true (dashboard and admin layouts).

## Test plan
- [ ] Sign in at `/login`, confirm "Sign out" appears in the header nav.
- [ ] Click "Sign out" — verify redirect to `/login` and that protected routes (`/dashboard`, `/admin/...`) bounce back to login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)