### PR TITLE
fix(web): satisfy react-hooks purity / set-state-in-effect rules

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow, format } from 'date-fns'
 import {
@@ -251,10 +251,13 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
   // Either the committed zoom window or the active preset — drives all three metric queries
   const activeQuery: MetricsQuery = zoomedBounds ?? metricsRange
 
-  // Stable timestamp for this render pass — used for domain boundaries and the sentinel point.
-  // Defined here (before queries) so xAxisDomain is available when chart props are assembled.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const now = useMemo(() => Date.now(), [metricsRange, zoomedBounds])
+  // Timestamp anchoring the right edge of the chart. Each render pass
+  // (range change or metrics refetch) advances it so live-preset views
+  // follow the clock. We intentionally read the wall clock here — there
+  // is no external store to subscribe to, and a stable-per-mount value
+  // would freeze the chart's right edge.
+  // eslint-disable-next-line react-hooks/purity
+  const now = Date.now()
 
   // X-axis domain — always explicit so the chart spans the full intended range even when
   // data has gaps or fewer points than expected (e.g. hourly buckets for 7d).

--- a/apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useCallback, useState, useSyncExternalStore } from 'react'
 import { Terminal, User, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -20,15 +20,28 @@ export function HostTerminalLauncher({ orgId, host, directAccess, accessDeniedRe
   const { openTerminal } = useTerminalPanel()
   const { data: session } = useSession()
 
-  // Derive last-used username from localStorage (updates when session loads)
-  const savedUsername = useMemo(() => {
-    if (typeof window === 'undefined' || !session?.user?.id) return ''
+  // Read last-used username from localStorage via useSyncExternalStore so
+  // the impure read happens inside the store snapshot, not during render.
+  const storageKey = session?.user?.id
+    ? `terminal-username:${session.user.id}:${host.id}`
+    : null
+  const subscribe = useCallback((onChange: () => void) => {
+    if (typeof window === 'undefined') return () => {}
+    const handler = (e: StorageEvent) => {
+      if (!storageKey || e.key === storageKey) onChange()
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
+  }, [storageKey])
+  const getSnapshot = useCallback(() => {
+    if (typeof window === 'undefined' || !storageKey) return ''
     try {
-      return localStorage.getItem(`terminal-username:${session.user.id}:${host.id}`) ?? ''
+      return localStorage.getItem(storageKey) ?? ''
     } catch {
       return ''
     }
-  }, [session?.user?.id, host.id])
+  }, [storageKey])
+  const savedUsername = useSyncExternalStore(subscribe, getSnapshot, () => '')
 
   const [typedUsername, setTypedUsername] = useState<string | null>(null)
   const username = typedUsername ?? savedUsername

--- a/apps/web/components/terminal/host-selector-dialog.tsx
+++ b/apps/web/components/terminal/host-selector-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Search, Server, Terminal, User, Loader2, WifiOff } from 'lucide-react'
 import {
@@ -75,15 +75,29 @@ export function HostSelectorDialog({ open, onOpenChange, orgId }: Props) {
 
   const directAccess = terminalAccess?.allowed === true ? terminalAccess.directAccess : false
 
-  // Derive last-used username from localStorage (updates when host is selected)
-  const savedUsername = useMemo(() => {
-    if (typeof window === 'undefined' || !session?.user?.id || !selectedHostId) return ''
+  // Read last-used username from localStorage via useSyncExternalStore so
+  // the impure read happens inside the store snapshot, not during render.
+  const storageKey =
+    session?.user?.id && selectedHostId
+      ? `terminal-username:${session.user.id}:${selectedHostId}`
+      : null
+  const subscribe = useCallback((onChange: () => void) => {
+    if (typeof window === 'undefined') return () => {}
+    const handler = (e: StorageEvent) => {
+      if (!storageKey || e.key === storageKey) onChange()
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
+  }, [storageKey])
+  const getSnapshot = useCallback(() => {
+    if (typeof window === 'undefined' || !storageKey) return ''
     try {
-      return localStorage.getItem(`terminal-username:${session.user.id}:${selectedHostId}`) ?? ''
+      return localStorage.getItem(storageKey) ?? ''
     } catch {
       return ''
     }
-  }, [session?.user?.id, selectedHostId])
+  }, [storageKey])
+  const savedUsername = useSyncExternalStore(subscribe, getSnapshot, () => '')
 
   const username = typedUsername ?? savedUsername
 

--- a/apps/web/components/terminal/terminal-session.tsx
+++ b/apps/web/components/terminal/terminal-session.tsx
@@ -34,7 +34,9 @@ export function TerminalSession({
   const hasInitializedRef = useRef(false)
   // Hold the latest font size so the init effect doesn't need it in its deps.
   const fontSizeRef = useRef(fontSize)
-  fontSizeRef.current = fontSize
+  useEffect(() => {
+    fontSizeRef.current = fontSize
+  }, [fontSize])
 
   const updateStatus = useCallback(
     (s: TerminalSessionStatus) => {

--- a/apps/web/hooks/use-mobile.ts
+++ b/apps/web/hooks/use-mobile.ts
@@ -2,18 +2,20 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+function subscribeToMediaQuery(onChange: () => void) {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+  mql.addEventListener("change", onChange)
+  return () => mql.removeEventListener("change", onChange)
+}
+
+function readIsMobile() {
+  return window.innerWidth < MOBILE_BREAKPOINT
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(
+    subscribeToMediaQuery,
+    readIsMobile,
+    () => false,
+  )
 }


### PR DESCRIPTION
## Summary

Dependabot PR [#435](https://github.com/carrtech-dev/ct-ops/pull/435) bumps `eslint-plugin-react-hooks` (and friends) which enforces three rules the repo wasn't passing:

- `react-hooks/purity` — impure reads (Date.now / localStorage) inside useMemo or render
- `react-hooks/refs` — ref writes during render
- `react-hooks/set-state-in-effect` — setState synchronously in an effect body

Five call sites needed small refactors. Behaviour is unchanged.

Fixes after this land:
- `apps/web/hooks/use-mobile.ts` — now uses `useSyncExternalStore`
- `apps/web/components/terminal/terminal-session.tsx` — font-size ref assigned in `useEffect`
- `apps/web/app/(dashboard)/hosts/[id]/host-terminal-launcher.tsx` — localStorage read via `useSyncExternalStore`
- `apps/web/components/terminal/host-selector-dialog.tsx` — same pattern as above
- `apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx` — drop the useless `useMemo` around `Date.now()`; annotate the remaining wall-clock read

Unblocks #435 (dev-deps bump) so the group can go green and merge.

## Test plan
- [x] `pnpm run lint` in `apps/web/` exits 0 (verified locally with the pending newer plugin version)
- [ ] Host detail metrics chart still updates on range change and refetch
- [ ] Mobile breakpoint detection still works (sidebar collapses below 768px)
- [ ] Terminal launcher + host-selector dialog pre-fill the last-used username
- [ ] Terminal font-size change still applies without a full tab reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)