### PR TITLE
fix(terminal): support same-origin WebSocket for Cloudflare tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,9 +54,23 @@ BETTER_AUTH_SECRET=
 # === Terminal ===
 
 # 🔒 WebSocket URL of the ingest service for browser terminal connections.
-# Must be reachable from the user's browser (not just from the server).
-# Use wss:// in production — ws:// sends the terminal stream and the
-# session JWT in plaintext over the network.
+#
+# Two modes:
+#
+#   1. Direct — set an absolute URL (e.g. ws://host:8080 or wss://host:8080).
+#      The browser connects directly to the ingest service. The URL MUST be
+#      reachable from every user's browser, not just from the server.
+#
+#   2. Same-origin reverse proxy — leave this blank. The browser opens the
+#      WebSocket against the page's own origin (e.g. wss://infrawatch.example.com
+#      /ws/terminal/...). Your reverse proxy / Cloudflare tunnel must route
+#      /ws/terminal/* to the ingest service on port 8080 and pass the
+#      HTTP Upgrade header through. This is the mode to use when only the web
+#      app is exposed through a Cloudflare tunnel (port 8080 is not reachable
+#      from the public internet).
+#
+# Use wss:// (or an https:// origin for same-origin mode) in production — ws://
+# sends the terminal stream and the session JWT in plaintext over the network.
 INGEST_WS_URL=ws://localhost:8080
 
 # === Optional: load-test admin endpoint ===

--- a/apps/docs/docs/features/terminal.md
+++ b/apps/docs/docs/features/terminal.md
@@ -103,3 +103,80 @@ All terminal sessions are logged to the event spine — commands typed and outpu
 ## Authentication
 
 Each terminal session authenticates using per-user credentials derived from the agent JWT. The web app issues a short-lived session token for each terminal tab. This token is included in the WebSocket handshake and validated by the agent before the shell is spawned.
+
+---
+
+## Deployment: Reverse Proxies and Cloudflare Tunnels
+
+The terminal relies on a WebSocket connection from the browser to the ingest service on port `8080`. The `INGEST_WS_URL` environment variable controls which URL the browser uses.
+
+There are two supported modes.
+
+### Direct mode (default)
+
+`INGEST_WS_URL=ws://host:8080` (or `wss://host:8080`). The browser opens the WebSocket directly to that URL. This is the simplest setup for local/LAN deployments where the ingest port is reachable from every user's browser.
+
+### Same-origin mode (reverse proxy / Cloudflare tunnel)
+
+Leave `INGEST_WS_URL` blank. The browser opens the WebSocket against the page's own origin, e.g. `wss://ct-ops.example.com/ws/terminal/<id>`. Your reverse proxy or tunnel must route `/ws/terminal/*` to the ingest service on port `8080` and forward the HTTP Upgrade header.
+
+This is the mode to use when only the web app is publicly reachable (for example, when you expose the server through a Cloudflare tunnel that points at the web container on port `3000`).
+
+#### Cloudflare Tunnel example
+
+In your `cloudflared` config, add a path-based ingress rule for `/ws/terminal/*` **before** the catch-all rule for the web app:
+
+```yaml
+ingress:
+  - hostname: ct-ops.example.com
+    path: ^/ws/terminal/.*
+    service: http://localhost:8080
+  - hostname: ct-ops.example.com
+    service: http://localhost:3000
+  - service: http_status:404
+```
+
+If you use the Cloudflare dashboard's Public Hostname UI, create two public hostnames for the same domain: one with Path set to `^/ws/terminal/.*` pointing at `http://localhost:8080`, and a second with no path pointing at `http://localhost:3000`. Cloudflare Tunnels forward WebSocket upgrades transparently — no extra configuration is needed on the tunnel side.
+
+Then either unset `INGEST_WS_URL` in your `.env` or set it to an empty value:
+
+```env
+INGEST_WS_URL=
+```
+
+#### Nginx example
+
+```nginx
+location /ws/terminal/ {
+    proxy_pass http://ingest:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
+location / {
+    proxy_pass http://web:3000;
+    proxy_set_header Host $host;
+}
+```
+
+#### Caddy example
+
+```caddy
+ct-ops.example.com {
+    reverse_proxy /ws/terminal/* ingest:8080
+    reverse_proxy web:3000
+}
+```
+
+### Troubleshooting
+
+If the terminal spins at "Connecting…" and never attaches:
+
+- **Check the browser's network tab** for the WebSocket request. It should show a `101 Switching Protocols` response. If you see a `502`, `503`, `520`, or the request times out, your reverse proxy is not forwarding the Upgrade header or cannot reach the ingest service.
+- **Verify that `/ws/terminal/...` is routed to port 8080**, not port 3000 — the web app does not answer this path.
+- **Confirm your tunnel forwards WebSockets**. Cloudflare Tunnels do so by default; other proxies may need explicit Upgrade/Connection header forwarding.
+- **If `INGEST_WS_URL` is set to an absolute URL**, the browser will ignore same-origin routing and try to connect directly. Make sure the URL is reachable from every user's browser, or clear the variable to switch to same-origin mode.

--- a/apps/web/components/terminal/terminal-session.tsx
+++ b/apps/web/components/terminal/terminal-session.tsx
@@ -180,7 +180,13 @@ export function TerminalSession({
           return
         }
 
-        const ws = new WebSocket(result.ingestWsUrl)
+        // A path-only ingestWsUrl (e.g. "/ws/terminal/...") means "use the
+        // same origin as the page" — required for reverse-proxy / tunnel
+        // deployments where the ingest service is not directly reachable.
+        const wsUrl = result.ingestWsUrl.startsWith('/')
+          ? `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}${result.ingestWsUrl}`
+          : result.ingestWsUrl
+        const ws = new WebSocket(wsUrl)
         wsRef.current = ws
 
         let agentDidConnect = false

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -111,10 +111,25 @@ export async function createTerminalSession(
       status: 'pending',
     })
 
-    const ingestWsUrl = process.env['INGEST_WS_URL'] ?? 'ws://localhost:8080'
+    // When INGEST_WS_URL is an absolute URL, the browser connects directly to
+    // the ingest service. When it is empty or a path, we return a path-only
+    // URL so the browser connects to the same origin it loaded the page from.
+    // Same-origin mode is required for deployments behind a reverse proxy or
+    // Cloudflare tunnel, where only the web app's hostname is publicly
+    // reachable and the proxy routes /ws/terminal/* to the ingest service.
+    const rawBase = (process.env['INGEST_WS_URL'] ?? '').trim().replace(/\/+$/, '')
+    // Accept http(s):// for convenience and rewrite to ws(s):// — new WebSocket()
+    // only accepts the ws schemes.
+    const normalised = rawBase
+      .replace(/^http:\/\//i, 'ws://')
+      .replace(/^https:\/\//i, 'wss://')
+    const isAbsolute = /^wss?:\/\//i.test(normalised)
+    const ingestWsUrl = isAbsolute
+      ? `${normalised}/ws/terminal/${sessionId}`
+      : `/ws/terminal/${sessionId}`
     return {
       sessionId,
-      ingestWsUrl: `${ingestWsUrl}/ws/terminal/${sessionId}`,
+      ingestWsUrl,
     }
   } catch (err) {
     console.error('Failed to create terminal session:', err)

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -35,7 +35,10 @@ services:
       NODE_ENV: production
       AGENT_DIST_DIR: /var/lib/infrawatch/agent-dist
       AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
-      INGEST_WS_URL: ${INGEST_WS_URL:-ws://localhost:8080}
+      # Leave INGEST_WS_URL blank when running behind a reverse proxy or
+      # Cloudflare tunnel — the browser will use the page's own origin and
+      # the proxy must route /ws/terminal/* to the ingest container on 8080.
+      INGEST_WS_URL: ${INGEST_WS_URL-ws://localhost:8080}
       INFRAWATCH_LOADTEST_ADMIN_KEY: ${INFRAWATCH_LOADTEST_ADMIN_KEY:-}
     volumes:
       - agent_dist:/var/lib/infrawatch/agent-dist


### PR DESCRIPTION
## Summary

When CT-Ops is accessed through a Cloudflare tunnel (or any reverse proxy that only exposes the web app's hostname), the in-app terminal never connects. The browser reads `INGEST_WS_URL` from the server action and opens the WebSocket directly to that URL — but a tunnel typically only fronts the web app on port 3000, so the absolute `ws://host:8080` URL is unreachable from a remote browser.

This PR adds a **same-origin mode** so the WebSocket can traverse the same tunnel as the rest of the web traffic.

## Changes

- `apps/web/lib/actions/terminal.ts` — if `INGEST_WS_URL` is blank, the server action returns a path-only URL (`/ws/terminal/<id>`). Absolute URLs still work unchanged. `http(s)://` values are rewritten to `ws(s)://` for convenience.
- `apps/web/components/terminal/terminal-session.tsx` — when the returned URL is path-only, the browser resolves it against `window.location` (picking `wss:` for HTTPS pages, `ws:` for HTTP).
- `docker-compose.single.yml` — switched the default operator from `:-` to `-` so an explicit empty `INGEST_WS_URL` in `.env` is no longer silently replaced with the localhost default. Existing deployments are unchanged.
- `.env.example` — documents the two modes (direct vs. same-origin reverse proxy).
- `apps/docs/docs/features/terminal.md` — new "Deployment: Reverse Proxies and Cloudflare Tunnels" section with `cloudflared`, nginx, and Caddy examples, plus a troubleshooting checklist.

## How to use behind a Cloudflare tunnel

1. Add an ingress rule routing `/ws/terminal/*` to `localhost:8080` (full example in the docs).
2. Set `INGEST_WS_URL=` (empty) in `.env` and restart the web container.
3. Terminal opens over `wss://<tunnel-host>/ws/terminal/<id>`, which goes through the same tunnel.

Absolute `INGEST_WS_URL` values remain the default, so existing LAN deployments are unaffected.

## Test plan

- [ ] Local LAN deployment (`INGEST_WS_URL=ws://<lan-ip>:8080`) — terminal still connects directly
- [ ] Cloudflare tunnel deployment with `INGEST_WS_URL=` and path-based ingress rule — terminal connects via `wss://<tunnel-host>/ws/terminal/...`
- [ ] nginx reverse proxy with `/ws/terminal/` upstream to ingest:8080 — terminal connects
- [ ] `INGEST_WS_URL=https://...` and `http://...` normalised to `wss://` / `ws://`
- [x] `pnpm run build` (TypeScript) — clean
- [x] `go build ./...` in `apps/ingest` — clean