### PR TITLE
feat(licence): LICENCE_PUBLIC_KEY env var override with dev-key-in-prod rejection

### DIFF
--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -22,7 +22,11 @@ All CT-Ops configuration is via environment variables. There are no config files
 
 ### Licence verification
 
-CT-Ops validates licence JWTs using an RSA public key. The production public key for verifying licences purchased from infrawatch.io is **baked into the web image** — there is nothing to configure. In development the server uses a separate built-in dev key, used only when `NODE_ENV !== 'production'`.
+CT-Ops validates licence JWTs using an RSA public key. The production public key for verifying licences purchased from infrawatch.io is **baked into the web image** — there is nothing to configure for standard deployments. In development the server uses a separate built-in dev key, used only when `NODE_ENV !== 'production'`.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `LICENCE_PUBLIC_KEY` | — 🔒 | *(baked-in prod key)* | PEM-encoded RSA public key used to verify licence JWTs. **Do not set this in normal deployments.** Reserved for emergency key rotation and internal QA/staging environments using a non-production keypair. In production, the dev key is explicitly rejected even if supplied here. |
 
 ### Example `.env.local` (development)
 

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -34,9 +34,23 @@ EQIDAQAB
 -----END PUBLIC KEY-----`
 
 export function resolveLicencePublicKeyPem(): string {
+  const override = process.env.LICENCE_PUBLIC_KEY?.trim()
+
+  if (override) {
+    // Prevent the dev key being smuggled into production via the env var override.
+    if (process.env.NODE_ENV === 'production' && override === DEV_PUBLIC_KEY_PEM.trim()) {
+      throw new Error(
+        'LICENCE_PUBLIC_KEY is set to the development public key in a production environment. ' +
+          'Remove LICENCE_PUBLIC_KEY to use the baked-in production key, or supply a valid production override.',
+      )
+    }
+    return override
+  }
+
   if (process.env.NODE_ENV === 'production') {
     return PROD_PUBLIC_KEY_PEM.trim()
   }
+
   return DEV_PUBLIC_KEY_PEM.trim()
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `LICENCE_PUBLIC_KEY` env var as an optional override to `resolveLicencePublicKeyPem()` — intended only for emergency key rotation and internal QA/staging environments
- Explicitly rejects the dev public key if supplied via `LICENCE_PUBLIC_KEY` when `NODE_ENV=production`, preventing it being smuggled into production deployments
- Updates `apps/docs/docs/getting-started/configuration.md` to document `LICENCE_PUBLIC_KEY` as an advanced override (not a required variable)

The production public key is still baked into the image — standard deployments need no env var at all.

Closes #399

## Test plan

- [ ] `NODE_ENV=production` with no `LICENCE_PUBLIC_KEY` set → uses baked-in prod key (no change in behaviour)
- [ ] `NODE_ENV=production` with `LICENCE_PUBLIC_KEY` set to the dev key → throws with a clear error message
- [ ] `NODE_ENV=production` with `LICENCE_PUBLIC_KEY` set to a valid alternative prod key → uses the override
- [ ] `NODE_ENV=development` with no `LICENCE_PUBLIC_KEY` → uses dev key (`pnpm dev` works zero-config)

https://claude.ai/code/session_01WDsAa89KV318L9zfMXQ2at
EOF
)