### PR TITLE
chore(support): document support-portal env vars in .env.example

### DIFF
--- a/apps/licence-purchase/.env.example
+++ b/apps/licence-purchase/.env.example
@@ -77,3 +77,36 @@ OPS_NOTIFICATION_EMAIL=ops@infrawatch.io
 SUPPORT_EMAIL=support@infrawatch.io
 TERMS_URL=https://infrawatch.io/terms
 PRIVACY_URL=https://infrawatch.io/privacy
+
+# ── Support portal / AI triage ────────────────────────────────────────────────
+# The support portal lets customers raise tickets; Claude drafts the first reply
+# with read-only GitHub access, and staff can join at any time. See
+# apps/docs/docs/features/support-portal.md and architecture/support-ai.md.
+
+# Anthropic API key — required for AI triage. Without it the kill switch
+# effectively fails open (tickets queue for staff but no AI reply is produced).
+ANTHROPIC_API_KEY=
+
+# Hard kill switch. Set to 1 to force-disable AI regardless of the DB toggle.
+# Use this for operational emergencies (leaked key, runaway cost, etc).
+SUPPORT_AI_KILL_SWITCH=0
+
+# Models. Defaults match current generation; override only if you need to pin.
+SUPPORT_AI_MODEL_ID=claude-sonnet-4-6
+SUPPORT_AI_MODERATION_MODEL_ID=claude-haiku-4-5
+
+# GitHub repo the AI can read via search_code / read_file tools. Use a
+# fine-grained PAT with Contents:read on this repo only — no write scopes.
+SUPPORT_GITHUB_REPO=carrtech-dev/ct-ops
+GITHUB_SUPPORT_READONLY_TOKEN=
+
+# Optional comma-separated glob patterns. Any tool call whose path matches is
+# rejected before the HTTP call to GitHub. Leave empty to allow the whole repo.
+# Example: apps/web/enterprise/customer-list/**,secrets/**
+SUPPORT_GITHUB_REPO_BLOCKLIST=
+
+# Rolling-hour cap of AI responses per ticket. Hitting the cap pauses the ticket.
+SUPPORT_AI_MAX_RESPONSES_PER_HOUR=10
+
+# Worker poll interval in ms. Start the worker with: pnpm support:worker
+SUPPORT_WORKER_POLL_MS=2000


### PR DESCRIPTION
## Summary

Follow-up to [carrtech-dev/ct-ops#465](https://github.com/carrtech-dev/ct-ops/pull/465). The support portal env vars were added to `lib/env.ts` but I missed adding them to `.env.example`, so a fresh checkout gives no hint that `ANTHROPIC_API_KEY`, the GitHub read-only PAT, or the kill switch exist. This adds a dedicated section with inline guidance on what each var does.

## Test plan

- [ ] `cp apps/licence-purchase/.env.example apps/licence-purchase/.env.local` — the new section is present with all support-portal vars
- [ ] No functional code changes; CI passing is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)