### PR TITLE
fix(ci): use file input for agent binary SBOM scan

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Generate SBOM for binary
         uses: anchore/sbom-action@v0
         with:
-          path: dist/infrawatch-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}
+          file: dist/infrawatch-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}
           format: spdx-json
           output-file: dist/infrawatch-agent-${{ matrix.asset_suffix }}.spdx.json
           upload-artifact: false


### PR DESCRIPTION
## Summary
- `anchore/sbom-action@v0`'s `path:` input is directory-only — passing the binary file path caused syft to fail with `local-directory: not a directory source: dist/infrawatch-agent-linux-amd64`.
- That failure aborted the Build matrix and caused the `agent/v0.28.1` GitHub release to be tagged **without any binary assets**, which in turn makes `/api/agent/download` return 503 for every platform.
- Switching to the `file:` input (mutually exclusive with `path:`) scans the single binary as intended.

## Why the server returns 503
The `/api/agent/download` route ([resolveAgentBinary](apps/web/lib/agent/binary.ts#L37)) tries GitHub when no cached binary exists, finds the release tag but no matching asset, and returns 503 via `binaryUnavailableMessage`. The tag was created by run [24651136423](https://github.com/carrtech-dev/ct-ops/actions/runs/24651136423), whose SBOM step failed immediately after release creation.

## Test plan
- [ ] After merge, the next release-please cut runs the Build matrix through to completion and uploads all `infrawatch-agent-*` assets + `.sha256` + `.spdx.json` to the release.
- [ ] Existing `agent/v0.28.1` release will still have no assets — see comment below for the manual upload / downgrade to `v0.28.0` unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)