### PR TITLE
ci(security): add CodeQL, gosec, semgrep, and trivy SAST workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyse:
+    name: Analyse ${{ matrix.language }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+          - language: go
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: |
+            agent/go.sum
+            apps/ingest/go.sum
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyse
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,123 @@
+name: SAST
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "47 5 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gosec:
+    name: gosec (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: agent
+            path: agent
+          - module: ingest
+            path: apps/ingest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: ${{ matrix.path }}/go.sum
+
+      - name: Run gosec
+        uses: securego/gosec@master
+        with:
+          args: "-no-fail -fmt sarif -out results.sarif ./..."
+        env:
+          GOFLAGS: "-buildvcs=false"
+        working-directory: ${{ matrix.path }}
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ matrix.path }}/results.sarif
+          category: gosec-${{ matrix.module }}
+
+  semgrep:
+    name: semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run semgrep
+        run: |
+          semgrep scan \
+            --config p/ci \
+            --config p/security-audit \
+            --config p/owasp-top-ten \
+            --config p/secrets \
+            --error=false \
+            --sarif --output=semgrep.sarif
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+  trivy-fs:
+    name: trivy (filesystem)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: CRITICAL,HIGH,MEDIUM
+          ignore-unfixed: true
+          exit-code: "0"
+          skip-dirs: ".git,node_modules"
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  trivy-config:
+    name: trivy (config / IaC)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run trivy config scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: "0"
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -34,10 +34,14 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: ${{ matrix.path }}/go.sum
 
+      - name: Install gosec
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh \
+            | sh -s -- -b "$HOME/.local/bin" v2.22.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Run gosec
-        uses: securego/gosec@master
-        with:
-          args: "-no-fail -fmt sarif -out results.sarif ./..."
+        run: gosec -no-fail -fmt sarif -out results.sarif ./...
         env:
           GOFLAGS: "-buildvcs=false"
         working-directory: ${{ matrix.path }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -62,13 +62,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run semgrep
+        continue-on-error: true
         run: |
           semgrep scan \
             --config p/ci \
             --config p/security-audit \
             --config p/owasp-top-ten \
             --config p/secrets \
-            --error=false \
             --sarif --output=semgrep.sarif
 
       - name: Upload SARIF


### PR DESCRIPTION
## Summary

- `.github/workflows/codeql.yml` — CodeQL for TypeScript/JavaScript and Go, `security-and-quality` query pack
- `.github/workflows/sast.yml` — gosec per Go module, semgrep (ci / security-audit / owasp-top-ten / secrets), and trivy in both filesystem and config/IaC modes
- All scanners upload SARIF to GitHub Code Scanning and are non-blocking for this first pass so the first wave of findings can be triaged without turning PRs red. Any of them can be promoted to a required check once the backlog is clean.

Closes #361

## Test plan
- [ ] Verify each job runs on this PR and uploads results to the Security tab
- [ ] Triage the initial findings; allow-list or fix as appropriate
- [ ] Decide per-scanner whether to fail the build on new HIGH/CRITICAL findings once the backlog is quiet

🤖 Generated with [Claude Code](https://claude.com/claude-code)