### PR TITLE
chore(ci): broaden dependabot major-version ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,16 @@ updates:
       docker:
         patterns:
           - "*"
+    ignore:
+      # Base-image majors break the Dockerfile contract (e.g. node 25
+      # dropped corepack, alpine major bumps shuffle apk packages).
+      # Do these manually.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "golang"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "alpine"
+        update-types: ["version-update:semver-major"]
 
   # --- Node / pnpm workspaces ----------------------------------------------
   - package-ecosystem: "npm"
@@ -62,7 +72,8 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # Major framework bumps are never silent — do them by hand.
+      # Major framework / tooling bumps are never silent — do them by hand.
+      # Rationale for each entry is in the commit that added it.
       - dependency-name: "next"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react"
@@ -78,6 +89,23 @@ updates:
       - dependency-name: "drizzle-kit"
         update-types: ["version-update:semver-major"]
       - dependency-name: "better-auth"
+        update-types: ["version-update:semver-major"]
+      # ESLint 10 breaks eslint-plugin-react until the plugin ships an
+      # ESLint 10 compatible release; the bump currently fails the build.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-next"
+        update-types: ["version-update:semver-major"]
+      # @types/node majors track the Node runtime major — only bump in
+      # lockstep with the engines field.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      # Stripe majors include breaking API version bumps.
+      - dependency-name: "stripe"
         update-types: ["version-update:semver-major"]
 
   # --- Go modules -----------------------------------------------------------


### PR DESCRIPTION
## Summary

After [#428](https://github.com/carrtech-dev/ct-ops/pull/428) landed, the first weekly Dependabot run opened 7 major-bump PRs that cannot go green without coordinated human work:

| PR | Bump | Reason it fails |
|----|------|-----------------|
| [#445](https://github.com/carrtech-dev/ct-ops/pull/445) | \`@types/node\` 20 → 25 | Dependabot doesn't regenerate \`pnpm-lock.yaml\` for major npm bumps in pnpm workspaces |
| [#444](https://github.com/carrtech-dev/ct-ops/pull/444) | \`eslint\` 9 → 10 (web) | same |
| [#443](https://github.com/carrtech-dev/ct-ops/pull/443) | \`@types/node\` 20 → 25 (licence-purchase) | same |
| [#442](https://github.com/carrtech-dev/ct-ops/pull/442) | \`eslint\` 9 → 10 (licence-purchase) | same |
| [#441](https://github.com/carrtech-dev/ct-ops/pull/441) | \`stripe\` 19 → 22 | same, plus breaking API-version bump |
| [#440](https://github.com/carrtech-dev/ct-ops/pull/440) | \`eslint\` 9 → 10 (root) | \`eslint-plugin-react\` is not ESLint-10 compatible |
| [#433](https://github.com/carrtech-dev/ct-ops/pull/433) | Docker \`node\` 22 → 25 | Node 25 dropped corepack; \`RUN corepack enable\` exits 127 |

This PR adds each of those deps to the major-version ignore list so Dependabot stops retrying them every week. Grouped minor/patch runs (which all passed) are unaffected.

After this merges I'll close the 7 broken PRs.

## Test plan
- [ ] On next Dependabot run, confirm no fresh major-bump PRs appear for the ignored deps
- [ ] Confirm the grouped minor/patch PRs (#432, #434, #435, #436) still open on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)