### PR TITLE
fix(sec): M-22 + M-10 + H-05 + H-06 + H-09 security hardening

### DIFF
--- a/apps/web/app/(auth)/register/register-form.tsx
+++ b/apps/web/app/(auth)/register/register-form.tsx
@@ -25,7 +25,7 @@ const registerSchema = z
   .object({
     name: z.string().min(2, 'Name must be at least 2 characters'),
     email: z.string().email('Enter a valid email address'),
-    password: z.string().min(8, 'Password must be at least 8 characters'),
+    password: z.string().min(12, 'Password must be at least 12 characters').max(128, 'Password must be at most 128 characters'),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -4,8 +4,25 @@ import { users, accounts, sessions, ldapConfigurations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
-import { randomBytes, createHmac } from 'crypto'
+import { randomBytes } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
+
+// Produce a signed cookie value in exactly the format Hono's serializeSigned uses:
+// encodeURIComponent(`${value}.${btoa(HMAC-SHA256(value, secret))}`).
+// Better Auth's getSession delegates cookie verification to Hono, so this must
+// match Hono's implementation byte-for-byte to avoid silent session failures.
+async function makeSessionCookieValue(token: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(token))
+  const base64Sig = btoa(String.fromCharCode(...new Uint8Array(sig)))
+  return encodeURIComponent(`${token}.${base64Sig}`)
+}
 
 // 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
 const ldapRateLimit = createRateLimiter(60_000, 5)
@@ -149,12 +166,8 @@ export async function POST(request: NextRequest) {
       userAgent: request.headers.get('user-agent') ?? null,
     })
 
-    // Sign the session token using HMAC-SHA256 to match Better Auth's signed cookie format.
-    // Better Auth uses setSignedCookie which produces: encodeURIComponent(token.base64(HMAC-SHA256(token, secret)))
-    // and getSignedCookie verifies the signature before returning the token.
     const authSecret = process.env['BETTER_AUTH_SECRET'] ?? ''
-    const signature = createHmac('sha256', authSecret).update(sessionToken).digest('base64')
-    const signedToken = `${sessionToken}.${signature}`
+    const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
 
     const response = NextResponse.json({
       success: true,
@@ -165,13 +178,11 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    response.cookies.set('better-auth.session_token', signedToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      path: '/',
-      expires: expiresAt,
-    })
+    // Set the cookie with an already-encoded value (Next.js would double-encode otherwise).
+    response.headers.append(
+      'Set-Cookie',
+      `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
+    )
 
     return withAuthDelay(requestStart, response)
   }

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -38,6 +38,9 @@ import { triggerAgentUninstall, getTaskRun } from '@/lib/actions/task-runs'
 import { assignTagsToResource, getOrgDefaultTags, mergeTagLayers } from '@/lib/actions/tags'
 import { runMatchingTagRules } from '@/lib/actions/tag-rules'
 import type { HostMetadata, TagPair } from '@/lib/db/schema'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+const createEnrolmentTokenLimiter = createRateLimiter(60_000, 10)
 
 export type OfflinePeriod = { start: number; end: number | null }
 
@@ -456,6 +459,9 @@ export async function createEnrolmentToken(
     tags?: Array<{ key: string; value: string }>
   },
 ): Promise<{ token: string; id: string } | { error: string }> {
+  if (!createEnrolmentTokenLimiter.check(orgId)) {
+    return { error: 'Too many requests — please wait before creating another enrolment token.' }
+  }
   const parsed = createEnrolmentTokenSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -3,6 +3,9 @@
 import { z } from 'zod'
 import { createHmac } from 'crypto'
 import nodemailer from 'nodemailer'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+const testNotificationLimiter = createRateLimiter(60_000, 5)
 import { db } from '@/lib/db'
 import { alertRules, alertInstances, notificationChannels, alertSilences, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, desc, inArray, sql, lte, gte, count } from 'drizzle-orm'
@@ -693,6 +696,9 @@ export async function sendTestNotification(
   orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
+  if (!testNotificationLimiter.check(orgId)) {
+    return { error: 'Too many requests — please wait before sending another test notification.' }
+  }
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
       eq(notificationChannels.id, channelId),

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -16,6 +16,9 @@ import {
   type ParsedCertificate,
 } from '@/lib/certificates/fetch'
 import { assertPublicHost } from '@/lib/net/ssrf-guard'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+const trackFromUrlLimiter = createRateLimiter(60_000, 20)
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -236,6 +239,9 @@ export async function trackCertificateFromUrl(
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) {
     return { error: 'Organisation mismatch' }
+  }
+  if (!trackFromUrlLimiter.check(orgId)) {
+    return { error: 'Too many requests — please wait before adding more certificates.' }
   }
 
   const parsed = trackFromUrlSchema.safeParse(input)

--- a/apps/web/lib/actions/host-groups.ts
+++ b/apps/web/lib/actions/host-groups.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { z } from 'zod'
 import { db } from '@/lib/db'
 import { hostGroups, hostGroupMembers, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, sql } from 'drizzle-orm'
@@ -9,19 +10,28 @@ import type { Host } from '@/lib/db/schema'
 export type HostGroupWithCount = HostGroup & { hostCount: number }
 export type HostGroupWithMembers = HostGroup & { members: Host[] }
 
+const groupSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(1000).optional(),
+})
+
 // ── Group CRUD ─────────────────────────────────────────────────────────────
 
 export async function createGroup(
   orgId: string,
-  data: { name: string; description?: string },
+  input: unknown,
 ): Promise<{ success: true; group: HostGroup } | { error: string }> {
+  const parsed = groupSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
   try {
     const rows = await db
       .insert(hostGroups)
       .values({
         organisationId: orgId,
-        name: data.name,
-        description: data.description ?? null,
+        name: parsed.data.name,
+        description: parsed.data.description ?? null,
       })
       .returning()
     const group = rows[0]
@@ -36,12 +46,16 @@ export async function createGroup(
 export async function updateGroup(
   orgId: string,
   groupId: string,
-  data: { name: string; description?: string },
+  input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  const parsed = groupSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
   try {
     const result = await db
       .update(hostGroups)
-      .set({ name: data.name, description: data.description ?? null, updatedAt: new Date() })
+      .set({ name: parsed.data.name, description: parsed.data.description ?? null, updatedAt: new Date() })
       .where(and(eq(hostGroups.id, groupId), eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)))
       .returning({ id: hostGroups.id })
 

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -5,7 +5,19 @@ import { db } from '@/lib/db'
 import { ldapConfigurations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import type { LdapConfiguration } from '@/lib/db/schema'
-import { encrypt } from '@/lib/crypto/encrypt'
+import { encrypt, decrypt } from '@/lib/crypto/encrypt'
+
+function safeDecrypt(value: string): string {
+  try { return decrypt(value) } catch { return value }
+}
+
+function decryptConfigForDisplay<T extends { bindDn: string; tlsCertificate: string | null }>(config: T): T {
+  return {
+    ...config,
+    bindDn: safeDecrypt(config.bindDn),
+    tlsCertificate: config.tlsCertificate ? safeDecrypt(config.tlsCertificate) : null,
+  }
+}
 import { testConnection as ldapTestConnection, searchUsers, lookupUserByDn, escapeLdapFilterValue } from '@/lib/ldap/client'
 import type { LdapUser, LdapUserDetail } from '@/lib/ldap/client'
 
@@ -53,13 +65,14 @@ const updateLdapConfigSchema = z.object({
 export async function getLdapConfigurations(
   orgId: string,
 ): Promise<LdapConfiguration[]> {
-  return db.query.ldapConfigurations.findMany({
+  const rows = await db.query.ldapConfigurations.findMany({
     where: and(
       eq(ldapConfigurations.organisationId, orgId),
       isNull(ldapConfigurations.deletedAt),
     ),
     orderBy: ldapConfigurations.createdAt,
   })
+  return rows.map(decryptConfigForDisplay)
 }
 
 export async function getLdapConfiguration(
@@ -73,7 +86,7 @@ export async function getLdapConfiguration(
       isNull(ldapConfigurations.deletedAt),
     ),
   })
-  return result ?? null
+  return result ? decryptConfigForDisplay(result) : null
 }
 
 export async function createLdapConfiguration(
@@ -86,8 +99,6 @@ export async function createLdapConfiguration(
   }
 
   try {
-    const encryptedPassword = encrypt(parsed.data.bindPassword)
-
     const [row] = await db
       .insert(ldapConfigurations)
       .values({
@@ -97,10 +108,10 @@ export async function createLdapConfiguration(
         port: parsed.data.port,
         useTls: parsed.data.useTls,
         useStartTls: parsed.data.useStartTls,
-        tlsCertificate: parsed.data.tlsCertificate || null,
+        tlsCertificate: parsed.data.tlsCertificate ? encrypt(parsed.data.tlsCertificate) : null,
         baseDn: parsed.data.baseDn,
-        bindDn: parsed.data.bindDn,
-        bindPassword: encryptedPassword,
+        bindDn: encrypt(parsed.data.bindDn),
+        bindPassword: encrypt(parsed.data.bindPassword),
         userSearchBase: parsed.data.userSearchBase || null,
         userSearchFilter: parsed.data.userSearchFilter,
         groupSearchBase: parsed.data.groupSearchBase || null,
@@ -147,9 +158,9 @@ export async function updateLdapConfiguration(
   if (data.port !== undefined) updates.port = data.port
   if (data.useTls !== undefined) updates.useTls = data.useTls
   if (data.useStartTls !== undefined) updates.useStartTls = data.useStartTls
-  if (data.tlsCertificate !== undefined) updates.tlsCertificate = data.tlsCertificate || null
+  if (data.tlsCertificate !== undefined) updates.tlsCertificate = data.tlsCertificate ? encrypt(data.tlsCertificate) : null
   if (data.baseDn !== undefined) updates.baseDn = data.baseDn
-  if (data.bindDn !== undefined) updates.bindDn = data.bindDn
+  if (data.bindDn !== undefined) updates.bindDn = encrypt(data.bindDn)
   if (data.bindPassword !== undefined) updates.bindPassword = encrypt(data.bindPassword)
   if (data.userSearchBase !== undefined) updates.userSearchBase = data.userSearchBase || null
   if (data.userSearchFilter !== undefined) updates.userSearchFilter = data.userSearchFilter

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -131,7 +131,7 @@ export async function updateNotificationPreference(
 
 const changePasswordSchema = z.object({
   currentPassword: z.string().min(1, 'Current password is required'),
-  newPassword: z.string().min(8, 'New password must be at least 8 characters'),
+  newPassword: z.string().min(12, 'New password must be at least 12 characters').max(128, 'New password must be at most 128 characters'),
 })
 
 export async function updatePassword(

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -25,6 +25,10 @@ import { requireFeature } from '@/lib/actions/licence-guard'
 import { escapeLikePattern } from '@/lib/utils'
 import { compareVersions } from '@/lib/version-compare'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+const triggerScanLimiter = createRateLimiter(60_000, 5)
+const softwareReportLimiter = createRateLimiter(60_000, 10)
 
 // ── Settings ──────────────────────────────────────────────────────────────────
 
@@ -94,6 +98,9 @@ export async function triggerSoftwareScan(
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
+  }
+  if (!triggerScanLimiter.check(orgId)) {
+    return { error: 'Too many scan requests — please wait before triggering another scan.' }
   }
 
   try {
@@ -300,6 +307,9 @@ export async function getSoftwareReport(
   filters: SoftwareReportFilters = {},
 ): Promise<SoftwareReportResult> {
   await requireFeature(orgId, 'reportsExport')
+  if (!softwareReportLimiter.check(orgId)) {
+    throw new Error('Too many requests — please wait before generating another report.')
+  }
   const page = filters.page ?? 1
   const pageSize = Math.min(filters.pageSize ?? 50, 200)
   const offset = (page - 1) * pageSize

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -17,6 +17,8 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false,
+    minPasswordLength: 12,
+    maxPasswordLength: 128,
   },
   plugins: [
     twoFactor({

--- a/apps/web/lib/ldap/client.ts
+++ b/apps/web/lib/ldap/client.ts
@@ -25,11 +25,19 @@ export function escapeLdapFilterValue(value: string): string {
     .replace(/\0/g, '\\00')
 }
 
+function safeDecrypt(value: string): string {
+  try { return decrypt(value) } catch { return value }
+}
+
 function getTlsOptions(config: LdapConfiguration): Record<string, unknown> | undefined {
   if (!config.useTls && !config.useStartTls) return undefined
   return config.tlsCertificate
-    ? { ca: [config.tlsCertificate], rejectUnauthorized: true }
+    ? { ca: [safeDecrypt(config.tlsCertificate)], rejectUnauthorized: true }
     : { rejectUnauthorized: false }
+}
+
+function getBindDn(config: LdapConfiguration): string {
+  return safeDecrypt(config.bindDn)
 }
 
 function createClient(config: LdapConfiguration): Client {
@@ -75,7 +83,7 @@ export async function testConnection(
   config: LdapConfiguration,
 ): Promise<{ success: true } | { error: string }> {
   try {
-    const client = await connectAndBind(config, config.bindDn, getBindPassword(config))
+    const client = await connectAndBind(config, getBindDn(config), getBindPassword(config))
     await client.unbind()
     return { success: true }
   } catch (err) {
@@ -90,7 +98,7 @@ export async function searchUsers(
 ): Promise<LdapUser[]> {
   let client: Client | undefined
   try {
-    client = await connectAndBind(config, config.bindDn, getBindPassword(config))
+    client = await connectAndBind(config, getBindDn(config), getBindPassword(config))
 
     const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
 
@@ -256,7 +264,7 @@ export async function lookupUserByDn(
 ): Promise<LdapUserDetail | null> {
   let client: Client | undefined
   try {
-    client = await connectAndBind(config, config.bindDn, getBindPassword(config))
+    client = await connectAndBind(config, getBindDn(config), getBindPassword(config))
 
     const { searchEntries } = await client.search(dn, {
       filter: '(objectClass=*)',
@@ -310,7 +318,7 @@ export async function authenticateUser(
   let client: Client | undefined
   try {
     // First bind as service account to search for the user
-    client = await connectAndBind(config, config.bindDn, getBindPassword(config))
+    client = await connectAndBind(config, getBindDn(config), getBindPassword(config))
 
     const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
 


### PR DESCRIPTION
## Summary

**M-22** — `createGroup`/`updateGroup` in `host-groups.ts`: Added Zod schema validation (name min 1/max 255, description max 1000) before any DB write. Signatures changed to `input: unknown`.

**M-10** — Per-org sliding-window rate limiters on five previously-unthrottled server actions:
- `sendTestNotification` — 5/org/min (outbound HTTP)
- `triggerSoftwareScan` — 5/org/min (agent task dispatch)
- `getSoftwareReport` — 10/org/min (large DB scan)
- `trackCertificateFromUrl` — 20/org/min (TLS connection)
- `createEnrolmentToken` — 10/org/min

**H-05** — LDAP `bindDn` and `tlsCertificate` encrypted at rest with AES-256-GCM (same mechanism as `bindPassword`). Safe-decrypt fallback preserves backward compatibility with existing rows. LDAP client decrypts before use; `getLdapConfigurations`/`getLdapConfiguration` decrypt before returning to the UI.

**H-06** — Minimum password length raised from 8 to 12, maximum capped at 128 characters. Enforced in both the register form Zod schema and `profile.ts` server action, plus Better Auth's `minPasswordLength`/`maxPasswordLength` config (API-layer enforcement).

**H-09** — LDAP session cookie signing aligned with Hono's `serializeSigned` format (which Better Auth delegates to for `getSignedCookie` verification). Replaced Node.js `createHmac` with `crypto.subtle.sign` + `btoa` to produce byte-identical output. Also switched from `response.cookies.set()` to raw `Set-Cookie` header to avoid double-encoding the pre-encoded value.

## Test plan

- [ ] Create host group with name > 255 chars → validation error
- [ ] Create host group with valid input → succeeds
- [ ] Send 6 test notifications in < 1 min for same org → 6th returns rate-limit error
- [ ] Create LDAP config → verify `bindDn`/`tlsCertificate` stored encrypted in DB
- [ ] Load LDAP config in UI → fields display correctly (decrypted)
- [ ] LDAP login → subsequent protected-route access works (session cookie valid)
- [ ] Register with 11-char password → validation error; 12-char → succeeds
- [ ] Change password to 11 chars via profile → error
- [ ] `pnpm run type-check` exits 0

Closes #337 (M-22)
Closes #325 (M-10)
Closes #289 (H-05)
Closes #290 (H-06)
Closes #293 (H-09)

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY