### PR TITLE
Resolve PR #520 conflicts with main

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -53,6 +53,18 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
+
   # ── Binary build matrix ──────────────────────────────────────────────────
   # Only runs when the release PR is merged (i.e. a real release was created).
   build:
@@ -127,6 +139,18 @@ jobs:
             dist/ct-ops-agent-${{ matrix.asset_suffix }}${{ matrix.exe_suffix }}
             dist/ct-ops-agent-${{ matrix.asset_suffix }}.sha256
             dist/ct-ops-agent-${{ matrix.asset_suffix }}.spdx.json
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
 
   # ── Customer bundle for web releases ─────────────────────────────────────
   # Runs in the same workflow run as release-please so the GITHUB_TOKEN
@@ -538,3 +562,15 @@ jobs:
             ${{ steps.bundle.outputs.versioned }}
             ct-ops-single.zip
             ct-ops-web.spdx.json
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,12 @@ jobs:
             agent/go.sum
             apps/ingest/go.sum
 
+      - name: Set up Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Initialise CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,3 +62,18 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          # CodeQL stores its database under RUNNER_TEMP — remove it so the
+          # next matrix leg (or next run) doesn't pay for the old copy.
+          rm -rf "${RUNNER_TEMP:-/tmp}/codeql_databases" 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -64,3 +64,15 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -103,6 +103,23 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Clean up runner disk
+        # GitHub-hosted runners (ubuntu-24.04-arm) are ephemeral; only the
+        # self-hosted leg needs explicit disk cleanup.
+        if: always() && matrix.runner == 'self-hosted'
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          # Docker image builds are the single biggest consumer of disk on the
+          # runner — prune buildx + dangling layers aggressively. "until=1h"
+          # protects parallel jobs that might still be using warm cache.
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
+
   merge-ingest:
     name: Merge ingest image manifests
     runs-on: self-hosted
@@ -147,3 +164,13 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}/ingest@sha256:%s ' *)
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -107,6 +107,23 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Clean up runner disk
+        # GitHub-hosted runners (ubuntu-24.04-arm) are ephemeral; only the
+        # self-hosted leg needs explicit disk cleanup.
+        if: always() && matrix.runner == 'self-hosted'
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          # Docker image builds are the single biggest consumer of disk on the
+          # runner — prune buildx + dangling layers aggressively. "until=1h"
+          # protects parallel jobs that might still be using warm cache.
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
+
   merge-web:
     name: Merge web image manifests
     runs-on: self-hosted
@@ -151,3 +168,13 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}/web@sha256:%s ' *)
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/pr-checks-go.yml
+++ b/.github/workflows/pr-checks-go.yml
@@ -46,3 +46,18 @@ jobs:
       - name: Test ingest
         run: go test ./...
         working-directory: apps/ingest
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          # Reclaim any root-owned files Docker may have left behind so the
+          # delete below can actually remove them.
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          # "until=1h" keeps cache layers a parallel job might still be using.
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/pr-checks-web.yml
+++ b/.github/workflows/pr-checks-web.yml
@@ -62,3 +62,18 @@ jobs:
           BETTER_AUTH_SECRET: dummy-secret-for-ci-build-only-at-least-32
           BETTER_AUTH_URL: http://localhost:3000
           NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          # Reclaim any root-owned files Docker may have left behind so the
+          # delete below can actually remove them.
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          # "until=1h" keeps cache layers a parallel job might still be using.
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -57,6 +57,18 @@ jobs:
           sarif_file: ${{ matrix.path }}/results.sarif
           category: gosec-${{ matrix.module }}
 
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
+
   semgrep:
     name: semgrep
     runs-on: self-hosted
@@ -104,6 +116,15 @@ jobs:
           sarif_file: semgrep.sarif
           category: semgrep
 
+      - name: Clean up runner disk
+        if: always()
+        # Runs inside the semgrep container — no docker access. Clear the
+        # mounted workspace so the next run starts on a clean slate.
+        run: |
+          set +e
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          exit 0
+
   trivy-fs:
     name: trivy (filesystem)
     runs-on: self-hosted
@@ -133,6 +154,20 @@ jobs:
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          # Trivy caches vulnerability DBs under ~/.cache/trivy — let it drop
+          # entries older than 1h so we don't re-download on every job.
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
 
   crypto-lint:
     name: crypto-lint (no weak hashes / ciphers)
@@ -180,6 +215,18 @@ jobs:
             exit 1
           fi
 
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0
+
   trivy-config:
     name: trivy (config / IaC)
     runs-on: self-hosted
@@ -207,3 +254,15 @@ jobs:
         with:
           sarif_file: trivy-config.sarif
           category: trivy-config
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -54,3 +54,15 @@ jobs:
               --report-format sarif \
               --report-path gitleaks.sarif
           fi
+
+      - name: Clean up runner disk
+        if: always()
+        run: |
+          set +e
+          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
+            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
+          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
+          rm -rf /tmp/digests 2>/dev/null || true
+          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
+          docker system prune -f --filter "until=1h" 2>/dev/null || true
+          exit 0


### PR DESCRIPTION
Merges current `main` into the PR #520 branch to resolve the conflicts that left it in a `dirty` mergeable state.

## Conflict

Only one real conflict: `.github/workflows/agent-release.yml`, where:

- **PR #520** (`claude/fix-duplicate-builds-0pL35`) appended two new reusable-workflow jobs — `build-web-image` and `build-ingest-image` — after the `bundle-web` job's final `Upload to release` step.
- **main** (via PR #519, `ci: clean up self-hosted runners after each job`) appended a `Clean up runner disk` step to the end of the `bundle-web` job at the same position.

Both regions claimed the same anchor line, so git marked the whole block as conflicting.

## Resolution

Kept both changes:

1. `Clean up runner disk` is retained as the last step of `bundle-web` (matching the pattern PR #519 applied to every other job in the file).
2. `build-web-image` and `build-ingest-image` are retained as new top-level jobs after `bundle-web`.

The other files changed on both sides (`docker-publish-web.yml`, `docker-publish-ingest.yml`, and the various `pr-checks-*`/`codeql`/`sast`/`secret-scan`/`deploy-docs` files) auto-merged cleanly — PR #519's additions sit at the end of each job and don't overlap with PR #520's `workflow_call` conversions.

Validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/agent-release.yml'))"`.

Merging this PR into `claude/fix-duplicate-builds-0pL35` will clear the conflict on #520.

https://claude.ai/code/session_01Je86CDt9E1Jnuymtbnijgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Je86CDt9E1Jnuymtbnijgs)_