### PR TITLE
fix(ingest): run container as non-root user and add HEALTHCHECK

### DIFF
--- a/apps/ingest/Dockerfile
+++ b/apps/ingest/Dockerfile
@@ -16,22 +16,31 @@ RUN go build -o /dist/ingest ./apps/ingest/cmd/ingest
 
 FROM alpine:3.20
 
-RUN apk add --no-cache ca-certificates wget
+RUN apk add --no-cache ca-certificates wget && \
+    addgroup --system --gid 1001 ingest && \
+    adduser --system --uid 1001 --ingroup ingest ingest
 
 COPY --from=builder /dist/ingest /usr/local/bin/ingest
+
+# Create runtime directories. /var/lib/infrawatch must be writable so the
+# ingest process can generate a JWT signing key on first boot.
+RUN mkdir -p /etc/infrawatch/tls /var/lib/infrawatch && \
+    chown -R ingest:ingest /etc/infrawatch /var/lib/infrawatch
 
 # Bake the release-please manifest into the image. Both the web and ingest
 # images are built from the same commit, so they always agree on the
 # required agent version. Production users running from GHCR have no source
 # checkout to bind-mount.
-COPY .release-please-manifest.json /etc/infrawatch/release-please-manifest.json
-
-# Create runtime directories
-RUN mkdir -p /etc/infrawatch/tls /var/lib/infrawatch
+COPY --chown=ingest:ingest .release-please-manifest.json /etc/infrawatch/release-please-manifest.json
 
 ENV INGEST_RELEASE_MANIFEST_PATH=/etc/infrawatch/release-please-manifest.json
 
+USER ingest
+
 EXPOSE 9443 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["ingest"]
 CMD ["-config", "/etc/infrawatch/ingest.yaml"]


### PR DESCRIPTION
## Summary

- Creates a dedicated `ingest` system user (uid/gid 1001) and drops to it with `USER ingest` so the container no longer runs as root.
- Chowns `/etc/infrawatch` and `/var/lib/infrawatch` to the new user — the ingest process writes `jwt_key.pem` there on first boot.
- Adds a `HEALTHCHECK` that probes the existing `/healthz` endpoint on the HTTP port (8080).

Addresses Trivy findings [DS-0002](https://avd.aquasec.com/misconfig/ds-0002) (HIGH) and [DS-0026](https://avd.aquasec.com/misconfig/ds-0026) (LOW) currently flagged on `apps/ingest/Dockerfile`. Resolving these on `main` will also clean the "Trivy" code-scanning check on #449.

## Test plan

- [x] `docker build` succeeds locally
- [x] `docker run --entrypoint id` reports `uid=1001(ingest)`
- [x] `docker inspect` shows the HEALTHCHECK wired up
- [ ] Run ingest against a real DB and confirm it writes `jwt_key.pem` under the new user

🤖 Generated with [Claude Code](https://claude.com/claude-code)