### PR TITLE
ci(release): re-enable apps/ingest release-please tracking (ingest/v0.1.0 anchor exists)

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -46,6 +46,8 @@ jobs:
       tag_name:               ${{ steps.release.outputs['agent--tag_name'] }}
       web_release_created:    ${{ steps.release.outputs['apps/web--release_created'] }}
       web_tag_name:           ${{ steps.release.outputs['apps/web--tag_name'] }}
+      ingest_release_created: ${{ steps.release.outputs['apps/ingest--release_created'] }}
+      ingest_tag_name:        ${{ steps.release.outputs['apps/ingest--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -578,3 +580,14 @@ jobs:
       packages: write
     with:
       tag_name: ${{ needs.release-please.outputs.web_tag_name }}
+
+  build-ingest-image:
+    name: Build ingest image
+    needs: release-please
+    if: needs.release-please.outputs.ingest_release_created == 'true'
+    uses: ./.github/workflows/docker-publish-ingest.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      tag_name: ${{ needs.release-please.outputs.ingest_tag_name }}

--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -1,30 +1,16 @@
 name: Build and publish Docker image (ingest)
 
+# Invoked by agent-release.yml when release-please cuts a new `ingest/vX.Y.Z`
+# release. Must run inside the same workflow that release-please runs in —
+# tag pushes made with GITHUB_TOKEN do not trigger downstream workflows.
+
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'apps/ingest/**'
-      - 'agent/go.mod'
-      - 'agent/go.sum'
-      - 'proto/**'
-      - 'go.work'
-      - 'go.work.sum'
-      - '.release-please-manifest.json'
-      - '.github/workflows/docker-publish-ingest.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'apps/ingest/**'
-      - 'agent/go.mod'
-      - 'agent/go.sum'
-      - 'proto/**'
-      - 'go.work'
-      - 'go.work.sum'
-      - '.release-please-manifest.json'
-      - '.github/workflows/docker-publish-ingest.yml'
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Release tag (e.g. ingest/v0.1.0). Used as the checkout ref and stripped of its `ingest/` prefix to tag the image.
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -57,6 +43,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag_name }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -149,14 +137,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Derive version
+        id: version
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          echo "value=${TAG_NAME#ingest/}" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/ingest
           tags: |
-            type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.version.outputs.value }}
+            type=raw,value=latest
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "agent": "0.30.0",
-  "apps/web": "0.65.0"
+  "apps/web": "0.65.0",
+  "apps/ingest": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,13 @@
       "tag-separator": "/",
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md"
+    },
+    "apps/ingest": {
+      "release-type": "simple",
+      "component": "ingest",
+      "tag-separator": "/",
+      "include-component-in-tag": true,
+      "changelog-path": "apps/ingest/CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
## Summary

Restores the per-release ingest image build cadence that PR #520 introduced and PR #525 rolled back. Now that an `ingest/v0.1.0` tag + GitHub Release exist at main HEAD, release-please has a real anchor for the apps/ingest path and won't have to bootstrap by walking the whole repo history — which was the behaviour that kept killing the self-hosted runner's GitHub API session with `read ECONNRESET`.

## Changes

- `release-please-config.json` + `.release-please-manifest.json`: re-add the `apps/ingest` package at `0.1.0`.
- `.github/workflows/agent-release.yml`: re-add the `ingest_release_created` / `ingest_tag_name` outputs and the `build-ingest-image` reusable-workflow invocation (gated on `ingest_release_created == 'true'`).
- `.github/workflows/docker-publish-ingest.yml`: convert back to a `workflow_call` reusable workflow driven by `tag_name` (image tagged `vX.Y.Z` + `latest`). The `push: main` + `pull_request` triggers that PR #525 restored as a stopgap go away — ingest images now build once per release-please release instead of on every ingest-source push.

The `release-please` job stays on `ubuntu-latest` from PR #526 — that is the actual fix for the ECONNRESET; this PR just layers the release-cadence wiring back on top.

## Test plan

- [ ] PR checks are green.
- [ ] After merge, Release workflow run on main succeeds at the `release-please` step (no more ECONNRESET; the new `ingest/v0.1.0` tag is the anchor).
- [ ] No `build-ingest-image` job fires on this push (no new ingest release).
- [ ] Next `fix(ingest):` or `feat(ingest):` on main opens a release-please PR for `ingest/v0.1.1` / `v0.2.0`; merging that PR fires the `build-ingest-image` reusable workflow once, publishing a properly-versioned + `latest` manifest to GHCR.

https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUyNVH9adZRx8F59f6raaR)_