### PR TITLE
fix(certificates): drop SHA1 fingerprint from cert checker

### DIFF
--- a/apps/docs/docs/features/certificate-checker.md
+++ b/apps/docs/docs/features/certificate-checker.md
@@ -72,7 +72,7 @@ Use the **Download** button in the results header to export the leaf certificate
 | **Summary** | Valid from/to, key type/size, issuer, expiry countdown |
 | **Subject** | CN, O, OU, C, ST, L, full DN |
 | **Issuer** | CN, O, full DN |
-| **Validity & Fingerprints** | Not before, not after, serial number, SHA-1 / SHA-256 / SHA-512 fingerprints |
+| **Validity & Fingerprints** | Not before, not after, serial number, SHA-256 / SHA-512 fingerprints |
 | **Key & Algorithm** | Key algorithm, key size, curve (EC), signature algorithm, Subject Key ID, Authority Key ID |
 | **Extensions** | CA flag, path length, key usage, extended key usage, certificate policies |
 | **Subject Alternative Names** | All DNS, IP, email, and URI SANs |

--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -505,7 +505,6 @@ function CertificateResults({ cert, keyMatch, onDownload, orgId, source }: {
           <InfoRow label="Not Before" value={format(new Date(cert.notBefore), "MMM d, yyyy HH:mm:ss 'UTC'")} />
           <InfoRow label="Not After" value={format(new Date(cert.notAfter), "MMM d, yyyy HH:mm:ss 'UTC'")} />
           <InfoRow label="Serial Number" value={cert.serialNumber} mono copyable />
-          <InfoRow label="SHA-1 Fingerprint" value={cert.fingerprintSha1} mono copyable />
           <InfoRow label="SHA-256 Fingerprint" value={cert.fingerprintSha256} mono copyable />
           <InfoRow label="SHA-512 Fingerprint" value={cert.fingerprintSha512} mono copyable />
         </dl>

--- a/apps/web/lib/certificates/fetch.ts
+++ b/apps/web/lib/certificates/fetch.ts
@@ -36,7 +36,6 @@ export interface ParsedCertificate {
   isExpiringSoon: boolean
 
   serialNumber: string
-  fingerprintSha1: string
   fingerprintSha256: string
   fingerprintSha512: string
   isSelfSigned: boolean
@@ -97,9 +96,6 @@ export function parseForgeCert(forgeCert: forge.pki.Certificate, pemStr: string)
   const isSelfSigned = forgeCert.isIssuer(forgeCert)
 
   const derBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(forgeCert)).getBytes()
-  const sha1 = colonHex(
-    forge.md.sha1.create().update(derBytes).digest().toHex()
-  )
   const sha256 = colonHex(
     forge.md.sha256.create().update(derBytes).digest().toHex()
   )
@@ -258,7 +254,6 @@ export function parseForgeCert(forgeCert: forge.pki.Certificate, pemStr: string)
     isExpired: daysRemaining < 0,
     isExpiringSoon: daysRemaining >= 0 && daysRemaining <= 30,
     serialNumber: colonHex(forgeCert.serialNumber),
-    fingerprintSha1: sha1,
     fingerprintSha256: sha256,
     fingerprintSha512: sha512,
     isSelfSigned,


### PR DESCRIPTION
## Summary
- The certificate-checker output displayed SHA1 alongside SHA-256 / SHA-512 fingerprints. SHA1 has been collision-broken since 2017 and no modern verification workflow uses a SHA1 fingerprint to identify a certificate. Keeping it in the UI invited operators to copy/compare the wrong value when pinning or auditing.
- Removes \`fingerprintSha1\` from the \`ParsedCertificate\` interface, the \`forge.md.sha1\` calculation in \`parseForgeCert\`, and the \"SHA-1 Fingerprint\" InfoRow.
- Kept the \`signatureAlgorithm\` label \"SHA1withRSA\" — that's a label for what the cert author chose (needed to diagnose legacy certs), not us computing SHA1.
- Updates the cert-checker docs page to match.

Closes #348

## Test plan
- [ ] \`pnpm --filter web type-check\` passes (it does locally)
- [ ] Visit the cert-checker page, fetch a public cert, confirm the \"Validity & Fingerprints\" section shows only Serial / SHA-256 / SHA-512
- [ ] No other consumers of \`fingerprintSha1\` exist (verified by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)