### PR TITLE
feat(support): auto-refresh ticket pages while waiting for AI replies

### DIFF
--- a/apps/licence-purchase/app/(admin)/admin/support/[ticketId]/page.tsx
+++ b/apps/licence-purchase/app/(admin)/admin/support/[ticketId]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { MessageBubble } from '@/components/support/message-bubble'
 import { AdminTicketControls } from '@/components/support/admin-ticket-controls'
 import { AdminReplyForm } from '@/components/support/admin-reply-form'
+import { TicketAutoRefresh } from '@/components/support/ticket-auto-refresh'
 import { getAdminTicket } from '@/lib/actions/support'
 
 export const metadata = { title: 'Ticket · Admin' }
@@ -17,8 +18,11 @@ export default async function AdminTicketPage({
   if (!data) notFound()
   const { ticket, messages, orgName } = data
 
+  const isClosed = ticket.status === 'closed'
+
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
+      <TicketAutoRefresh enabled={!isClosed} />
       <div className="mb-4 text-sm">
         <Link href="/admin/support" className="text-muted-foreground hover:text-foreground">
           ← All tickets

--- a/apps/licence-purchase/app/(dashboard)/support/[ticketId]/page.tsx
+++ b/apps/licence-purchase/app/(dashboard)/support/[ticketId]/page.tsx
@@ -4,6 +4,7 @@ import { PageHeader } from '@/components/shared/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { MessageBubble } from '@/components/support/message-bubble'
 import { ReplyForm } from '@/components/support/reply-form'
+import { TicketAutoRefresh } from '@/components/support/ticket-auto-refresh'
 import { getMyTicket } from '@/lib/actions/support'
 
 export const metadata = { title: 'Ticket' }
@@ -21,6 +22,7 @@ export default async function CustomerTicketPage({
 
   return (
     <>
+      <TicketAutoRefresh enabled={!isClosed} />
       <div className="mb-4 text-sm">
         <Link href="/support" className="text-muted-foreground hover:text-foreground">
           ← Back to tickets

--- a/apps/licence-purchase/components/support/ticket-auto-refresh.tsx
+++ b/apps/licence-purchase/components/support/ticket-auto-refresh.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+// Polls the server component that renders this page by calling router.refresh()
+// on an interval. React Server Components stream only the changed payload back,
+// so this is cheaper than a full reload and preserves scroll position.
+//
+// Pauses while the tab is hidden so we don't burn cycles polling a page nobody
+// is looking at, and resumes on visibility change.
+export function TicketAutoRefresh({
+  intervalMs = 5000,
+  enabled = true,
+}: {
+  intervalMs?: number
+  enabled?: boolean
+}) {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+
+    function tick() {
+      if (cancelled) return
+      if (document.visibilityState !== 'visible') return
+      router.refresh()
+    }
+
+    const id = window.setInterval(tick, intervalMs)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [router, intervalMs, enabled])
+
+  return null
+}


### PR DESCRIPTION
## Summary

The AI reply lands in the DB 10–30 s after a customer posts, but both the customer-facing and admin ticket views are server-rendered once on navigation — so the reply was only visible after a manual refresh. This adds a tiny client component that calls `router.refresh()` on a 5 s interval while the tab is visible. React Server Component streaming means only the changed payload flows back, so this is cheaper than a full reload and preserves scroll position.

- [components/support/ticket-auto-refresh.tsx](apps/licence-purchase/components/support/ticket-auto-refresh.tsx) — client component, renders nothing, owns the interval
- Wired into both [customer ticket page](apps/licence-purchase/app/(dashboard)/support/[ticketId]/page.tsx) and [admin ticket page](apps/licence-purchase/app/(admin)/admin/support/[ticketId]/page.tsx)
- Polling disabled when the ticket is `closed` (no new messages possible)
- Polling pauses while `document.visibilityState !== 'visible'` so we don't burn cycles on a backgrounded tab

**Why not TanStack Query?** The dep is installed but no `QueryClientProvider` exists in `licence-purchase`. Adding the provider + query hooks for a single polling case is more surface than justified. `router.refresh()` reuses the existing server-action auth path and integrates with the RSC cache for free.

## Test plan

- [x] `pnpm run type-check` passes (licence-purchase)
- [x] `pnpm run build` passes
- [ ] Open a ticket in two browser tabs — reply in tab A, watch tab B update within ~5 s without refresh
- [ ] Switch tabs away — network tab shows no polling; return → polling resumes
- [ ] Admin ticket view updates automatically when customer posts a new message
- [ ] Close a ticket — no further polling requests in the network panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)