### PR TITLE
ci(release): revert apps/ingest release-please integration to unblock Release workflow

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -41,8 +41,6 @@ jobs:
       tag_name:               ${{ steps.release.outputs['agent--tag_name'] }}
       web_release_created:    ${{ steps.release.outputs['apps/web--release_created'] }}
       web_tag_name:           ${{ steps.release.outputs['apps/web--tag_name'] }}
-      ingest_release_created: ${{ steps.release.outputs['apps/ingest--release_created'] }}
-      ingest_tag_name:        ${{ steps.release.outputs['apps/ingest--tag_name'] }}
     steps:
       - name: Reset workspace ownership
         run: |
@@ -592,14 +590,3 @@ jobs:
       packages: write
     with:
       tag_name: ${{ needs.release-please.outputs.web_tag_name }}
-
-  build-ingest-image:
-    name: Build ingest image
-    needs: release-please
-    if: needs.release-please.outputs.ingest_release_created == 'true'
-    uses: ./.github/workflows/docker-publish-ingest.yml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      tag_name: ${{ needs.release-please.outputs.ingest_tag_name }}

--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -1,16 +1,30 @@
 name: Build and publish Docker image (ingest)
 
-# Invoked by agent-release.yml when release-please cuts a new `ingest/vX.Y.Z`
-# release. Must run inside the same workflow that release-please runs in —
-# tag pushes made with GITHUB_TOKEN do not trigger downstream workflows.
-
 on:
-  workflow_call:
-    inputs:
-      tag_name:
-        description: Release tag (e.g. ingest/v0.1.0). Used as the checkout ref and stripped of its `ingest/` prefix to tag the image.
-        required: true
-        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/ingest/**'
+      - 'agent/go.mod'
+      - 'agent/go.sum'
+      - 'proto/**'
+      - 'go.work'
+      - 'go.work.sum'
+      - '.release-please-manifest.json'
+      - '.github/workflows/docker-publish-ingest.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/ingest/**'
+      - 'agent/go.mod'
+      - 'agent/go.sum'
+      - 'proto/**'
+      - 'go.work'
+      - 'go.work.sum'
+      - '.release-please-manifest.json'
+      - '.github/workflows/docker-publish-ingest.yml'
 
 env:
   REGISTRY: ghcr.io
@@ -43,8 +57,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.tag_name }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -137,21 +149,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Derive version
-        id: version
-        env:
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: |
-          echo "value=${TAG_NAME#ingest/}" >> "$GITHUB_OUTPUT"
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/ingest
           tags: |
-            type=raw,value=${{ steps.version.outputs.value }}
-            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
   "agent": "0.30.0",
-  "apps/web": "0.64.1",
-  "apps/ingest": "0.1.0"
+  "apps/web": "0.64.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,14 +14,6 @@
       "tag-separator": "/",
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md"
-    },
-    "apps/ingest": {
-      "release-type": "simple",
-      "component": "ingest",
-      "tag-separator": "/",
-      "include-component-in-tag": true,
-      "changelog-path": "apps/ingest/CHANGELOG.md",
-      "bootstrap-sha": "0e9528387c990e60e551f9826077519e363193f3"
     }
   }
 }


### PR DESCRIPTION
## Summary

The bootstrap-sha anchor added in PR #524 didn't fix the `Release` workflow — release-please v17.3.0 still walks past the anchor and hits `read ECONNRESET` on the self-hosted runner while scanning ~100 merge commits looking for an `apps/ingest` release point that doesn't exist. Every push to main (#415, #416, #417) has failed the same way, which also blocks the agent binary release jobs and the web Docker image build because those are gated on release-please outputs.

The only reliable fix is to give release-please a real `ingest/v0.1.0` tag + GitHub Release to anchor against — but that has to be created through the GitHub UI and can't be done from CI. Until that happens, this reverts PR #520's ingest-specific release-please wiring so the rest of the release pipeline can run.

## What changes

- `release-please-config.json` / `.release-please-manifest.json`: drop the `apps/ingest` package entry (and the bootstrap-sha that didn't help).
- `.github/workflows/agent-release.yml`: drop the `ingest_release_created` / `ingest_tag_name` outputs and the `build-ingest-image` reusable-workflow invocation.
- `.github/workflows/docker-publish-ingest.yml`: restore the `push: main` + `pull_request` triggers (with the original path filters) so ingest Docker images keep publishing on every ingest-source change. The `Clean up runner disk` steps from PR #519 are preserved.

## Trade-off

PR #520's "ingest image rebuilds only on a release-please release" optimisation is lost. Ingest images go back to publishing sha-tagged + `latest` on every push to main that touches `apps/ingest/**`. Re-introducing per-release ingest builds needs a follow-up that first bootstraps an `ingest/v0.1.0` tag + release via the GitHub UI, then reverses this commit.

## Test plan

- [ ] PR checks are green (PR Checks, SAST, Secret Scan, CodeQL).
- [ ] After merge, `Release` workflow run on main completes successfully — release-please no longer ECONNRESETs.
- [ ] If release-please opens a "chore: release main" PR for pending `feat(web):` / `fix(web):` commits from PR #523, it merges cleanly.
- [ ] Ingest image build workflow triggers on the next push to `apps/ingest/**`.

https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR)_