### PR TITLE
fix(web): propagate skip_verify to bootstrap curl in install script

### DIFF
--- a/apps/web/app/api/agent/install/route.ts
+++ b/apps/web/app/api/agent/install/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
 
   const script = token
     ? buildAutoInstallScript(serverURL, token, ingestAddress, skipVerify)
-    : buildDownloadScript(serverURL, ingestAddress)
+    : buildDownloadScript(serverURL, ingestAddress, skipVerify)
 
   return new NextResponse(script, {
     headers: {
@@ -63,6 +63,12 @@ function buildAutoInstallScript(
   skipVerify: boolean,
 ): string {
   const tlsFlag = skipVerify ? ' --tls-skip-verify' : ''
+  // skip_verify=true also relaxes the bootstrap curl that downloads the
+  // binary — without this, operators piping the script through bash hit a
+  // "self-signed certificate" error even after passing -k to the outer
+  // curl, because the outer flag does not propagate to commands in the
+  // downloaded script.
+  const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
   return `#!/bin/sh
 set -e
 
@@ -82,7 +88,7 @@ esac
 
 # ── Download binary ────────────────────────────────────────────────────────────
 echo "Downloading ct-ops-agent for \${OS}/\${ARCH}..."
-curl -fsSL "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
+curl ${curlFlags} "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
 chmod +x ct-ops-agent
 echo "Binary downloaded."
 
@@ -91,7 +97,12 @@ sudo ./ct-ops-agent --install --token "${token}" --address "${ingestAddress}"${t
 `
 }
 
-function buildDownloadScript(serverURL: string, ingestAddress: string): string {
+function buildDownloadScript(
+  serverURL: string,
+  ingestAddress: string,
+  skipVerify: boolean,
+): string {
+  const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
   return `#!/bin/sh
 set -e
 
@@ -111,7 +122,7 @@ esac
 
 # ── Download binary ────────────────────────────────────────────────────────────
 echo "Downloading ct-ops-agent for \${OS}/\${ARCH}..."
-curl -fsSL "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
+curl ${curlFlags} "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
 chmod +x ct-ops-agent
 
 echo ""


### PR DESCRIPTION
## Why

After PR #514 the default agent download URL is `https://...` served by the bundled nginx with a self-signed cert. The install one-liner fails on any operator's first attempt:

```
curl: (60) SSL certificate problem: self-signed certificate
```

Passing `-k` to the outer `curl ... | bash` doesn't help — the outer flag has nothing to do with commands inside the downloaded script. The `skip_verify=true` query param only translated to the agent's `--tls-skip-verify` gRPC flag; nothing relaxed the bootstrap curl that downloads the binary.

## What

When `skip_verify=true` is set on `/api/agent/install`, render `curl -fsSLk` (instead of `-fsSL`) in both the auto-install and download-only variants of the generated script. The agent's TLS behaviour is unchanged.

## Test plan

- [ ] `curl -fsSL "https://<host>/api/agent/install?token=...&skip_verify=true"` produces a script containing `curl -fsSLk` for the download step.
- [ ] Piping that script through `bash` completes the binary download against a self-signed nginx cert.
- [ ] Omitting `skip_verify=true` still produces `curl -fsSL` (strict verification) — behaviour unchanged.
- [ ] `tsc` passes.

https://claude.ai/code/session_01Kksrr6hyjkqxgBrzHsetAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kksrr6hyjkqxgBrzHsetAU)_