### PR TITLE
feat(licence-purchase): show Admin link in nav for super_admins

### DIFF
--- a/apps/licence-purchase/components/shared/nav.tsx
+++ b/apps/licence-purchase/components/shared/nav.tsx
@@ -2,8 +2,16 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { ShieldCheck } from 'lucide-react'
 import { LogoutButton } from '@/components/shared/logout-button'
+import { getOptionalSession } from '@/lib/auth/session'
 
-export function Nav({ isAuthenticated }: { isAuthenticated?: boolean }) {
+// `isAuthenticated` is accepted for call sites that already compute it, but the
+// nav also resolves the session itself so it can show the Admin link to
+// super_admins without each page having to pass `role` through.
+export async function Nav({ isAuthenticated }: { isAuthenticated?: boolean } = {}) {
+  const session = await getOptionalSession()
+  const authed = isAuthenticated ?? !!session
+  const isSuperAdmin = session?.user.role === 'super_admin'
+
   return (
     <header className="border-b bg-background">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
@@ -21,7 +29,15 @@ export function Nav({ isAuthenticated }: { isAuthenticated?: boolean }) {
           <Link href="https://docs.infrawatch.io" className="rounded-md px-3 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground">
             Docs
           </Link>
-          {isAuthenticated ? (
+          {isSuperAdmin ? (
+            <Link
+              href="/admin/products"
+              className="rounded-md px-3 py-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Admin
+            </Link>
+          ) : null}
+          {authed ? (
             <>
               <Button asChild size="sm">
                 <Link href="/dashboard">Dashboard</Link>


### PR DESCRIPTION
## Summary
- Admin UI at `/admin/products` was unreachable without typing the URL directly.
- `Nav` now resolves the session itself and shows an **Admin** link when `session.user.role === 'super_admin'`.
- `isAuthenticated` prop kept optional so existing call sites don't change.

## Test plan
- [ ] As a non-super_admin, confirm no Admin link appears.
- [ ] As a super_admin, confirm Admin link appears and opens `/admin/products`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)