### PR TITLE
fix(auth/db/ldap): rate limits, host deletion TOCTOU, LDAP filter injection (H-25, M-21, C-04, M-32)

### DIFF
--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -5,9 +5,24 @@ import { eq, and, isNull } from 'drizzle-orm'
 import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
 import { randomBytes, createHmac } from 'crypto'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+// 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
+const ldapRateLimit = createRateLimiter(60_000, 5)
 
 export async function POST(request: NextRequest) {
   try {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? request.headers.get('x-real-ip')
+    ?? 'unknown'
+
+  if (!ldapRateLimit.check(ip)) {
+    return NextResponse.json(
+      { error: 'Too many login attempts — please wait before trying again.' },
+      { status: 429 },
+    )
+  }
+
   const body = await request.json()
   const { username, password } = body as { username?: string; password?: string }
 

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -877,12 +877,24 @@ export async function deleteHost(
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
   try {
-    const host = await db.query.hosts.findFirst({
-      where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)),
-    })
-    if (!host) return { error: 'Host not found' }
+    // Capture the result of the "not found" check that happens inside the
+    // transaction so we can surface it as an error after the transaction closes.
+    let hostNotFound = false
 
     await db.transaction(async (tx) => {
+      // Lock the host row for the duration of this transaction so that
+      // concurrent delete requests cannot race past this check (TOCTOU fix).
+      const [host] = await tx
+        .select()
+        .from(hosts)
+        .where(and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)))
+        .for('update')
+
+      if (!host) {
+        hostNotFound = true
+        return
+      }
+
       // 1. Identity events (references service_account_id, ssh_key_id, host_id)
       await tx
         .delete(identityEvents)
@@ -1047,6 +1059,7 @@ export async function deleteHost(
       }
     })
 
+    if (hostNotFound) return { error: 'Host not found' }
     return { success: true }
   } catch (err) {
     console.error('Failed to delete host:', err)

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -1,11 +1,24 @@
 'use server'
 
+import { headers } from 'next/headers'
 import { db } from '@/lib/db'
 import { invitations, users } from '@/lib/db/schema'
 import { eq, and, isNull, gt } from 'drizzle-orm'
 import type { Invitation } from '@/lib/db/schema'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+// 10 invite-token lookups per IP per 60 s — prevents token enumeration
+const inviteRateLimit = createRateLimiter(60_000, 10)
+
+async function getClientIp(): Promise<string> {
+  const h = await headers()
+  return h.get('x-forwarded-for')?.split(',')[0]?.trim() ?? h.get('x-real-ip') ?? 'unknown'
+}
 
 export async function getInviteByToken(token: string): Promise<Invitation | null> {
+  const ip = await getClientIp()
+  if (!inviteRateLimit.check(ip)) return null
+
   const invite = await db.query.invitations.findFirst({
     where: and(
       eq(invitations.token, token),
@@ -21,6 +34,11 @@ export async function acceptInvite(
   token: string,
   userId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const ip = await getClientIp()
+  if (!inviteRateLimit.check(ip)) {
+    return { error: 'Too many requests — please wait before trying again.' }
+  }
+
   try {
     const invite = await db.query.invitations.findFirst({
       where: and(

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -6,7 +6,7 @@ import { ldapConfigurations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import type { LdapConfiguration } from '@/lib/db/schema'
 import { encrypt } from '@/lib/crypto/encrypt'
-import { testConnection as ldapTestConnection, searchUsers, lookupUserByDn } from '@/lib/ldap/client'
+import { testConnection as ldapTestConnection, searchUsers, lookupUserByDn, escapeLdapFilterValue } from '@/lib/ldap/client'
 import type { LdapUser, LdapUserDetail } from '@/lib/ldap/client'
 
 const createLdapConfigSchema = z.object({
@@ -251,7 +251,7 @@ export async function searchLdapDirectory(
   if (!config) return { error: 'Configuration not found' }
 
   try {
-    const filter = config.userSearchFilter.replace('{{username}}', `${query.trim()}*`)
+    const filter = config.userSearchFilter.replace('{{username}}', `${escapeLdapFilterValue(query.trim())}*`)
     const users = await searchUsers(config, filter)
     return { success: true, users: users.slice(0, 5).map(toLdapUserResult) }
   } catch (err) {

--- a/apps/web/lib/ldap/client.ts
+++ b/apps/web/lib/ldap/client.ts
@@ -15,6 +15,16 @@ export interface LdapUser {
   passwordLastChangedAt?: Date | null
 }
 
+// RFC 4515 §3: escape special characters before interpolating user input into LDAP filters.
+export function escapeLdapFilterValue(value: string): string {
+  return value
+    .replace(/\\/g, '\\5c')
+    .replace(/\*/g, '\\2a')
+    .replace(/\(/g, '\\28')
+    .replace(/\)/g, '\\29')
+    .replace(/\0/g, '\\00')
+}
+
 function getTlsOptions(config: LdapConfiguration): Record<string, unknown> | undefined {
   if (!config.useTls && !config.useStartTls) return undefined
   return config.tlsCertificate
@@ -304,7 +314,7 @@ export async function authenticateUser(
 
     const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
 
-    const searchFilter = config.userSearchFilter.replace('{{username}}', username)
+    const searchFilter = config.userSearchFilter.replace('{{username}}', escapeLdapFilterValue(username))
 
     const { searchEntries } = await client.search(searchBase, {
       filter: searchFilter,

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -1,0 +1,23 @@
+/**
+ * Simple per-process sliding-window rate limiter.
+ * Suitable for single-node deployments; multi-node needs Redis.
+ */
+export interface RateLimiter {
+  /** Returns true if the request is allowed, false if it should be rejected. */
+  check(key: string): boolean
+}
+
+export function createRateLimiter(windowMs: number, max: number): RateLimiter {
+  const store = new Map<string, number[]>()
+  return {
+    check(key: string): boolean {
+      const now = Date.now()
+      const cutoff = now - windowMs
+      const hits = (store.get(key) ?? []).filter((t) => t > cutoff)
+      if (hits.length >= max) return false
+      hits.push(now)
+      store.set(key, hits)
+      return true
+    },
+  }
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { createRateLimiter } from '@/lib/rate-limit'
 
 // Cookie set by Better Auth on sign-in
 const SESSION_COOKIE = 'better-auth.session_token'
@@ -19,6 +20,16 @@ const PROTECTED_PATHS = [
   '/profile',
 ]
 
+// Credential-bearing Better Auth paths — brute-force and token-stuffing targets.
+// 10 POST requests per IP per 60 s is generous for legitimate users but stops
+// automated attacks quickly. Multi-node deployments should use Redis instead.
+const BETTER_AUTH_SENSITIVE_PATHS = [
+  '/api/auth/sign-in',
+  '/api/auth/forget-password',
+  '/api/auth/reset-password',
+]
+const authRateLimit = createRateLimiter(60_000, 10)
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const sessionToken = request.cookies.get(SESSION_COOKIE)?.value
@@ -34,11 +45,31 @@ export function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-request-id', requestId)
 
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+
+  // Rate-limit credential-bearing auth endpoints to prevent brute-force attacks.
+  if (
+    request.method === 'POST' &&
+    BETTER_AUTH_SENSITIVE_PATHS.some((p) => pathname.startsWith(p))
+  ) {
+    if (!authRateLimit.check(ip)) {
+      const limitResponse = NextResponse.json(
+        { error: 'Too many requests — please wait before trying again.' },
+        { status: 429 },
+      )
+      limitResponse.headers.set('X-Request-Id', requestId)
+      return limitResponse
+    }
+  }
+
   if (!isAuthenticated && isProtectedRoute) {
     const redirectResponse = NextResponse.redirect(new URL('/login', request.url))
     redirectResponse.headers.set('X-Request-Id', requestId)
     return redirectResponse
   }
+
+  void isAuthRoute
 
   const response = NextResponse.next({ request: { headers: requestHeaders } })
   // Echo the ID back to the client so it appears in browser DevTools / client logs.
@@ -47,5 +78,8 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico).*)'],
+  // Include /api/auth so the rate limiter above applies to sign-in and
+  // password-reset endpoints. Auth-redirect logic only fires for PROTECTED_PATHS
+  // (page routes), so API routes are unaffected.
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 }


### PR DESCRIPTION
## Summary

**H-25 — Rate limiting on auth-adjacent endpoints:**

| Endpoint | Limit | Location |
|---|---|---|
| LDAP login (`/api/auth/ldap`) | 5 req / 60 s per IP | `ldap/route.ts` |
| Better Auth sign-in / forget-password / reset-password | 10 req / 60 s per IP | `proxy.ts` |
| `getInviteByToken` / `acceptInvite` server actions | 10 req / 60 s per IP | `lib/actions/auth.ts` |

A shared `createRateLimiter` factory (`lib/rate-limit.ts`) replaces the copy-paste `Map` pattern. `proxy.ts` matcher now includes `/api/auth` paths so the limiter fires before Better Auth handles requests; auth-redirect logic only fires for page routes so Better Auth is unaffected.

**M-21 — Host deletion cascade TOCTOU fix:**

`deleteHost` previously fetched the host row outside the transaction, then used the stale `agentId` inside it. A concurrent request could race between the check and the cascade, leaving agent rows orphaned. The fix moves the existence check inside the transaction as a `SELECT … FOR UPDATE`, ensuring the row is locked for the full duration of the cascade.

**C-04 / M-32 — LDAP filter injection (RFC 4515):**

`config.userSearchFilter.replace('{{username}}', username)` was interpolating user-controlled input directly into LDAP search filters without escaping metacharacters (`\`, `*`, `(`, `)`, NUL). An attacker-crafted username such as `*))(|(uid=*` could alter filter semantics, bypassing authentication or enumerating directory data.

Adds `escapeLdapFilterValue()` in `lib/ldap/client.ts` (RFC 4515 §3 encoding) and applies it at both injection points:
- `authenticateUser()` — login username (`client.ts:307`)
- `searchLdapUsers()` — directory search query (`actions/ldap.ts:254`)

The trailing `*` wildcard for prefix-matching in directory search is preserved outside the escaped value.

## Test plan

- [ ] Sending > 5 LDAP login attempts within 60 s from the same IP returns `429`
- [ ] Sending > 10 `POST /api/auth/sign-in/email` requests within 60 s returns `429`
- [ ] Normal sign-in, invite acceptance, and password-reset still work within the limit
- [ ] Deleting a host succeeds and removes all related rows atomically
- [ ] Deleting a non-existent host returns `Host not found`
- [ ] LDAP login with username containing `*`, `(`, `)`, `\` does not alter filter semantics
- [ ] Directory search with special characters returns expected results or empty set, not an injection result
- [ ] CI lint / type-check / build passes

Closes #309
Closes #336
Closes #276
Closes #347

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY