### PR TITLE
fix(ingest): cast token param to text in GetEnrolmentToken WHERE clause

### DIFF
--- a/apps/ingest/internal/db/queries/enrolment.sql.go
+++ b/apps/ingest/internal/db/queries/enrolment.sql.go
@@ -43,7 +43,7 @@ func GetEnrolmentToken(ctx context.Context, pool *pgxpool.Pool, token string) (*
 	const q = `
 		SELECT id, organisation_id, label, token, auto_approve, max_uses, usage_count, expires_at, metadata
 		FROM agent_enrolment_tokens
-		WHERE (token_hash = encode(sha256($1::bytea), 'hex') OR (token_hash IS NULL AND token = $1))
+		WHERE (token_hash = encode(sha256($1::bytea), 'hex') OR (token_hash IS NULL AND token = $1::text))
 		  AND deleted_at IS NULL
 		  AND (expires_at IS NULL OR expires_at > NOW())
 		  AND (max_uses IS NULL OR usage_count < max_uses)


### PR DESCRIPTION
## Summary

Every agent `Register` RPC has been failing with `code=Internal` since PR #501 added token hashing. The ingest log showed the real cause:

```
looking up enrolment token  err="ERROR: operator does not exist: text = bytea (SQLSTATE 42883)"
```

The `GetEnrolmentToken` query in `apps/ingest/internal/db/queries/enrolment.sql.go` has two branches OR'd together:

```sql
WHERE (token_hash = encode(sha256($1::bytea), 'hex')
       OR (token_hash IS NULL AND token = $1))
```

The explicit `$1::bytea` on the left pins the parameter's inferred type to `bytea`. On the right, `token` is `text`, so Postgres sees `text = bytea`, which has no operator, and rejects the whole statement. Every Register call — old token or freshly generated — hits this branch evaluation and fails, which is why the `BREAKING` re-enrolment (per PR #511) didn't help either.

Fix: cast the fallback use of the parameter to `::text` so both sides are text regardless of the type pinned by the hashed-branch cast. The hashed branch is unchanged.

Confirmed by `go build ./apps/ingest/...` on the branch.

## Test plan

- [ ] Deploy the updated ingest image
- [ ] Re-run the agent install on `ctlnxdbn001` — Register should now succeed (`status=pending` awaiting approval, or `status=active` if auto-approve)
- [ ] Verify `grpc unary  method=/agent.v1.IngestService/Register code=OK` appears in ingest logs
- [ ] Verify fallback branch still works for any token rows where `token_hash IS NULL` (pre-#501 tokens during the migration window)

https://claude.ai/code/session_01NT3A7VnL9xCnKvYstkbreX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NT3A7VnL9xCnKvYstkbreX)_