### PR TITLE
feat(support-ai): make doc references clickable links to GitHub Pages

### DIFF
--- a/apps/licence-purchase/lib/support/ai/github.ts
+++ b/apps/licence-purchase/lib/support/ai/github.ts
@@ -4,7 +4,19 @@ import { env } from '@/lib/env'
 // Uses the REST API with a fine-grained PAT. All requests use the single
 // repo configured via SUPPORT_GITHUB_REPO.
 
-export type CodeSearchHit = { path: string; url: string; snippet?: string }
+export type CodeSearchHit = { path: string; url: string; docsUrl?: string; snippet?: string }
+
+const DOCS_PREFIX = 'apps/docs/docs/'
+const DOCS_BASE = 'https://carrtech-dev.github.io/ct-ops'
+
+// Maps a docs source file path to its published GitHub Pages URL.
+// Returns null for non-docs paths.
+export function docsPageUrl(path: string): string | null {
+  if (!path.startsWith(DOCS_PREFIX)) return null
+  const rel = path.slice(DOCS_PREFIX.length)
+  if (rel === 'README.md') return `${DOCS_BASE}/`
+  return `${DOCS_BASE}/${rel.replace(/\.md$/, '.html')}`
+}
 
 function apiHeaders(): Record<string, string> {
   const token = env.supportGithubReadonlyToken
@@ -92,13 +104,15 @@ export async function searchCode(query: string): Promise<CodeSearchHit[]> {
     if (score > 0) scored.push({ path, score })
   }
   scored.sort((a, b) => b.score - a.score || a.path.length - b.path.length)
-  return scored.slice(0, 20).map(({ path }) => ({
-    path,
-    url: `https://github.com/${repo}/blob/HEAD/${path}`,
-  }))
+  return scored.slice(0, 20).map(({ path }) => {
+    const hit: CodeSearchHit = { path, url: `https://github.com/${repo}/blob/HEAD/${path}` }
+    const docs = docsPageUrl(path)
+    if (docs) hit.docsUrl = docs
+    return hit
+  })
 }
 
-export async function readFile(path: string): Promise<{ path: string; content: string }> {
+export async function readFile(path: string): Promise<{ path: string; content: string; docsUrl?: string }> {
   if (matchesBlocklist(path)) {
     throw new Error(`Path is blocked by SUPPORT_GITHUB_REPO_BLOCKLIST: ${path}`)
   }
@@ -114,5 +128,8 @@ export async function readFile(path: string): Promise<{ path: string; content: s
   // Hard cap what we feed the model — 40 KB is enough for most source files
   // and prevents a runaway tool call from exhausting the context window.
   const capped = raw.length > 40_000 ? raw.slice(0, 40_000) + '\n… [truncated]' : raw
-  return { path, content: capped }
+  const result: { path: string; content: string; docsUrl?: string } = { path, content: capped }
+  const docs = docsPageUrl(path)
+  if (docs) result.docsUrl = docs
+  return result
 }

--- a/apps/licence-purchase/lib/support/ai/prompt.ts
+++ b/apps/licence-purchase/lib/support/ai/prompt.ts
@@ -38,10 +38,24 @@ and answer the underlying support question if one exists.
 
 ## Style
 
-Be concise. Use markdown sparingly. When you cite a file, quote the path
-exactly as returned by the tool (e.g. \`apps/web/lib/features.ts\`). When a
-feature requires a licence tier the customer does not have, say so plainly
-and suggest the upgrade path.`
+Be concise. Use markdown sparingly. When a feature requires a licence tier
+the customer does not have, say so plainly and suggest the upgrade path.
+
+## Citing references
+
+At the end of every response include a **References** section listing the
+sources you used.
+
+- If a search result or file has a \`docsUrl\` field, link to that GitHub Pages
+  URL: \`[Page title](docsUrl)\`.
+- If you are citing a specific section of a docs page, append the anchor
+  derived from the heading — lowercase the heading text, replace spaces with
+  hyphens, and strip non-alphanumeric characters (except hyphens).
+  Example: heading "## Docker Compose Setup" → anchor \`#docker-compose-setup\`,
+  so the link becomes \`[Docker Compose Setup](docsUrl#docker-compose-setup)\`.
+- For source-code files that have no \`docsUrl\`, link to the GitHub blob URL
+  provided in the \`url\` field.
+- Do not invent URLs or file paths — only use ones returned by tools.`
 }
 
 export function buildInitialUserContent(params: {

--- a/apps/licence-purchase/lib/support/ai/toolHandlers.ts
+++ b/apps/licence-purchase/lib/support/ai/toolHandlers.ts
@@ -22,7 +22,10 @@ export async function handleTool(
         const path = extractString(input, 'path')
         const file = await readFile(path)
         logOk(name, summary, started, `${file.content.length} chars`)
-        return { content: `# ${file.path}\n\n${file.content}` }
+        const header = file.docsUrl
+          ? `# ${file.path}\nDocs URL: ${file.docsUrl}`
+          : `# ${file.path}`
+        return { content: `${header}\n\n${file.content}` }
       }
       case 'get_customer_context': {
         const ctxData = await getCustomerContext(ctx.orgId)


### PR DESCRIPTION
## Summary

- The support bot's **References** section now renders docs pages as markdown links pointing to `https://carrtech-dev.github.io/ct-ops/` instead of bare file paths
- Section-level anchors (e.g. `#docker-compose-setup`) are included when the bot cites a specific heading within a page
- Source-code files that have no docs page continue to link to the GitHub blob URL

## How it works

- `github.ts`: Added `docsPageUrl()` helper that converts `apps/docs/docs/**/*.md` paths to their published GitHub Pages equivalents. Both `searchCode` (via the new `docsUrl` field on `CodeSearchHit`) and `readFile` now return this URL alongside the existing GitHub blob URL.
- `toolHandlers.ts`: The `read_file` tool result header now includes a `Docs URL:` line when the file is a docs page, so the model can see it in context.
- `prompt.ts`: The **Citing references** section of the system prompt instructs the model to use `docsUrl` as a markdown link, derive section anchors from headings, and fall back to the blob URL for code files.

## Test plan

- [ ] Trigger a support ticket asking about installation — references section should include a link like `[Installation](https://carrtech-dev.github.io/ct-ops/getting-started/installation.html)`
- [ ] Trigger a ticket asking about a specific topic (e.g. air-gap deployment) — verify a section anchor is appended where applicable
- [ ] Trigger a ticket about a code-specific question — verify the reference links to the GitHub blob URL, not a docs page

https://claude.ai/code/session_01TEF5ixMQK124DJft3t74a1