### PR TITLE
ci(release): generate SPDX SBOMs for every release artifact

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -92,6 +92,15 @@ jobs:
             -o "dist/infrawatch-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}" \
             ./agent/cmd/agent
 
+      - name: Generate SBOM for binary
+        uses: anchore/sbom-action@v0
+        with:
+          path: dist/infrawatch-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}
+          format: spdx-json
+          output-file: dist/infrawatch-agent-${{ matrix.asset_suffix }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Checksum and upload to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,9 +108,12 @@ jobs:
           cd dist
           sha256sum "infrawatch-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}" \
             > "infrawatch-agent-${{ matrix.asset_suffix }}.sha256"
+          sha256sum "infrawatch-agent-${{ matrix.asset_suffix }}.spdx.json" \
+            >> "infrawatch-agent-${{ matrix.asset_suffix }}.sha256"
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
             "infrawatch-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}" \
-            "infrawatch-agent-${{ matrix.asset_suffix }}.sha256"
+            "infrawatch-agent-${{ matrix.asset_suffix }}.sha256" \
+            "infrawatch-agent-${{ matrix.asset_suffix }}.spdx.json"
 
   # ── Customer bundle for web releases ─────────────────────────────────────
   # Runs in the same workflow run as release-please so the GITHUB_TOKEN
@@ -136,6 +148,15 @@ jobs:
           (cd dist && zip -r "../infrawatch-single-${VERSION}.zip" infrawatch)
           cp "infrawatch-single-${VERSION}.zip" infrawatch-single.zip
 
+      - name: Generate SBOM for web bundle source
+        uses: anchore/sbom-action@v0
+        with:
+          path: apps/web
+          format: spdx-json
+          output-file: infrawatch-web.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,4 +167,5 @@ jobs:
           gh release upload "$TAG" \
             "infrawatch-single-${VERSION}.zip" \
             "infrawatch-single.zip" \
+            "infrawatch-web.spdx.json" \
             --clobber

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/web,push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
           cache-from: type=gha,scope=web-${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=web-${{ matrix.suffix }}
 
@@ -170,6 +172,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/ingest,push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
           cache-from: type=gha,scope=ingest-${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=ingest-${{ matrix.suffix }}
 


### PR DESCRIPTION
## Summary

- Attach an SPDX JSON SBOM to every agent binary in the GitHub release (derived from Go build info via `anchore/sbom-action`)
- Attach an SBOM of the `apps/web` source tree to every web customer bundle release
- Turn on `sbom: true` + `provenance: mode=max` for both the web and ingest image builds so image attestations are pushed alongside each multi-arch manifest

Closes #364

## Test plan
- [ ] On the next agent release PR merge, confirm `*.spdx.json` files appear on the GitHub release
- [ ] On the next web release PR merge, confirm `infrawatch-web.spdx.json` appears on the GitHub release
- [ ] After the next `docker-publish` run on `main`, verify `docker buildx imagetools inspect ghcr.io/<owner>/infrawatch/web:latest --format '{{ json .SBOM }}'` returns SBOM data

🤖 Generated with [Claude Code](https://claude.com/claude-code)