### PR TITLE
ci(release): add workflow_dispatch to docker-publish workflows

### DIFF
--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -3,12 +3,23 @@ name: Build and publish Docker image (ingest)
 # Invoked by agent-release.yml when release-please cuts a new `ingest/vX.Y.Z`
 # release. Must run inside the same workflow that release-please runs in —
 # tag pushes made with GITHUB_TOKEN do not trigger downstream workflows.
+#
+# Also runnable manually via `workflow_dispatch` so an operator can rebuild
+# a published release if the release-please → reusable-workflow handoff ever
+# skips or fails. Provide `tag_name` (e.g. `ingest/v0.1.0`) to target a
+# specific release.
 
 on:
   workflow_call:
     inputs:
       tag_name:
         description: Release tag (e.g. ingest/v0.1.0). Used as the checkout ref and stripped of its `ingest/` prefix to tag the image.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to build (e.g. ingest/v0.1.0). Must already exist.
         required: true
         type: string
 

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -3,12 +3,23 @@ name: Build and publish Docker image (web)
 # Invoked by agent-release.yml when release-please cuts a new `web/vX.Y.Z`
 # release. Must run inside the same workflow that release-please runs in —
 # tag pushes made with GITHUB_TOKEN do not trigger downstream workflows.
+#
+# Also runnable manually via `workflow_dispatch` so an operator can rebuild
+# a published release if the release-please → reusable-workflow handoff ever
+# skips or fails. Provide `tag_name` (e.g. `web/v0.65.0`) to target a
+# specific release.
 
 on:
   workflow_call:
     inputs:
       tag_name:
         description: Release tag (e.g. web/v0.64.1). Used as the checkout ref and stripped of its `web/` prefix to tag the image.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to build (e.g. web/v0.65.0). Must already exist.
         required: true
         type: string
 


### PR DESCRIPTION
## Why

The release-please run on commit `92f0fc3` (release PR #527 merge) produced the `web/v0.65.0` GitHub Release but **skipped every downstream job**: `Build web image`, `Build ingest image`, `Customer bundle (web)`, and the agent binary matrix. The workflow graph shows all three conditional jobs greyed out, with `release-please` itself finishing in 17s and reporting Success — meaning the `if: needs.release-please.outputs.*_release_created == 'true'` gates evaluated to false.

Re-running the workflow does not recover: release-please is idempotent, and on re-run it sees `web/v0.65.0` already exists and again emits `false` for the release-created outputs. The image never publishes.

## What this PR does

Add `workflow_dispatch` (alongside the existing `workflow_call`) to both `docker-publish-web.yml` and `docker-publish-ingest.yml`, with a `tag_name` input that mirrors the `workflow_call` schema. Because both triggers declare the same input, `inputs.tag_name` resolves identically and **no other job logic changes** — the manual path runs exactly the same steps as the automatic path.

## How we recover `v0.65.0`

Once merged, in the Actions UI:

1. Open **Build and publish Docker image (web)**.
2. Click **Run workflow**.
3. Enter `tag_name = web/v0.65.0`.
4. Run.

This checks out the `web/v0.65.0` tag, builds linux/amd64 + linux/arm64, and pushes the multi-arch manifest to GHCR tagged `v0.65.0` and `latest`.

## Why this is the permanent fix

The automatic release-please → reusable-workflow chain depends on a single workflow run producing the right outputs and the reusable workflow firing cleanly in the same run. Any slip — release-please output oddity, runner unavailability, timing of the v4 action — and the release is stranded with no recovery path short of cutting a new version. A manual `workflow_dispatch` on the same reusable workflow decouples recovery from release-please and makes the pipeline resilient to exactly this failure class.

## Follow-up (out of scope)

The `Customer bundle (web)` job lives inline in `agent-release.yml`, not in a reusable workflow, so it can't be recovered the same way. If this failure class recurs, that job should be extracted into its own reusable workflow with `workflow_dispatch` too. Noted but not fixed here — keeping this PR surgical.

## Test plan

- [ ] Merge PR.
- [ ] Run **Build and publish Docker image (web)** workflow with `tag_name = web/v0.65.0`.
- [ ] Verify `ghcr.io/carrtech-dev/ct-ops/web:v0.65.0` and `:latest` pull cleanly.
- [ ] Pull `:v0.65.0` and sanity-check the image renders the new Bundlers → Jenkins tab.

https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL)_