### PR TITLE
fix(security): constant-time comparison for admin key + cert fingerprint

### DIFF
--- a/apps/ingest/internal/handlers/cert_refresh_sweeper.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -77,7 +78,11 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 	newFingerprint := fingerprintSha256Hex(leaf.Raw)
 	newStatus := computeCertStatus(leaf.NotAfter, 30)
 
-	if newFingerprint == row.FingerprintSHA256 {
+	// Defence in depth: even though both fingerprints are computed/loaded
+	// internally rather than supplied by an attacker, comparing certificate
+	// identity material in constant time keeps us in the habit and makes a
+	// future refactor that exposes one side to user input safer by default.
+	if subtle.ConstantTimeCompare([]byte(newFingerprint), []byte(row.FingerprintSHA256)) == 1 {
 		// Same cert — just refresh status + timestamps.
 		if err := queries.MarkCertRefreshed(ctx, pool, row.ID, newStatus); err != nil {
 			slog.Warn("cert refresh: mark refreshed", "cert_id", row.ID, "err", err)

--- a/apps/web/app/api/admin/hosts/bulk-delete/route.ts
+++ b/apps/web/app/api/admin/hosts/bulk-delete/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 import { and, isNull, like } from 'drizzle-orm'
+import { timingSafeEqual } from 'crypto'
 import { db } from '@/lib/db'
 import { hosts } from '@/lib/db/schema'
 import { deleteHost } from '@/lib/actions/agents'
@@ -14,6 +15,13 @@ const bodySchema = z.object({
     .max(200)
     .regex(/^loadtest-/, "hostnamePrefix must start with 'loadtest-'"),
 })
+
+function constantTimeEqualUtf8(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8')
+  const bBuf = Buffer.from(b, 'utf8')
+  if (aBuf.length !== bBuf.length) return false
+  return timingSafeEqual(aBuf, bBuf)
+}
 
 // POST /api/admin/hosts/bulk-delete
 // Admin-key-gated endpoint used by the `infrawatch-loadtest cleanup` CLI to
@@ -29,7 +37,11 @@ export async function POST(request: NextRequest) {
     )
   }
   const presented = request.headers.get('x-loadtest-admin-key')
-  if (!presented || presented !== configuredKey) {
+  // Compare in constant time so a remote attacker cannot recover the key
+  // byte-by-byte by measuring response latency. Buffer length is leaked
+  // (Buffer.compare requires equal lengths), which is acceptable: a well-
+  // generated key is fixed-length, so length alone reveals nothing useful.
+  if (!presented || !constantTimeEqualUtf8(presented, configuredKey)) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 


### PR DESCRIPTION
## Summary
Audit of \`===\` / \`==\` comparisons against secret-shaped values surfaced two real candidates:

1. **\`apps/web/app/api/admin/hosts/bulk-delete/route.ts\`** — the \`x-loadtest-admin-key\` header was checked with \`!==\`. The endpoint is network-reachable and gates a privileged \"bulk delete hosts by prefix\" action; \`!==\` short-circuits at the first differing byte, so a remote attacker with precise timing can in principle recover the configured key byte by byte. Switched to \`crypto.timingSafeEqual\` via a small UTF-8-safe helper that equalises lengths first.
2. **\`apps/ingest/internal/handlers/cert_refresh_sweeper.go\`** — the renewed vs. stored SHA-256 fingerprint comparison used \`==\`. Both sides are internal today, so this is defence in depth rather than a present vulnerability, but it costs nothing to use \`crypto/subtle.ConstantTimeCompare\` and keeps the habit consistent for future refactors.

The wider TS audit (Better Auth cookie HMAC, webhook signing, JWT verification) found no other candidates — those paths either generate signatures only or delegate verification to a library that is already constant-time.

Closes #352

## Test plan
- [ ] \`pnpm --filter web type-check\` passes (it does locally)
- [ ] \`go build ./...\` in \`apps/ingest\` passes (it does locally)
- [ ] Manual: hit \`POST /api/admin/hosts/bulk-delete\` with the wrong key — still returns 401 \`{ \"error\": \"Unauthorized\" }\`
- [ ] Manual: hit it with the right key — still allowed through to body validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)