### PR TITLE
ci(release): release-event fallback trigger + move merge jobs off self-hosted

### DIFF
--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -135,7 +135,12 @@ jobs:
   merge-ingest:
     name: Merge ingest image manifests
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'ingest/')
-    runs-on: self-hosted
+    # Hosted runner: this job is the single point of failure for the
+    # final manifest tag, and a self-hosted outage here strands a release
+    # even when both arch builds succeeded. The job is tiny — a few
+    # seconds of `docker buildx imagetools create` — so the GH-minute
+    # cost is negligible compared to the reliability gain.
+    runs-on: ubuntu-latest
     needs: build-ingest
     permissions:
       contents: read
@@ -148,9 +153,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Clean digests directory
-        run: rm -rf /tmp/digests
 
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -182,13 +184,3 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}/ingest@sha256:%s ' *)
-
-      - name: Clean up runner disk
-        if: always()
-        run: |
-          set +e
-          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
-          rm -rf /tmp/digests 2>/dev/null || true
-          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
-          docker system prune -f --filter "until=1h" 2>/dev/null || true
-          exit 0

--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -1,13 +1,18 @@
 name: Build and publish Docker image (ingest)
 
-# Invoked by agent-release.yml when release-please cuts a new `ingest/vX.Y.Z`
-# release. Must run inside the same workflow that release-please runs in —
-# tag pushes made with GITHUB_TOKEN do not trigger downstream workflows.
+# Three trigger paths, all of which build the same image from the same
+# release tag — belt-and-braces because each path has its own failure mode:
 #
-# Also runnable manually via `workflow_dispatch` so an operator can rebuild
-# a published release if the release-please → reusable-workflow handoff ever
-# skips or fails. Provide `tag_name` (e.g. `ingest/v0.1.0`) to target a
-# specific release.
+#   1. workflow_call from agent-release.yml when release-please cuts a new
+#      `ingest/vX.Y.Z` release. Primary path, in-process with release-please.
+#   2. release: { types: [published] } — fires off the GitHub Release
+#      creation event itself, so even if the in-workflow handoff above
+#      silently skips, the build still happens. Filtered with a job-level
+#      `if:` so only `ingest/v*` releases trigger the ingest image.
+#   3. workflow_dispatch — manual one-click rebuild of any published tag.
+#
+# Concurrent firings of (1) and (2) are safe: both push the same
+# content-addressed digest to the same multi-arch manifest tag.
 
 on:
   workflow_call:
@@ -22,14 +27,22 @@ on:
         description: Release tag to build (e.g. ingest/v0.1.0). Must already exist.
         required: true
         type: string
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/ct-ops
+  # Resolved once at workflow level so steps don't have to re-derive it.
+  # `inputs` is undefined on the `release` trigger, so the `||` falls
+  # through to the release payload's tag.
+  TAG_NAME: ${{ inputs.tag_name || github.event.release.tag_name }}
 
 jobs:
   build-ingest:
     name: Build ingest image (${{ matrix.platform }})
+    # Only act on ingest/* releases — `release` events fire for every tag.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'ingest/')
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -55,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ env.TAG_NAME }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -121,6 +134,7 @@ jobs:
 
   merge-ingest:
     name: Merge ingest image manifests
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'ingest/')
     runs-on: self-hosted
     needs: build-ingest
     permissions:
@@ -150,8 +164,6 @@ jobs:
 
       - name: Derive version
         id: version
-        env:
-          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           echo "value=${TAG_NAME#ingest/}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -139,7 +139,12 @@ jobs:
   merge-web:
     name: Merge web image manifests
     if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'web/')
-    runs-on: self-hosted
+    # Hosted runner: this job is the single point of failure for the
+    # final manifest tag, and a self-hosted outage here strands a release
+    # even when both arch builds succeeded. The job is tiny — a few
+    # seconds of `docker buildx imagetools create` — so the GH-minute
+    # cost is negligible compared to the reliability gain.
+    runs-on: ubuntu-latest
     needs: build-web
     permissions:
       contents: read
@@ -152,9 +157,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Clean digests directory
-        run: rm -rf /tmp/digests
 
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -186,13 +188,3 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}/web@sha256:%s ' *)
-
-      - name: Clean up runner disk
-        if: always()
-        run: |
-          set +e
-          find "$GITHUB_WORKSPACE" -mindepth 1 -delete 2>/dev/null || true
-          rm -rf /tmp/digests 2>/dev/null || true
-          docker buildx prune -f --filter "until=1h" 2>/dev/null || true
-          docker system prune -f --filter "until=1h" 2>/dev/null || true
-          exit 0

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -1,13 +1,21 @@
 name: Build and publish Docker image (web)
 
-# Invoked by agent-release.yml when release-please cuts a new `web/vX.Y.Z`
-# release. Must run inside the same workflow that release-please runs in —
-# tag pushes made with GITHUB_TOKEN do not trigger downstream workflows.
+# Three trigger paths, all of which build the same image from the same
+# release tag — belt-and-braces because each path has its own failure mode:
 #
-# Also runnable manually via `workflow_dispatch` so an operator can rebuild
-# a published release if the release-please → reusable-workflow handoff ever
-# skips or fails. Provide `tag_name` (e.g. `web/v0.65.0`) to target a
-# specific release.
+#   1. workflow_call from agent-release.yml when release-please cuts a new
+#      `web/vX.Y.Z` release. This is the primary path, in-process with
+#      release-please so it sees the just-created tag immediately.
+#   2. release: { types: [published] } — fires off the GitHub Release
+#      creation event itself, so even if the in-workflow handoff above
+#      silently skips (e.g. release-please-action emits an empty
+#      `release_created` output), the build still happens. Filtered with a
+#      job-level `if:` so only `web/v*` releases trigger the web image.
+#   3. workflow_dispatch — manual one-click rebuild of any published tag,
+#      for recovering from upstream-runner failures or re-issuing an image.
+#
+# Concurrent firings of (1) and (2) are safe: both push the same
+# content-addressed digest to the same multi-arch manifest tag.
 
 on:
   workflow_call:
@@ -22,14 +30,23 @@ on:
         description: Release tag to build (e.g. web/v0.65.0). Must already exist.
         required: true
         type: string
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/ct-ops
+  # Resolved once at workflow level so steps don't have to re-derive it.
+  # `inputs` is undefined on the `release` trigger, so the `||` falls
+  # through to the release payload's tag.
+  TAG_NAME: ${{ inputs.tag_name || github.event.release.tag_name }}
 
 jobs:
   build-web:
     name: Build web image (${{ matrix.platform }})
+    # Only act on web/* releases — `release` events fire for every tag in
+    # the repo, including agent/* and ingest/*.
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'web/')
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -55,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ env.TAG_NAME }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -121,6 +138,7 @@ jobs:
 
   merge-web:
     name: Merge web image manifests
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'web/')
     runs-on: self-hosted
     needs: build-web
     permissions:
@@ -150,8 +168,6 @@ jobs:
 
       - name: Derive version
         id: version
-        env:
-          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           echo "value=${TAG_NAME#web/}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Closes the two failure modes that caused **web/v0.65.0** to be tagged
without a corresponding image on GHCR. After this PR there are three
independent paths that can publish the image, and the manifest-merge
job no longer depends on the self-hosted runner pool.

## Failure modes addressed

**1. release-please → reusable-workflow handoff silently skips.**
The current trigger is `workflow_call` invoked from `agent-release.yml`
gated on `needs.release-please.outputs.web_release_created == 'true'`.
If `release-please-action` ever emits an empty/false value on the run
that creates the release (which is what we suspect happened for
v0.65.0 — release tagged, image build skipped), the build is silently
not triggered.

**2. Self-hosted runner is offline / flaky during the merge step.**
Both arch builds can succeed but the merge job that creates the
multi-arch manifest tag was on `runs-on: self-hosted`. A runner outage
there strands the release with two orphan digests and no
`vX.Y.Z` / `latest` tag pointing at them.

## Changes

### Commit A — release-event trigger as fallback path

Adds `release: { types: [published] }` to both
`docker-publish-web.yml` and `docker-publish-ingest.yml`, plus a
job-level `if:` that filters on tag prefix so the web workflow only
acts on `web/*` releases (and ingest on `ingest/*`). Tag resolution
moved to a single workflow-level `TAG_NAME: ${{ inputs.tag_name ||
github.event.release.tag_name }}` so all three triggers
(`workflow_call`, `workflow_dispatch`, `release`) share the same
downstream code paths.

If both path A (release-please handoff) and path B (release event)
fire for the same release, both runs push the same content-addressed
digest to the same multi-arch tag — safe and idempotent. Worst case is
one duplicate run.

### Commit B — manifest-merge off self-hosted

`merge-web` and `merge-ingest` move from `runs-on: self-hosted` to
`runs-on: ubuntu-latest`. The job is `docker buildx imagetools create`
plus a digest download — seconds of runner time — so the GH-minute
cost is trivial against the reliability improvement. Workspace cleanup
steps that only existed for the self-hosted case are dropped.

The bigger `build-{web,ingest}` amd64 leg stays on self-hosted for now
to keep that cost profile unchanged; can be hoisted later if amd64
itself becomes unreliable.

## Resulting paths to a published image

```
                                ┌─ workflow_call (release-please handoff)
release-please cuts release ───┼─ release: published      ◀── new fallback
                                └─ workflow_dispatch       ◀── manual recovery
```

Any one of three is enough; all three would be safe.

## Test plan

- [ ] PR checks green.
- [ ] After merge, verify the next `web/v*` release in main lights up
      both the `workflow_call` invocation **and** a separate
      release-event run (intentional duplicate, both should succeed and
      push the same digest).
- [ ] Confirm `merge-web` runs on `ubuntu-latest`.
- [ ] Sanity: re-trigger `workflow_dispatch` with `tag_name=web/v0.65.0`
      to make sure the manual recovery path still works after the
      tag-resolution refactor.

https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL)_