### PR TITLE
feat(support): flag AI tool failures to admins, not customers

### DIFF
--- a/apps/docs/docs/architecture/support-ai.md
+++ b/apps/docs/docs/architecture/support-ai.md
@@ -53,6 +53,7 @@ The system prompt is marked with `cache_control: ephemeral` so Anthropic's promp
 5. **Redaction** — the module's `redact.ts` strips emails, phone numbers, JWTs, AWS keys, Stripe keys, GitHub PATs and long base64 blobs before anything reaches the API.
 6. **Pseudonymisation** — the model sees `org_<orgId>`, never the raw customer name or email.
 7. **Rate limits** — 10 AI responses per ticket per hour via `support_ai_rate`. Hitting the cap pauses the ticket.
+8. **Tool-failure containment** — when ≥2 tool calls in a single turn error out and they're ≥50% of that turn's calls, the orchestrator **does not** post an apology reply. Instead it sets `aiPaused=true`, `aiFlagReason="AI tool error (…)"`, flips the ticket to `pending_staff`, and returns an `error` outcome from `runAiTurn`. The customer sees silence rather than a "having trouble" message; the admin health banner picks up the flag within seconds.
 
 ---
 

--- a/apps/docs/docs/features/support-portal.md
+++ b/apps/docs/docs/features/support-portal.md
@@ -56,6 +56,17 @@ Each ticket is capped at 10 AI responses per rolling hour. If a ticket hits the 
 
 ---
 
+## Admin health banner
+
+When any support ticket needs staff attention, a strip appears at the top of every admin page. It shows:
+
+- the count of tickets currently awaiting a staff reply (`pending_staff` status), linking to the ticket list;
+- the count of tickets flagged with an AI error (e.g. the model couldn't reach the GitHub repo) along with clickable pills that go straight to each flagged ticket.
+
+The banner is driven by a server-side read of the tickets table and auto-refreshes every 15 seconds while any flag is active (30 seconds when clean). If the customer would otherwise have seen an "I'm having trouble reaching the codebase" style apology, the system now pauses the ticket and raises the flag instead — the customer just waits for a human reply rather than being told we have technical issues.
+
+---
+
 ## Data that leaves your network
 
 When AI triage is enabled, the following data is sent to Anthropic's API on each AI turn:

--- a/apps/licence-purchase/app/(admin)/layout.tsx
+++ b/apps/licence-purchase/app/(admin)/layout.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { requireSuperAdmin } from '@/lib/auth/require-super-admin'
 import { Nav } from '@/components/shared/nav'
 import { Footer } from '@/components/shared/footer'
+import { AdminHealthBanner } from '@/components/support/admin-health-banner'
 
 export const metadata = { title: 'Admin' }
 
@@ -29,6 +30,7 @@ export default async function AdminLayout({ children }: { children: ReactNode })
           </Link>
         </div>
       </div>
+      <AdminHealthBanner />
       <main className="flex-1">{children}</main>
       <Footer />
     </div>

--- a/apps/licence-purchase/components/support/admin-health-banner.tsx
+++ b/apps/licence-purchase/components/support/admin-health-banner.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+import { getSupportHealth } from '@/lib/actions/support'
+import { TicketAutoRefresh } from './ticket-auto-refresh'
+
+// Always-visible admin health strip. Rendered from the admin layout so it
+// appears on every admin page. Auto-refreshes in the background so counts
+// update without a manual reload. Hidden entirely when everything is clean.
+export async function AdminHealthBanner() {
+  const health = await getSupportHealth()
+  const { unansweredCount, flaggedCount, flagged } = health
+  const needsAttention = unansweredCount > 0 || flaggedCount > 0
+  if (!needsAttention) return <TicketAutoRefresh intervalMs={30_000} />
+
+  return (
+    <>
+      <TicketAutoRefresh intervalMs={15_000} />
+      <div className="border-b border-amber-500/40 bg-amber-500/10">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-3 px-4 py-2 text-sm text-amber-900 dark:text-amber-200">
+          <span className="font-semibold uppercase tracking-wide">Support</span>
+          {unansweredCount > 0 ? (
+            <Link
+              href="/admin/support"
+              className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/30 px-2.5 py-0.5 font-medium hover:bg-amber-500/40"
+            >
+              <span className="tabular-nums">{unansweredCount}</span>
+              <span>awaiting staff reply</span>
+            </Link>
+          ) : null}
+          {flaggedCount > 0 ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-red-500/20 px-2.5 py-0.5 font-medium text-red-900 dark:text-red-200">
+              <span className="tabular-nums">{flaggedCount}</span>
+              <span>AI error{flaggedCount === 1 ? '' : 's'}</span>
+            </span>
+          ) : null}
+          {flagged.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {flagged.map((t) => (
+                <Link
+                  key={t.id}
+                  href={`/admin/support/${t.id}`}
+                  title={t.flagReason ?? undefined}
+                  className="inline-flex max-w-[24ch] items-center gap-1 rounded border border-red-500/40 bg-background/50 px-2 py-0.5 text-xs text-foreground hover:bg-background"
+                >
+                  <span className="truncate">{t.subject}</span>
+                </Link>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/licence-purchase/lib/actions/support.ts
+++ b/apps/licence-purchase/lib/actions/support.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { z } from 'zod'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm'
 import { revalidatePath } from 'next/cache'
 import { db } from '@/lib/db'
 import {
@@ -224,6 +224,52 @@ export async function listAllTicketsForAdmin(): Promise<SupportTicket[]> {
   return db.query.supportTickets.findMany({
     orderBy: [desc(supportTickets.lastMessageAt)],
   })
+}
+
+export type SupportHealth = {
+  unansweredCount: number
+  flaggedCount: number
+  flagged: Array<{ id: string; subject: string; flagReason: string | null }>
+}
+
+// Summary counts used by the admin health banner. Super-admin only.
+// - unanswered: tickets awaiting a staff response (pending_staff, not closed/resolved).
+// - flagged: tickets paused because of an AI tool error or injection flag.
+export async function getSupportHealth(): Promise<SupportHealth> {
+  await assertSuperAdmin()
+
+  const unansweredRows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(supportTickets)
+    .where(
+      and(
+        eq(supportTickets.status, 'pending_staff'),
+      ),
+    )
+  const unansweredCount = unansweredRows[0]?.count ?? 0
+
+  const flaggedTickets = await db
+    .select({
+      id: supportTickets.id,
+      subject: supportTickets.subject,
+      flagReason: supportTickets.aiFlagReason,
+    })
+    .from(supportTickets)
+    .where(
+      and(
+        eq(supportTickets.aiPaused, true),
+        isNotNull(supportTickets.aiFlagReason),
+        inArray(supportTickets.status, ['open', 'pending_customer', 'pending_staff']),
+      ),
+    )
+    .orderBy(desc(supportTickets.updatedAt))
+    .limit(10)
+
+  return {
+    unansweredCount,
+    flaggedCount: flaggedTickets.length,
+    flagged: flaggedTickets,
+  }
 }
 
 export async function getAdminTicket(id: string): Promise<{

--- a/apps/licence-purchase/lib/support/ai/index.ts
+++ b/apps/licence-purchase/lib/support/ai/index.ts
@@ -105,6 +105,9 @@ export async function runAiTurn(ticketId: string): Promise<RunOutcome> {
   let finalText = ''
   let totalInput = 0
   let totalOutput = 0
+  let toolErrorCount = 0
+  let toolCallCount = 0
+  let firstToolError: { tool: string; detail: string } | null = null
 
   for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
     const res = await client.messages.create({
@@ -137,7 +140,14 @@ export async function runAiTurn(ticketId: string): Promise<RunOutcome> {
 
     const toolResults: Anthropic.ToolResultBlockParam[] = []
     for (const tu of toolUses) {
+      toolCallCount += 1
       const r = await handleTool(tu.name, tu.input, { orgId: ticket.organisationId })
+      if (r.is_error) {
+        toolErrorCount += 1
+        if (!firstToolError) {
+          firstToolError = { tool: tu.name, detail: r.content.slice(0, 400) }
+        }
+      }
       toolResults.push({
         type: 'tool_result',
         tool_use_id: tu.id,
@@ -146,6 +156,25 @@ export async function runAiTurn(ticketId: string): Promise<RunOutcome> {
       })
     }
     messages.push({ role: 'user', content: toolResults })
+  }
+
+  // If tools kept failing, don't post an apology reply to the customer — that
+  // leaks implementation trouble and makes us look broken. Flag the ticket so
+  // the admin health banner picks it up and staff can take over.
+  const toolsBroken =
+    toolCallCount >= 2 && toolErrorCount >= 2 && toolErrorCount / toolCallCount >= 0.5
+  if (toolsBroken && firstToolError) {
+    const reason = `AI tool error (${firstToolError.tool}): ${firstToolError.detail}`
+    await db
+      .update(supportTickets)
+      .set({
+        aiPaused: true,
+        aiFlagReason: reason,
+        status: 'pending_staff',
+        updatedAt: new Date(),
+      })
+      .where(eq(supportTickets.id, ticketId))
+    return { kind: 'error', reason: 'tool-errors' }
   }
 
   if (!finalText) finalText = 'I was unable to produce a reply. A human will follow up shortly.'


### PR DESCRIPTION
## Summary

Two tightly-coupled changes that stop us apologising to customers when the AI hits a backend issue, and surface those issues to admins instead.

### 1. Tool-failure containment in the orchestrator

When Claude's tools (`search_code` / `read_file` / `get_customer_context`) error, the model used to still produce a reply — typically *"I'm having trouble reaching the codebase right now."* That leaks a technical problem to the customer and makes the product look broken.

[lib/support/ai/index.ts](apps/licence-purchase/lib/support/ai/index.ts) now counts `is_error` tool results per turn. If a turn has **≥2 tool errors AND ≥50% error rate**, the orchestrator:
- pauses the ticket (`aiPaused = true`)
- sets `aiFlagReason` to the first tool error (tool name + first 400 chars of message)
- flips status to `pending_staff`
- returns `{ kind: 'error', reason: 'tool-errors' }` without inserting an AI message

The customer sees silence (ticket waiting quietly for a human), not an apology.

### 2. Admin health banner

Otherwise the flags would pile up invisibly. A new `AdminHealthBanner` is rendered in [app/(admin)/layout.tsx](apps/licence-purchase/app/(admin)/layout.tsx) so it appears on every admin page.

- New server action `getSupportHealth()` returns `{ unansweredCount, flaggedCount, flagged[] }`, super-admin only.
- Banner hidden entirely when everything is clean.
- When flagged: shows pill for "N awaiting staff reply" → links to the list, pill for "M AI errors", and clickable chips for each specific flagged ticket with the flag reason in the title attr.
- Auto-refreshes every 15 s while anything is flagged, 30 s when clean — same `TicketAutoRefresh` component we landed in #472.

### Docs

- [apps/docs/docs/features/support-portal.md](apps/docs/docs/features/support-portal.md) — new "Admin health banner" section.
- [apps/docs/docs/architecture/support-ai.md](apps/docs/docs/architecture/support-ai.md) — "Tool-failure containment" added as defence #8.

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run build` passes
- [ ] With a bad `GITHUB_SUPPORT_READONLY_TOKEN`, submit a ticket — worker stdout shows `[support.ai.tool] ERR` lines, **no AI reply is posted**, ticket status becomes `pending_staff`, admin banner shows the ticket with flag reason on hover.
- [ ] Fix the token, post again — AI replies normally, banner stays hidden.
- [ ] Clean state: banner isn't visible on `/admin`, `/admin/products`, or `/admin/support`.
- [ ] With a flagged ticket, banner renders on every admin page and links deep to the flagged ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)