### PR TITLE
fix(security): agent/latest caching+rate-limit, licence JWT typ, entrypoint fail-fast (M-25, M-03, L-12)

### DIFF
--- a/apps/web/app/api/agent/latest/route.ts
+++ b/apps/web/app/api/agent/latest/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
 import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from '@/lib/agent/repo'
 
 interface GitHubRelease {
@@ -8,44 +9,89 @@ interface GitHubRelease {
   html_url: string
 }
 
-/**
- * Returns the latest agent release version.
- * Filters GitHub releases to those tagged agent/v* and returns the newest.
- */
+interface ReleasePayload {
+  version: string
+  tag: string
+  published_at: string
+  release_url: string
+}
+
+// ── Server-side TTL cache (per-process) ───────────────────────────────────────
+// Prevents every request from fanning out to the GitHub API.
+// Multi-instance deployments benefit further from the upstream CDN / fetch cache.
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+let cacheEntry: { data: ReleasePayload; expiresAt: number } | null = null
+
+// ── Per-IP rate limiter ───────────────────────────────────────────────────────
+// Limits unauthenticated callers to 10 requests per minute so a single source
+// cannot keep triggering cache misses and fanning out to GitHub.
+const ipTimestamps = new Map<string, number[]>()
+const RATE_LIMIT_WINDOW_MS = 60_000
+const RATE_LIMIT_MAX = 10
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now()
+  const timestamps = ipTimestamps.get(ip) ?? []
+  const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS)
+  if (recent.length >= RATE_LIMIT_MAX) return false
+  recent.push(now)
+  ipTimestamps.set(ip, recent)
+  return true
+}
+
 export async function GET() {
-  const headers: Record<string, string> = {
+  const reqHeaders = await headers()
+  const ip = reqHeaders.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json(
+      { error: 'Rate limited — please wait a moment before retrying.' },
+      { status: 429 },
+    )
+  }
+
+  // Serve from cache if still fresh
+  const now = Date.now()
+  if (cacheEntry && cacheEntry.expiresAt > now) {
+    return NextResponse.json(cacheEntry.data, { headers: { 'X-Cache': 'HIT' } })
+  }
+
+  // Fetch from GitHub (one outbound call per cache miss)
+  const fetchHeaders: Record<string, string> = {
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
   }
   if (process.env.GITHUB_TOKEN) {
-    headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`
+    fetchHeaders['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`
   }
 
   const res = await fetch(
     `https://api.github.com/repos/${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}/releases?per_page=20`,
-    { headers, next: { revalidate: 300 } }
+    { headers: fetchHeaders },
   )
 
   if (!res.ok) {
     return NextResponse.json(
       { error: `GitHub API error: ${res.status}` },
-      { status: 502 }
+      { status: 502 },
     )
   }
 
-  const releases: GitHubRelease[] = await res.json()
+  const releases = (await res.json()) as GitHubRelease[]
   const agentRelease = releases.find((r) => r.tag_name.startsWith('agent/v'))
 
   if (!agentRelease) {
     return NextResponse.json({ error: 'No agent release found' }, { status: 404 })
   }
 
-  const version = agentRelease.tag_name.replace('agent/', '')
-
-  return NextResponse.json({
-    version,
+  const data: ReleasePayload = {
+    version: agentRelease.tag_name.replace('agent/', ''),
     tag: agentRelease.tag_name,
     published_at: agentRelease.published_at,
     release_url: agentRelease.html_url,
-  })
+  }
+
+  cacheEntry = { data, expiresAt: now + CACHE_TTL_MS }
+
+  return NextResponse.json(data, { headers: { 'X-Cache': 'MISS' } })
 }

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+# Fail fast if critical environment variables are missing.
+# Silent fallbacks (empty DATABASE_URL, empty auth secret, etc.) produce
+# subtle, hard-to-diagnose failures that surface only at first use.
+: "${DATABASE_URL:?DATABASE_URL must be set}"
+: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+: "${BETTER_AUTH_URL:?BETTER_AUTH_URL must be set}"
+
 # Ensure the agent-dist volume mount is writable by the nextjs user.
 # Docker named volumes are created as root; this fixes ownership on each start.
 if [ -d "/var/lib/infrawatch/agent-dist" ]; then

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -89,6 +89,9 @@ export async function validateLicenceKey(key: string): Promise<LicenceValidation
       algorithms: ['RS256'],
       issuer: LICENCE_ISSUER,
       audience: LICENCE_AUDIENCE,
+      // Explicitly assert the token type so that JWT type-confusion attacks
+      // (e.g. using a licence token as a different JWT) are rejected.
+      typ: 'JWT',
     })
 
     if (!isPaidTier(payload['tier'])) {


### PR DESCRIPTION
## Summary

- **M-25** (`app/api/agent/latest/route.ts`): The unauthenticated `/api/agent/latest` endpoint previously made an uncached outbound GitHub API call on every request, making it a DoS amplifier. Now has a 5-minute server-side TTL cache and per-IP rate limit (10 req / 60 s).

- **M-03** (`lib/licence.ts`): `jwtVerify` already enforced `algorithms: ['RS256']` and explicit issuer/audience, correctly rejecting `alg=none`. Added `typ: 'JWT'` to also prevent JWT type-confusion attacks.

- **L-12** (`entrypoint.sh`): Added fail-fast `${VAR:?}` guards for `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `BETTER_AUTH_URL`. Missing values previously produced silent failures surfacing only at first use; the container now exits immediately with a descriptive error.

## Test plan

- [ ] Hitting `/api/agent/latest` twice within 5 minutes returns `X-Cache: HIT` on the second request
- [ ] Sending > 10 requests from the same IP within 60 s returns `429`
- [ ] Starting the container without `DATABASE_URL` set exits with a clear error message
- [ ] Submitting a licence JWT with a non-RS256 algorithm is rejected
- [ ] CI lint / type-check / build passes

Closes #340
Closes #318
Closes #359

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY