### PR TITLE
fix(certs): cap TLS cert size/chain depth and reject dangerous cert-file paths (M-19, M-11)

### DIFF
--- a/apps/web/lib/actions/checks.ts
+++ b/apps/web/lib/actions/checks.ts
@@ -33,7 +33,14 @@ const certificateConfigSchema = z.object({
 })
 
 const certFileConfigSchema = z.object({
-  filePath: z.string().min(1),
+  filePath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .refine((p) => !p.includes('..'), { message: 'File path must not contain ".."' })
+    .refine((p) => !/^\/(?:proc|sys|dev)(?:\/|$)/.test(p), {
+      message: 'File path must not reference system pseudo-filesystems (/proc, /sys, /dev)',
+    }),
   format: z.enum(['pem', 'pkcs12', 'jks']),
   password: z.string().optional(),
   alias: z.string().optional(),

--- a/apps/web/lib/certificates/fetch.ts
+++ b/apps/web/lib/certificates/fetch.ts
@@ -384,6 +384,11 @@ export function resolveUrlTarget(rawUrl: string, portOverride?: number, serverNa
   return { host, port, serverName }
 }
 
+// 64 KB per cert is well above any real-world certificate; rejects degenerate TLS responses.
+const MAX_CERT_BYTES = 65_536
+// Practical PKI chains are ≤ 5; cap at 10 to prevent memory exhaustion from crafted loops.
+const MAX_CHAIN_DEPTH = 10
+
 export function fetchCertPemsFromUrl(host: string, port: number, serverName: string): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const socket = tls.connect(
@@ -398,6 +403,10 @@ export function fetchCertPemsFromUrl(host: string, port: number, serverName: str
         let current: tls.DetailedPeerCertificate | null = peerCert
         const seen = new Set<string>()
         while (current && current.raw && !seen.has(current.fingerprint256)) {
+          if (current.raw.length > MAX_CERT_BYTES) {
+            return reject(new Error(`Server returned a certificate exceeding the ${MAX_CERT_BYTES}-byte size limit`))
+          }
+          if (seen.size >= MAX_CHAIN_DEPTH) break
           seen.add(current.fingerprint256)
           const b64 = current.raw.toString('base64').match(/.{1,64}/g)!.join('\n')
           pems.push(`-----BEGIN CERTIFICATE-----\n${b64}\n-----END CERTIFICATE-----`)


### PR DESCRIPTION
## Summary

- **M-19** (`lib/certificates/fetch.ts`): `fetchCertPemsFromUrl` now rejects any individual certificate whose raw DER exceeds 64 KB, and breaks the chain traversal loop after 10 entries. A malicious TLS server could previously exhaust process memory by returning oversized or deeply nested certificate chains.
- **M-11** (`lib/actions/checks.ts`): `certFileConfigSchema.filePath` now rejects path-traversal sequences (`..`), paths into `/proc`, `/sys`, or `/dev`, and paths longer than 4096 bytes. The agent remains the ultimate enforcement point, but the server should not forward such paths at all.

## Test plan

- [ ] Verify cert tracking from a normal HTTPS URL still works end-to-end
- [ ] Attempt to create a `cert_file` check with `filePath: "../../etc/shadow"` — expect a Zod validation error
- [ ] Attempt to create a `cert_file` check with `filePath: "/proc/self/mem"` — expect a Zod validation error
- [ ] Attempt to create a `cert_file` check with a valid path like `/etc/ssl/certs/ca-cert.pem` — expect success
- [ ] CI lint / type-check / build passes

Closes #334
Closes #326

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY