### PR TITLE
fix(licence-purchase): use inArray for tier price lookup

### DIFF
--- a/apps/licence-purchase/lib/catalog/queries.ts
+++ b/apps/licence-purchase/lib/catalog/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { products, productTiers, productTierPrices } from '@/lib/db/schema'
 import type { Product, ProductTier, ProductTierPrice } from '@/lib/db/schema'
@@ -82,9 +82,9 @@ export async function listTiersForProduct(
       options.activeOnly
         ? and(
             eq(productTierPrices.isActive, true),
-            sql`${productTierPrices.tierId} = ANY(${tierIds})`,
+            inArray(productTierPrices.tierId, tierIds),
           )
-        : sql`${productTierPrices.tierId} = ANY(${tierIds})`,
+        : inArray(productTierPrices.tierId, tierIds),
     )
 
   const byTier = new Map<string, ProductTierPrice[]>()


### PR DESCRIPTION
## Summary
- Admin product edit page was crashing with a runtime Drizzle query error on `listTiersForProduct`
- Root cause: `sql\`... = ANY(\${tierIds})\`` expanded the JS array as a parameter tuple (`($1)`) rather than a Postgres `text[]`, which is invalid for `ANY()`
- Fix: switch to `inArray(productTierPrices.tierId, tierIds)` which emits correct `IN (...)` syntax

## Test plan
- [ ] Open `/admin/products/<slug>` in the licence-purchase app — page renders instead of throwing
- [ ] Verify both active-only and non-active-only code paths still return tiers with their prices grouped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)