### PR TITLE
docs(security): publish vulnerability disclosure policy and security.txt

### DIFF
--- a/SECURITY_DISCLOSURE.md
+++ b/SECURITY_DISCLOSURE.md
@@ -1,0 +1,99 @@
+# Security Disclosure Policy
+
+We take the security of Infrawatch / CT-Ops seriously. This document describes
+how to report a vulnerability, what to expect once you do, and the scope of
+our coordinated disclosure programme.
+
+This policy applies to the upstream project hosted at
+<https://github.com/carrtech-dev/ct-ops>. Operators running their own
+deployment may publish additional or overriding contact information in their
+own `/.well-known/security.txt` file.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security problems. Use one of
+the following channels so that we can triage privately:
+
+- **GitHub Security Advisory** (preferred):
+  <https://github.com/carrtech-dev/ct-ops/security/advisories/new>
+- **Email:** security@infrawatch.io
+
+Include as much detail as you can:
+
+- A description of the vulnerability and the affected component (web app,
+  ingest service, agent, consumer, etc.).
+- Steps to reproduce — a proof-of-concept, curl transcript, or minimal patch
+  is ideal.
+- The version, commit SHA, or container image digest you tested against.
+- Any mitigations you are aware of.
+- Whether you would like to be credited in the advisory, and the name /
+  handle you would like us to use.
+
+If the issue is sensitive enough that you would prefer to encrypt the report,
+please open an advisory at the GitHub link above — advisories are private
+until published.
+
+## What to expect
+
+- **Acknowledgement:** within 3 business days of receipt.
+- **Initial triage:** within 10 business days, with a severity assessment and
+  a rough remediation timeline.
+- **Fix development:** we aim to ship fixes for Critical / High severity
+  findings within 30 days of acknowledgement, and for Medium / Low findings
+  within 90 days. Complex issues may take longer; we will keep you informed.
+- **Coordinated disclosure:** we will agree a disclosure date with you before
+  publishing the advisory. By default we request up to 90 days from
+  acknowledgement before public disclosure.
+- **Credit:** reporters are credited in the published advisory unless they
+  ask to remain anonymous.
+
+## Scope
+
+In scope:
+
+- The web application (`apps/web/`)
+- The gRPC ingest service (`apps/ingest/`)
+- Queue consumers (`consumers/`)
+- The Go agent (`agent/`)
+- The installer and packaged container images
+- The official deployment profiles (`deploy/`)
+- Anything under `proto/` and `packages/`
+
+Out of scope:
+
+- Social-engineering, phishing, and physical attacks against the project
+  maintainers or operators of third-party deployments.
+- Denial-of-service attacks that rely on volumetric traffic.
+- Findings that require already having root on a host running the agent.
+- Vulnerabilities in third-party dependencies for which no upstream fix is
+  available — please report these upstream; we will coordinate the bump once
+  a fix lands.
+- Operator misconfiguration issues (weak database passwords, missing TLS,
+  exposed dashboards) that are covered in the deployment docs. We welcome
+  documentation fixes for anything that is unclear.
+
+If you are unsure whether something is in scope, err on the side of reporting
+it — we would rather hear about it and triage it out than miss a real issue.
+
+## Safe harbour
+
+We will not pursue legal action against security researchers who:
+
+- Make a good-faith effort to comply with this policy.
+- Avoid privacy violations, data destruction, and service degradation.
+- Only interact with accounts they own or have explicit permission to test.
+- Do not exploit findings beyond what is necessary to demonstrate the issue.
+- Give us a reasonable amount of time to remediate before any public
+  disclosure.
+
+## Hall of fame
+
+Published advisories live at
+<https://github.com/carrtech-dev/ct-ops/security/advisories>. Reporters who
+would like to be listed will be credited there.
+
+## Keeping this policy current
+
+This policy is versioned alongside the code. If you spot anything outdated,
+please open a pull request — including fixes to the `Expires` date in
+`apps/web/public/.well-known/security.txt`.

--- a/apps/docs/docs/.vuepress/config.ts
+++ b/apps/docs/docs/.vuepress/config.ts
@@ -92,6 +92,10 @@ export default defineUserConfig({
         text: 'Licensing',
         link: '/licensing.md',
       },
+      {
+        text: 'Security',
+        link: '/security.md',
+      },
     ],
   }),
 

--- a/apps/docs/docs/security.md
+++ b/apps/docs/docs/security.md
@@ -1,0 +1,47 @@
+# Security & Vulnerability Disclosure
+
+CT-Ops follows a coordinated vulnerability disclosure policy. The full text
+lives at [SECURITY_DISCLOSURE.md](https://github.com/carrtech-dev/ct-ops/blob/main/SECURITY_DISCLOSURE.md)
+in the repository.
+
+## Reporting a vulnerability
+
+Do **not** open a public GitHub issue. Use one of:
+
+- **GitHub Security Advisory** (preferred):
+  <https://github.com/carrtech-dev/ct-ops/security/advisories/new>
+- **Email:** security@infrawatch.io
+
+Please include reproduction steps, affected version / commit / image digest,
+and any known mitigations.
+
+## What to expect
+
+- Acknowledgement within 3 business days.
+- Initial triage and severity assessment within 10 business days.
+- Target fix windows: 30 days for Critical / High, 90 days for Medium / Low.
+- We will agree a disclosure date with you before publishing any advisory.
+
+## security.txt
+
+Every deployment serves [`/.well-known/security.txt`](https://github.com/carrtech-dev/ct-ops/blob/main/apps/web/public/.well-known/security.txt)
+as per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116). The file ships
+with the upstream project's contact details; operators running their own
+deployment may replace it with their own security contact so that researchers
+can reach the team responsible for that installation.
+
+To override for a deployment, edit `apps/web/public/.well-known/security.txt`
+in your fork before building the image, or mount a replacement file over the
+path in your container.
+
+## Safe harbour
+
+See [SECURITY_DISCLOSURE.md](https://github.com/carrtech-dev/ct-ops/blob/main/SECURITY_DISCLOSURE.md#safe-harbour)
+for the full safe-harbour statement. In short: act in good faith, avoid data
+destruction or privacy violations, give us a reasonable window to remediate,
+and we will not pursue legal action.
+
+## Published advisories
+
+Past and pending advisories are listed at
+<https://github.com/carrtech-dev/ct-ops/security/advisories>.

--- a/apps/web/public/.well-known/security.txt
+++ b/apps/web/public/.well-known/security.txt
@@ -1,0 +1,13 @@
+# Infrawatch / CT-Ops security contact — RFC 9116
+#
+# This file is served by the self-hosted web app at /.well-known/security.txt.
+# Operators who deploy CT-Ops are welcome to replace the Contact lines below
+# with their own security contact so that researchers report to the team
+# responsible for this specific deployment. The upstream project will continue
+# to honour reports sent via the GitHub Security Advisory link.
+
+Contact: https://github.com/carrtech-dev/ct-ops/security/advisories/new
+Contact: mailto:security@infrawatch.io
+Expires: 2027-04-19T00:00:00.000Z
+Preferred-Languages: en
+Policy: https://github.com/carrtech-dev/ct-ops/blob/main/SECURITY_DISCLOSURE.md


### PR DESCRIPTION
## Summary

- Add `/.well-known/security.txt` (RFC 9116) served by the Next.js web app, pointing researchers at GitHub Security Advisories and a backup email
- Add `SECURITY_DISCLOSURE.md` at the repo root covering scope, response SLAs, safe harbour, and credit
- Add a matching `Security` page to the docs site (sidebar entry next to Licensing) so operators know the file exists and can override the contact for their own deployment

Closes #360

## Test plan
- [ ] Confirm the docs sidebar shows the new Security entry after the site rebuilds
- [ ] Confirm `curl https://<deployment>/.well-known/security.txt` returns the new file once the image is rebuilt
- [ ] Review `Expires` date in `security.txt` annually and bump before it lapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)