### PR TITLE
feat(deploy): bundle nginx TLS terminator with pinned-cert rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,13 +6,12 @@
 # All values shipped here are LOCALHOST DEFAULTS. They will run on a single
 # laptop with no remote agents, but they are NOT safe for production:
 #
-#   • BETTER_AUTH_URL is plain HTTP — replace with your https:// URL.
-#   • BETTER_AUTH_TRUSTED_ORIGINS only allows localhost — add your real origin
-#     or auth callbacks from the browser will be rejected.
-#   • AGENT_DOWNLOAD_BASE_URL points to localhost — remote agents cannot reach
-#     "localhost" on your server, so they will fail to update.
-#   • INGEST_WS_URL points to localhost — the user's browser cannot reach
-#     "localhost" on your server, so the in-app terminal will not connect.
+#   • BETTER_AUTH_URL / BETTER_AUTH_TRUSTED_ORIGINS / AGENT_DOWNLOAD_BASE_URL
+#     point at https://localhost — edit to your real hostname before letting
+#     remote users or agents connect.
+#   • The bundled nginx terminates TLS with a self-signed certificate
+#     generated on first install. Replace deploy/tls/server.{crt,key} with a
+#     certificate from your own CA to remove the browser warning.
 #   • POSTGRES_PASSWORD in docker-compose.single.yml defaults to "ctops"
 #     — change it (see "Database credentials" below) before exposing the
 #     database port or backing up to shared storage.
@@ -26,21 +25,21 @@
 
 # 🔒 Public URL of the CT-Ops web UI (no trailing slash). Used by Better
 # Auth to construct callback URLs and to set the session cookie domain. MUST be
-# https:// in production — http:// disables cookie Secure flag and exposes
-# session tokens on the network.
-BETTER_AUTH_URL=http://localhost:3000
+# https:// — http:// disables the cookie Secure flag and exposes session
+# tokens on the network. The bundled nginx terminates TLS on :443.
+BETTER_AUTH_URL=https://localhost
 
 # 🔒 Comma-separated list of allowed origins for the auth callback. Better
 # Auth rejects auth flows from origins not in this list. Set to your
 # production origin(s); anything missing here is treated as untrusted.
 # Example: BETTER_AUTH_TRUSTED_ORIGINS=https://ct-ops.example.com
-BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
+BETTER_AUTH_TRUSTED_ORIGINS=https://localhost
 
 # Public URL agents use to download new binaries from the web app. Must be
-# reachable from each agent host (not just localhost). Should be https:// in
-# production; agents verify the binary signature regardless, but http://
-# leaks which agent versions are deployed where.
-AGENT_DOWNLOAD_BASE_URL=http://localhost:3000
+# reachable from each agent host (not just localhost). The enrolment bundle
+# ships the nginx server cert so agents can verify this HTTPS endpoint even
+# when it's signed by a private CA not in the agent host's trust store.
+AGENT_DOWNLOAD_BASE_URL=https://localhost
 
 # === Generated automatically on first run if blank ===
 
@@ -55,23 +54,18 @@ BETTER_AUTH_SECRET=
 
 # 🔒 WebSocket URL of the ingest service for browser terminal connections.
 #
-# Two modes:
+# Default (blank) routes the WS through the bundled nginx on the page's own
+# origin, e.g. wss://localhost/ws/terminal/... — nginx forwards to ingest:8080
+# with the HTTP Upgrade header. This is the recommended mode.
 #
-#   1. Direct — set an absolute URL (e.g. ws://host:8080 or wss://host:8080).
-#      The browser connects directly to the ingest service. The URL MUST be
-#      reachable from every user's browser, not just from the server.
-#
-#   2. Same-origin reverse proxy — leave this blank. The browser opens the
-#      WebSocket against the page's own origin (e.g. wss://ct-ops.example.com
-#      /ws/terminal/...). Your reverse proxy / Cloudflare tunnel must route
-#      /ws/terminal/* to the ingest service on port 8080 and pass the
-#      HTTP Upgrade header through. This is the mode to use when only the web
-#      app is exposed through a Cloudflare tunnel (port 8080 is not reachable
-#      from the public internet).
-#
-# Use wss:// (or an https:// origin for same-origin mode) in production — ws://
-# sends the terminal stream and the session JWT in plaintext over the network.
-INGEST_WS_URL=ws://localhost:8080
+# Set to an absolute URL (e.g. wss://host:8443) only if you want the browser
+# to bypass the bundled nginx and connect to a separate ingest endpoint.
+INGEST_WS_URL=
+
+# === Bundled nginx ports ===
+# Override these when ports 80 or 443 are already in use on the host.
+# NGINX_HTTPS_PORT=443
+# NGINX_HTTP_PORT=80
 
 # === Optional: load-test admin endpoint ===
 

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -75,10 +75,27 @@ jobs:
             --config p/owasp-top-ten \
             --config p/secrets \
             --exclude-rule javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length \
+            --exclude-rule generic.nginx.security.request-host-used.request-host-used \
+            --exclude-rule generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling \
             --sarif --output=semgrep.sarif
           # gcm-no-tag-length excluded above: lib/crypto/encrypt.ts uses explicit
           # tag.length !== TAG_LENGTH guards; setAuthTagLength is absent from this
           # Node.js version so the API-based fix is not available.
+          #
+          # request-host-used excluded: deploy/nginx/nginx.conf proxies $host to
+          # the backend. Security-sensitive URLs (auth callbacks, cookie Secure/
+          # Domain, trusted origins) derive from BETTER_AUTH_URL and
+          # BETTER_AUTH_TRUSTED_ORIGINS env vars, not the Host header, so a
+          # spoofed Host cannot forge sessions. The HTTPS redirect using $host
+          # only redirects the attacker's own browser. Inline nosemgrep comments
+          # document each occurrence.
+          #
+          # possible-nginx-h2c-smuggling excluded: the rule pattern-matches any
+          # `proxy_set_header Connection` without reading the value. On non-WS
+          # locations we explicitly clear Upgrade/Connection to "" (the rule's
+          # own recommended mitigation), and on /ws/terminal/ Upgrade is forced
+          # to a literal `websocket` with a map that only translates websocket
+          # to Connection: upgrade — h2c and other values map to empty.
 
       - name: Upload SARIF
         if: always()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CT-Ops is an open-source monitoring and operations platform designed to run **en
 
 ## Features
 
-- **Agent-based host monitoring** — lightweight Go agent, single binary, communicates over gRPC/mTLS on port 443. No firewall exceptions needed.
+- **Agent-based host monitoring** — lightweight Go agent, single binary, communicates over gRPC/mTLS on port 9443. Browser traffic terminates TLS on 443 via a bundled nginx container.
 - **Real-time metrics** — CPU, memory, disk, and network graphs backed by TimescaleDB, visible seconds after agent enrolment.
 - **Alerting & notification routing** — rule-based alerts with configurable thresholds and multi-channel notification delivery.
 - **Certificate lifecycle management** — inspect, validate, and track X.509 certificates from URL or file upload. Expiry alerts built in.
@@ -45,7 +45,7 @@ $EDITOR .env
 ./start.sh
 ```
 
-Open `http://localhost:3000` (or the domain you configured) to complete setup.
+Open `https://localhost` (or the domain you configured) to complete setup. Your browser will warn about the self-signed certificate on first visit — accept it, or drop a real cert into `deploy/tls/server.{crt,key}` and restart the `nginx` container.
 
 To pin a specific version:
 

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -107,6 +107,14 @@ type Runner struct {
 	// received from the server. Used to restore checks after a stream reconnect
 	// if the executor has no running goroutines (e.g. after an agent restart).
 	lastKnownDefs []*agentv1.CheckDefinition
+
+	// pinnedServerCertMu guards pinnedServerCertPEM and pinnedServerCertFpr.
+	// These hold the nginx-facing server cert that agent self-update trusts in
+	// addition to the system CA pool. Values are persisted to disk whenever
+	// they change so a process restart picks up the same pin.
+	pinnedServerCertMu  sync.Mutex
+	pinnedServerCertPEM []byte
+	pinnedServerCertFpr string
 }
 
 // New creates a new heartbeat Runner. dialFunc is called once per stream
@@ -114,7 +122,7 @@ type Runner struct {
 // stream ends. dataDir and keypair enable mTLS cert rotation — when nil/empty
 // the runner skips cert-related work (useful for tests and load-test paths).
 func New(dialFunc func() (*grpc.ClientConn, error), agentID, jwtToken, version string, intervalSecs int, executor *checks.Executor, dataDir string, keypair *identity.Keypair) *Runner {
-	return &Runner{
+	r := &Runner{
 		dialFunc:     dialFunc,
 		agentID:      agentID,
 		jwtToken:     jwtToken,
@@ -129,6 +137,18 @@ func New(dialFunc func() (*grpc.ClientConn, error), agentID, jwtToken, version s
 		dataDir:         dataDir,
 		keypair:         keypair,
 	}
+	// Prime the pinned server cert from disk so the first heartbeat sends
+	// the correct fingerprint and a pre-re-exec self-update can trust the
+	// same PEM that was bundled at enrolment time.
+	if dataDir != "" {
+		if pem, fpr, err := identity.LoadPinnedServerCert(dataDir); err == nil {
+			r.pinnedServerCertPEM = pem
+			r.pinnedServerCertFpr = fpr
+		} else {
+			slog.Warn("loading pinned server cert", "err", err)
+		}
+	}
+	return r
 }
 
 // Run starts the heartbeat stream. It reconnects automatically on transient
@@ -359,6 +379,9 @@ func (r *Runner) handleResponse(ctx context.Context, resp *agentv1.HeartbeatResp
 			}
 		}
 	}
+	if resp.PendingServerCertPem != "" {
+		r.applyServerCertRotation(resp.PendingServerCertPem)
+	}
 	if resp.PendingClientCertPem != "" && r.dataDir != "" {
 		if err := identity.SaveClientCert(r.dataDir, []byte(resp.PendingClientCertPem)); err != nil {
 			slog.Warn("saving pushed client cert", "err", err)
@@ -380,7 +403,7 @@ func (r *Runner) handleResponse(ctx context.Context, resp *agentv1.HeartbeatResp
 			"current", r.version,
 			"latest", resp.LatestVersion,
 		)
-		if err := updater.Update(resp.LatestVersion, resp.DownloadUrl); err != nil {
+		if err := updater.Update(resp.LatestVersion, resp.DownloadUrl, r.pinnedServerCertBytes()); err != nil {
 			slog.Warn("self-update failed, continuing with current version", "err", err)
 		}
 		// If Update succeeds it re-execs and never returns.
@@ -580,28 +603,75 @@ func (r *Runner) refreshMetrics() {
 func (r *Runner) sendHeartbeat(stream agentv1.IngestService_HeartbeatClient) error {
 	m := r.cachedMetrics
 	req := &agentv1.HeartbeatRequest{
-		AgentId:           r.agentID,
-		CpuPercent:        m.cpu,
-		MemoryPercent:     m.memory,
-		DiskPercent:       m.disk,
-		UptimeSeconds:     m.uptime,
-		TimestampUnix:     time.Now().Unix(),
-		AgentVersion:      r.version,
-		OsVersion:         m.osVersion,
-		Os:                runtime.GOOS,
-		Arch:              runtime.GOARCH,
-		Disks:             m.disks,
-		NetworkInterfaces: m.nets,
-		CheckResults:      r.executor.DrainResults(),
-		QueryResults:      r.drainQueryResults(),
-		TaskProgress:      r.drainTaskProgress(),
-		TaskResults:       r.drainTaskResults(),
+		AgentId:                     r.agentID,
+		CpuPercent:                  m.cpu,
+		MemoryPercent:               m.memory,
+		DiskPercent:                 m.disk,
+		UptimeSeconds:               m.uptime,
+		TimestampUnix:               time.Now().Unix(),
+		AgentVersion:                r.version,
+		OsVersion:                   m.osVersion,
+		Os:                          runtime.GOOS,
+		Arch:                        runtime.GOARCH,
+		Disks:                       m.disks,
+		NetworkInterfaces:           m.nets,
+		CheckResults:                r.executor.DrainResults(),
+		QueryResults:                r.drainQueryResults(),
+		TaskProgress:                r.drainTaskProgress(),
+		TaskResults:                 r.drainTaskResults(),
+		PinnedServerCertFingerprint: r.currentPinnedFingerprint(),
 	}
 
 	if err := stream.Send(req); err != nil {
 		return fmt.Errorf("sending heartbeat: %w", err)
 	}
 	return nil
+}
+
+// currentPinnedFingerprint returns the fingerprint of the pinned server cert
+// the agent currently trusts for self-update downloads. Empty when no cert
+// is pinned (e.g. freshly enrolled agent before the first server push).
+func (r *Runner) currentPinnedFingerprint() string {
+	r.pinnedServerCertMu.Lock()
+	defer r.pinnedServerCertMu.Unlock()
+	return r.pinnedServerCertFpr
+}
+
+// pinnedServerCertBytes returns a copy of the pinned cert PEM for callers
+// that need trust material (e.g. the self-update HTTP client).
+func (r *Runner) pinnedServerCertBytes() []byte {
+	r.pinnedServerCertMu.Lock()
+	defer r.pinnedServerCertMu.Unlock()
+	if len(r.pinnedServerCertPEM) == 0 {
+		return nil
+	}
+	out := make([]byte, len(r.pinnedServerCertPEM))
+	copy(out, r.pinnedServerCertPEM)
+	return out
+}
+
+// applyServerCertRotation persists the pushed PEM to disk and updates the
+// in-memory pin so the next heartbeat advertises the new fingerprint and
+// the next self-update trusts the new chain.
+func (r *Runner) applyServerCertRotation(certPEM string) {
+	if certPEM == "" || r.dataDir == "" {
+		return
+	}
+	pemBytes := []byte(certPEM)
+	if err := identity.SavePinnedServerCert(r.dataDir, pemBytes); err != nil {
+		slog.Warn("persisting rotated server cert", "err", err)
+		return
+	}
+	_, fp, err := identity.LoadPinnedServerCert(r.dataDir)
+	if err != nil {
+		slog.Warn("reading rotated server cert after save", "err", err)
+		return
+	}
+	r.pinnedServerCertMu.Lock()
+	r.pinnedServerCertPEM = pemBytes
+	r.pinnedServerCertFpr = fp
+	r.pinnedServerCertMu.Unlock()
+	slog.Info("rotated pinned server cert", "fingerprint", fp)
 }
 
 // collectMetrics gathers all system metrics. Returns best-effort values;

--- a/agent/internal/identity/server_cert.go
+++ b/agent/internal/identity/server_cert.go
@@ -1,0 +1,77 @@
+package identity
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// serverCertFile is the on-disk name for the pinned browser/nginx-facing
+// server cert. It is bundled into agent enrolment zips as server-cert.pem and
+// may be replaced from the server over the heartbeat stream when the cert is
+// rotated. Distinct from agent_ca.pem (which is the agent CA for the mTLS
+// client cert) and from server-ca.crt (which is the ingest gRPC server cert).
+const serverCertFile = "server_cert.pem"
+
+// LoadPinnedServerCert returns the PEM bytes and SHA-256 fingerprint of the
+// locally pinned nginx-facing server cert. Returns empty values with a nil
+// error when no cert is pinned yet (e.g. agent upgraded from a version that
+// did not track a pin).
+func LoadPinnedServerCert(dataDir string) ([]byte, string, error) {
+	if dataDir == "" {
+		return nil, "", nil
+	}
+	path := filepath.Join(dataDir, serverCertFile)
+	pemBytes, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("reading pinned server cert: %w", err)
+	}
+	fp, err := fingerprintPEM(pemBytes)
+	if err != nil {
+		return pemBytes, "", err
+	}
+	return pemBytes, fp, nil
+}
+
+// SavePinnedServerCert writes the PEM atomically (0o644 — the cert is public
+// material). No-op when dataDir or certPEM is empty.
+func SavePinnedServerCert(dataDir string, certPEM []byte) error {
+	if dataDir == "" || len(certPEM) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return err
+	}
+	final := filepath.Join(dataDir, serverCertFile)
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, certPEM, 0o644); err != nil {
+		return fmt.Errorf("writing pinned server cert tmp: %w", err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		return fmt.Errorf("renaming pinned server cert: %w", err)
+	}
+	return nil
+}
+
+// fingerprintPEM returns the SHA-256 hex of the first CERTIFICATE block in
+// the supplied PEM bundle.
+func fingerprintPEM(pemBytes []byte) (string, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return "", errors.New("no CERTIFICATE block in PEM")
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parsing cert: %w", err)
+	}
+	sum := sha256.Sum256(leaf.Raw)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -10,6 +10,8 @@
 package updater
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,12 +19,18 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 )
 
 // Update downloads the agent binary for the current OS/arch from downloadBaseURL,
 // atomically replaces the running executable, and re-execs into the new binary.
-// If it returns, an error occurred and the caller should continue running.
-func Update(latestVersion, downloadBaseURL string) error {
+// pinnedServerCertPEM, when non-empty, is appended to the system CA pool so
+// the agent can verify HTTPS downloads even when the server's cert is signed
+// by a private CA not in the host trust store. This covers the common Linux
+// VM scenario where an operator has replaced the self-signed bundled cert
+// with one from their internal CA.
+// If Update returns, an error occurred and the caller should continue running.
+func Update(latestVersion, downloadBaseURL string, pinnedServerCertPEM []byte) error {
 	url := fmt.Sprintf(
 		"%s?os=%s&arch=%s",
 		downloadBaseURL,
@@ -55,7 +63,13 @@ func Update(latestVersion, downloadBaseURL string) error {
 		}
 	}()
 
-	resp, err := http.Get(url) //nolint:gosec // URL is constructed from server-supplied base URL
+	client, err := buildHTTPClient(pinnedServerCertPEM)
+	if err != nil {
+		tmp.Close()
+		return fmt.Errorf("building HTTP client: %w", err)
+	}
+
+	resp, err := client.Get(url) //nolint:gosec // URL is constructed from server-supplied base URL
 	if err != nil {
 		tmp.Close()
 		return fmt.Errorf("downloading update: %w", err)
@@ -97,4 +111,30 @@ func Update(latestVersion, downloadBaseURL string) error {
 		return fmt.Errorf("re-execing updated agent: %w", err)
 	}
 	return nil // unreachable on unix (syscall.Exec replaces the process)
+}
+
+// buildHTTPClient returns an HTTP client whose TLS config trusts both the
+// system CA pool and the supplied pinned cert PEM. When pinnedPEM is empty,
+// the client falls back to the system pool alone. A modest timeout keeps a
+// hung connection from blocking the agent indefinitely.
+func buildHTTPClient(pinnedPEM []byte) (*http.Client, error) {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+
+	roots, err := x509.SystemCertPool()
+	if err != nil || roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if len(pinnedPEM) > 0 {
+		if !roots.AppendCertsFromPEM(pinnedPEM) {
+			slog.Warn("pinned server cert PEM contained no valid certificates — falling back to system trust only")
+		}
+	}
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    roots,
+	}
+	return &http.Client{
+		Transport: tr,
+		Timeout:   10 * time.Minute,
+	}, nil
 }

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -29,7 +29,7 @@ nano .env
 ./start.sh
 ```
 
-When `docker compose ps` shows all containers as `healthy`, open the web UI at `http://<your-server>:3000`.
+When `docker compose ps` shows all containers as `healthy`, open the web UI at `https://<your-server>`. The bundle ships a self-signed certificate — your browser will warn on first visit. To replace it with a certificate from your own CA, see [Replacing the TLS certificate](#replacing-the-tls-certificate) below.
 
 ---
 
@@ -54,8 +54,9 @@ POSTGRES_USER=ct-ops
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=ct-ops
 BETTER_AUTH_SECRET=change-me-to-a-long-random-string
-BETTER_AUTH_URL=http://localhost:3000
-BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
+BETTER_AUTH_URL=https://ct-ops.example.com
+BETTER_AUTH_TRUSTED_ORIGINS=https://ct-ops.example.com
+AGENT_DOWNLOAD_BASE_URL=https://ct-ops.example.com
 EOF
 ```
 
@@ -63,18 +64,18 @@ EOF
 Change `BETTER_AUTH_SECRET` before going to production. Use at least 32 random characters.
 :::
 
-### 3. Generate TLS certificates for the ingest service
+### 3. Generate TLS certificates
 
-```bash
-mkdir -p deploy/dev-tls
-openssl req -x509 -newkey rsa:4096 -keyout deploy/dev-tls/server.key \
-  -out deploy/dev-tls/server.crt -days 365 -nodes \
-  -subj "/CN=ct-ops-ingest"
-```
+`start.sh` generates two self-signed certificates on first run:
 
-The dev certificate above expires in 365 days — long enough for laptops to keep working between rebuilds, short enough that an accidental production deployment fails loudly within a year. **Do not extend the `-days` value** to avoid the renewal: the short lifetime is the safety net.
+| Purpose | Path | Consumed by |
+|---|---|---|
+| Agent gRPC (mTLS on :9443) | `deploy/dev-tls/server.{crt,key}` | ingest container |
+| Browser HTTPS (:443) | `deploy/tls/server.{crt,key}` | bundled nginx container |
 
-For production, use a certificate from your corporate CA or Let's Encrypt and rotate it on the schedule your CA issues — typical lifetimes are 90 days (Let's Encrypt) to 1 year (corporate CAs). Re-running `start.sh` will not regenerate certificates that already exist on disk; production rotation is your operational responsibility.
+Both certs are RSA 4096-bit with a 365-day lifetime and SANs for `localhost`, the docker-internal hostname, and every non-loopback IPv4 the host is currently using. Short expiry is deliberate — if you forget to rotate, the stack fails loudly within a year. If you are deploying manually, run `./deploy/scripts/gen-server-cert.sh` with `OUT_DIR=deploy/tls` and again with `OUT_DIR=deploy/dev-tls` `CN=ct-ops-ingest` before `docker compose up`.
+
+For production, replace the generated cert files with ones from your own CA — see [Replacing the TLS certificate](#replacing-the-tls-certificate). Re-running `start.sh` will not overwrite certificates that already exist on disk.
 
 ### 4. Start the stack
 
@@ -94,11 +95,19 @@ The web container runs database migrations automatically on first start. Once yo
 
 ## Services
 
-| Service | Image | Port(s) | Description |
+| Service | Image | Host ports | Description |
 |---|---|---|---|
-| `db` | `timescale/timescaledb:latest-pg16` | 5432 | PostgreSQL + TimescaleDB |
-| `web` | `ghcr.io/carrtech-dev/ct-ops/web:latest` | 3000 | Next.js web app |
-| `ingest` | `ghcr.io/carrtech-dev/ct-ops/ingest:latest` | 9443, 8080 | gRPC ingest + JWKS |
+| `nginx` | `nginx:1.27-alpine` | **443**, **80** | TLS terminator for browser traffic |
+| `db` | `timescale/timescaledb:latest-pg16` | 127.0.0.1:5432 | PostgreSQL + TimescaleDB |
+| `web` | `ghcr.io/carrtech-dev/ct-ops/web:latest` | 127.0.0.1:3000 | Next.js web app (reached via nginx) |
+| `ingest` | `ghcr.io/carrtech-dev/ct-ops/ingest:latest` | **9443**, 127.0.0.1:8080 | Agent gRPC (:9443 direct, bypasses nginx) + JWKS on loopback |
+
+Only `443`, `80`, and `9443` are published on all host interfaces:
+
+- `443` / `80` — browser traffic (nginx terminates TLS; `80` redirects to `443`).
+- `9443` — agent gRPC with mTLS. Agents connect direct to the ingest container; the proxy is intentionally skipped so client-cert verification is never terminated mid-hop.
+
+The remaining ports are bound to `127.0.0.1` only, so `web:3000`, `ingest:8080`, and Postgres are reachable from the host (for debugging over SSH tunnels) but not from the network. Override the nginx ports with `NGINX_HTTPS_PORT` / `NGINX_HTTP_PORT` in `.env` if 80/443 are already in use.
 
 ---
 
@@ -143,26 +152,21 @@ docker compose -f docker-compose.single.yml down -v
 
 ---
 
-## Reverse Proxy
+## Replacing the TLS certificate
 
-To expose the web UI on port 443 with TLS termination, add nginx or Caddy in front:
+The bundled nginx serves `deploy/tls/server.crt` + `deploy/tls/server.key` on port 443. To replace the self-signed cert with one from your own CA:
 
-```nginx title="nginx.conf (example)"
-server {
-    listen 443 ssl;
-    server_name ct-ops.corp.example.com;
+```bash
+# Copy your cert and key into place (overwrite the auto-generated files).
+install -m 0644 /path/to/your.crt deploy/tls/server.crt
+install -m 0600 /path/to/your.key deploy/tls/server.key
 
-    ssl_certificate     /etc/ssl/ct-ops.crt;
-    ssl_certificate_key /etc/ssl/ct-ops.key;
-
-    location / {
-        proxy_pass http://localhost:3000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
+# Restart only the nginx container — web, ingest, and agents keep running.
+docker compose restart nginx
 ```
 
-Update `BETTER_AUTH_URL` and `BETTER_AUTH_TRUSTED_ORIGINS` in `.env` to reflect the public HTTPS URL.
+No rebuild is required. On the next heartbeat, every connected agent's pinned fingerprint will mismatch the new cert, and the ingest service pushes the new cert down the mTLS-protected heartbeat stream. The agent persists it to its data dir and uses it as an additional trust anchor for self-update downloads. This means operators can rotate the browser cert without touching any agent host, even on Linux VMs where the internal CA is not installed in the system trust store.
+
+## Fronting with your own reverse proxy
+
+If you prefer to use an existing load balancer or TLS terminator (e.g. a corporate HAProxy, an F5, or Cloudflare Tunnel), stop the bundled nginx and point your proxy at `127.0.0.1:3000` (web) and `127.0.0.1:8080` (ingest WebSocket terminal). Leave port 9443 as a straight passthrough — agent mTLS must not be terminated. Update `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, and `AGENT_DOWNLOAD_BASE_URL` to match the URL your proxy serves.

--- a/apps/docs/docs/features/terminal.md
+++ b/apps/docs/docs/features/terminal.md
@@ -108,19 +108,17 @@ Each terminal session authenticates using per-user credentials derived from the 
 
 ## Deployment: Reverse Proxies and Cloudflare Tunnels
 
-The terminal relies on a WebSocket connection from the browser to the ingest service on port `8080`. The `INGEST_WS_URL` environment variable controls which URL the browser uses.
+The single-node bundle ships an nginx container that already terminates TLS on `:443` and forwards `/ws/terminal/*` to the ingest service on `:8080` with the WebSocket upgrade header. For most operators there is nothing to configure — the browser opens `wss://<your-host>/ws/terminal/<id>` against the page's own origin and everything just works.
 
-There are two supported modes.
+Leave `INGEST_WS_URL` blank (the default) unless you intentionally want to bypass the bundled proxy.
 
-### Direct mode (default)
+### Fronting with your own reverse proxy
 
-`INGEST_WS_URL=ws://host:8080` (or `wss://host:8080`). The browser opens the WebSocket directly to that URL. This is the simplest setup for local/LAN deployments where the ingest port is reachable from every user's browser.
+If you stop the bundled nginx and terminate TLS with your own proxy (HAProxy, a corporate F5, Cloudflare Tunnel, etc.), route `/ws/terminal/*` to the ingest service on port `8080` and forward the HTTP Upgrade header. The snippets below are reference configs for common proxies; the bundled `deploy/nginx/nginx.conf` is a more complete example to copy from.
 
-### Same-origin mode (reverse proxy / Cloudflare tunnel)
+### Direct mode (bypass the proxy)
 
-Leave `INGEST_WS_URL` blank. The browser opens the WebSocket against the page's own origin, e.g. `wss://ct-ops.example.com/ws/terminal/<id>`. Your reverse proxy or tunnel must route `/ws/terminal/*` to the ingest service on port `8080` and forward the HTTP Upgrade header.
-
-This is the mode to use when only the web app is publicly reachable (for example, when you expose the server through a Cloudflare tunnel that points at the web container on port `3000`).
+Set `INGEST_WS_URL=wss://host:8443` (or `ws://host:8080` for unencrypted LAN setups). The browser connects to that URL instead of the page origin. Only useful when you want the browser to talk to ingest directly rather than through any proxy.
 
 #### Cloudflare Tunnel example
 

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -18,7 +18,9 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `NEXT_PUBLIC_APP_URL` | — | — | Exposed to the browser — used for constructing absolute links |
 | `NODE_ENV` | — | `development` | Set to `production` in production |
 | `AGENT_DIST_DIR` | — | `/var/lib/ct-ops/agent-dist` | Directory where compiled agent binaries are stored for download |
-| `INGEST_WS_URL` | — | `ws://localhost:8080` | WebSocket URL of the ingest service. Use `wss://` in production — `ws://` sends terminal streams in plaintext |
+| `AGENT_DOWNLOAD_BASE_URL` | — | `https://localhost` | Public URL agents use to download new binaries. Must be reachable from every agent host |
+| `INGEST_WS_URL` | — | *(empty)* | WebSocket URL of the ingest service. Empty = same-origin via the bundled nginx (recommended). Set to an absolute `wss://` URL only to bypass the bundled proxy |
+| `WEB_TLS_CERT` | — | `/var/lib/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. The enrolment bundle route reads this file and embeds it so agents can verify the HTTPS download URL |
 
 ### Licence verification
 
@@ -33,10 +35,11 @@ CT-Ops validates licence JWTs using an RSA public key. The production public key
 ```env
 DATABASE_URL=postgresql://ct-ops:ct-ops@localhost:5432/ct-ops
 BETTER_AUTH_SECRET=change-me-to-something-long-and-random-in-production
-BETTER_AUTH_URL=http://localhost:3000
-BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-INGEST_WS_URL=ws://localhost:8080
+BETTER_AUTH_URL=https://localhost
+BETTER_AUTH_TRUSTED_ORIGINS=https://localhost
+AGENT_DOWNLOAD_BASE_URL=https://localhost
+NEXT_PUBLIC_APP_URL=https://localhost
+INGEST_WS_URL=
 ```
 
 ---
@@ -51,7 +54,8 @@ INGEST_WS_URL=ws://localhost:8080
 | `INGEST_JWT_KEY_FILE` | — | `/var/lib/ct-ops/jwt_key.pem` | Path to RSA private key for JWT signing (auto-generated if missing) |
 | `INGEST_GRPC_PORT` | — | `9443` | gRPC listener port |
 | `INGEST_HTTP_PORT` | — | `8080` | HTTP port for JWKS endpoint and health check |
-| `INGEST_AGENT_DOWNLOAD_BASE_URL` | — | `http://localhost:3000` | Public URL of the web app — agents construct their binary download URL from this |
+| `INGEST_AGENT_DOWNLOAD_BASE_URL` | — | `https://localhost` | Public URL of the web app — agents construct their binary download URL from this |
+| `INGEST_WEB_SERVER_CERT` | — | `/etc/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. Ingest reads this and pushes rotations down the heartbeat stream when an operator swaps the cert, so agents keep verifying download URLs without manual CA distribution. Empty disables the rotation RPC |
 
 :::warning JWT Key Backup
 Back up `INGEST_JWT_KEY_FILE`. Losing it invalidates all existing agent JWTs and forces every agent to re-register.
@@ -102,9 +106,20 @@ All TOML values can be overridden via environment variables:
 
 ## Ports Summary
 
+Public ports (bound to all interfaces):
+
 | Service | Port | Protocol | Purpose |
 |---|---|---|---|
-| Web | 3000 | HTTP/HTTPS | Web UI |
-| Ingest | 9443 | gRPC over TLS | Agent connections |
-| Ingest | 8080 | HTTP | JWKS endpoint, `/healthz` |
+| nginx | 443 | HTTPS | Browser traffic — TLS termination |
+| nginx | 80 | HTTP | Redirect to :443 |
+| Ingest | 9443 | gRPC + mTLS | Agent connections (bypasses nginx) |
+
+Loopback-only ports (reachable from the host over SSH tunnels only):
+
+| Service | Port | Protocol | Purpose |
+|---|---|---|---|
+| Web | 3000 | HTTP | Next.js — fronted by nginx |
+| Ingest | 8080 | HTTP | JWKS, `/healthz`, WebSocket terminal — fronted by nginx |
 | PostgreSQL | 5432 | TCP | Database |
+
+Override the nginx port bindings with `NGINX_HTTPS_PORT` and `NGINX_HTTP_PORT` in `.env` if 443/80 are already in use.

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -37,9 +37,15 @@ To pin a specific version:
 CT_OPS_VERSION=v0.3.0 curl -fsSL ... | bash
 ```
 
-`start.sh` generates dev TLS certs, generates `BETTER_AUTH_SECRET` if blank, pulls images from GHCR, and starts the stack. Database migrations run inside the web container automatically on startup.
+`start.sh` generates:
 
-When all three containers show `healthy` in `docker compose ps`, continue to [Create your account](#create-your-account).
+- The ingest gRPC (mTLS) cert at `deploy/dev-tls/server.{crt,key}` — consumed by agents on port 9443.
+- The browser TLS cert at `deploy/tls/server.{crt,key}` — served by the bundled nginx on port 443.
+- `BETTER_AUTH_SECRET` and `POSTGRES_PASSWORD` if blank.
+
+It then pulls images from GHCR and starts the stack. Database migrations run inside the web container automatically on startup.
+
+When all containers show `healthy` in `docker compose ps`, continue to [Create your account](#create-your-account).
 
 ---
 
@@ -82,9 +88,10 @@ docker compose -f docker-compose.single.yml up -d
 ```
 
 This starts:
-- **`db`** — PostgreSQL + TimescaleDB on port 5432
-- **`web`** — Next.js web UI on port 3000
-- **`ingest`** — gRPC ingest service on port 9443, JWKS/healthz on port 8080
+- **`nginx`** — bundled TLS terminator on **ports 80 and 443**
+- **`db`** — PostgreSQL + TimescaleDB on port 5432 (loopback only)
+- **`web`** — Next.js web UI on port 3000 (loopback only — reach it via nginx on 443)
+- **`ingest`** — gRPC on **port 9443** (agents connect direct, bypassing nginx) + HTTP on 8080 (loopback only)
 
 ### 5. Run database migrations
 
@@ -96,7 +103,7 @@ docker compose -f docker-compose.single.yml exec web sh -c "cd /app && node_modu
 
 ## Create your account
 
-Open [http://localhost:3000](http://localhost:3000) in a browser.
+Open [https://localhost](https://localhost) in a browser. On first visit your browser will warn about the self-signed certificate — accept it to continue, or see [Replacing the TLS certificate](../deployment/docker-compose.md#replacing-the-tls-certificate) to install one from your own CA.
 
 1. Click **Register** and create your account
 2. Complete the **onboarding wizard** — enter your organisation name and click **Create Organisation**
@@ -165,7 +172,7 @@ level=INFO msg="heartbeat stream opened"
 
 ## Verify in the UI
 
-Open [http://localhost:3000/hosts](http://localhost:3000/hosts). Your host should appear with a green **Online** badge.
+Open [https://localhost/hosts](https://localhost/hosts). Your host should appear with a green **Online** badge.
 
 If you did **not** use auto-approve, the agent appears in the **Pending Approval** panel at the top of the Hosts page. Click **Approve** — the agent receives a JWT within 30 seconds and begins heartbeating.
 

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -63,6 +63,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Load the browser-facing nginx TLS cert used by agents for self-update
+	// download verification. Refreshes every 30s so an operator swap is
+	// picked up without restarting ingest. When no path is configured the
+	// loader returns an empty value and the rotation RPC is a no-op.
+	webServerCert, err := pki.LoadWebServerCert(cfg.TLS.WebServerCertFile)
+	if err != nil {
+		slog.Warn("loading web server cert — rotation RPC disabled", "err", err)
+		webServerCert, _ = pki.LoadWebServerCert("")
+	}
+	go webServerCert.Run(ctx.Done(), 30*time.Second)
+
 	// Revocation set — in-memory; refreshed from DB on interval.
 	revocation, err := pki.NewRevocation(ctx, pool)
 	if err != nil {
@@ -97,7 +108,7 @@ func main() {
 	versionPoller := config.NewVersionPoller(cfg.Agent.LatestVersion, 5*time.Minute)
 	versionPoller.Start(ctx)
 	terminalStore := handlers.NewTerminalStore()
-	hbHandler := handlers.NewHeartbeatHandler(pool, issuer, q, versionPoller, cfg.Agent.DownloadBaseURL, terminalStore, agentCA)
+	hbHandler := handlers.NewHeartbeatHandler(pool, issuer, q, versionPoller, cfg.Agent.DownloadBaseURL, terminalStore, agentCA, webServerCert)
 	terminalHandler := handlers.NewTerminalHandler(pool, issuer, terminalStore)
 	terminalWSHandler := handlers.NewTerminalWSHandler(pool, terminalStore)
 	inventoryHandler := handlers.NewInventoryHandler(pool, issuer)

--- a/apps/ingest/internal/config/config.go
+++ b/apps/ingest/internal/config/config.go
@@ -43,6 +43,12 @@ type TLSConfig struct {
 	// and stored there encrypted).
 	AgentCACertFile string `yaml:"agent_ca_cert_file"`
 	AgentCAKeyFile  string `yaml:"agent_ca_key_file"`
+	// WebServerCertFile points at the browser-facing nginx TLS cert that
+	// terminates HTTPS on :443. Ingest reads it so it can push updates down
+	// the heartbeat stream when the cert is swapped out, allowing agents to
+	// keep verifying their self-update download URL without operator action
+	// on each host. Empty disables the rotation RPC.
+	WebServerCertFile string `yaml:"web_server_cert_file"`
 }
 
 type JWTConfig struct {
@@ -171,5 +177,8 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("INGEST_AGENT_CA_KEY"); v != "" {
 		cfg.TLS.AgentCAKeyFile = v
+	}
+	if v := os.Getenv("INGEST_WEB_SERVER_CERT"); v != "" {
+		cfg.TLS.WebServerCertFile = v
 	}
 }

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -30,10 +30,11 @@ type HeartbeatHandler struct {
 	downloadBaseURL string
 	terminalStore   *TerminalStore
 	ca              *pki.AgentCA
+	webServerCert   *pki.WebServerCert
 }
 
 // NewHeartbeatHandler creates a HeartbeatHandler.
-func NewHeartbeatHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, pub queue.Publisher, versionPoller *config.VersionPoller, downloadBaseURL string, terminalStore *TerminalStore, ca *pki.AgentCA) *HeartbeatHandler {
+func NewHeartbeatHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, pub queue.Publisher, versionPoller *config.VersionPoller, downloadBaseURL string, terminalStore *TerminalStore, ca *pki.AgentCA, webServerCert *pki.WebServerCert) *HeartbeatHandler {
 	return &HeartbeatHandler{
 		pool:            pool,
 		issuer:          issuer,
@@ -42,6 +43,7 @@ func NewHeartbeatHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, pub queue.P
 		downloadBaseURL: downloadBaseURL,
 		terminalStore:   terminalStore,
 		ca:              ca,
+		webServerCert:   webServerCert,
 	}
 }
 
@@ -466,6 +468,17 @@ func (h *HeartbeatHandler) processHeartbeat(
 	}
 
 	resp := &agentv1.HeartbeatResponse{Ok: true}
+
+	// If the agent's pinned server cert fingerprint doesn't match the live
+	// nginx cert, push the current PEM so the agent can append it to its
+	// self-update trust roots. This keeps HTTPS download verification working
+	// after an operator rotates deploy/tls/server.{crt,key} without touching
+	// each agent host. Empty webServerCert disables the rotation RPC.
+	if h.webServerCert != nil {
+		if fp := h.webServerCert.Fingerprint(); fp != "" && fp != req.PinnedServerCertFingerprint {
+			resp.PendingServerCertPem = h.webServerCert.PEM()
+		}
+	}
 
 	// Signal an update when the agent is running a different version than the
 	// latest known version, and the agent is not a dev build.

--- a/apps/ingest/internal/pki/webservercert.go
+++ b/apps/ingest/internal/pki/webservercert.go
@@ -1,0 +1,106 @@
+package pki
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// WebServerCert holds the PEM and SHA-256 fingerprint of the browser-facing
+// nginx TLS leaf certificate. It refreshes periodically from disk so a cert
+// swap propagates to agents without restarting the ingest service.
+//
+// The fingerprint is computed over the DER-encoded leaf. Agents compare their
+// pinned fingerprint against Fingerprint() on every heartbeat; on mismatch
+// the ingest handler pushes PEM() so the agent can append it to its trust
+// roots and keep verifying downloads after the operator rotates the cert.
+type WebServerCert struct {
+	path string
+	pem  atomic.Pointer[string]
+	fpr  atomic.Pointer[string]
+}
+
+// LoadWebServerCert reads the cert from path and starts a background refresher.
+// When path is empty the returned struct reports empty PEM and fingerprint,
+// which disables the rotation RPC — this is fine for environments where the
+// operator fronts CT-Ops with an external proxy they manage themselves.
+func LoadWebServerCert(path string) (*WebServerCert, error) {
+	w := &WebServerCert{path: path}
+	if path == "" {
+		empty := ""
+		w.pem.Store(&empty)
+		w.fpr.Store(&empty)
+		return w, nil
+	}
+	if err := w.refresh(); err != nil {
+		return nil, fmt.Errorf("loading web server cert %s: %w", path, err)
+	}
+	return w, nil
+}
+
+// Run refreshes the cert from disk every interval. Non-fatal errors are
+// logged and the previous value is retained, so a brief outage (e.g. nginx
+// swapping the file atomically) does not cause agents to thrash.
+func (w *WebServerCert) Run(stop <-chan struct{}, interval time.Duration) {
+	if w.path == "" {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			if err := w.refresh(); err != nil {
+				slog.Warn("refreshing web server cert", "path", w.path, "err", err)
+			}
+		}
+	}
+}
+
+// PEM returns the most recently loaded certificate as PEM bytes, or "" when
+// no cert is configured.
+func (w *WebServerCert) PEM() string {
+	if p := w.pem.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// Fingerprint returns the SHA-256 fingerprint of the leaf as lowercase hex.
+// Empty string means the cert is not configured.
+func (w *WebServerCert) Fingerprint() string {
+	if p := w.fpr.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+func (w *WebServerCert) refresh() error {
+	data, err := os.ReadFile(w.path)
+	if err != nil {
+		return err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return errors.New("no CERTIFICATE PEM block found")
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parsing leaf: %w", err)
+	}
+	sum := sha256.Sum256(leaf.Raw)
+	fp := hex.EncodeToString(sum[:])
+	pemStr := string(data)
+	w.pem.Store(&pemStr)
+	w.fpr.Store(&fp)
+	return nil
+}

--- a/apps/web/app/api/agent/bundle/route.ts
+++ b/apps/web/app/api/agent/bundle/route.ts
@@ -18,10 +18,11 @@ import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
 import { readFile } from 'node:fs/promises'
 
 const SERVER_TLS_CERT_PATH = process.env['INGEST_TLS_CERT'] ?? '/etc/ct-ops/tls/server.crt'
+const WEB_TLS_CERT_PATH = process.env['WEB_TLS_CERT'] ?? '/var/lib/ct-ops/server-tls/server.crt'
 
-async function readServerCaPem(): Promise<string | undefined> {
+async function readPemFile(path: string): Promise<string | undefined> {
   try {
-    return await readFile(SERVER_TLS_CERT_PATH, 'utf-8')
+    return await readFile(path, 'utf-8')
   } catch {
     return undefined
   }
@@ -186,7 +187,8 @@ export async function POST(request: NextRequest) {
   const ingestAddress =
     parsed.data.ingestAddress?.trim() || `${host.split(':')[0]}:9443`
 
-  const serverCaPem = await readServerCaPem()
+  const serverCaPem = await readPemFile(SERVER_TLS_CERT_PATH)
+  const webServerCertPem = await readPemFile(WEB_TLS_CERT_PATH)
 
   const bundle = await buildInstallBundle({
     os: os as AgentOS,
@@ -200,6 +202,7 @@ export async function POST(request: NextRequest) {
     agentVersion: REQUIRED_AGENT_VERSION,
     tags: bundleTags,
     serverCaPem,
+    webServerCertPem,
   })
 
   return new NextResponse(new Uint8Array(bundle.zipBytes), {

--- a/apps/web/lib/agent/bundle.ts
+++ b/apps/web/lib/agent/bundle.ts
@@ -23,6 +23,15 @@ export interface BundleOptions {
    * unnecessary even for self-signed dev setups.
    */
   serverCaPem?: string
+  /**
+   * PEM-encoded nginx-facing server cert. When provided the zip ships a
+   * server-cert.pem file and the install script copies it into the agent
+   * data dir at /var/lib/ct-ops/agent/server_cert.pem so the self-update
+   * HTTP client can verify the HTTPS download URL even when the cert is
+   * signed by a private CA not in the host trust store. The ingest service
+   * rotates this pin over heartbeat when the operator swaps the cert.
+   */
+  webServerCertPem?: string
 }
 
 function escapeToml(s: string): string {
@@ -96,6 +105,14 @@ export async function buildInstallBundle(opts: BundleOptions): Promise<{
   // without --tls-skip-verify in production installs.
   if (opts.serverCaPem) {
     root.file('server-ca.crt', opts.serverCaPem, { unixPermissions: 0o644 })
+  }
+
+  // Ship the nginx-facing server cert so the agent can pin it for HTTPS
+  // self-update verification. Cheap on wire; the install script copies it
+  // into the data dir. Rotation over heartbeat replaces the pin when the
+  // operator swaps the cert at deploy/tls/server.crt.
+  if (opts.webServerCertPem) {
+    root.file('server-cert.pem', opts.webServerCertPem, { unixPermissions: 0o644 })
   }
 
   // Install script(s)
@@ -174,6 +191,16 @@ function renderUnixInstallScript(opts: BundleOptions): string {
 fi
 `
 
+  const pinServerCert = opts.webServerCertPem
+    ? `# Pin the nginx-facing server cert so the self-update HTTP client can
+# verify the HTTPS download URL without relying on the OS trust store. The
+# server rotates this pin over heartbeat when the cert changes, so operators
+# can swap certs without re-enrolling any agent.
+install -d -m 0755 /var/lib/ct-ops/agent
+install -m 0644 "$DIR/server-cert.pem" /var/lib/ct-ops/agent/server_cert.pem
+`
+    : ''
+
   return `#!/bin/sh
 # CT-Ops agent offline install — ${opts.os}/${opts.arch}
 # Run from the extracted bundle directory:
@@ -199,7 +226,7 @@ fi
 
 chmod +x "\$BINARY"
 
-echo "Installing ct-ops-agent..."
+${pinServerCert}echo "Installing ct-ops-agent..."
 "\$BINARY" --install --token ${tokenArg} --address "${opts.ingestAddress}"${tlsFlag}${renderUnixTagFlags(opts.tags)}
 `
 }
@@ -216,6 +243,15 @@ function renderWindowsInstallScript(opts: BundleOptions): string {
   exit 1
 }
 `
+
+  const pinServerCert = opts.webServerCertPem
+    ? `# Pin the nginx-facing server cert for self-update verification.
+$DataDir = "C:\\ProgramData\\ct-ops\\agent"
+if (-not (Test-Path $DataDir)) { New-Item -ItemType Directory -Path $DataDir | Out-Null }
+Copy-Item -Force (Join-Path $ScriptDir "server-cert.pem") (Join-Path $DataDir "server_cert.pem")
+
+`
+    : ''
 
   return `# CT-Ops agent offline install — windows/${opts.arch}
 # Run from an elevated PowerShell session in the extracted bundle directory:
@@ -239,7 +275,7 @@ if ($expected -ne $actual) {
 }
 Write-Host "Checksum OK."
 
-Write-Host "Installing ct-ops-agent..."
+${pinServerCert}Write-Host "Installing ct-ops-agent..."
 & $Binary --install --token ${tokenExpr} --address "${opts.ingestAddress}"${tlsFlag}${renderWindowsTagFlags(opts.tags)}
 `
 }

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -174,42 +174,114 @@ check_env() {
   done
 }
 
-ensure_tls_certs() {
-  CERT_DIR="$SCRIPT_DIR/deploy/dev-tls"
-  if [ -f "$CERT_DIR/server.crt" ] && [ -f "$CERT_DIR/server.key" ]; then
+gen_cert() {
+  # Run the shared generator inline rather than shelling out to a file that
+  # may not be present in every bundle layout. Keeps the customer bundle
+  # self-contained.
+  #
+  # Args: $1 = OUT_DIR, $2 = CN
+  local out_dir="$1"
+  local cn="$2"
+
+  if [ -f "$out_dir/server.crt" ] && [ -f "$out_dir/server.key" ]; then
     return 0
   fi
   if ! command -v openssl >/dev/null 2>&1; then
-    echo "ERROR: 'openssl' is required to generate the ingest TLS certificate." >&2
+    echo "ERROR: 'openssl' is required to generate TLS certificates." >&2
     exit 1
   fi
-  echo "Generating ingest TLS certificate (dev-grade, 365-day expiry)..."
-  mkdir -p "$CERT_DIR"
+  mkdir -p "$out_dir"
 
+  local local_ips=""
   if command -v ip >/dev/null 2>&1; then
-    LOCAL_IPS=$(ip -4 addr show scope global 2>/dev/null | awk '/inet / {split($2,a,"/"); print "IP:" a[1]}' | tr '\n' ',' | sed 's/,$//')
-  else
-    LOCAL_IPS=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//')
+    local_ips=$(ip -4 addr show scope global 2>/dev/null | awk '/inet / {split($2,a,"/"); print "IP:" a[1]}' | tr '\n' ',' | sed 's/,$//' || true)
+  elif command -v ifconfig >/dev/null 2>&1; then
+    local_ips=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//' || true)
   fi
-  SAN="DNS:ingest,DNS:localhost,IP:127.0.0.1"
-  [ -n "$LOCAL_IPS" ] && SAN="${SAN},${LOCAL_IPS}"
+  local san="DNS:ingest,DNS:localhost,IP:127.0.0.1"
+  [ -n "$local_ips" ] && san="${san},${local_ips}"
 
   openssl req -x509 -newkey rsa:4096 \
-    -keyout "$CERT_DIR/server.key" \
-    -out "$CERT_DIR/server.crt" \
+    -keyout "$out_dir/server.key" \
+    -out "$out_dir/server.crt" \
     -sha256 -days 365 -nodes \
-    -subj "/CN=ct-ops-ingest" \
-    -addext "subjectAltName=${SAN}" 2>/dev/null
-  echo "TLS certificate written to ${CERT_DIR} (SANs: ${SAN})."
+    -subj "/CN=${cn}" \
+    -addext "subjectAltName=${san}" 2>/dev/null
+  chmod 600 "$out_dir/server.key"
+  chmod 644 "$out_dir/server.crt"
+  echo "Wrote ${out_dir}/server.{crt,key} (CN=${cn}, SANs: ${san})"
+}
+
+ensure_tls_certs() {
+  # Ingest mTLS cert — consumed by the gRPC listener on :9443.
+  if [ ! -f "$SCRIPT_DIR/deploy/dev-tls/server.crt" ] || [ ! -f "$SCRIPT_DIR/deploy/dev-tls/server.key" ]; then
+    echo "Generating ingest TLS certificate (self-signed, 365-day expiry)..."
+    gen_cert "$SCRIPT_DIR/deploy/dev-tls" "ct-ops-ingest"
+  fi
+
+  # Browser-facing server cert — consumed by the bundled nginx on :443.
+  # If both files exist we skip generation regardless of origin, so operators
+  # can pre-seed a real cert into deploy/tls/ before the first install.
+  if [ ! -f "$SCRIPT_DIR/deploy/tls/server.crt" ] || [ ! -f "$SCRIPT_DIR/deploy/tls/server.key" ]; then
+    echo "Generating nginx TLS certificate (self-signed, 365-day expiry)..."
+    gen_cert "$SCRIPT_DIR/deploy/tls" "ct-ops"
+    echo "Replace deploy/tls/server.crt and deploy/tls/server.key with your own"
+    echo "certificate at any time to remove the browser warning."
+  fi
+}
+
+# check_ports_free fails fast when :80 or :443 are already bound on the host,
+# pointing the operator at the NGINX_HTTPS_PORT / NGINX_HTTP_PORT overrides.
+check_ports_free() {
+  local https_port="${NGINX_HTTPS_PORT:-443}"
+  local http_port="${NGINX_HTTP_PORT:-80}"
+  local in_use=()
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(^|:)${https_port}$" && in_use+=("${https_port}")
+    ss -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(^|:)${http_port}$"  && in_use+=("${http_port}")
+  fi
+  if [ ${#in_use[@]} -gt 0 ]; then
+    echo "ERROR: the following ports are already bound on this host: ${in_use[*]}" >&2
+    echo "  Either free them or override the nginx ports in .env:" >&2
+    echo "    NGINX_HTTPS_PORT=8443" >&2
+    echo "    NGINX_HTTP_PORT=8080" >&2
+    exit 1
+  fi
+}
+
+# warn_legacy_env emits a one-line notice for each http://localhost:3000-style
+# value carried over from a pre-nginx install. We do not rewrite .env —
+# operators who intentionally front CT-Ops with a different reverse proxy
+# would lose their config. See docs/getting-started/configuration.md.
+warn_legacy_env() {
+  local legacy=()
+  local var
+  for var in BETTER_AUTH_URL BETTER_AUTH_TRUSTED_ORIGINS AGENT_DOWNLOAD_BASE_URL; do
+    local val="${!var:-}"
+    if [ -n "$val" ] && [ "${val#http://}" != "$val" ]; then
+      legacy+=("$var=$val")
+    fi
+  done
+  if [ ${#legacy[@]} -gt 0 ]; then
+    echo ""
+    echo "NOTICE: .env contains plaintext HTTP values from a previous install:"
+    for entry in "${legacy[@]}"; do echo "  - $entry"; done
+    echo "The bundled nginx now terminates TLS on https://<host>. Update these"
+    echo "values to https:// URLs when you're ready. Not rewriting automatically"
+    echo "so operators fronting CT-Ops with a different proxy keep working."
+    echo ""
+  fi
 }
 
 start_stack() {
   require_docker
   check_env
+  warn_legacy_env
+  check_ports_free
   ensure_tls_certs
 
   echo "Pulling latest images from GHCR..."
-  if ! docker compose pull db web ingest; then
+  if ! docker compose pull db web ingest nginx; then
     echo "" >&2
     echo "ERROR: failed to pull one or more images from GHCR." >&2
     echo "  - Check your network access to ghcr.io" >&2
@@ -237,7 +309,9 @@ start_stack() {
   fi
 
   echo ""
-  echo "CT-Ops is starting. Open ${BETTER_AUTH_URL:-http://localhost:3000} in your browser."
+  echo "CT-Ops is starting. Open ${BETTER_AUTH_URL:-https://localhost} in your browser."
+  echo "Your browser will warn about the self-signed certificate on first visit — accept it"
+  echo "or replace deploy/tls/server.{crt,key} with a certificate from your own CA."
   echo "Tail logs with:  ./start.sh --logs"
   echo "Stop with:       ./start.sh --down"
 }

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -1,0 +1,130 @@
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  # Map the Upgrade request header onto the Connection response so WebSocket
+  # upgrades to the terminal WS endpoint pass through unchanged.
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+  log_format main '$remote_addr - $remote_user [$time_local] '
+                  '"$request" $status $body_bytes_sent '
+                  '"$http_referer" "$http_user_agent"';
+
+  access_log /dev/stdout main;
+  error_log  /dev/stderr warn;
+
+  sendfile          on;
+  tcp_nopush        on;
+  tcp_nodelay       on;
+  keepalive_timeout 75s;
+
+  # 100 MB is ample for agent binary downloads and future bundle endpoints.
+  # If you upload large files through the web UI, raise this here and in
+  # Next.js route config.
+  client_max_body_size 100m;
+
+  # Upstreams.
+  upstream ct_ops_web {
+    server web:3000;
+    keepalive 16;
+  }
+
+  upstream ct_ops_ingest_ws {
+    server ingest:8080;
+    keepalive 8;
+  }
+
+  # Plain HTTP — redirect to HTTPS (but keep /nginx-healthz plaintext so
+  # external load balancers can probe without terminating TLS themselves).
+  server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    location = /nginx-healthz {
+      access_log off;
+      return 200 "ok\n";
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  # HTTPS — terminates TLS and proxies to the web app and the ingest WS
+  # terminal. Agent mTLS on :9443 never traverses this server.
+  server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/tls/server.crt;
+    ssl_certificate_key /etc/nginx/tls/server.key;
+
+    ssl_protocols         TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305';
+    ssl_session_cache    shared:SSL:10m;
+    ssl_session_timeout  1h;
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options    "nosniff" always;
+    add_header X-Frame-Options           "SAMEORIGIN" always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+    location = /nginx-healthz {
+      access_log off;
+      return 200 "ok\n";
+    }
+
+    # WebSocket terminal — the ingest service terminates the WS itself, we
+    # just pass through the upgrade and keep the connection alive for up to
+    # an hour so idle terminals aren't killed.
+    location /ws/terminal/ {
+      proxy_pass http://ct_ops_ingest_ws;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade    $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_set_header Host       $host;
+      proxy_set_header X-Real-IP  $remote_addr;
+      proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+
+    # Server-Sent Events stream from the host detail page. Must disable
+    # buffering so clients see events as soon as they're emitted rather than
+    # waiting for nginx's buffer to fill.
+    location ~ ^/api/hosts/[^/]+/stream$ {
+      proxy_pass http://ct_ops_web;
+      proxy_http_version 1.1;
+      proxy_set_header Host       $host;
+      proxy_set_header X-Real-IP  $remote_addr;
+      proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_read_timeout 3600s;
+      chunked_transfer_encoding on;
+    }
+
+    # Everything else goes to the Next.js app.
+    location / {
+      proxy_pass http://ct_ops_web;
+      proxy_http_version 1.1;
+      proxy_set_header Host              $host;
+      proxy_set_header X-Real-IP         $remote_addr;
+      proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Host  $host;
+    }
+  }
+}

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -5,11 +5,14 @@ events {
 }
 
 http {
-  # Map the Upgrade request header onto the Connection response so WebSocket
-  # upgrades to the terminal WS endpoint pass through unchanged.
+  # Only WebSocket upgrades are supported. Any other value (including `h2c`,
+  # which would enable HTTP/2-cleartext smuggling past this proxy) maps to an
+  # empty string, meaning nginx does not set Connection: upgrade and the
+  # upstream connection stays HTTP/1.1. Matches case-insensitively because
+  # some browsers send `Upgrade: WebSocket` with capital W.
   map $http_upgrade $connection_upgrade {
-    default upgrade;
-    ''      close;
+    default        "";
+    ~*^websocket$  upgrade;
   }
 
   log_format main '$remote_addr - $remote_user [$time_local] '
@@ -52,7 +55,12 @@ http {
       return 200 "ok\n";
     }
 
+    # Redirect to the same host the client requested so plaintext links keep
+    # pointing at the intended origin. An attacker supplying a spoofed Host
+    # only redirects their own browser — no server-side trust is placed on
+    # this value.
     location / {
+      # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       return 301 https://$host$request_uri;
     }
   }
@@ -85,13 +93,15 @@ http {
     }
 
     # WebSocket terminal — the ingest service terminates the WS itself, we
-    # just pass through the upgrade and keep the connection alive for up to
-    # an hour so idle terminals aren't killed.
+    # just pass through the upgrade. The Upgrade header is forced to a
+    # literal `websocket` rather than forwarding the client's raw value so
+    # H2C or other upgrade smuggling attempts cannot reach the backend.
     location /ws/terminal/ {
       proxy_pass http://ct_ops_ingest_ws;
       proxy_http_version 1.1;
-      proxy_set_header Upgrade    $http_upgrade;
+      proxy_set_header Upgrade    websocket;
       proxy_set_header Connection $connection_upgrade;
+      # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       proxy_set_header Host       $host;
       proxy_set_header X-Real-IP  $remote_addr;
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -102,10 +112,14 @@ http {
 
     # Server-Sent Events stream from the host detail page. Must disable
     # buffering so clients see events as soon as they're emitted rather than
-    # waiting for nginx's buffer to fill.
+    # waiting for nginx's buffer to fill. Strip any Upgrade/Connection
+    # headers to prevent H2C smuggling against the Next.js backend.
     location ~ ^/api/hosts/[^/]+/stream$ {
       proxy_pass http://ct_ops_web;
       proxy_http_version 1.1;
+      proxy_set_header Upgrade    "";
+      proxy_set_header Connection "";
+      # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       proxy_set_header Host       $host;
       proxy_set_header X-Real-IP  $remote_addr;
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -116,15 +130,23 @@ http {
       chunked_transfer_encoding on;
     }
 
-    # Everything else goes to the Next.js app.
+    # Everything else goes to the Next.js app. The Host header is forwarded
+    # so Next.js can build same-origin redirects correctly. Security-sensitive
+    # URL construction (auth callbacks, cookie Secure/Domain attributes) is
+    # driven by BETTER_AUTH_URL and BETTER_AUTH_TRUSTED_ORIGINS env vars, not
+    # the Host header — a spoofed Host cannot escalate privileges or forge
+    # sessions. Upgrade/Connection are explicitly cleared to block H2C
+    # smuggling against the backend.
     location / {
       proxy_pass http://ct_ops_web;
       proxy_http_version 1.1;
+      proxy_set_header Upgrade    "";
+      proxy_set_header Connection "";
+      # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       proxy_set_header Host              $host;
       proxy_set_header X-Real-IP         $remote_addr;
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto https;
-      proxy_set_header X-Forwarded-Host  $host;
     }
   }
 }

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -100,6 +100,10 @@ http {
       proxy_pass http://ct_ops_ingest_ws;
       proxy_http_version 1.1;
       proxy_set_header Upgrade    websocket;
+      # $connection_upgrade only resolves to `upgrade` when the client's
+      # Upgrade header was websocket (see map above); any other value,
+      # including h2c, maps to empty so no upgrade happens.
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
       proxy_set_header Connection $connection_upgrade;
       # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       proxy_set_header Host       $host;
@@ -117,7 +121,13 @@ http {
     location ~ ^/api/hosts/[^/]+/stream$ {
       proxy_pass http://ct_ops_web;
       proxy_http_version 1.1;
+      # Explicitly clear Upgrade/Connection so no upgrade (h2c or otherwise)
+      # can reach the Next.js backend. This is the mitigation Semgrep
+      # recommends; suppressing the rule because the scanner still pattern-
+      # matches `proxy_set_header Connection` without reading the value.
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
       proxy_set_header Upgrade    "";
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
       proxy_set_header Connection "";
       # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       proxy_set_header Host       $host;
@@ -140,7 +150,11 @@ http {
     location / {
       proxy_pass http://ct_ops_web;
       proxy_http_version 1.1;
+      # Explicitly clear Upgrade/Connection so no upgrade (h2c or otherwise)
+      # can reach the Next.js backend.
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
       proxy_set_header Upgrade    "";
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
       proxy_set_header Connection "";
       # nosemgrep: generic.nginx.security.request-host-used.request-host-used
       proxy_set_header Host              $host;

--- a/deploy/scripts/gen-dev-tls.sh
+++ b/deploy/scripts/gen-dev-tls.sh
@@ -1,55 +1,21 @@
 #!/usr/bin/env bash
-# Generates a self-signed TLS certificate for local development.
-# Output: deploy/dev-tls/server.crt and deploy/dev-tls/server.key
+# Generates a self-signed TLS certificate for local development of the ingest
+# service (gRPC on :9443). Output lands in deploy/dev-tls/server.{crt,key}.
 #
-# These files are gitignored. Re-run this script after cloning or cleaning.
+# This is a thin wrapper around deploy/scripts/gen-server-cert.sh so dev and
+# production cert generation share a single implementation.
+#
 # For production, replace with a proper certificate from your CA.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-OUTPUT_DIR="${ROOT_DIR}/deploy/dev-tls"
 
-mkdir -p "${OUTPUT_DIR}"
+OUT_DIR="${ROOT_DIR}/deploy/dev-tls" \
+CN="localhost" \
+  "${SCRIPT_DIR}/gen-server-cert.sh"
 
-CERT="${OUTPUT_DIR}/server.crt"
-KEY="${OUTPUT_DIR}/server.key"
-
-if [[ -f "${CERT}" && -f "${KEY}" ]]; then
-  echo "Dev TLS certificates already exist at ${OUTPUT_DIR}"
-  echo "Delete them and re-run this script to regenerate."
-  exit 0
-fi
-
-echo "Generating self-signed dev TLS certificate..."
-
-# Collect all non-loopback IPv4 addresses to include as SANs so remote agents can connect
-if command -v ip &>/dev/null; then
-  LOCAL_IPS=$(ip -4 addr show scope global 2>/dev/null | awk '/inet / {split($2,a,"/"); print "IP:" a[1]}' | tr '\n' ',' | sed 's/,$//')
-else
-  LOCAL_IPS=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//')
-fi
-SAN="DNS:localhost,DNS:ingest,IP:127.0.0.1"
-if [ -n "${LOCAL_IPS}" ]; then
-  SAN="${SAN},${LOCAL_IPS}"
-fi
-
-openssl req -x509 \
-  -newkey rsa:4096 \
-  -keyout "${KEY}" \
-  -out "${CERT}" \
-  -days 365 \
-  -nodes \
-  -subj "/CN=localhost" \
-  -addext "subjectAltName=${SAN}" \
-  2>/dev/null
-
-echo "SANs: ${SAN}"
-
-echo "Generated:"
-echo "  Certificate: ${CERT}"
-echo "  Key:         ${KEY}"
 echo ""
 echo "To trust this certificate in the agent config, set:"
-echo "  ca_cert_file = \"${CERT}\""
+echo "  ca_cert_file = \"${ROOT_DIR}/deploy/dev-tls/server.crt\""

--- a/deploy/scripts/gen-server-cert.sh
+++ b/deploy/scripts/gen-server-cert.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Generates a self-signed TLS certificate (RSA 4096, SHA-256, 365-day).
+#
+# Used by:
+#   - deploy/customer-bundle/start.sh to produce the browser-facing nginx cert
+#   - deploy/scripts/gen-dev-tls.sh to produce the ingest mTLS dev cert
+#
+# Env vars:
+#   OUT_DIR      Directory to write server.crt / server.key. Required.
+#   CN           Certificate common name. Default: ct-ops.
+#   EXTRA_SANS   Extra SAN entries appended to the auto-discovered list,
+#                comma-separated. Example: DNS:ct-ops.example.com
+#   FORCE        When "1", regenerate even if both files already exist.
+#
+# Behaviour:
+#   - Idempotent: exits 0 if OUT_DIR/server.crt and server.key both exist
+#     unless FORCE=1.
+#   - Always includes DNS:localhost, DNS:ingest, IP:127.0.0.1 in the SAN list.
+#   - Appends every non-loopback IPv4 address on the host (so remote agents
+#     can verify by IP against a cert generated on the server).
+#   - Writes the key with mode 600 and the cert with mode 644.
+
+set -euo pipefail
+
+: "${OUT_DIR:?OUT_DIR must be set}"
+CN="${CN:-ct-ops}"
+EXTRA_SANS="${EXTRA_SANS:-}"
+FORCE="${FORCE:-0}"
+
+CERT="${OUT_DIR}/server.crt"
+KEY="${OUT_DIR}/server.key"
+
+if [ "$FORCE" != "1" ] && [ -f "$CERT" ] && [ -f "$KEY" ]; then
+  echo "Server certificate already present at ${OUT_DIR} — skipping generation."
+  echo "Set FORCE=1 to regenerate."
+  exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: 'openssl' is required to generate server certificates." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+LOCAL_IPS=""
+if command -v ip >/dev/null 2>&1; then
+  LOCAL_IPS=$(ip -4 addr show scope global 2>/dev/null | awk '/inet / {split($2,a,"/"); print "IP:" a[1]}' | tr '\n' ',' | sed 's/,$//' || true)
+elif command -v ifconfig >/dev/null 2>&1; then
+  LOCAL_IPS=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//' || true)
+fi
+
+SAN="DNS:localhost,DNS:ingest,IP:127.0.0.1"
+[ -n "$LOCAL_IPS" ] && SAN="${SAN},${LOCAL_IPS}"
+[ -n "$EXTRA_SANS" ] && SAN="${SAN},${EXTRA_SANS}"
+
+openssl req -x509 -newkey rsa:4096 \
+  -keyout "$KEY" \
+  -out "$CERT" \
+  -sha256 -days 365 -nodes \
+  -subj "/CN=${CN}" \
+  -addext "subjectAltName=${SAN}" 2>/dev/null
+
+chmod 600 "$KEY"
+chmod 644 "$CERT"
+
+echo "Wrote ${CERT} (CN=${CN}, SANs: ${SAN})"

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      # Loopback-only — nothing outside this host speaks to Postgres directly.
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ctops -d ctops"]
       interval: 10s
@@ -26,22 +27,34 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "3000:3000"
+      # Loopback-only — browser traffic flows in via the nginx container on :443.
+      # Keeping :3000 on 127.0.0.1 lets operators tunnel for debugging without
+      # exposing plaintext HTTP externally.
+      - "127.0.0.1:3000:3000"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ctops}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-ctops}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set in your .env file}
-      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
-      BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-http://localhost:3000}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://localhost}
+      BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-https://localhost}
       NODE_ENV: production
       AGENT_DIST_DIR: /var/lib/ct-ops/agent-dist
-      AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
-      # Leave INGEST_WS_URL blank when running behind a reverse proxy or
-      # Cloudflare tunnel — the browser will use the page's own origin and
-      # the proxy must route /ws/terminal/* to the ingest container on 8080.
-      INGEST_WS_URL: ${INGEST_WS_URL-ws://localhost:8080}
+      AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-https://localhost}
+      # Empty by default so the browser uses the page's own origin and nginx
+      # routes /ws/terminal/* to the ingest container. Override with an
+      # absolute wss:// URL only if you intentionally want the browser to
+      # bypass nginx and connect to ingest directly.
+      INGEST_WS_URL: ${INGEST_WS_URL-}
+      # Path to the nginx-facing server cert. The enrolment bundle route reads
+      # this file and ships it to agents so they can verify the HTTPS URL used
+      # for self-update downloads, even when it is signed by a private CA not
+      # in the agent host's trust store.
+      WEB_TLS_CERT: /var/lib/ct-ops/server-tls/server.crt
       CT_OPS_LOADTEST_ADMIN_KEY: ${CT_OPS_LOADTEST_ADMIN_KEY:-}
     volumes:
       - agent_dist:/var/lib/ct-ops/agent-dist
+      # Read-only mount of the nginx-facing server cert so the enrolment
+      # bundle route can embed it in agent downloads.
+      - ./deploy/tls:/var/lib/ct-ops/server-tls:ro
 
   ingest:
     image: ${INGEST_IMAGE:-ghcr.io/carrtech-dev/ct-ops/ingest:latest}
@@ -53,8 +66,10 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "9443:9443"   # gRPC (TLS)
-      - "8080:8080"   # JWKS + healthz HTTP
+      - "9443:9443"   # gRPC (mTLS) — agents connect here directly, bypassing nginx.
+      # Loopback-only — nginx reaches :8080 over the docker network; there is
+      # no reason to expose plaintext JWKS/healthz/WS externally.
+      - "127.0.0.1:8080:8080"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-ctops}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-ctops}
       INGEST_TLS_CERT: /etc/ct-ops/tls/server.crt
@@ -70,21 +85,45 @@ services:
       LDAP_ENCRYPTION_KEY: ${LDAP_ENCRYPTION_KEY:-${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}}
       # Public base URL of the web app — agents construct their download URL
       # from this, so it must be reachable from the agent host (not just from
-      # inside the docker network). Override via .env / start.sh for remote
-      # agents; defaults to localhost for single-host dev.
-      INGEST_AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}
+      # inside the docker network). Defaults to the nginx TLS endpoint.
+      INGEST_AGENT_DOWNLOAD_BASE_URL: ${AGENT_DOWNLOAD_BASE_URL:-https://localhost}
+      # Path to the nginx-facing server cert. Ingest reads this so it can
+      # compare the fingerprint an agent sends in its heartbeat against the
+      # current live cert — when they differ, ingest pushes the new cert down
+      # the heartbeat stream so the agent can keep verifying downloads after
+      # the operator swaps in a new cert without re-enrolling every host.
+      INGEST_WEB_SERVER_CERT: /etc/ct-ops/server-tls/server.crt
       # The release-please manifest is baked into the ingest image at build
       # time (see apps/ingest/Dockerfile) and INGEST_RELEASE_MANIFEST_PATH is
       # set there as well, so production users running from GHCR do not need
       # a source checkout for the agent version to be discovered.
     volumes:
       - ./deploy/dev-tls:/etc/ct-ops/tls:ro
+      - ./deploy/tls:/etc/ct-ops/server-tls:ro
       - ingest_data:/var/lib/ct-ops
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5
+
+  nginx:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    depends_on:
+      - web
+      - ingest
+    ports:
+      - "${NGINX_HTTPS_PORT:-443}:443"
+      - "${NGINX_HTTP_PORT:-80}:80"
+    volumes:
+      - ./deploy/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./deploy/tls:/etc/nginx/tls:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1/nginx-healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 
 volumes:
   db_data:

--- a/proto/agent/v1/heartbeat.proto
+++ b/proto/agent/v1/heartbeat.proto
@@ -111,6 +111,14 @@ message HeartbeatRequest {
   repeated AgentQueryResult  query_results      = 14;
   repeated AgentTaskProgress task_progress      = 15;
   repeated AgentTaskResult   task_results       = 16;
+  // SHA-256 hex fingerprint of the server cert the agent currently trusts
+  // for HTTPS self-update downloads. Empty when the agent has no pin yet
+  // (e.g. pre-upgrade agent) or uses only the system trust store.
+  // The ingest service compares this against the live nginx server cert;
+  // on mismatch, it returns the current cert in pending_server_cert_pem so
+  // the agent can continue to verify downloads after an operator swap
+  // without manual CA distribution on each agent host.
+  string pinned_server_cert_fingerprint = 17;
 }
 
 message HeartbeatResponse {
@@ -134,4 +142,9 @@ message HeartbeatResponse {
   // Agent CA cert bundle (PEM). Sent alongside a pending cert or when the CA
   // has rotated — the agent stashes this so it can display the chain.
   string agent_ca_cert_pem = 15;
+  // PEM of the nginx-facing server cert currently in force on the server.
+  // Populated only when the agent's pinned_server_cert_fingerprint differs
+  // from the live cert. The agent persists this to its data dir and appends
+  // it to the trust roots used by the self-update HTTP client.
+  string pending_server_cert_pem = 16;
 }

--- a/proto/gen/go/agent/v1/heartbeat.pb.go
+++ b/proto/gen/go/agent/v1/heartbeat.pb.go
@@ -798,8 +798,16 @@ type HeartbeatRequest struct {
 	QueryResults      []*AgentQueryResult    `protobuf:"bytes,14,rep,name=query_results,json=queryResults,proto3" json:"query_results,omitempty"`
 	TaskProgress      []*AgentTaskProgress   `protobuf:"bytes,15,rep,name=task_progress,json=taskProgress,proto3" json:"task_progress,omitempty"`
 	TaskResults       []*AgentTaskResult     `protobuf:"bytes,16,rep,name=task_results,json=taskResults,proto3" json:"task_results,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// SHA-256 hex fingerprint of the server cert the agent currently trusts
+	// for HTTPS self-update downloads. Empty when the agent has no pin yet
+	// (e.g. pre-upgrade agent) or uses only the system trust store.
+	// The ingest service compares this against the live nginx server cert;
+	// on mismatch, it returns the current cert in pending_server_cert_pem so
+	// the agent can continue to verify downloads after an operator swap
+	// without manual CA distribution on each agent host.
+	PinnedServerCertFingerprint string `protobuf:"bytes,17,opt,name=pinned_server_cert_fingerprint,json=pinnedServerCertFingerprint,proto3" json:"pinned_server_cert_fingerprint,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *HeartbeatRequest) Reset() {
@@ -944,6 +952,13 @@ func (x *HeartbeatRequest) GetTaskResults() []*AgentTaskResult {
 	return nil
 }
 
+func (x *HeartbeatRequest) GetPinnedServerCertFingerprint() string {
+	if x != nil {
+		return x.PinnedServerCertFingerprint
+	}
+	return ""
+}
+
 type HeartbeatResponse struct {
 	state                   protoimpl.MessageState    `protogen:"open.v1"`
 	Ok                      bool                      `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
@@ -966,8 +981,13 @@ type HeartbeatResponse struct {
 	// Agent CA cert bundle (PEM). Sent alongside a pending cert or when the CA
 	// has rotated — the agent stashes this so it can display the chain.
 	AgentCaCertPem string `protobuf:"bytes,15,opt,name=agent_ca_cert_pem,json=agentCaCertPem,proto3" json:"agent_ca_cert_pem,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// PEM of the nginx-facing server cert currently in force on the server.
+	// Populated only when the agent's pinned_server_cert_fingerprint differs
+	// from the live cert. The agent persists this to its data dir and appends
+	// it to the trust roots used by the self-update HTTP client.
+	PendingServerCertPem string `protobuf:"bytes,16,opt,name=pending_server_cert_pem,json=pendingServerCertPem,proto3" json:"pending_server_cert_pem,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *HeartbeatResponse) Reset() {
@@ -1105,6 +1125,13 @@ func (x *HeartbeatResponse) GetAgentCaCertPem() string {
 	return ""
 }
 
+func (x *HeartbeatResponse) GetPendingServerCertPem() string {
+	if x != nil {
+		return x.PendingServerCertPem
+	}
+	return ""
+}
+
 var File_agent_v1_heartbeat_proto protoreflect.FileDescriptor
 
 const file_agent_v1_heartbeat_proto_rawDesc = "" +
@@ -1179,7 +1206,7 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\texit_code\x18\x03 \x01(\x05R\bexitCode\x12\x1f\n" +
 	"\vresult_json\x18\x04 \x01(\tR\n" +
 	"resultJson\x12\x14\n" +
-	"\x05error\x18\x05 \x01(\tR\x05error\"\xc0\x05\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"\x85\x06\n" +
 	"\x10HeartbeatRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x1f\n" +
 	"\vcpu_percent\x18\x02 \x01(\x02R\n" +
@@ -1199,7 +1226,8 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\rcheck_results\x18\r \x03(\v2\x15.agent.v1.CheckResultR\fcheckResults\x12?\n" +
 	"\rquery_results\x18\x0e \x03(\v2\x1a.agent.v1.AgentQueryResultR\fqueryResults\x12@\n" +
 	"\rtask_progress\x18\x0f \x03(\v2\x1b.agent.v1.AgentTaskProgressR\ftaskProgress\x12<\n" +
-	"\ftask_results\x18\x10 \x03(\v2\x19.agent.v1.AgentTaskResultR\vtaskResults\"\xf2\x05\n" +
+	"\ftask_results\x18\x10 \x03(\v2\x19.agent.v1.AgentTaskResultR\vtaskResults\x12C\n" +
+	"\x1epinned_server_cert_fingerprint\x18\x11 \x01(\tR\x1bpinnedServerCertFingerprint\"\xa9\x06\n" +
 	"\x11HeartbeatResponse\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x18\n" +
 	"\acommand\x18\x02 \x01(\tR\acommand\x12'\n" +
@@ -1216,7 +1244,8 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\x18cancel_terminal_sessions\x18\f \x03(\tR\x16cancelTerminalSessions\x125\n" +
 	"\x17pending_client_cert_pem\x18\r \x01(\tR\x14pendingClientCertPem\x12I\n" +
 	"\"pending_client_cert_not_after_unix\x18\x0e \x01(\x03R\x1dpendingClientCertNotAfterUnix\x12)\n" +
-	"\x11agent_ca_cert_pem\x18\x0f \x01(\tR\x0eagentCaCertPemB7Z5github.com/carrtech-dev/ct-ops/proto/agent/v1;agentv1b\x06proto3"
+	"\x11agent_ca_cert_pem\x18\x0f \x01(\tR\x0eagentCaCertPem\x125\n" +
+	"\x17pending_server_cert_pem\x18\x10 \x01(\tR\x14pendingServerCertPemB7Z5github.com/carrtech-dev/ct-ops/proto/agent/v1;agentv1b\x06proto3"
 
 var (
 	file_agent_v1_heartbeat_proto_rawDescOnce sync.Once


### PR DESCRIPTION
## Summary

- Adds an `nginx` container to `docker-compose.single.yml` that terminates TLS on `:443` for browser traffic, fronting the web app on `:3000` and the ingest WebSocket terminal on `:8080`. Agent mTLS on `:9443` stays direct — the proxy never sees it, so PR #511's mTLS guarantees are preserved end-to-end.
- `start.sh` auto-generates a self-signed cert into `deploy/tls/server.{crt,key}` on first install; operators drop in their own cert by replacing those two files and restarting the `nginx` container.
- Adds a cert-rotation mechanism over the existing mTLS heartbeat: agent sends a fingerprint, ingest compares against the live nginx cert, pushes the new PEM on mismatch. Makes swapping the browser cert a non-event for agent self-update — even on Linux VMs where the operator's internal CA isn't in the host trust store.
- Rebinds `web:3000` and `ingest:8080` to `127.0.0.1` so the external surface is strictly `:80`, `:443`, `:9443`.

## What changed

### Infrastructure
- `deploy/nginx/nginx.conf` — new. TLS 1.2+, HTTP/2, HSTS, WS upgrade for `/ws/terminal/*`, SSE-friendly `proxy_buffering off` for `/api/hosts/*/stream`, 80→443 redirect, `/nginx-healthz`.
- `deploy/scripts/gen-server-cert.sh` — new. Shared self-signed cert generator (`OUT_DIR`, `CN`, `EXTRA_SANS`, `FORCE`). `gen-dev-tls.sh` now wraps it.
- `docker-compose.single.yml` — new `nginx` service, loopback rebinds, HTTPS default URLs, cert mounts into web (for bundle embedding) and ingest (for rotation RPC).
- `deploy/customer-bundle/start.sh` — pre-flight check on :80/:443, generates both certs, warns on legacy `http://localhost:3000` env values, updates completion banner.
- `.env.example` — defaults shift to `https://localhost`, `INGEST_WS_URL=` (same-origin), adds `NGINX_HTTPS_PORT`/`NGINX_HTTP_PORT` overrides.

### Cert rotation RPC
- `proto/agent/v1/heartbeat.proto` — adds `HeartbeatRequest.pinned_server_cert_fingerprint` (17) and `HeartbeatResponse.pending_server_cert_pem` (16). Go bindings regenerated.
- `apps/ingest/internal/pki/webservercert.go` — new. Loads + periodically refreshes the nginx cert; exposes PEM + SHA-256 fingerprint.
- `apps/ingest/internal/config/config.go` — adds `TLS.WebServerCertFile` + `INGEST_WEB_SERVER_CERT` env var.
- `apps/ingest/internal/handlers/heartbeat.go` — compares incoming fingerprint against live cert; pushes PEM on mismatch.
- `agent/internal/identity/server_cert.go` — new. Atomic load/save of pinned PEM + fingerprint computation.
- `agent/internal/heartbeat/heartbeat.go` — primes pin from disk on startup, sends fingerprint on every heartbeat, handles rotation push, passes PEM to updater.
- `agent/internal/updater/updater.go` — builds HTTPS client with `SystemCertPool() + pinned cert` as trust roots, 10-min timeout.
- `apps/web/app/api/agent/bundle/route.ts` + `apps/web/lib/agent/bundle.ts` — read `WEB_TLS_CERT`, embed `server-cert.pem` in the zip, install scripts copy it into the agent data dir.

### Docs
- Deployment / installation / configuration pages updated with new port map, HTTPS defaults, and a "Replacing the TLS certificate" section that documents the drop-in-and-restart workflow plus the automatic agent rotation.
- Terminal page simplified — bundled nginx handles the proxy hop.
- README fixes incorrect "port 443" claim for agents (it's 9443) and updates quick-start URL to https://localhost.

## Test plan

- [ ] Fresh install: `./deploy/customer-bundle/start.sh` generates both certs, all containers healthy, `curl -kI https://localhost/` returns 200.
- [ ] `curl -I http://localhost/` returns 301 → https.
- [ ] External port scan: `:443`, `:80`, `:9443` reachable; `:3000`, `:8080`, `:5432` not reachable externally.
- [ ] Browser login works over HTTPS, session cookie has `Secure` flag.
- [ ] WS terminal connects via `wss://localhost/ws/terminal/<id>` and survives >10 min idle.
- [ ] SSE stream on host detail page delivers updates promptly (no buffering).
- [ ] Enrol an agent and verify it connects on `:9443` (confirmed via `ss -tnp`). Stop nginx; heartbeats continue.
- [ ] Trigger self-update with the default self-signed cert — succeeds via pinned trust.
- [ ] Swap `deploy/tls/server.{crt,key}` for a public-CA cert, `docker compose restart nginx`. Verify the next agent heartbeat receives the new PEM and a subsequent self-update verifies cleanly.
- [ ] Repeat the swap with a cert signed by a CA **not** in any agent host's trust store — this is the gap the rotation RPC closes.
- [ ] Pre-seed a real cert into `deploy/tls/` before first run; verify `start.sh` skips generation.
- [ ] Upgrade path: stale `.env` with `http://localhost:3000` values triggers the migration warning and is not rewritten.

## Out of scope

- `docker-compose.dev.yml`, standard/HA profiles (unchanged).
- ACME / Let's Encrypt automation (manual cert swap only).
- A dedicated server CA signing the nginx cert (self-signed is sufficient for air-gap).

https://claude.ai/code/session_01Kksrr6hyjkqxgBrzHsetAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kksrr6hyjkqxgBrzHsetAU)_