### PR TITLE
fix(web): Jenkins bundler — query LTS catalogue, drop hard-coded Java baselines

### DIFF
--- a/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
@@ -42,8 +42,8 @@ type PluginRow = ResolvedPlugin & {
 type Report = {
   core: {
     version: string
-    minimumJava: number
-    javaSource: 'updates.jenkins.io' | 'estimated'
+    minimumJava: number | null
+    javaSource: 'updates.jenkins.io' | 'unavailable'
     javaCompatible: boolean | null
     warUrl: string | null
   }
@@ -551,10 +551,16 @@ function ReportCard({
           </div>
           <div>
             <span className="text-muted-foreground">Minimum Java for WAR: </span>
-            <span className="font-mono">Java {report.core.minimumJava}+</span>{' '}
-            <span className="text-xs text-muted-foreground">
-              ({report.core.javaSource === 'updates.jenkins.io' ? 'from updates.jenkins.io' : 'estimated — upstream catalogue did not cover this version'})
-            </span>
+            {report.core.minimumJava != null ? (
+              <>
+                <span className="font-mono">Java {report.core.minimumJava}+</span>{' '}
+                <span className="text-xs text-muted-foreground">(from updates.jenkins.io)</span>
+              </>
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                Could not determine — updates.jenkins.io has no catalogue for this WAR
+              </span>
+            )}
           </div>
           <div className="sm:col-span-2">
             <span className="text-muted-foreground">WAR download: </span>
@@ -568,7 +574,7 @@ function ReportCard({
           </div>
         </div>
 
-        {javaOk === false && (
+        {javaOk === false && report.core.minimumJava != null && (
           <Alert variant="destructive">
             <AlertTriangle className="size-4" />
             <AlertTitle>Java version is too old for this WAR</AlertTitle>
@@ -577,12 +583,31 @@ function ReportCard({
             </AlertDescription>
           </Alert>
         )}
-        {javaOk === true && (
+        {javaOk === true && report.core.minimumJava != null && (
           <Alert>
             <CheckCircle2 className="size-4" />
             <AlertTitle>Java version looks compatible</AlertTitle>
             <AlertDescription>
               Jenkins {report.core.version} needs Java {report.core.minimumJava}+; you specified a compatible version.
+            </AlertDescription>
+          </Alert>
+        )}
+        {report.core.javaSource === 'unavailable' && (
+          <Alert>
+            <AlertTriangle className="size-4" />
+            <AlertTitle>Java compatibility could not be checked</AlertTitle>
+            <AlertDescription>
+              updates.jenkins.io did not return a catalogue for Jenkins {report.core.version}, so
+              we can&apos;t confirm the minimum Java version. Check{' '}
+              <a
+                href="https://www.jenkins.io/doc/book/platform-information/support-policy-java/"
+                className="underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                jenkins.io&apos;s Java support policy
+              </a>{' '}
+              before deploying this WAR.
             </AlertDescription>
           </Alert>
         )}

--- a/apps/web/app/api/tools/jenkins-bundler/route.ts
+++ b/apps/web/app/api/tools/jenkins-bundler/route.ts
@@ -4,7 +4,6 @@ import {
   type UpdateCenterPlugin,
   getLatestLtsVersion,
   getUpdateCenterForCore,
-  minimumJavaForCore,
   resolveWarUrl,
 } from '@/lib/jenkins/update-center'
 import { compareVersions } from '@/lib/version-compare'
@@ -27,12 +26,13 @@ export type ResolvedPlugin = {
 export type ResolveResponse = {
   ok: true
   coreVersion: string
-  coreMinimumJava: number
-  // Where the `coreMinimumJava` value came from. Surfaced to the UI so the
-  // user knows whether the answer is the upstream-authoritative one or a
-  // local best-guess (e.g. when updates.jenkins.io has no per-version
-  // catalogue for the requested WAR).
-  coreJavaSource: 'updates.jenkins.io' | 'estimated'
+  // Null when updates.jenkins.io did not publish a per-version catalogue for
+  // the requested WAR, in which case we have no authoritative answer and we
+  // refuse to guess. The UI surfaces this as "could not determine".
+  coreMinimumJava: number | null
+  coreJavaSource: 'updates.jenkins.io' | 'unavailable'
+  // Null when either the user didn't specify a Java version, or we couldn't
+  // determine the WAR's requirement.
   javaCompatible: boolean | null
   warUrl: string | null
   plugins: ResolvedPlugin[]
@@ -168,16 +168,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       resolveWarUrl(coreVersion),
     ])
 
-    // Prefer the live answer from updates.jenkins.io's per-version catalogue,
-    // but only when its `core.version` matched the user's request. Otherwise
-    // (no per-version catalogue, or the action fell back to "current") we
-    // can't trust that field for this WAR, and we fall back to the local
-    // baseline table — flagged as `estimated` so the UI can say so.
+    // The only Java-requirement source we trust is updates.jenkins.io's
+    // per-version catalogue, and only when its `core.version` matches the
+    // user's WAR. If the catalogue isn't published for this version (or only
+    // the "current" weekly catalogue responded), we report `unavailable`
+    // rather than guessing.
     const liveJava = uc.coreVersionMatches ? extractJavaMajor(uc.coreRequiredJavaVersion) : null
-    const coreMinimumJava = liveJava ?? minimumJavaForCore(coreVersion)
+    const coreMinimumJava = liveJava
     const coreJavaSource: ResolveResponse['coreJavaSource'] =
-      liveJava != null ? 'updates.jenkins.io' : 'estimated'
-    const javaCompatible = javaVersion == null ? null : javaVersion >= coreMinimumJava
+      liveJava != null ? 'updates.jenkins.io' : 'unavailable'
+    const javaCompatible =
+      javaVersion == null || coreMinimumJava == null ? null : javaVersion >= coreMinimumJava
 
     const resolved = resolvePlugins(requested, coreVersion, uc.plugins, javaVersion ?? null)
 

--- a/apps/web/lib/jenkins/update-center.ts
+++ b/apps/web/lib/jenkins/update-center.ts
@@ -6,8 +6,6 @@
  * All network access goes through this module so the API route stays thin
  * and the URL allow-list lives in one place.
  */
-import { compareVersions } from '@/lib/version-compare'
-
 const JENKINS_UPDATE_BASE = 'https://updates.jenkins.io'
 const JENKINS_DOWNLOAD_BASE = 'https://get.jenkins.io'
 
@@ -99,19 +97,22 @@ export async function getLatestLtsVersion(): Promise<string> {
 /**
  * Fetches the update-center catalogue for a specific core version.
  *
- * Jenkins infrastructure (`update-center2`) generates `dynamic-{version}`
- * catalogues per published core release, and the catalogue's `core` object
- * describes that exact core (including `requiredJavaVersion`). We query
- * that endpoint first so the Java requirement comes from upstream, not a
- * stale local table. If the per-version endpoint isn't published (rare,
- * but possible for one-off weeklies), we fall back to the "current"
- * catalogue — which is fine for resolving plugin compatibility but its
- * `core` describes a different version, so we mark the result with
- * `coreVersionMatches: false` and the caller treats `coreRequiredJavaVersion`
- * as untrustworthy.
+ * Jenkins infrastructure (`update-center2`) publishes per-version catalogues
+ * under two prefixes: `dynamic-stable-{version}` for LTS releases (e.g.
+ * `2.555.1`) and `dynamic-{version}` for weekly releases (e.g. `2.543`).
+ * Both catalogues' `core` object describes that exact core including the
+ * authoritative `requiredJavaVersion` for that WAR. We try the LTS path
+ * first because that's what users select via the "Latest LTS" button, then
+ * fall through to the weekly path, and finally to the "current" catalogue.
+ * The "current" catalogue is fine for resolving plugin compatibility but its
+ * `core` describes the latest weekly — never the user's chosen WAR — so we
+ * mark the result with `coreVersionMatches: false` and the caller treats
+ * `coreRequiredJavaVersion` as untrustworthy (and surfaces "could not
+ * determine" rather than guessing).
  */
 export async function getUpdateCenterForCore(coreVersion: string): Promise<UpdateCenter> {
   const candidates = [
+    `${JENKINS_UPDATE_BASE}/dynamic-stable-${coreVersion}/update-center.actual.json`,
     `${JENKINS_UPDATE_BASE}/dynamic-${coreVersion}/update-center.actual.json`,
     `${JENKINS_UPDATE_BASE}/current/update-center.actual.json`,
   ]
@@ -155,31 +156,6 @@ export async function getUpdateCenterForCore(coreVersion: string): Promise<Updat
     coreRequiredJavaVersion: matches ? raw.core?.requiredJavaVersion : undefined,
     plugins,
   }
-}
-
-/**
- * Best-effort mapping of core WAR version → minimum Java version.
- *
- * The update-center catalogue carries `core.requiredJavaVersion` for the
- * catalogue's pinned core, but when the user selects a different WAR version
- * we need a standalone answer. This table tracks the publicly announced
- * Java baseline for each line.
- *
- * See: https://www.jenkins.io/doc/book/platform-information/support-policy-java/
- */
-const JAVA_BASELINES: Array<{ from: string; minJava: number }> = [
-  { from: '2.479', minJava: 17 },
-  { from: '2.463', minJava: 17 },
-  { from: '2.426', minJava: 11 },
-  { from: '2.357', minJava: 11 },
-  { from: '2.164', minJava: 8 },
-]
-
-export function minimumJavaForCore(coreVersion: string): number {
-  for (const row of JAVA_BASELINES) {
-    if (compareVersions(coreVersion, row.from) >= 0) return row.minJava
-  }
-  return 8
 }
 
 /** Built WAR download URL for a given core version. Tries the LTS path first. */


### PR DESCRIPTION
## Summary

The Jenkins air-gap bundler was reporting Java 17 as compatible with Jenkins 2.555.1, which actually requires Java 21+ ([jenkins.io/doc/upgrade-guide/2.555](https://www.jenkins.io/doc/upgrade-guide/2.555/), [Java support policy](https://www.jenkins.io/doc/book/platform-information/support-policy-java/)). Two issues combined to produce the wrong answer:

- **Wrong update-center URL for LTS releases.** `getUpdateCenterForCore` only tried `https://updates.jenkins.io/dynamic-{version}/update-center.actual.json`, but Jenkins infra publishes LTS catalogues under `dynamic-stable-{version}/...`. So for any LTS WAR the per-version lookup 404'd and we fell through to the `current` catalogue, whose `core.version` never matches the user's WAR — `coreVersionMatches` was always `false` for LTS, the live `requiredJavaVersion` was discarded, and the answer came from the local fallback table.
- **Stale, hard-coded `JAVA_BASELINES` fallback.** The table capped at `2.479 → Java 17`, so every post-2.541 LTS line was silently misreported as Java-17-compatible.

## Changes

- `apps/web/lib/jenkins/update-center.ts`: try `dynamic-stable-{v}` → `dynamic-{v}` → `current` so LTS catalogues are reachable; **remove `JAVA_BASELINES` and `minimumJavaForCore` entirely** — we no longer hard-code Jenkins/Java compatibility, the only source is `updates.jenkins.io` at request time.
- `apps/web/app/api/tools/jenkins-bundler/route.ts`: `coreMinimumJava` is now `number | null`, and `coreJavaSource` is `'updates.jenkins.io' | 'unavailable'`. When the catalogue isn't published for the requested WAR we return `unavailable` instead of guessing. `javaCompatible` becomes `null` when we can't determine the requirement.
- `apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx`: handle the `unavailable` case — show "Could not determine — updates.jenkins.io has no catalogue for this WAR" plus an alert linking to the official Java support policy, and suppress the green/red compatibility verdicts when we don't have a live answer.

## Test plan

- [ ] Run the bundler against `2.555.1` with Java `17` → should now report Java 21+ required (live, from `updates.jenkins.io`) and flag Java 17 as too old.
- [ ] Run against `2.555.1` with Java `21` → green "Java version looks compatible".
- [ ] Run against the latest LTS via the **Latest LTS** button → expected source label `(from updates.jenkins.io)`.
- [ ] Run against an older LTS line (e.g. `2.479.x`) with Java `17` → still compatible, still labelled `from updates.jenkins.io`.
- [ ] Pick a fictional version like `9.999.999` → "Java compatibility could not be checked" alert appears, no verdict, plugin resolution still works against the `current` catalogue.
- [ ] `pnpm run type-check` and `pnpm run lint` clean (verified locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Jd6WzHriizyorfJSvxSsi)_