### PR TITLE
ci(codeql): install Node.js for javascript-typescript analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,12 @@ jobs:
             agent/go.sum
             apps/ingest/go.sum
 
+      - name: Set up Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Initialise CodeQL
         uses: github/codeql-action/init@v4
         with:


### PR DESCRIPTION
## Summary

Fixes the `Analyse javascript-typescript` job in the CodeQL workflow, which has been failing on every push to `main` (most recently run #189 on commit 580c0a6).

## Root cause

The self-hosted runners don't have Node.js on `PATH`. CodeQL's TypeScript extractor requires `node` to parse TS/TSX sources, so it was failing immediately in the `Analyse` step:

```
[build-stderr] Could not start Node.js. It is required for TypeScript extraction.
[build-stderr] Please install Node.js and ensure 'node' is on the PATH.
...
A fatal error occurred: Exit status 1 from command:
[.../codeql/javascript/tools/autobuild.sh]
```

The Go matrix entry has always worked because `actions/setup-go` was already wired up — the JS/TS entry just never had the equivalent.

## Fix

Add `actions/setup-node@v4` with `node-version: "20"` (matching the root `package.json` `engines.node` constraint), gated on `matrix.language == 'javascript-typescript'` so the Go job is unaffected.

Node is cached in `$RUNNER_TOOL_CACHE` on the self-hosted runners, so this only adds ~20s to the first run and ~1-2s after that.

## Test plan

- [ ] After merge, the CodeQL workflow runs on `main` and the `Analyse javascript-typescript` job succeeds.
- [ ] The `Analyse go` job continues to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_017iY22FFuTcrh8V7jQuqM6a)_