### PR TITLE
fix(web): Jenkins bundler — live Java requirement, allow WAR-only

### DIFF
--- a/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
@@ -43,6 +43,7 @@ type Report = {
   core: {
     version: string
     minimumJava: number
+    javaSource: 'updates.jenkins.io' | 'estimated'
     javaCompatible: boolean | null
     warUrl: string | null
   }
@@ -215,14 +216,11 @@ export function JenkinsBundler() {
     setResolveError(null)
     setReport(null)
     setDownloadError(null)
+    // Empty plugin list is allowed — bundling just the WAR is a valid use.
     const pluginList = pluginsText
       .split(/\r?\n|,/)
       .map((s) => s.trim())
       .filter((s) => s.length > 0 && !s.startsWith('#'))
-    if (pluginList.length === 0) {
-      setResolveError('Enter at least one plugin name')
-      return
-    }
     if (!/^\d+\.\d+(\.\d+)?$/.test(coreVersion.trim())) {
       setResolveError('Enter a valid Jenkins core version, e.g. 2.462.3')
       return
@@ -251,6 +249,7 @@ export function JenkinsBundler() {
         core: {
           version: resolved.coreVersion,
           minimumJava: resolved.coreMinimumJava,
+          javaSource: resolved.coreJavaSource,
           javaCompatible: resolved.javaCompatible,
           warUrl: resolved.warUrl,
         },
@@ -428,7 +427,7 @@ export function JenkinsBundler() {
               </div>
               <Textarea
                 id="plugins"
-                placeholder={'One plugin short name per line, e.g.\ngit\ncredentials\nworkflow-aggregator\n…'}
+                placeholder={'One plugin short name per line, e.g.\ngit\ncredentials\nworkflow-aggregator\n…\n\n(Leave blank to bundle just the WAR.)'}
                 value={pluginsText}
                 onChange={(e) => setPluginsText(e.target.value)}
                 rows={10}
@@ -438,6 +437,7 @@ export function JenkinsBundler() {
               <p className="text-xs text-muted-foreground">
                 Use the plugin <em>short name</em> (not the display name). Lines beginning with <code>#</code> are ignored,
                 and <code>name:version</code> pins are tolerated but the latest compatible version is always selected.
+                Leave the field empty to bundle just the WAR file.
               </p>
             </div>
 
@@ -457,7 +457,7 @@ export function JenkinsBundler() {
               <Button
                 type="button"
                 onClick={downloadBundle}
-                disabled={!report || downloading || compatibleCount === 0}
+                disabled={!report || downloading || totalToDownload === 0}
                 variant="default"
               >
                 {downloading ? (
@@ -551,7 +551,10 @@ function ReportCard({
           </div>
           <div>
             <span className="text-muted-foreground">Minimum Java for WAR: </span>
-            <span className="font-mono">Java {report.core.minimumJava}+</span>
+            <span className="font-mono">Java {report.core.minimumJava}+</span>{' '}
+            <span className="text-xs text-muted-foreground">
+              ({report.core.javaSource === 'updates.jenkins.io' ? 'from updates.jenkins.io' : 'estimated — upstream catalogue did not cover this version'})
+            </span>
           </div>
           <div className="sm:col-span-2">
             <span className="text-muted-foreground">WAR download: </span>
@@ -584,11 +587,20 @@ function ReportCard({
           </Alert>
         )}
 
-        <div className="flex flex-wrap gap-2 text-xs">
-          <Badge className="bg-emerald-600 hover:bg-emerald-600">{compatibleCount} compatible</Badge>
-          {incompatibleCount > 0 && <Badge variant="destructive">{incompatibleCount} incompatible / missing</Badge>}
-        </div>
+        {report.plugins.length > 0 && (
+          <div className="flex flex-wrap gap-2 text-xs">
+            <Badge className="bg-emerald-600 hover:bg-emerald-600">{compatibleCount} compatible</Badge>
+            {incompatibleCount > 0 && <Badge variant="destructive">{incompatibleCount} incompatible / missing</Badge>}
+          </div>
+        )}
 
+        {report.plugins.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            No plugins requested — the bundle will contain just the WAR file.
+          </p>
+        )}
+
+        {report.plugins.length > 0 && (
         <div className="overflow-x-auto rounded-md border">
           <Table>
             <TableHeader>
@@ -633,6 +645,7 @@ function ReportCard({
             </TableBody>
           </Table>
         </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/apps/web/app/api/tools/jenkins-bundler/route.ts
+++ b/apps/web/app/api/tools/jenkins-bundler/route.ts
@@ -28,6 +28,11 @@ export type ResolveResponse = {
   ok: true
   coreVersion: string
   coreMinimumJava: number
+  // Where the `coreMinimumJava` value came from. Surfaced to the UI so the
+  // user knows whether the answer is the upstream-authoritative one or a
+  // local best-guess (e.g. when updates.jenkins.io has no per-version
+  // catalogue for the requested WAR).
+  coreJavaSource: 'updates.jenkins.io' | 'estimated'
   javaCompatible: boolean | null
   warUrl: string | null
   plugins: ResolvedPlugin[]
@@ -43,7 +48,8 @@ const LatestLtsSchema = z.object({ action: z.literal('latest-lts') })
 const ResolveSchema = z.object({
   action: z.literal('resolve'),
   coreVersion: z.string().regex(/^\d+\.\d+(\.\d+)?$/, 'Expected version like 2.462.3'),
-  plugins: z.array(z.string().min(1).max(200)).min(1).max(500),
+  // Empty plugin list is allowed — a user can bundle just the WAR.
+  plugins: z.array(z.string().min(1).max(200)).max(500),
   javaVersion: z.number().int().min(1).max(99).optional(),
 })
 
@@ -161,7 +167,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       getUpdateCenterForCore(coreVersion),
       resolveWarUrl(coreVersion),
     ])
-    const coreMinimumJava = minimumJavaForCore(coreVersion)
+
+    // Prefer the live answer from updates.jenkins.io's per-version catalogue,
+    // but only when its `core.version` matched the user's request. Otherwise
+    // (no per-version catalogue, or the action fell back to "current") we
+    // can't trust that field for this WAR, and we fall back to the local
+    // baseline table — flagged as `estimated` so the UI can say so.
+    const liveJava = uc.coreVersionMatches ? extractJavaMajor(uc.coreRequiredJavaVersion) : null
+    const coreMinimumJava = liveJava ?? minimumJavaForCore(coreVersion)
+    const coreJavaSource: ResolveResponse['coreJavaSource'] =
+      liveJava != null ? 'updates.jenkins.io' : 'estimated'
     const javaCompatible = javaVersion == null ? null : javaVersion >= coreMinimumJava
 
     const resolved = resolvePlugins(requested, coreVersion, uc.plugins, javaVersion ?? null)
@@ -170,6 +185,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       ok: true,
       coreVersion,
       coreMinimumJava,
+      coreJavaSource,
       javaCompatible,
       warUrl,
       plugins: resolved,

--- a/apps/web/lib/jenkins/update-center.ts
+++ b/apps/web/lib/jenkins/update-center.ts
@@ -25,6 +25,12 @@ export type UpdateCenterPlugin = {
 
 export type UpdateCenter = {
   coreVersion: string
+  // True iff the catalogue we successfully fetched is for the exact core
+  // version requested. Only when this is true should `coreRequiredJavaVersion`
+  // be trusted as the authoritative answer for the user's WAR — otherwise
+  // we've fallen back to a broader catalogue whose `core` describes a
+  // different version.
+  coreVersionMatches: boolean
   coreRequiredJavaVersion?: string
   plugins: Record<string, UpdateCenterPlugin>
 }
@@ -93,14 +99,19 @@ export async function getLatestLtsVersion(): Promise<string> {
 /**
  * Fetches the update-center catalogue for a specific core version.
  *
- * Jenkins serves per-version catalogues under dynamic-stable-X (for LTS lines)
- * and dynamic-X (for weekly). If neither path exists we fall back to the
- * "current" catalogue, which may list plugins whose `requiredCore` exceeds
- * the user's core — consumers filter on that field.
+ * Jenkins infrastructure (`update-center2`) generates `dynamic-{version}`
+ * catalogues per published core release, and the catalogue's `core` object
+ * describes that exact core (including `requiredJavaVersion`). We query
+ * that endpoint first so the Java requirement comes from upstream, not a
+ * stale local table. If the per-version endpoint isn't published (rare,
+ * but possible for one-off weeklies), we fall back to the "current"
+ * catalogue — which is fine for resolving plugin compatibility but its
+ * `core` describes a different version, so we mark the result with
+ * `coreVersionMatches: false` and the caller treats `coreRequiredJavaVersion`
+ * as untrustworthy.
  */
 export async function getUpdateCenterForCore(coreVersion: string): Promise<UpdateCenter> {
   const candidates = [
-    `${JENKINS_UPDATE_BASE}/dynamic-stable-${coreVersion}/update-center.actual.json`,
     `${JENKINS_UPDATE_BASE}/dynamic-${coreVersion}/update-center.actual.json`,
     `${JENKINS_UPDATE_BASE}/current/update-center.actual.json`,
   ]
@@ -137,9 +148,11 @@ export async function getUpdateCenterForCore(coreVersion: string): Promise<Updat
     }
   }
 
+  const matches = raw.core?.version === coreVersion
   return {
     coreVersion: raw.core?.version ?? coreVersion,
-    coreRequiredJavaVersion: raw.core?.requiredJavaVersion,
+    coreVersionMatches: matches,
+    coreRequiredJavaVersion: matches ? raw.core?.requiredJavaVersion : undefined,
     plugins,
   }
 }


### PR DESCRIPTION
## Summary

Two bugs in the Jenkins tab of *Tooling → Air-gap Bundlers*.

### 1. Java-version compatibility used a stale local table

The previous code consulted a hand-maintained `JAVA_BASELINES` table in
`update-center.ts` rather than the upstream catalogue. Every time
Jenkins moves a JDK floor (most recently between 2.479 → 2.555), that
table is wrong until someone updates it. Reported case: Jenkins 2.555.1
was being marked Java-17-compatible when it isn't.

Fix: query `core.requiredJavaVersion` from
`https://updates.jenkins.io/dynamic-{version}/update-center.actual.json`
— the per-version catalogue Jenkins publishes for every released core —
and trust upstream.

The catalogue lookup falls back to `current/update-center.actual.json`
if the per-version one isn't published (rare, but possible for one-off
weeklies). When we fall back, the `core` block describes a different
Jenkins, so we now track `coreVersionMatches: boolean` and only treat
`coreRequiredJavaVersion` as authoritative when it's `true`. The local
baseline table is kept as a last-ditch fallback, but the response
surfaces `coreJavaSource: 'updates.jenkins.io' | 'estimated'` so the UI
can label the answer accordingly.

Also dropped the bogus `dynamic-stable-{version}` candidate URL — that
path isn't actually published by Jenkins infra.

### 2. Zero-plugin bundles were rejected

A user who only needs the WAR (e.g. air-gap upgrade where plugins are
already in place) couldn't get past the resolve step — the schema
required at least one plugin name. Allow zero plugins end-to-end:

- `z.array(...).min(1)` → `.max(500)` only on the API schema.
- Drop the "Enter at least one plugin name" client-side guard.
- Download button now disables on `totalToDownload === 0` instead of
  `compatibleCount === 0`, so an available WAR alone is enough.
- The plugin compatibility badges and the per-plugin table are hidden
  when no plugins were requested; a single line of helper text replaces
  them.
- The textarea placeholder and the helper paragraph mention the WAR-only
  mode.

## Test plan

- [ ] Resolve `2.555.1` with no Java specified → report shows
      `Java X+ (from updates.jenkins.io)` with whatever upstream says.
- [ ] Resolve `2.555.1` with Java `17` → red banner if upstream says
      Java ≥18 is required, green banner otherwise. Either way, the
      number on the banner matches the upstream value.
- [ ] Resolve a known LTS like `2.462.3` with empty plugin list →
      compatibility report renders with no plugin table, Download
      button enables, downloaded zip contains `jenkins.war` +
      `bundle-manifest.json` and an empty `plugins/` (or no plugins/
      folder at all).
- [ ] Resolve a one-off weekly that updates.jenkins.io has no per-version
      catalogue for → Java requirement is labelled `(estimated — upstream
      catalogue did not cover this version)`.

https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL)_