### PR TITLE
ci(release): run release-please on GitHub-hosted runner to dodge self-hosted ECONNRESET

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -33,37 +33,25 @@ env:
 
 jobs:
   # ── Release PR management ────────────────────────────────────────────────
+  # Runs on a GitHub-hosted runner — the release-please action makes many
+  # GitHub API calls when walking the monorepo history, and the self-hosted
+  # runner's outbound connection to api.github.com has been killing those
+  # sessions with `read ECONNRESET` partway through. Hosted runners don't
+  # need the docker-based workspace-ownership reset or the buildx prune.
   release-please:
     name: Create or update release PR
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       release_created:        ${{ steps.release.outputs['agent--release_created'] }}
       tag_name:               ${{ steps.release.outputs['agent--tag_name'] }}
       web_release_created:    ${{ steps.release.outputs['apps/web--release_created'] }}
       web_tag_name:           ${{ steps.release.outputs['apps/web--tag_name'] }}
     steps:
-      - name: Reset workspace ownership
-        run: |
-          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
-            chown -R $(id -u):$(id -g) /ws 2>/dev/null || true
-
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Clean up runner disk
-        if: always()
-        run: |
-          set +e
-          docker run --rm -v "$GITHUB_WORKSPACE:/ws" alpine \
-            chown -R "$(id -u):$(id -g)" /ws 2>/dev/null || true
-          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
-          rm -rf /tmp/digests 2>/dev/null || true
-          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
-          docker system prune -f --filter "until=1h" 2>/dev/null || true
-          exit 0
 
   # ── Binary build matrix ──────────────────────────────────────────────────
   # Only runs when the release PR is merged (i.e. a real release was created).


### PR DESCRIPTION
## Summary

PR #525 removed `apps/ingest` from release-please, but Release run #418 (post-merge) still failed with the same `release-please failed: read ECONNRESET` error. So the ingest bootstrap scan wasn't the root cause — the failure is the self-hosted runner's outbound session to `api.github.com` being torn down mid-scan, regardless of which packages release-please is tracking.

release-please-action is just a Node process making API calls; it doesn't need self-hosted. Moving the `release-please` job to `ubuntu-latest` bypasses the flaky outbound connection entirely. The downstream `build` matrix, `bundle-web`, and `build-web-image` jobs still run on self-hosted with their existing runner-cleanup steps.

## Changes

- `.github/workflows/agent-release.yml`: set `release-please` job `runs-on: ubuntu-latest`.
- Drop the docker-based `Reset workspace ownership` and `Clean up runner disk` steps from this one job — hosted runners are ephemeral, no cleanup needed, and no self-hosted root-owned workspace to chown back.
- Added an in-file comment recording why the job lives on a hosted runner.

## Test plan

- [ ] PR checks are green.
- [ ] After merge, Release workflow run on main succeeds at the `release-please` step (no more ECONNRESET).
- [ ] If release-please opens a "chore: release main" PR for the pending `feat(web):` / `fix(web):` commits from PR #523, it merges cleanly and the subsequent Release run fires the `build`, `bundle-web`, and `build-web-image` jobs on self-hosted as before.

https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR)_