### PR TITLE
ci(release): anchor apps/ingest to bootstrap-sha so release-please stops timing out

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,8 @@
       "component": "ingest",
       "tag-separator": "/",
       "include-component-in-tag": true,
-      "changelog-path": "apps/ingest/CHANGELOG.md"
+      "changelog-path": "apps/ingest/CHANGELOG.md",
+      "bootstrap-sha": "0e9528387c990e60e551f9826077519e363193f3"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes the `Release` workflow failing with `release-please failed: read ECONNRESET` on every push to main (runs #415 and #416, and every subsequent push until this lands).
- Root cause: PR #520 added `apps/ingest` as a new release-please package with `"apps/ingest": "0.1.0"` in `.release-please-manifest.json`, but no `ingest/v*` tag exists. Without an anchor tag and without a `bootstrap-sha`, release-please walks the entire commit history on every run, which hammers the GitHub API from the self-hosted runner long enough for the TCP connection to get reset.
- Fix: add `"bootstrap-sha": "0e9528387c990e60e551f9826077519e363193f3"` to the `apps/ingest` package entry. That's commit `0e95283` — the one that introduced apps/ingest to release-please — so the scan only looks at the handful of commits since then.

## Why everything else goes red too

Every downstream job in `agent-release.yml` (`build`, `bundle-web`, `build-web-image`, `build-ingest-image`) is gated on `needs.release-please.outputs.*_release_created`. When the `release-please` job errors out, those jobs get skipped and the whole workflow is marked as failed.

## Test plan

- [ ] Merge this PR — the resulting push to main triggers the Release workflow.
- [ ] `release-please` job completes successfully (no ECONNRESET).
- [ ] A release-please PR opens for the pending `feat(web):` / `fix(web):` commits from PR #523 (web bump) and, if applicable, a first `ingest/v0.1.0` release PR.
- [ ] No other workflow regressions (PR Checks, SAST, Secret Scan, CodeQL still green).

https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR)_