### PR TITLE
fix(web): cascade delete host_network_memberships when deleting host

### DIFF
--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -27,6 +27,7 @@ import {
   terminalSessions,
   softwarePackages,
   softwareScans,
+  hostNetworkMemberships,
 } from '@/lib/db/schema'
 import { eq, and, isNull, gt, gte, lte, asc, desc, sql, inArray, ilike, or, count } from 'drizzle-orm'
 import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
@@ -1075,6 +1076,14 @@ export async function deleteHost(
       await tx
         .delete(hostGroupMembers)
         .where(eq(hostGroupMembers.hostId, hostId))
+
+      // 14d. Host network memberships (FK to hosts)
+      await tx
+        .delete(hostNetworkMemberships)
+        .where(and(
+          eq(hostNetworkMemberships.hostId, hostId),
+          eq(hostNetworkMemberships.organisationId, orgId),
+        ))
 
       // 15. Host itself
       await tx


### PR DESCRIPTION
## Summary
- `deleteHost` cascade was missing `host_network_memberships`, causing host deletion to fail with a foreign key violation (`host_network_memberships_host_id_hosts_id_fk`).
- Added a delete step before the `hosts` row is removed, scoped by both `hostId` and `organisationId` to match the multi-tenant pattern used throughout the cascade.

## Test plan
- [ ] Delete a host that has one or more network memberships — succeeds without FK error.
- [ ] Delete a host with no network memberships — still succeeds.
- [ ] `pnpm run build` in `apps/web` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)