### PR TITLE
fix(agent): write to Windows Event Log when running as a service

### DIFF
--- a/agent/cmd/agent/eventlog_windows.go
+++ b/agent/cmd/agent/eventlog_windows.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+
+	"github.com/infrawatch/agent/internal/install"
+)
+
+// Event IDs written alongside each record. Windows surfaces them in Event
+// Viewer's "Event ID" column — fixed values are fine because we're not
+// distinguishing event classes, only severities.
+const (
+	eventIDInfo    uint32 = 1
+	eventIDWarning uint32 = 2
+	eventIDError   uint32 = 3
+)
+
+// eventLogHandler is a slog.Handler that forwards records to the Windows
+// Application event log under the InfrawatchAgent source. Messages are
+// rendered inline (message + key=value attrs) because AsEventCreate-style
+// sources have no message table to look up strings at render time.
+type eventLogHandler struct {
+	elog  *eventlog.Log
+	level slog.Level
+	attrs []slog.Attr
+	group string
+}
+
+func (h *eventLogHandler) Enabled(_ context.Context, l slog.Level) bool {
+	return l >= h.level
+}
+
+func (h *eventLogHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+	for _, a := range h.attrs {
+		appendAttr(&b, h.group, a)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		appendAttr(&b, h.group, a)
+		return true
+	})
+	msg := b.String()
+
+	switch {
+	case r.Level >= slog.LevelError:
+		return h.elog.Error(eventIDError, msg)
+	case r.Level >= slog.LevelWarn:
+		return h.elog.Warning(eventIDWarning, msg)
+	default:
+		return h.elog.Info(eventIDInfo, msg)
+	}
+}
+
+func (h *eventLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	merged := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	merged = append(merged, h.attrs...)
+	merged = append(merged, attrs...)
+	return &eventLogHandler{elog: h.elog, level: h.level, attrs: merged, group: h.group}
+}
+
+func (h *eventLogHandler) WithGroup(name string) slog.Handler {
+	g := name
+	if h.group != "" {
+		g = h.group + "." + name
+	}
+	return &eventLogHandler{elog: h.elog, level: h.level, attrs: h.attrs, group: g}
+}
+
+func appendAttr(b *strings.Builder, group string, a slog.Attr) {
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+	key := a.Key
+	if group != "" {
+		key = group + "." + key
+	}
+	fmt.Fprintf(b, " %s=%v", key, a.Value.Any())
+}
+
+// openEventLogHandler opens the Application event log source and returns a
+// slog.Handler that writes to it. Returns nil if the source cannot be opened
+// (e.g. the install step that registered it was skipped), so the caller can
+// fall back to stdout.
+func openEventLogHandler(level slog.Level) slog.Handler {
+	elog, err := eventlog.Open(install.EventLogSource)
+	if err != nil {
+		return nil
+	}
+	return &eventLogHandler{elog: elog, level: level}
+}

--- a/agent/cmd/agent/service_windows.go
+++ b/agent/cmd/agent/service_windows.go
@@ -42,6 +42,14 @@ func runService(ctx context.Context, cancel context.CancelFunc, runFn func(conte
 		return runFn(ctx)
 	}
 
+	// Under the SCM there is no attached console, so the default stdout
+	// handler discards everything. Swap the default slog handler to one that
+	// writes to the Windows Event Log so operators can actually see agent
+	// output. Fall through to stdout if the source isn't registered.
+	if h := openEventLogHandler(slog.LevelInfo); h != nil {
+		slog.SetDefault(slog.New(h))
+	}
+
 	ws := &windowsService{cancel: cancel}
 	// Run the agent loop in a goroutine — svc.Run blocks until the service stops.
 	go func() {

--- a/agent/internal/install/eventlog_other.go
+++ b/agent/internal/install/eventlog_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package install
+
+// Non-Windows platforms have no event log — installation/removal are no-ops so
+// the shared install/uninstall flows can call these unconditionally.
+
+const EventLogSource = ""
+
+func installEventLogSource() error { return nil }
+func removeEventLogSource() error  { return nil }

--- a/agent/internal/install/eventlog_windows.go
+++ b/agent/internal/install/eventlog_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package install
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// EventLogSource is the Windows Event Log source name the agent writes under.
+// Registered on install, removed on uninstall, opened by the running service.
+const EventLogSource = "InfrawatchAgent"
+
+// installEventLogSource registers the agent as an event source under the
+// Application log. AsEventCreate avoids needing a compiled message table —
+// messages are supplied at write time. Safe to call when the source already
+// exists (the ERROR_FILE_EXISTS case is treated as success).
+func installEventLogSource() error {
+	const types = eventlog.Info | eventlog.Warning | eventlog.Error
+	err := eventlog.InstallAsEventCreate(EventLogSource, types)
+	if err == nil || errors.Is(err, syscall.ERROR_FILE_EXISTS) {
+		return nil
+	}
+	return err
+}
+
+// removeEventLogSource deletes the agent's Application-log source. Treats
+// "source does not exist" as success so uninstall stays idempotent.
+func removeEventLogSource() error {
+	err := eventlog.Remove(EventLogSource)
+	if err == nil || errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+		return nil
+	}
+	return err
+}

--- a/agent/internal/install/install.go
+++ b/agent/internal/install/install.go
@@ -240,6 +240,14 @@ func installWindows(orgToken, ingestAddress string, tlsSkipVerify bool, tags []s
 		return fmt.Errorf("writing config: %w", err)
 	}
 
+	// Register under the Application event log before the service starts so the
+	// agent's first log lines on service entry land in the right source rather
+	// than a synthetic "Application" fallback.
+	if err := installEventLogSource(); err != nil {
+		// Non-fatal: the service still runs, it just won't write to Event Log.
+		slog.Warn("registering Windows Event Log source", "err", err)
+	}
+
 	binPath := fmt.Sprintf(`"%s" -config "%s"`, dest, cfgFile)
 	if err := run("sc.exe", "create", "InfrawatchAgent",
 		"binPath=", binPath,
@@ -258,7 +266,10 @@ func installWindows(orgToken, ingestAddress string, tlsSkipVerify bool, tags []s
 		return fmt.Errorf("starting Windows service: %w", err)
 	}
 
-	printSuccess("sc query InfrawatchAgent", `Get-EventLog -LogName Application -Source InfrawatchAgent`)
+	printSuccess(
+		"sc query InfrawatchAgent",
+		`Get-WinEvent -LogName Application -FilterXPath "*[System/Provider/@Name='InfrawatchAgent']" -MaxEvents 20`,
+	)
 	return nil
 }
 

--- a/agent/internal/install/uninstall.go
+++ b/agent/internal/install/uninstall.go
@@ -99,6 +99,12 @@ func uninstallWindows() error {
 	_ = run("sc.exe", "stop", "InfrawatchAgent")
 	_ = run("sc.exe", "delete", "InfrawatchAgent")
 
+	// Deregister the Application event log source so Windows no longer lists
+	// the agent under HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application.
+	if err := removeEventLogSource(); err != nil {
+		slog.Warn("removing Windows Event Log source", "err", err)
+	}
+
 	// Remove binary directory and config/data directory
 	removeDir(binDir)
 	removeDir(cfgDir)

--- a/apps/docs/docs/architecture/agent.md
+++ b/apps/docs/docs/architecture/agent.md
@@ -150,16 +150,28 @@ journalctl -u ct-ops-agent -f
 
 ## Log Output
 
-The agent logs structured text to stdout:
+The agent emits structured `slog` records. The service manager decides where they land:
+
+| Platform | Destination | How to view |
+|---|---|---|
+| **Linux** (systemd) | systemd journal (`StandardOutput=journal`) | `journalctl -u infrawatch-agent -f` |
+| **macOS** (launchd) | `/var/log/infrawatch-agent.log` (mode `0640`, root:wheel) | `tail -f /var/log/infrawatch-agent.log` |
+| **Windows** (SCM) | Application event log, source `InfrawatchAgent` (registered at install) | `Get-WinEvent -LogName Application -FilterXPath "*[System/Provider/@Name='InfrawatchAgent']" -MaxEvents 50` |
+
+When started interactively (not via the service manager), logs always go to stdout regardless of platform.
+
+Sample records:
 
 ```
-level=INFO msg="agent identity ready" data_dir=/var/lib/ct-ops/agent
+level=INFO msg="agent identity ready" data_dir=/var/lib/infrawatch/agent
 level=INFO msg="registering agent" address=ingest.corp.example.com:9443
 level=INFO msg="registration response" status=active agent_id=clxyz123...
 level=INFO msg="agent registered and active"
 level=INFO msg="starting heartbeat" interval_secs=30
 level=INFO msg="heartbeat stream opened"
 ```
+
+On Windows, slog levels map to event log types: `INFO`/`DEBUG` → Information, `WARN` → Warning, `ERROR` → Error. Uninstall removes the event source registration.
 
 ---
 


### PR DESCRIPTION
## Summary
Windows service instances of the agent previously lost all log output — SCM starts the process with no attached console, so the default stdout slog handler discarded everything, and nothing registered an Event Log source despite the install success message telling operators to look there.

This change makes Windows observability match Linux (journal) and macOS (`/var/log/infrawatch-agent.log`):

- **Install** registers `InfrawatchAgent` under Application via `eventlog.InstallAsEventCreate` (idempotent).
- **Uninstall** removes it (idempotent).
- **Runtime**, under `svc.IsWindowsService()`, swaps `slog.Default` to a handler that forwards records to the event log. Levels map `INFO`/`DEBUG` → Information, `WARN` → Warning, `ERROR` → Error.
- **Interactive runs** (foreground/dev) still log to stdout unchanged.
- **Linux / macOS** paths are untouched.
- Install success message updated to a valid `Get-WinEvent` query.
- Docs in `architecture/agent.md` now document per-platform log destinations.

## Verification
- `go build` passes cross-compiled for linux/amd64, darwin/amd64, darwin/arm64, windows/amd64.
- `go vet` clean for both hosts on the touched packages.
- Existing `go test ./...` passes.

## Release note
This carries a `fix(agent):` scope on purpose so release-please bumps the patch (→ v0.28.2) and the agent-release workflow — now with PR #461's SBOM fix — uploads binaries to the new release.

## Test plan
- [ ] After release-please cuts v0.28.2 and the agent-release workflow completes, install on a Windows host.
- [ ] Confirm Event Viewer → Application shows InfrawatchAgent entries at Info/Warning/Error levels during startup, heartbeat, and shutdown.
- [ ] Uninstall and confirm the source is gone from `HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application`.
- [ ] Confirm Linux and macOS installs behave unchanged (journal / log file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)