### PR TITLE
feat(web): bake agent binaries into the web image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 apps/web/node_modules
 apps/ingest/vendor
+apps/web/data
 dist
 deploy/dev-tls
 .git

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'apps/web/**'
+      - 'agent/**'
+      - 'proto/gen/go/**'
       - 'packages/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
@@ -18,6 +20,8 @@ on:
       - main
     paths:
       - 'apps/web/**'
+      - 'agent/**'
+      - 'proto/gen/go/**'
       - 'packages/**'
       - 'package.json'
       - 'pnpm-lock.yaml'

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,6 +3,31 @@ FROM node:22-alpine AS base
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@10 --activate
 
+# --- Agent binary build stage ---
+# Cross-compiles every supported agent binary so the web image is self-contained.
+# The download route falls back to these baked binaries when the operator-managed
+# volume is empty and GitHub is unreachable (air-gap installs).
+FROM golang:1.25-alpine AS agent-builder
+RUN apk add --no-cache jq
+WORKDIR /src
+# `replace github.com/carrtech-dev/ct-ops/proto => ../proto/gen/go` in agent/go.mod
+# means proto/gen/go must be present at the same relative location.
+COPY agent/         ./agent/
+COPY proto/gen/go/  ./proto/gen/go/
+COPY .release-please-manifest.json ./
+RUN AGENT_VERSION="v$(jq -r '.agent' .release-please-manifest.json)" && \
+    mkdir -p /out && cd agent && \
+    for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do \
+      os="${p%%/*}"; arch="${p##*/}"; \
+      ext=""; [ "$os" = "windows" ] && ext=".exe"; \
+      echo "Building agent ${os}/${arch} (version ${AGENT_VERSION})..."; \
+      CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
+        -trimpath \
+        -ldflags="-s -w -X main.version=${AGENT_VERSION}" \
+        -o "/out/ct-ops-agent-${os}-${arch}${ext}" \
+        ./cmd/agent; \
+    done
+
 # --- Dependencies stage ---
 FROM base AS deps
 WORKDIR /app
@@ -72,10 +97,12 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/
 # Release-please manifest — read at runtime to determine the required agent version
 COPY --from=builder --chown=nextjs:nodejs /app/.release-please-manifest.json /app/.release-please-manifest.json
 
-# Agent binaries — baked into the image as a bootstrap fallback for air-gapped
-# deployments where the operator-managed agent_dist volume starts empty and
-# GitHub is unreachable. The download route checks this directory last.
-COPY --chown=nextjs:nodejs apps/web/data/agent-dist ./apps/web/data/agent-dist
+# Agent binaries — built fresh in the agent-builder stage so every web image is
+# self-contained. The download route's resolveAgentBinary() checks this directory
+# as a fallback when the operator-managed agent_dist volume is empty and GitHub
+# is unreachable (air-gap installs).
+RUN mkdir -p /app/apps/web/data/agent-dist && chown nextjs:nodejs /app/apps/web/data/agent-dist
+COPY --from=agent-builder --chown=nextjs:nodejs --chmod=755 /out/ ./apps/web/data/agent-dist/
 
 # Migration script — from builder stage (same source, no caching concern)
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/migrate.js ./apps/web/migrate.js


### PR DESCRIPTION
## Summary

Makes the web image self-contained so agent installs work in **every** scenario (online, air-gap, degraded GitHub) without runtime dependencies.

### The problem

`/api/agent/download` had a runtime dependency on GitHub:
1. `instrumentation.ts` → `prewarmAgentCache()` fetched the latest agent release at startup and cached binaries to a docker volume
2. The download route served from that cache

This silently broke whenever:
- The customer was air-gapped (no `api.github.com`)
- The agent release on GitHub had no binary assets (the broken upload path #506 just fixed)
- The customer had network issues during web container startup

Result: `curl .../api/agent/install` → `503` with `make agent` as the only recovery.

### The fix

Cross-compile every supported agent binary **inside the web Dockerfile** as an additional build stage and copy them into `/app/apps/web/data/agent-dist/`. The existing fallback in `resolveAgentBinary()` (lib/agent/binary.ts:68-74) already serves from this path, so no app code changes.

Now:
- **Online installs** — work as before, GitHub fetch is now an unnecessary fast-path; baked binaries serve as backup
- **Air-gap installs** — work without any extra steps; the offline installer's `images.tar.gz` already contains the web image which now contains the agents
- **Degraded GitHub** — works; baked binaries serve

### Changes

- `apps/web/Dockerfile` — new `agent-builder` stage compiles all 5 platform binaries with `-X main.version=...` matching the CI agent build; runner stage copies them in (~63 MB total)
- `.github/workflows/docker-publish-web.yml` — path filters now include `agent/**` and `proto/gen/go/**` so an agent-only fix rebuilds the web image with fresh binaries
- `.dockerignore` — exclude `apps/web/data/` so dev-machine artifacts can't contaminate CI builds

### Verification

Built locally:
- All 5 binaries built (linux/{amd64,arm64}, darwin/{amd64,arm64}, windows/amd64), version `v0.28.3` baked in
- Final image contains exactly the 5 binaries at the expected path with correct ownership/permissions
- Sample binary execution: `/app/apps/web/data/agent-dist/ct-ops-agent-linux-amd64 --version` → `ct-ops-agent v0.28.3`
- Image size delta: roughly +60 MB (the 5 binaries)

### Test plan

- [ ] CI builds web image successfully on both platforms
- [ ] `web/v0.61.9` (or next release) image contains baked agents
- [ ] After upgrading customer install, `/api/agent/install?token=...` succeeds without internet
- [ ] After upgrading customer install, agent binary downloads without internet
- [ ] Online install path still works (existing GitHub flow + new baked fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)