### PR TITLE
fix(deploy): add tls-init sidecar so nginx auto-generates certs on first boot

### DIFF
--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -111,8 +111,12 @@ services:
     image: nginx:1.27-alpine
     restart: unless-stopped
     depends_on:
-      - web
-      - ingest
+      tls-init:
+        condition: service_completed_successfully
+      web:
+        condition: service_started
+      ingest:
+        condition: service_started
     ports:
       - "${NGINX_HTTPS_PORT:-443}:443"
       - "${NGINX_HTTP_PORT:-80}:80"
@@ -124,6 +128,42 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+
+  # Generates the nginx server cert on first boot if deploy/tls is empty.
+  # Reuses the nginx:alpine image (openssl is included) so we don't add a
+  # second image to the pull list — this matters for air-gap bundles. The
+  # cert is created as a run-once job: container exits 0 when done, and
+  # nginx starts only after a successful exit (depends_on above). When
+  # start.sh has already populated deploy/tls/ this is a no-op.
+  tls-init:
+    image: nginx:1.27-alpine
+    restart: "no"
+    user: "0:0"
+    volumes:
+      - ./deploy/tls:/tls
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        if [ -f /tls/server.crt ] && [ -f /tls/server.key ]; then
+          echo "tls-init: cert already present at /tls — skipping generation."
+          exit 0
+        fi
+        if ! command -v openssl >/dev/null 2>&1; then
+          echo "tls-init: installing openssl..."
+          apk add --no-cache openssl >/dev/null
+        fi
+        echo "tls-init: generating self-signed cert at /tls..."
+        openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+          -keyout /tls/server.key \
+          -out /tls/server.crt \
+          -subj "/CN=ct-ops" \
+          -addext "subjectAltName=DNS:localhost,DNS:ingest,IP:127.0.0.1" 2>/dev/null
+        chmod 600 /tls/server.key
+        chmod 644 /tls/server.crt
+        echo "tls-init: wrote /tls/server.{crt,key}. Replace with your own cert"
+        echo "tls-init: at any time to remove the browser warning."
 
 volumes:
   db_data:


### PR DESCRIPTION
## Why

PR #514 added a bundled nginx container that terminates TLS on `:443` using `./deploy/tls/server.{crt,key}`. Cert generation was delegated to `start.sh`, which works fine in the customer-bundle layout but leaves the stack broken when started any other way — for example, a dev checkout running `docker compose -f docker-compose.single.yml up -d` directly.

Symptom (from a real run):

```
nginx: [emerg] cannot load certificate "/etc/nginx/tls/server.crt":
BIO_new_file() failed ... No such file or directory
```

The bind mount resolves to an empty host directory and nginx crash-loops until compose or the operator gives up.

## What

Add a `tls-init` run-once sidecar that generates the cert in-container if `deploy/tls/` is empty. Nginx's `depends_on` is updated to wait for `tls-init: service_completed_successfully`, so the main service only starts when the cert is present.

- Same `nginx:1.27-alpine` image — no new image in the pull list (matters for air-gap bundles).
- `apk add --no-cache openssl` only if the CLI isn't already in the image; works on any Alpine version.
- Exits 0 immediately if the cert already exists, so `start.sh`-driven installs continue to work unchanged (`start.sh` pre-generates on the host with richer SANs from local IPs; the sidecar becomes a no-op).

## Test plan

- [ ] Fresh `docker compose -f docker-compose.single.yml up -d` on a clean checkout (no prior `start.sh` run): `docker compose logs tls-init` shows "generating self-signed cert", nginx comes up healthy, `curl -kI https://localhost/nginx-healthz` returns 200.
- [ ] Second `docker compose up -d`: tls-init logs "cert already present … skipping generation" and exits 0 without regenerating.
- [ ] Customer-bundle flow (`./start.sh`) still produces certs on the host before compose comes up; tls-init no-ops on first boot.
- [ ] Replace `deploy/tls/server.{crt,key}` with a different cert, `docker compose restart nginx`: new cert is served; tls-init still no-ops on subsequent restarts.

https://claude.ai/code/session_01Kksrr6hyjkqxgBrzHsetAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kksrr6hyjkqxgBrzHsetAU)_