### PR TITLE
fix(support): log tool calls and errors from the worker

### DIFF
--- a/apps/licence-purchase/lib/support/ai/toolHandlers.ts
+++ b/apps/licence-purchase/lib/support/ai/toolHandlers.ts
@@ -8,31 +8,54 @@ export async function handleTool(
   input: unknown,
   ctx: { orgId: string },
 ): Promise<ToolResult> {
+  const summary = summariseInput(name, input)
+  const started = Date.now()
   try {
     switch (name) {
       case 'search_code': {
         const query = extractString(input, 'query')
         const hits = await searchCode(query)
+        logOk(name, summary, started, `${hits.length} hits`)
         return { content: JSON.stringify(hits) }
       }
       case 'read_file': {
         const path = extractString(input, 'path')
         const file = await readFile(path)
+        logOk(name, summary, started, `${file.content.length} chars`)
         return { content: `# ${file.path}\n\n${file.content}` }
       }
       case 'get_customer_context': {
         const ctxData = await getCustomerContext(ctx.orgId)
+        logOk(name, summary, started, ctxData.tier)
         return { content: JSON.stringify(ctxData) }
       }
       default:
+        logErr(name, summary, started, `unknown tool`)
         return { content: `Unknown tool: ${name}`, is_error: true }
     }
   } catch (err) {
-    return {
-      content: err instanceof Error ? err.message : String(err),
-      is_error: true,
-    }
+    const msg = err instanceof Error ? err.message : String(err)
+    logErr(name, summary, started, msg)
+    return { content: msg, is_error: true }
   }
+}
+
+function summariseInput(name: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return ''
+  const rec = input as Record<string, unknown>
+  if (name === 'search_code' && typeof rec.query === 'string') return `query=${JSON.stringify(rec.query)}`
+  if (name === 'read_file' && typeof rec.path === 'string') return `path=${rec.path}`
+  return ''
+}
+
+function logOk(name: string, summary: string, started: number, detail: string): void {
+  const ms = Date.now() - started
+  console.log(`[support.ai.tool] ok ${name} ${summary} → ${detail} (${ms}ms)`)
+}
+
+function logErr(name: string, summary: string, started: number, detail: string): void {
+  const ms = Date.now() - started
+  console.error(`[support.ai.tool] ERR ${name} ${summary} → ${detail} (${ms}ms)`)
 }
 
 function extractString(input: unknown, key: string): string {


### PR DESCRIPTION
## Summary

When the support AI's tool calls (`search_code`, `read_file`, `get_customer_context`) error, the failure is returned to Claude as a `tool_result { is_error: true }` block — but nothing ever reaches the worker stdout. From the operator's side, a 401 on the GitHub PAT, a path hitting the blocklist, and a 422 from a malformed search query all look identical: Claude just replies "I couldn't reach the codebase."

This adds one log line per tool call with outcome + duration:

```
[support.ai.tool] ok search_code query="hosts" → 5 hits (312ms)
[support.ai.tool] ERR read_file path=apps/web/lib/x.ts → GitHub read failed (404): ... (198ms)
```

## Test plan

- [x] Type-check passes
- [ ] `pnpm support:worker` during a new ticket — stdout shows a line per tool call
- [ ] Intentionally unset `GITHUB_SUPPORT_READONLY_TOKEN` → worker prints an `ERR` with the 401 body

🤖 Generated with [Claude Code](https://claude.com/claude-code)