### PR TITLE
fix(auth): always include BETTER_AUTH_URL in trustedOrigins

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -24,10 +24,11 @@ BETTER_AUTH_SECRET=
 # cookie domain and to construct callback URLs. Use https:// in production;
 # http:// disables the cookie Secure flag.
 BETTER_AUTH_URL=http://localhost:3000
-# 🔒 Comma-separated list of allowed origins for the auth callback. Better
-# Auth rejects flows from origins not in this list. Add your real production
-# origin(s) here, otherwise auth callbacks will silently fail.
-BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
+# 🔒 Comma-separated list of additional trusted origins for auth callbacks.
+# BETTER_AUTH_URL is always trusted automatically — only add extra origins
+# here, e.g. a Cloudflare Tunnel URL or a mobile-accessible hostname.
+# Example: BETTER_AUTH_TRUSTED_ORIGINS=https://tunnel.example.com
+BETTER_AUTH_TRUSTED_ORIGINS=
 
 # --- LDAP (optional) ---
 # LDAP can also be configured via the Settings > LDAP / Directory UI.

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -27,7 +27,15 @@ export const auth = betterAuth({
       },
     }),
   ],
-  trustedOrigins: process.env['BETTER_AUTH_TRUSTED_ORIGINS']?.split(',') ?? [],
+  trustedOrigins: Array.from(
+    new Set([
+      process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000',
+      ...(process.env['BETTER_AUTH_TRUSTED_ORIGINS']
+        ?.split(',')
+        .map((o) => o.trim())
+        .filter(Boolean) ?? []),
+    ]),
+  ),
   secret: process.env['BETTER_AUTH_SECRET'] ?? '',
   baseURL: process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000',
 })


### PR DESCRIPTION
## Summary

- Better Auth's origin check was rejecting requests from `https://port-3000.carrtech.dev` (Cloudflare Tunnel) because `BETTER_AUTH_URL` (`http://localhost:3000`) was not automatically included in `trustedOrigins`
- `BETTER_AUTH_URL` is now always prepended to `trustedOrigins` so the app's own base URL is implicitly trusted without needing to repeat it in `BETTER_AUTH_TRUSTED_ORIGINS`
- Each entry in `BETTER_AUTH_TRUSTED_ORIGINS` is now whitespace-trimmed before use
- Updated `.env.example` to clarify that `BETTER_AUTH_URL` is auto-trusted and `BETTER_AUTH_TRUSTED_ORIGINS` is for _additional_ origins only (e.g. tunnel or mobile hostnames)

## Test plan

- [ ] Access the app locally at `http://localhost:3000` — auth should work as before
- [ ] Access via Cloudflare Tunnel at `https://port-3000.carrtech.dev` with `BETTER_AUTH_TRUSTED_ORIGINS=https://port-3000.carrtech.dev` in `.env.local` — "invalid origin" error should be gone and login should succeed

https://claude.ai/code/session_01TJ2mPU4yhU8XQxZT7hnztL