### PR TITLE
fix(security): H-11 keypair re-registration takeover, H-21 direct terminal access as root

### DIFF
--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -156,8 +156,16 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 			if err := queries.ReattachHostToAgent(ctx, h.pool, collision.HostID, collision.AgentID, hostname); err != nil {
 				slog.Warn("reattaching host during adoption", "err", err)
 			}
-			if err := queries.InsertAgentStatusHistory(ctx, h.pool, collision.AgentID, orgID, collision.AgentStatus, nil,
-				"adopted re-registration (keypair rotated; matched by hostname or IP)"); err != nil {
+			// A keypair change is a new identity claim — always require re-approval
+			// regardless of the prior agent status. Resuming "active" without
+			// re-approval would let anyone who learns the enrolment token silently
+			// hijack an already-trusted agent identity (H-11).
+			if err := queries.SetAgentStatus(ctx, h.pool, collision.AgentID, "pending"); err != nil {
+				slog.Error("resetting agent status to pending after keypair rotation", "err", err)
+				return nil, status.Error(codes.Internal, "internal error")
+			}
+			if err := queries.InsertAgentStatusHistory(ctx, h.pool, collision.AgentID, orgID, "pending", nil,
+				"keypair rotated on re-registration; requires admin re-approval"); err != nil {
 				slog.Warn("inserting adoption history", "err", err)
 			}
 			if err := queries.IncrementUsageCount(ctx, h.pool, token.ID); err != nil {
@@ -169,26 +177,10 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 				"hostname", hostname,
 				"prior_status", collision.AgentStatus,
 			)
-			// Preserve prior approval state. If the existing agent was active
-			// before going offline, return active + JWT immediately so the
-			// machine resumes without requiring re-approval.
-			if collision.AgentStatus == "active" {
-				jwtToken, err := h.issuer.IssueAgentToken(collision.AgentID, orgID)
-				if err != nil {
-					slog.Error("issuing JWT for adopted agent", "err", err)
-					return nil, status.Error(codes.Internal, "internal error")
-				}
-				return &agentv1.RegisterResponse{
-					AgentId:  collision.AgentID,
-					Status:   "active",
-					Message:  "re-registration adopted existing host; resumed active state",
-					JwtToken: jwtToken,
-				}, nil
-			}
 			return &agentv1.RegisterResponse{
 				AgentId: collision.AgentID,
-				Status:  collision.AgentStatus,
-				Message: "re-registration adopted existing host; status: " + collision.AgentStatus,
+				Status:  "pending",
+				Message: "re-registration adopted existing host; keypair rotated — awaiting admin approval",
 			}, nil
 		}
 	}

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -63,7 +63,10 @@ export async function checkTerminalAccess(
     return { allowed: false, reason: 'You are not authorised to access this host terminal' }
   }
 
-  return { allowed: true, directAccess: orgMeta.terminalDirectAccess === true }
+  // directAccess (shell runs as agent user/root) is restricted to admins only.
+  // Non-admin engineers can open a terminal but must supply a username (H-21).
+  const isAdmin = ADMIN_ROLES.includes(user.role)
+  return { allowed: true, directAccess: isAdmin && orgMeta.terminalDirectAccess === true }
 }
 
 // POSIX-compliant: starts with letter or underscore, contains only [a-zA-Z0-9_-], max 32 chars


### PR DESCRIPTION
## Summary

- **H-11 (HIGH)** — Re-registration identity takeover via keypair rotation: the ingest `Register` handler previously resumed `active` status and issued a JWT immediately when a hostname/IP collision matched an already-active agent and the new keypair was accepted. An attacker with a valid enrolment token could silently hijack a trusted agent identity. Fix: always reset the agent to `pending` after `RotateAgentPublicKey` and require a fresh admin approval.

- **H-21 (HIGH)** — Direct terminal access as root without role check: `checkTerminalAccess` returned `directAccess: true` for any non-read-only user when the org setting was enabled. `directAccess` opens a shell as the agent user (typically root). Fix: gate `directAccess` behind `ADMIN_ROLES`; engineers still get terminal access but must supply an explicit username.

## Files changed

| File | Issue | Change |
|---|---|---|
| `apps/ingest/internal/handlers/register.go` | H-11 | Always set agent to `pending` + record history after keypair rotation; remove immediate JWT issuance path |
| `apps/web/lib/actions/terminal.ts` | H-21 | `directAccess` now requires `ADMIN_ROLES.includes(user.role)` in addition to the org setting |

## Test plan

- [ ] Re-register an active agent with a new keypair → response status should be `pending`, no JWT in response
- [ ] Admin approves re-registered agent → agent becomes active again
- [ ] Engineer role opens terminal → prompted for username (no direct/root shell)
- [ ] Admin role with `terminalDirectAccess: true` → direct shell granted
- [ ] `go build ./...` passes (ingest)
- [ ] `tsc --noEmit` passes (web)

https://claude.ai/code/session_013qxGDnnZTjXL8mLknpGcqY