### PR TITLE
fix(start): shorten dev TLS cert from 10 years to 365 days

### DIFF
--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -72,7 +72,9 @@ openssl req -x509 -newkey rsa:4096 -keyout deploy/dev-tls/server.key \
   -subj "/CN=ct-ops-ingest"
 ```
 
-For production, use a certificate from your corporate CA or Let's Encrypt.
+The dev certificate above expires in 365 days — long enough for laptops to keep working between rebuilds, short enough that an accidental production deployment fails loudly within a year. **Do not extend the `-days` value** to avoid the renewal: the short lifetime is the safety net.
+
+For production, use a certificate from your corporate CA or Let's Encrypt and rotate it on the schedule your CA issues — typical lifetimes are 90 days (Let's Encrypt) to 1 year (corporate CAs). Re-running `start.sh` will not regenerate certificates that already exist on disk; production rotation is your operational responsibility.
 
 ### 4. Start the stack
 

--- a/start.sh
+++ b/start.sh
@@ -110,13 +110,17 @@ if [ ! -f "$CERT_DIR/server.crt" ] || [ ! -f "$CERT_DIR/server.key" ]; then
     SAN="${SAN},${LOCAL_IPS}"
   fi
 
+  # Dev certs deliberately expire in 365 days. They are NOT for production —
+  # production deployments must supply their own CA-issued certificates and
+  # rotate them per their own cert-management policy. A short-lived dev cert
+  # makes accidental production reuse fail loudly within a year.
   openssl req -x509 -newkey rsa:4096 \
     -keyout "$CERT_DIR/server.key" \
     -out "$CERT_DIR/server.crt" \
-    -sha256 -days 3650 -nodes \
+    -sha256 -days 365 -nodes \
     -subj "/CN=infrawatch-ingest" \
     -addext "subjectAltName=${SAN}" 2>/dev/null
-  echo "TLS certificates generated (SANs: ${SAN})."
+  echo "TLS certificates generated (SANs: ${SAN}, expiry: 365 days — dev only)."
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `start.sh` generated dev TLS certs with `-days 3650`. If those certs were copied into production, they'd keep working silently for a decade — exactly the situation the audit flagged in `[L-02]`.
- The companion script `deploy/scripts/gen-dev-tls.sh` and the `Makefile` `dev-tls` target already use `-days 365`. This change brings `start.sh` in line.
- Adds a comment in `start.sh` and a paragraph in the Docker Compose deployment doc explaining why dev certs are deliberately short-lived and that production cert rotation is the operator's responsibility.

Closes #349

## Test plan
- [ ] `./start.sh --local --db-only` on a clean checkout regenerates `deploy/dev-tls/server.{crt,key}` and the cert reports `notAfter` ~365 days out (`openssl x509 -in deploy/dev-tls/server.crt -noout -dates`).
- [ ] Existing dev certs with the old 10-year expiry are not regenerated (the `if [ ! -f ... ]` guard still skips them); operators who want the new lifetime delete `deploy/dev-tls/` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)