### PR TITLE
fix(notes): visibility toggle label wraps and overlaps tabs

### DIFF
--- a/apps/web/components/notes/note-editor-dialog.tsx
+++ b/apps/web/components/notes/note-editor-dialog.tsx
@@ -202,21 +202,36 @@ export function NoteEditorDialog(props: Props) {
 
             {(mode === 'create' || (mode === 'edit' && props.initial.isAuthor)) && (
               <div className="space-y-1.5">
-                <Label className="flex items-center gap-2">
-                  {isPrivate ? <Lock className="size-3.5" /> : <Eye className="size-3.5" />}
-                  Visibility
-                </Label>
-                <div className="flex items-center gap-3 h-9 px-3 rounded-md border border-input bg-transparent">
+                <Label className="flex items-center gap-2">Visibility</Label>
+                <div className="flex items-center gap-2 h-9 px-3 rounded-md border border-input bg-transparent">
                   <Switch
                     id="note-private"
                     checked={isPrivate}
                     onCheckedChange={setIsPrivate}
                     disabled={isSaving}
                   />
-                  <Label htmlFor="note-private" className="text-sm cursor-pointer">
-                    {isPrivate ? 'Private — only you and super admins' : 'Shared with everyone in your org'}
+                  <Label
+                    htmlFor="note-private"
+                    className="text-sm cursor-pointer inline-flex items-center gap-1.5 whitespace-nowrap"
+                  >
+                    {isPrivate ? (
+                      <>
+                        <Lock className="size-3.5" />
+                        Private
+                      </>
+                    ) : (
+                      <>
+                        <Eye className="size-3.5" />
+                        Shared
+                      </>
+                    )}
                   </Label>
                 </div>
+                <p className="text-xs text-muted-foreground">
+                  {isPrivate
+                    ? 'Only you and super admins can read this note.'
+                    : 'Everyone in your org who can see this host.'}
+                </p>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

The note-editor dialog's Visibility toggle had a long inline label (\"Shared with everyone in your org\" / \"Private — only you and super admins\") that overflowed its pill, wrapped onto multiple lines, and collided with the Write/Preview tabs below. Reported with a screenshot.

- Compact toggle now shows just **Shared** / **Private** with the icon, inside a fixed-height pill.
- Explanation moves to a helper line (\`text-muted-foreground\`) underneath, matching the \"Markdown supported…\" helper pattern used for the Body field.

Follows [#423](https://github.com/carrtech-dev/ct-ops/pull/423).

## Test plan

- [x] \`pnpm exec tsc --noEmit\` passes
- [x] \`pnpm exec eslint components/notes/note-editor-dialog.tsx\` clean
- [ ] Open the New note dialog on a narrow viewport, confirm Visibility pill stays one line and no longer overlaps the Body tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)