### PR TITLE
fix(support): load .env.local in the support worker

### DIFF
--- a/apps/licence-purchase/scripts/support-worker.ts
+++ b/apps/licence-purchase/scripts/support-worker.ts
@@ -5,6 +5,10 @@
 // for the ticket, and updates the row. No Redis required — fits the air-gap
 // story.
 
+import { config as loadDotenv } from 'dotenv'
+loadDotenv({ path: '.env.local' })
+loadDotenv({ path: '.env' })
+
 import { sql } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { supportAiJobs } from '@/lib/db/schema'


### PR DESCRIPTION
## Summary

The support worker (`pnpm support:worker`) runs under `tsx`, which doesn't auto-load `.env.local` the way Next.js does. Result: every poll threw `DATABASE_URL environment variable is required` and Claude was never called, even though the app itself was happy.

Fix mirrors [drizzle.config.ts](apps/licence-purchase/drizzle.config.ts) — load `dotenv` at the top of the worker entrypoint, preferring `.env.local` and falling back to `.env`.

## Test plan

- [x] Type-check passes
- [ ] With `.env.local` populated, `pnpm support:worker` starts and polls without errors
- [ ] A new ticket produces an AI reply within 10–30 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)