### PR TITLE
fix(agent): create agent and uninstall logs with mode 0640

### DIFF
--- a/agent/internal/install/install.go
+++ b/agent/internal/install/install.go
@@ -194,6 +194,17 @@ func installDarwin(orgToken, ingestAddress string, tlsSkipVerify bool, tags []st
 		return fmt.Errorf("writing launchd plist: %w", err)
 	}
 
+	// Pre-create the agent log file with 0640 (root:wheel by default on
+	// macOS) so launchd appends to an already-restricted file rather than
+	// creating it via the daemon's umask, which on macOS yields 0644 and
+	// makes the file world-readable. The agent runs as root and the log
+	// can contain hostnames, command output, and other fingerprinting
+	// material that there's no reason to expose to other local users.
+	if err := touchLogFile("/var/log/infrawatch-agent.log", 0o640); err != nil {
+		// Non-fatal — install can continue, but warn so an operator notices.
+		slog.Warn("pre-creating agent log file", "err", err)
+	}
+
 	if err := run("launchctl", "load", "-w", plistPath); err != nil {
 		return fmt.Errorf("loading launchd service: %w", err)
 	}
@@ -343,6 +354,21 @@ func writeFile(path, content string, mode os.FileMode) error {
 	}
 	slog.Info("file written", "path", path)
 	return nil
+}
+
+// touchLogFile creates path with the requested mode if it does not exist,
+// and applies the mode if it does. Used to lock down log files before a
+// daemon (launchd, systemd) appends to them, since those daemons honour
+// existing file permissions but create with the process umask otherwise.
+func touchLogFile(path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, mode)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
 }
 
 func run(name string, args ...string) error {

--- a/agent/internal/tasks/uninstall_unix.go
+++ b/agent/internal/tasks/uninstall_unix.go
@@ -43,13 +43,18 @@ func launchDetachedUninstaller(binPath string) error {
 // don't collide. A shell wrapper is used so we can redirect stdout/stderr to
 // the log file (systemd-run doesn't proxy the caller's stdio to the grandchild).
 func launchViaSystemdRun(binPath string) error {
+	// Pre-create the log file with owner+group-only mode so the shell's `>`
+	// redirection appends to an already-restricted file rather than creating
+	// it with the default umask (typically 0644 → world-readable).
+	preCreateLog(uninstallLogPath)
+
 	cmd := exec.Command(
 		"systemd-run",
 		"--no-block",
 		"--collect",
 		"--description=Infrawatch agent self-uninstall",
 		"/bin/sh", "-c",
-		fmt.Sprintf("exec %s -uninstall >%s 2>&1", binPath, uninstallLogPath),
+		fmt.Sprintf("exec %s -uninstall >>%s 2>&1", binPath, uninstallLogPath),
 	)
 	// Inherit stdio so the (brief) systemd-run output appears in the agent log.
 	cmd.Stdout = os.Stdout
@@ -57,10 +62,26 @@ func launchViaSystemdRun(binPath string) error {
 	return cmd.Run()
 }
 
+// preCreateLog touches a log file with 0640 mode so that subsequent appenders
+// (the shell, launchd) inherit the restrictive permissions instead of falling
+// back to the process umask. Best effort — failure is silently ignored.
+func preCreateLog(path string) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return
+	}
+	_ = f.Close()
+	// Re-apply mode in case the file already existed with looser permissions.
+	_ = os.Chmod(path, 0o640)
+}
+
 // launchViaSetsid is the non-systemd fallback: start the uninstaller in a new
 // session and return immediately. Sufficient on macOS and non-systemd Linux.
 func launchViaSetsid(binPath string) error {
-	logFile, err := os.OpenFile(uninstallLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	// 0640 keeps the uninstall log readable by root and the agent's group only.
+	// Uninstall logs frequently contain command stderr that can leak host paths,
+	// installed package names, and similar fingerprinting material.
+	logFile, err := os.OpenFile(uninstallLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640)
 	if err != nil {
 		// Logging is best-effort — don't abort the uninstall just because
 		// we can't open a log file (unusual but possible on read-only /tmp).


### PR DESCRIPTION
## Summary
The agent's log files were left to the daemon's umask:

- \`/var/log/infrawatch-agent.log\` (launchd-managed on macOS) ended up at 0644 because launchd creates the \`StandardOutPath\` / \`StandardErrorPath\` file with the default umask the first time the daemon writes to it.
- \`/tmp/infrawatch-uninstall.log\` was created with an explicit \`0644\` in the setsid fallback path and via shell \`>\` redirection in the systemd-run path — same world-readable result.

Agent and uninstall logs routinely contain hostnames, command stderr, package names, and environment-specific paths. There's no reason for that material to be visible to every local user.

### Changes
- \`agent/internal/install/install.go\` — pre-create \`/var/log/infrawatch-agent.log\` with \`0640\` **before** \`launchctl load\`, via a new \`touchLogFile\` helper that also reapplies the mode if the file already exists with looser permissions.
- \`agent/internal/tasks/uninstall_unix.go\` — open the uninstall log with \`0640\` in the setsid path, and pre-create it with \`0640\` before the systemd-run path's redirection (changed from \`>\` to \`>>\` so the shell appends rather than truncates the freshly-created file).

Closes #357

## Test plan
- [ ] \`go build ./...\` and \`go test ./internal/install/... ./internal/tasks/...\` in \`agent/\` pass (no test files exist for these packages — sanity build is the available signal)
- [ ] On macOS, run \`sudo ./infrawatch-agent --install ...\` against a host without the existing log file. After install, \`stat -f '%Sp %Su:%Sg' /var/log/infrawatch-agent.log\` reports \`-rw-r----- root:wheel\` (0640) instead of 0644.
- [ ] On Linux with systemd, trigger the uninstall task and confirm \`/tmp/infrawatch-uninstall.log\` is mode 0640.
- [ ] On Linux without systemd (setsid fallback), same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)