### PR TITLE
docs(env): annotate security-critical environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,28 +2,85 @@
 # Infrawatch — Configuration
 # =============================================================================
 # Copy this file to .env and edit the values below before running ./start.sh.
+#
+# All values shipped here are LOCALHOST DEFAULTS. They will run on a single
+# laptop with no remote agents, but they are NOT safe for production:
+#
+#   • BETTER_AUTH_URL is plain HTTP — replace with your https:// URL.
+#   • BETTER_AUTH_TRUSTED_ORIGINS only allows localhost — add your real origin
+#     or auth callbacks from the browser will be rejected.
+#   • AGENT_DOWNLOAD_BASE_URL points to localhost — remote agents cannot reach
+#     "localhost" on your server, so they will fail to update.
+#   • INGEST_WS_URL points to localhost — the user's browser cannot reach
+#     "localhost" on your server, so the in-app terminal will not connect.
+#   • POSTGRES_PASSWORD in docker-compose.single.yml defaults to "infrawatch"
+#     — change it (see "Database credentials" below) before exposing the
+#     database port or backing up to shared storage.
+#
+# Anything tagged 🔒 below is security-critical: the value affects who can log
+# in, whose traffic is trusted, or what an agent will execute. Treat changes
+# to those values as you would changes to a password.
 # =============================================================================
 
 # === Required: edit before first run ===
-# Public URL of the Infrawatch web UI (no trailing slash).
+
+# 🔒 Public URL of the Infrawatch web UI (no trailing slash). Used by Better
+# Auth to construct callback URLs and to set the session cookie domain. MUST be
+# https:// in production — http:// disables cookie Secure flag and exposes
+# session tokens on the network.
 BETTER_AUTH_URL=http://localhost:3000
 
-# Comma-separated list of allowed origins for the auth callback.
+# 🔒 Comma-separated list of allowed origins for the auth callback. Better
+# Auth rejects auth flows from origins not in this list. Set to your
+# production origin(s); anything missing here is treated as untrusted.
+# Example: BETTER_AUTH_TRUSTED_ORIGINS=https://infrawatch.example.com
 BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
 
-# Public URL agents use to download new binaries from the web app.
-# Must be reachable from each agent host (not just localhost).
+# Public URL agents use to download new binaries from the web app. Must be
+# reachable from each agent host (not just localhost). Should be https:// in
+# production; agents verify the binary signature regardless, but http://
+# leaks which agent versions are deployed where.
 AGENT_DOWNLOAD_BASE_URL=http://localhost:3000
 
 # === Generated automatically on first run if blank ===
-# 64-character random hex used to sign auth sessions. start.sh will
-# generate one for you on first run if you leave this empty.
+
+# 🔒 64-character random hex used to sign auth session cookies AND used as
+# input to LDAP bind-password decryption. Anyone with this value can forge
+# session cookies for any user in any organisation. start.sh will generate
+# one for you on first run if you leave this blank — do NOT copy a value
+# between environments. Rotating this invalidates all active sessions.
 BETTER_AUTH_SECRET=
 
 # === Terminal ===
-# WebSocket URL of the ingest service for browser terminal connections.
-# Must be reachable from the user's browser (not just the server).
+
+# 🔒 WebSocket URL of the ingest service for browser terminal connections.
+# Must be reachable from the user's browser (not just from the server).
+# Use wss:// in production — ws:// sends the terminal stream and the
+# session JWT in plaintext over the network.
 INGEST_WS_URL=ws://localhost:8080
+
+# === Optional: load-test admin endpoint ===
+
+# 🔒 Bearer credential that gates the /api/admin/hosts/bulk-delete endpoint
+# used by `infrawatch-loadtest cleanup` to remove virtual load-test hosts.
+# When unset, the endpoint returns 503 (disabled). Setting this enables a
+# privileged delete-by-prefix endpoint on the API surface — only set it on
+# environments where you actively run load tests, and use at least 32 random
+# bytes (e.g. `openssl rand -hex 32`). Never reuse across environments.
+# INFRAWATCH_LOADTEST_ADMIN_KEY=
+
+# === Database credentials ===
+
+# 🔒 PostgreSQL credentials. The defaults baked into docker-compose.single.yml
+# are "infrawatch / infrawatch / infrawatch" — fine for a laptop, but anyone
+# who can reach port 5432 on your server with those defaults gets full
+# database access (including all session tokens, encrypted LDAP passwords,
+# and licence keys). Override these in .env and they will be picked up by
+# docker compose; if you change them after the database has been initialised
+# you must also update them inside the database, not just here.
+# POSTGRES_USER=infrawatch
+# POSTGRES_PASSWORD=infrawatch
+# POSTGRES_DB=infrawatch
 
 # === Optional image overrides (advanced) ===
 # Pin to a specific image tag instead of :latest.

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -6,16 +6,19 @@ All CT-Ops configuration is via environment variables. There are no config files
 
 ## Web Application
 
+🔒 = security-critical. Treat changes to these as you would changes to a password.
+
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `DATABASE_URL` | ✓ | — | PostgreSQL connection string |
-| `BETTER_AUTH_SECRET` | ✓ | — | Secret key for signing sessions (min 32 chars, keep private) |
-| `BETTER_AUTH_URL` | ✓ | — | Public URL of the web app (e.g. `https://ct-ops.corp.example.com`) |
-| `BETTER_AUTH_TRUSTED_ORIGINS` | — | Same as `BETTER_AUTH_URL` | Comma-separated list of allowed origins for CORS |
+| `DATABASE_URL` | ✓ 🔒 | — | PostgreSQL connection string (contains credentials) |
+| `BETTER_AUTH_SECRET` | ✓ 🔒 | — | Secret used to sign session cookies AND for LDAP bind-password decryption (min 32 chars, never reuse across environments) |
+| `BETTER_AUTH_URL` | ✓ 🔒 | — | Public URL of the web app (e.g. `https://ct-ops.corp.example.com`). Use `https://` — `http://` disables cookie Secure flag |
+| `BETTER_AUTH_TRUSTED_ORIGINS` | ✓ 🔒 | — | Comma-separated list of allowed origins. Auth flows from origins not in this list are rejected |
+| `INFRAWATCH_LOADTEST_ADMIN_KEY` | — 🔒 | — | Bearer credential for `/api/admin/hosts/bulk-delete`. Endpoint returns 503 when unset. Set only on environments running load tests |
 | `NEXT_PUBLIC_APP_URL` | — | — | Exposed to the browser — used for constructing absolute links |
 | `NODE_ENV` | — | `development` | Set to `production` in production |
 | `AGENT_DIST_DIR` | — | `/var/lib/ct-ops/agent-dist` | Directory where compiled agent binaries are stored for download |
-| `INGEST_WS_URL` | — | `ws://localhost:8080` | WebSocket URL of the ingest service (for real-time agent status) |
+| `INGEST_WS_URL` | — | `ws://localhost:8080` | WebSocket URL of the ingest service. Use `wss://` in production — `ws://` sends terminal streams in plaintext |
 
 ### Licence verification
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,21 +2,38 @@
 # Infrawatch Web — Environment Variables (example)
 # =============================================================================
 # Copy this file to .env.local for local development.
-# In production these are passed via Docker environment or secrets manager.
+# In production these are passed via Docker environment or a secrets manager,
+# never via a checked-in file.
+#
+# Anything tagged 🔒 below is security-critical: the value affects who can
+# log in, whose traffic is trusted, or what an agent will execute.
 # =============================================================================
 
 # --- Database ---
+# 🔒 PostgreSQL connection string. Contains credentials in the URL — keep
+# the file mode at 0600 and never commit a real value.
 DATABASE_URL=postgresql://infrawatch:infrawatch@localhost:5432/infrawatch
 
 # --- Better Auth ---
-# Generate a secret with: openssl rand -base64 32
+# 🔒 Secret used to sign session cookies AND as KDF input for LDAP bind
+# password decryption. Anyone with this value can forge session cookies for
+# any user in any organisation. Generate with: openssl rand -base64 32.
+# NEVER reuse across environments — rotating invalidates all active sessions.
 BETTER_AUTH_SECRET=
+# 🔒 Public URL of this Infrawatch instance — Better Auth uses it to set
+# cookie domain and to construct callback URLs. Use https:// in production;
+# http:// disables the cookie Secure flag.
 BETTER_AUTH_URL=http://localhost:3000
+# 🔒 Comma-separated list of allowed origins for the auth callback. Better
+# Auth rejects flows from origins not in this list. Add your real production
+# origin(s) here, otherwise auth callbacks will silently fail.
 BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
 
 # --- LDAP (optional) ---
 # LDAP can also be configured via the Settings > LDAP / Directory UI.
 # Environment variables here act as a fallback when no DB-stored config exists.
+# 🔒 LDAP_BIND_PASSWORD is a service-account credential. Set via secrets
+# manager in production, not a checked-in file.
 # LDAP_HOST=ldap.example.com
 # LDAP_PORT=389
 # LDAP_USE_TLS=false
@@ -29,6 +46,8 @@ BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
 # Public-facing URL of this Infrawatch instance.
 # Used to build agent enrolment install commands and agent self-update URLs.
 # Must be reachable from agent hosts. Defaults to http://localhost:3000.
+# Use https:// in production — http:// leaks which agent versions are
+# deployed where (binary signature still verifies regardless).
 AGENT_DOWNLOAD_BASE_URL=http://localhost:3000
 # Directory where agent binaries are stored and served from.
 # On first request the server auto-downloads from the official GitHub release.


### PR DESCRIPTION
## Summary
- Both `.env.example` files shipped only localhost defaults with no in-file indication of which variables are security-critical. An operator deploying to production had no warning that, e.g., leaving `BETTER_AUTH_URL` on `http://` disables the cookie Secure flag, or that `BETTER_AUTH_SECRET` gates both session HMAC and LDAP bind-password decryption.
- Adds 🔒 markers and per-variable notes explaining the production risk of each localhost default.
- Adds the same markers to the public configuration table at `apps/docs/docs/getting-started/configuration.md`.
- Adds `INFRAWATCH_LOADTEST_ADMIN_KEY` and `POSTGRES_*` (which were live in `docker-compose.single.yml` but absent from the example) so operators see them when reviewing.

Closes #350

## Test plan
- [ ] Skim `.env.example` and confirm every 🔒 line names the concrete production risk (not just "this is sensitive").
- [ ] `pnpm --filter docs run docs:build` (or whatever the docs build command is) renders `apps/docs/docs/getting-started/configuration.md` without table parse errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)