### PR TITLE
fix(security): require HTTPS for notification webhooks, restrict SMTP ports, remove default DB password (M-12, H-31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,15 +71,12 @@ INGEST_WS_URL=ws://localhost:8080
 
 # === Database credentials ===
 
-# 🔒 PostgreSQL credentials. The defaults baked into docker-compose.single.yml
-# are "infrawatch / infrawatch / infrawatch" — fine for a laptop, but anyone
-# who can reach port 5432 on your server with those defaults gets full
-# database access (including all session tokens, encrypted LDAP passwords,
-# and licence keys). Override these in .env and they will be picked up by
-# docker compose; if you change them after the database has been initialised
-# you must also update them inside the database, not just here.
+# 🔒 PostgreSQL credentials. POSTGRES_PASSWORD is required — docker compose
+# will refuse to start without it. start.sh generates a random value on first
+# run if left blank. If you change POSTGRES_PASSWORD after the database has
+# been initialised you must also update it inside PostgreSQL, not just here.
 # POSTGRES_USER=infrawatch
-# POSTGRES_PASSWORD=infrawatch
+POSTGRES_PASSWORD=
 # POSTGRES_DB=infrawatch
 
 # === Optional image overrides (advanced) ===

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -65,12 +65,21 @@ const updateAlertRuleSchema = z.object({
 
 const smtpEncryptionSchema = z.enum(['none', 'starttls', 'tls'])
 
+// Standard SMTP submission ports. Port 25 (server-to-server relay) is included
+// for self-hosted mail servers; 465 (SMTPS), 587 (submission), 2525 (alt).
+const SMTP_ALLOWED_PORTS = [25, 465, 587, 2525] as const
+
+const httpsUrl = z
+  .string()
+  .url()
+  .refine((u) => u.startsWith('https://'), { message: 'URL must use HTTPS' })
+
 const createNotificationChannelSchema = z.discriminatedUnion('type', [
   z.object({
     name: z.string().min(1).max(100),
     type: z.literal('webhook'),
     config: z.object({
-      url: z.string().url(),
+      url: httpsUrl,
       secret: z.string().optional(),
     }),
   }),
@@ -79,7 +88,12 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
     type: z.literal('smtp'),
     config: z.object({
       host: z.string().min(1),
-      port: z.number().int().min(1).max(65535),
+      port: z
+        .number()
+        .int()
+        .refine((p) => (SMTP_ALLOWED_PORTS as readonly number[]).includes(p), {
+          message: `SMTP port must be one of: ${SMTP_ALLOWED_PORTS.join(', ')}`,
+        }),
       encryption: smtpEncryptionSchema,
       username: z.string().optional(),
       password: z.string().optional(),
@@ -92,7 +106,7 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
     name: z.string().min(1).max(100),
     type: z.literal('slack'),
     config: z.object({
-      webhookUrl: z.string().url(),
+      webhookUrl: httpsUrl,
     }),
   }),
   z.object({
@@ -567,14 +581,19 @@ export async function deleteNotificationChannel(
 
 const updateWebhookChannelSchema = z.object({
   name: z.string().min(1).max(100),
-  url: z.string().url(),
+  url: httpsUrl,
   secret: z.string().optional(),
 })
 
 const updateSmtpChannelSchema = z.object({
   name: z.string().min(1).max(100),
   host: z.string().min(1),
-  port: z.number().int().min(1).max(65535),
+  port: z
+    .number()
+    .int()
+    .refine((p) => (SMTP_ALLOWED_PORTS as readonly number[]).includes(p), {
+      message: `SMTP port must be one of: ${SMTP_ALLOWED_PORTS.join(', ')}`,
+    }),
   encryption: smtpEncryptionSchema,
   username: z.string().optional(),
   password: z.string().optional(),
@@ -585,7 +604,7 @@ const updateSmtpChannelSchema = z.object({
 
 const updateSlackChannelSchema = z.object({
   name: z.string().min(1).max(100),
-  webhookUrl: z.string().url(),
+  webhookUrl: httpsUrl,
 })
 
 const updateTelegramChannelSchema = z.object({

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -3,9 +3,9 @@ services:
     image: timescale/timescaledb:latest-pg16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: infrawatch
-      POSTGRES_PASSWORD: infrawatch
-      POSTGRES_DB: infrawatch
+      POSTGRES_USER: ${POSTGRES_USER:-infrawatch}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in your .env file. Run: openssl rand -hex 16}
+      POSTGRES_DB: ${POSTGRES_DB:-infrawatch}
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
@@ -28,8 +28,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      DATABASE_URL: postgresql://infrawatch:infrawatch@db:5432/infrawatch
-      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-change-me-in-production}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-infrawatch}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-infrawatch}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set in your .env file}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:3000}
       NODE_ENV: production
@@ -53,7 +53,7 @@ services:
       - "9443:9443"   # gRPC (TLS)
       - "8080:8080"   # JWKS + healthz HTTP
     environment:
-      DATABASE_URL: postgresql://infrawatch:infrawatch@db:5432/infrawatch
+      DATABASE_URL: postgresql://${POSTGRES_USER:-infrawatch}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-infrawatch}
       INGEST_TLS_CERT: /etc/infrawatch/tls/server.crt
       INGEST_TLS_KEY: /etc/infrawatch/tls/server.key
       INGEST_JWT_KEY_FILE: /var/lib/infrawatch/jwt_key.pem

--- a/start.sh
+++ b/start.sh
@@ -93,6 +93,26 @@ if [ -z "${BETTER_AUTH_SECRET:-}" ]; then
   echo "Generated BETTER_AUTH_SECRET and wrote it to .env."
 fi
 
+# Auto-generate POSTGRES_PASSWORD on first run if blank. The default
+# "infrawatch" password in the example config must not reach production.
+if [ -z "${POSTGRES_PASSWORD:-}" ]; then
+  if ! command -v openssl >/dev/null 2>&1; then
+    echo "ERROR: openssl is required to generate POSTGRES_PASSWORD" >&2
+    exit 1
+  fi
+  GENERATED_PG_PASS=$(openssl rand -hex 16)
+  if grep -q '^# POSTGRES_PASSWORD=' .env; then
+    awk -v p="$GENERATED_PG_PASS" '/^# POSTGRES_PASSWORD=/ {print "POSTGRES_PASSWORD=" p; next} {print}' .env > .env.tmp && mv .env.tmp .env
+  elif grep -q '^POSTGRES_PASSWORD=' .env; then
+    awk -v p="$GENERATED_PG_PASS" '/^POSTGRES_PASSWORD=/ {print "POSTGRES_PASSWORD=" p; next} {print}' .env > .env.tmp && mv .env.tmp .env
+  else
+    echo "POSTGRES_PASSWORD=$GENERATED_PG_PASS" >> .env
+  fi
+  chmod 600 .env
+  export POSTGRES_PASSWORD="$GENERATED_PG_PASS"
+  echo "Generated POSTGRES_PASSWORD and wrote it to .env."
+fi
+
 # Generate dev TLS certificates for the ingest service if they don't exist
 CERT_DIR="$SCRIPT_DIR/deploy/dev-tls"
 if [ ! -f "$CERT_DIR/server.crt" ] || [ ! -f "$CERT_DIR/server.key" ]; then


### PR DESCRIPTION
## Summary

- **M-12** (`lib/actions/alerts.ts`): Webhook and Slack notification channel URLs now require `https://` — plain HTTP is rejected by the Zod schema on both create and update. SMTP port is restricted to the standard submission ports `[25, 465, 587, 2525]`; arbitrary ports were a potential internal-service-probing vector.

- **H-31** (`docker-compose.single.yml`, `start.sh`, `.env.example`): `POSTGRES_PASSWORD` is no longer hardcoded as `"infrawatch"`. The docker compose file now uses `${POSTGRES_PASSWORD:?}` so it refuses to start without the variable. `start.sh` auto-generates a random 32-hex-char password on first run and writes it to `.env`, matching the existing `BETTER_AUTH_SECRET` pattern. `BETTER_AUTH_SECRET` fallback `change-me-in-production` is also removed.

## Test plan

- [ ] Creating a webhook channel with `http://` URL returns a validation error
- [ ] Creating a webhook channel with `https://` URL succeeds
- [ ] Creating an SMTP channel with port `8025` returns a validation error
- [ ] Creating an SMTP channel with port `587` succeeds
- [ ] Running `./start.sh` without `POSTGRES_PASSWORD` set auto-generates and writes it to `.env`
- [ ] Running `docker compose -f docker-compose.single.yml up` without `.env` exits with a clear error about `POSTGRES_PASSWORD`
- [ ] CI lint / type-check / build passes

Closes #327
Closes #315

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY