### PR TITLE
fix(ingest): set ReadHeaderTimeout on JWKS/healthz HTTP server

### DIFF
--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -126,8 +126,19 @@ func main() {
 		})
 		mux.Handle("/ws/terminal/", terminalWSHandler)
 		addr := fmt.Sprintf(":%d", cfg.HTTPPort)
+		// Explicit Server so we can set ReadHeaderTimeout — without it a slow
+		// client can hold a connection open indefinitely while dribbling
+		// header bytes (gosec G114, "Slowloris"). Read/Write/IdleTimeout are
+		// intentionally left at zero: the same mux serves the
+		// /ws/terminal/ WebSocket upgrade, whose post-upgrade connections
+		// must stay open for the lifetime of the terminal session.
+		srv := &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
 		slog.Info("JWKS HTTP server starting", "addr", addr)
-		if err := http.ListenAndServe(addr, mux); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("JWKS server error", "err", err)
 		}
 	}()


### PR DESCRIPTION
## Summary

`apps/ingest/cmd/ingest/main.go` uses `http.ListenAndServe` for the
JWKS / healthz / WebSocket-terminal HTTP server. That constructor
ships with no `ReadHeaderTimeout`, so a slow client can hold a
connection open indefinitely while dribbling header bytes — the classic
Slowloris exposure (gosec G114).

Switch to an explicit `http.Server{ReadHeaderTimeout: 10s}` wrapping
the same mux. **Read/Write/Idle timeouts are deliberately left at zero**
because the same mux serves `/ws/terminal/`, whose post-upgrade
WebSocket connections must stay open for the lifetime of the terminal
session — applying a short ReadTimeout there would silently tear down
active shells.

Local `go build ./...` clean.

## Why now

This is a real, low-risk security fix. It's also the trigger we need:
once it merges, release-please will open an `apps/ingest` release PR
for `ingest/v0.1.1`, and merging that will exercise the
release-please → image-build pipeline for ingest end-to-end (same path
that proved working for web/v0.65.1 earlier today). At that point
`ghcr.io/carrtech-dev/ct-ops/ingest:v0.1.1` should land on GHCR via
either the `workflow_call` handoff or the `release: published` fallback
that PR #530 added.

## Test plan

- [ ] PR checks green (gosec G114 finding for this line should clear).
- [ ] After merge, release-please opens "chore: release main" with an
      `ingest/v0.1.1` bump.
- [ ] After merging that PR, `ghcr.io/carrtech-dev/ct-ops/ingest:v0.1.1`
      manifest exists with both linux/amd64 + linux/arm64; `:latest`
      retags to point at the same digest.
- [ ] Smoke: post-merge ingest container responds 200 on `/healthz` and
      a terminal WebSocket session stays connected past the 10s
      ReadHeaderTimeout window (proving we didn't accidentally apply
      a timeout to post-upgrade traffic).

https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2YsWDUmR6ogkCbtsPangL)_