### PR TITLE
fix: cert upload validation (M-27) + CSV formula injection (M-23)

### DIFF
--- a/apps/web/app/api/reports/software/export/route.ts
+++ b/apps/web/app/api/reports/software/export/route.ts
@@ -40,11 +40,16 @@ const filterSchema = z.object({
   hostId: z.string().max(50).optional(),
 })
 
-/** Escape a CSV cell value. Prefixes formula-injection chars with a literal '. */
+/** Escape a CSV cell value.
+ * Uses a tab prefix for formula-injection chars: single-quote alone is
+ * insufficient because some spreadsheet applications (Google Sheets,
+ * LibreOffice) still execute a formula starting with "'=". A leading tab
+ * is not a formula indicator and is ignored visually in most UIs.
+ */
 function escapeCsvCell(value: string | number | null | undefined): string {
   const str = String(value ?? '')
   if (/^[=+\-@\t\r\n]/.test(str)) {
-    return `"'${str.replace(/"/g, '""')}"`
+    return `"\t${str.replace(/"/g, '""')}"`
   }
   if (str.includes('"') || str.includes(',') || str.includes('\n')) {
     return `"${str.replace(/"/g, '""')}"`

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -164,8 +164,17 @@ const trackFromUrlSchema = z.object({
   ).optional(),
 })
 
+// 64 KB is well beyond any real certificate chain; rejects degenerate payloads.
+const MAX_UPLOAD_PEM_BYTES = 65_536
+
 const trackFromUploadSchema = z.object({
-  pem: z.string().min(1),
+  pem: z
+    .string()
+    .min(1)
+    .max(MAX_UPLOAD_PEM_BYTES, 'Certificate data exceeds the 64 KB limit')
+    .refine((s) => s.includes('-----BEGIN'), {
+      message: 'Certificate must be in PEM format (-----BEGIN CERTIFICATE----- …)',
+    }),
   host: z.string().max(255).optional(),
   port: z.number().int().min(0).max(65535).optional(),
   serverName: z.string().max(255).optional(),


### PR DESCRIPTION
## Summary

**M-27 — Certificate upload validation** (`apps/web/lib/actions/certificates.ts`)
- Adds a 64 KB hard cap on the `pem` field — previously unbounded, allowing arbitrarily large payloads to reach the parser.
- Adds a `.refine` guard requiring the string to contain `-----BEGIN`, rejecting non-PEM input before it hits `parseCertificateBuffer`.

**M-23 — CSV formula-injection** (`apps/web/app/api/reports/software/export/route.ts`)
- Replaces the single-quote prefix with a tab prefix for cells starting with formula indicators (`=`, `+`, `-`, `@`, tab, CR, LF).
- Single-quote alone is defeated by Google Sheets and LibreOffice, which still execute formulas beginning with `'=`. A leading tab is not a formula indicator and is visually ignored by spreadsheet parsers.

Closes #342
Closes #338

## Test plan

**M-27**
- [ ] Upload a valid PEM certificate — should succeed as before.
- [ ] Upload a string > 64 KB — should return `'Certificate data exceeds the 64 KB limit'` error without hitting the parser.
- [ ] Upload a non-PEM string (e.g. plain text without `-----BEGIN`) — should return PEM format error.

**M-23**
- [ ] Export CSV with a package named `=HYPERLINK("http://evil.com","click")` — cell should open as plain text in Excel, Google Sheets, and LibreOffice without executing.
- [ ] Normal package names export unchanged.

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY