### PR TITLE
fix(web): repair customer installer bundle

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -166,10 +166,11 @@ jobs:
           set -euo pipefail
           TAG="${{ needs.release-please.outputs.web_tag_name }}"
           VERSION="${TAG#web/}"
-          mkdir -p dist/ct-ops
+          mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example
           cp deploy/customer-bundle/README.md dist/ct-ops/README.md
+          cp deploy/nginx/nginx.conf          dist/ct-ops/deploy/nginx/nginx.conf
           echo "$VERSION" > dist/ct-ops/VERSION
 
           # The customer start.sh is generated here rather than checked into
@@ -436,6 +437,10 @@ jobs:
           esac
           CUSTOMER_START_SH
 
+          # Keep the generated release artifact aligned with the checked-in
+          # customer bundle script. The inline heredoc above is retained only
+          # for compatibility with older workflow history.
+          cp deploy/customer-bundle/start.sh dist/ct-ops/start.sh
           chmod +x dist/ct-ops/start.sh
           bash -n dist/ct-ops/start.sh
 
@@ -521,6 +526,7 @@ jobs:
           echo "Transfer it to your air-gapped target host, unzip, and run ./start.sh"
           CUSTOMER_OFFLINE_SH
 
+          cp deploy/customer-bundle/build-offline-installer.sh dist/ct-ops/build-offline-installer.sh
           chmod +x dist/ct-ops/build-offline-installer.sh
           bash -n dist/ct-ops/build-offline-installer.sh
 

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -1,0 +1,48 @@
+name: Customer bundle check
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/agent-release.yml"
+      - ".github/workflows/customer-bundle-check.yml"
+      - "deploy/customer-bundle/**"
+      - "deploy/nginx/nginx.conf"
+      - "docker-compose.single.yml"
+      - ".env.example"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Stage customer bundle
+        run: |
+          set -euo pipefail
+          mkdir -p dist/ct-ops/deploy/nginx
+          cp docker-compose.single.yml dist/ct-ops/docker-compose.yml
+          cp .env.example dist/ct-ops/.env.example
+          cp deploy/customer-bundle/README.md dist/ct-ops/README.md
+          cp deploy/customer-bundle/start.sh dist/ct-ops/start.sh
+          cp deploy/customer-bundle/build-offline-installer.sh dist/ct-ops/build-offline-installer.sh
+          cp deploy/nginx/nginx.conf dist/ct-ops/deploy/nginx/nginx.conf
+          echo "test" > dist/ct-ops/VERSION
+          chmod +x dist/ct-ops/start.sh dist/ct-ops/build-offline-installer.sh
+
+      - name: Validate scripts and required files
+        working-directory: dist/ct-ops
+        run: |
+          set -euo pipefail
+          test -f docker-compose.yml
+          test -f deploy/nginx/nginx.conf
+          test -f .env.example
+          bash -n start.sh
+          bash -n build-offline-installer.sh
+
+      - name: Render compose config
+        working-directory: dist/ct-ops
+        env:
+          BETTER_AUTH_SECRET: build-time-placeholder
+          POSTGRES_PASSWORD: build-time-placeholder
+        run: docker compose config --quiet

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -31,6 +31,11 @@ nano .env
 
 When `docker compose ps` shows all containers as `healthy`, open the web UI at `https://<your-server>`. The bundle ships a self-signed certificate — your browser will warn on first visit. To replace it with a certificate from your own CA, see [Replacing the TLS certificate](#replacing-the-tls-certificate) below.
 
+If ports 80 or 443 are already in use on the host, set `NGINX_HTTP_PORT` and
+`NGINX_HTTPS_PORT` in `.env` before the second `./start.sh` run. Include the
+external HTTPS port in `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, and
+`AGENT_DOWNLOAD_BASE_URL`, for example `https://ct-ops.example.com:8443`.
+
 ---
 
 ## Manual Deploy
@@ -89,7 +94,7 @@ docker compose -f docker-compose.single.yml up -d
 docker compose -f docker-compose.single.yml logs -f web
 ```
 
-The web container runs database migrations automatically on first start. Once you see `Ready on http://0.0.0.0:3000`, the stack is up.
+The one-shot `migrate` container applies database migrations before web and ingest start. Once you see `Ready on http://0.0.0.0:3000`, the stack is up.
 
 ---
 
@@ -108,6 +113,11 @@ Only `443`, `80`, and `9443` are published on all host interfaces:
 - `9443` — agent gRPC with mTLS. Agents connect direct to the ingest container; the proxy is intentionally skipped so client-cert verification is never terminated mid-hop.
 
 The remaining ports are bound to `127.0.0.1` only, so `web:3000`, `ingest:8080`, and Postgres are reachable from the host (for debugging over SSH tunnels) but not from the network. Override the nginx ports with `NGINX_HTTPS_PORT` / `NGINX_HTTP_PORT` in `.env` if 80/443 are already in use.
+
+When installing inside a VM, LXC, or Incus instance that sits behind a NAT or
+private bridge, forward the external HTTPS port and `9443` to the instance.
+Agents must be able to reach `AGENT_DOWNLOAD_BASE_URL` and `host:9443` from
+their own network, not just from the container host.
 
 ---
 

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -43,9 +43,19 @@ CT_OPS_VERSION=v0.3.0 curl -fsSL ... | bash
 - The browser TLS cert at `deploy/tls/server.{crt,key}` — served by the bundled nginx on port 443.
 - `BETTER_AUTH_SECRET` and `POSTGRES_PASSWORD` if blank.
 
-It then pulls images from GHCR and starts the stack. Database migrations run inside the web container automatically on startup.
+It then pulls images from GHCR and starts the stack. Database migrations run in a one-shot migration container before web and ingest start.
 
 When all containers show `healthy` in `docker compose ps`, continue to [Create your account](#create-your-account).
+
+If ports 80 or 443 are already in use, set `NGINX_HTTP_PORT` and
+`NGINX_HTTPS_PORT` in `.env` before the second `./start.sh` run. Include the
+external HTTPS port in `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, and
+`AGENT_DOWNLOAD_BASE_URL`, for example `https://ct-ops.example.com:8443`.
+
+If you are installing inside a VM, LXC, or Incus instance behind a NAT or
+private bridge, forward the external HTTPS port and `9443` to the instance.
+Agents must be able to reach both the web URL and gRPC port from their own
+network.
 
 ---
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,7 +17,7 @@ COPY proto/gen/go/  ./proto/gen/go/
 COPY .release-please-manifest.json ./
 RUN AGENT_VERSION="v$(jq -r '.agent' .release-please-manifest.json)" && \
     mkdir -p /out && cd agent && \
-    for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do \
+    for p in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
       os="${p%%/*}"; arch="${p##*/}"; \
       ext=""; [ "$os" = "windows" ] && ext=".exe"; \
       echo "Building agent ${os}/${arch} (version ${AGENT_VERSION})..."; \

--- a/apps/web/lib/agent/cache-prewarm.ts
+++ b/apps/web/lib/agent/cache-prewarm.ts
@@ -4,6 +4,7 @@ import { REQUIRED_AGENT_VERSION } from './version'
 import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from './repo'
 
 const AGENT_DIST_DIR = process.env.AGENT_DIST_DIR ?? './data/agent-dist'
+const BAKED_AGENT_DIST_DIR = path.join(process.cwd(), 'data/agent-dist')
 
 const PLATFORMS = [
   { os: 'linux', arch: 'amd64' },
@@ -33,6 +34,14 @@ interface GitHubRelease {
  * prewarm failure must never prevent the server from starting.
  */
 export async function prewarmAgentCache(): Promise<void> {
+  const missingBaked = PLATFORMS.filter(
+    ({ os, arch }) => !fs.existsSync(path.join(BAKED_AGENT_DIST_DIR, binaryBaseName(os, arch)))
+  )
+  if (missingBaked.length === 0) {
+    console.log(`[agent-cache] Baked agent ${REQUIRED_AGENT_VERSION} binaries are available`)
+    return
+  }
+
   const tag = `agent/${REQUIRED_AGENT_VERSION}`
   let release: GitHubRelease | null = null
 
@@ -50,8 +59,9 @@ export async function prewarmAgentCache(): Promise<void> {
       }
     )
     if (res.status === 404) {
+      const missingPlatforms = missingBaked.map(({ os, arch }) => `${os}/${arch}`).join(', ')
       console.log(
-        `[agent-cache] Release ${tag} not found on GitHub — binaries must be built manually via \`make agent\``
+        `[agent-cache] Release ${tag} not found on GitHub and baked binaries are incomplete — missing ${missingPlatforms}`
       )
       return
     }
@@ -71,6 +81,11 @@ export async function prewarmAgentCache(): Promise<void> {
   await Promise.allSettled(
     PLATFORMS.map(({ os, arch }) => downloadIfMissing(release!, REQUIRED_AGENT_VERSION, os, arch))
   )
+}
+
+function binaryBaseName(os: string, arch: string): string {
+  const suffix = os === 'windows' ? '.exe' : ''
+  return `ct-ops-agent-${os}-${arch}${suffix}`
 }
 
 async function downloadIfMissing(

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -43,11 +43,20 @@ This will:
 3. Pull the latest `web`, `ingest`, and `db` images from GHCR
    (or load `images.tar.gz` if it is present — see *Air-gap installs* below)
 4. Start the stack
-5. The web container runs database migrations on its own startup
+5. A one-shot migration container applies database migrations before web and ingest start
 
-Open `http://localhost:3000` (or whatever you set as `BETTER_AUTH_URL`) and
+Open `https://localhost` (or whatever you set as `BETTER_AUTH_URL`) and
 follow the in-app onboarding to create your first organisation and admin
-user.
+user. Your browser will warn about the self-signed certificate on first
+visit unless you replace `deploy/tls/server.{crt,key}` with a certificate
+from your own CA.
+
+If ports 80 or 443 are already in use, set `NGINX_HTTP_PORT` and
+`NGINX_HTTPS_PORT` in `.env` before the second run. Include the external
+HTTPS port in `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, and
+`AGENT_DOWNLOAD_BASE_URL`, for example `https://ct-ops.example.com:8443`.
+If CT-Ops is running inside a VM, LXC, or Incus instance behind NAT, forward
+the external HTTPS port and `9443` to the instance.
 
 ## Commands
 

--- a/deploy/customer-bundle/build-offline-installer.sh
+++ b/deploy/customer-bundle/build-offline-installer.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# CT-Ops — Build Offline Installer
+#
+# Run on an internet-connected host after unzipping the standard CT-Ops
+# release. Pulls every image referenced by docker-compose.yml, saves them to
+# images.tar.gz, and re-zips this directory as
+# ct-ops-single-{VERSION}-airgap.zip in the parent directory.
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: 'docker' is not installed or not on PATH." >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "ERROR: 'docker compose' plugin not found." >&2
+  exit 1
+fi
+if ! command -v zip >/dev/null 2>&1; then
+  echo "ERROR: 'zip' is required to package the air-gap bundle." >&2
+  exit 1
+fi
+if [ ! -f docker-compose.yml ]; then
+  echo "ERROR: docker-compose.yml not found in $(pwd)." >&2
+  echo "Run this script from inside the unzipped CT-Ops bundle." >&2
+  exit 1
+fi
+
+VERSION=$(cat VERSION 2>/dev/null || echo "unknown")
+
+# Compose variable substitution is strict, so provide placeholders purely to
+# render config. These values are not persisted or used at runtime.
+export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-build-time-placeholder}"
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-build-time-placeholder}"
+
+echo "Resolving image names from docker-compose.yml..."
+IMAGES=$(docker compose config --images 2>/dev/null | sort -u)
+if [ -z "$IMAGES" ]; then
+  echo "ERROR: could not resolve any image names from docker-compose.yml" >&2
+  exit 1
+fi
+
+echo "Images:"
+while IFS= read -r img; do printf '  %s\n' "$img"; done <<< "$IMAGES"
+
+echo "Pulling images (this may take a while)..."
+while IFS= read -r img; do
+  docker pull "$img"
+done <<< "$IMAGES"
+
+echo "Saving images to images.tar.gz..."
+# shellcheck disable=SC2086
+docker save $IMAGES | gzip > images.tar.gz
+echo "  $(du -h images.tar.gz | cut -f1) written."
+
+PARENT="$(dirname "$SCRIPT_DIR")"
+DIRNAME="$(basename "$SCRIPT_DIR")"
+OUT="$PARENT/ct-ops-single-${VERSION}-airgap.zip"
+
+echo "Re-zipping bundle as $OUT..."
+(cd "$PARENT" && zip -r "$OUT" "$DIRNAME" \
+  -x "$DIRNAME/.env" \
+  -x "$DIRNAME/deploy/tls/*" \
+  -x "$DIRNAME/deploy/dev-tls/*" \
+  -x "$DIRNAME/ct-ops-single-*-airgap.zip" >/dev/null)
+
+echo ""
+echo "Air-gap bundle ready: $OUT"
+echo "Transfer it to your air-gapped target host, unzip, and run ./start.sh"

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -30,6 +30,10 @@ REQUIRED_VARS=(BETTER_AUTH_URL BETTER_AUTH_TRUSTED_ORIGINS BETTER_AUTH_SECRET PO
 # Optional variables — missing values get a warning, not an error. Most have
 # safe localhost defaults baked into docker-compose.yml.
 OPTIONAL_VARS=(AGENT_DOWNLOAD_BASE_URL INGEST_WS_URL CT_OPS_LOADTEST_ADMIN_KEY WEB_IMAGE INGEST_IMAGE)
+REQUIRED_FILES=(
+  docker-compose.yml
+  deploy/nginx/nginx.conf
+)
 
 show_help() {
   cat <<EOF
@@ -58,6 +62,37 @@ require_docker() {
     echo "Upgrade Docker Engine to a release that bundles the Compose plugin." >&2
     exit 1
   fi
+}
+
+check_bundle_files() {
+  local missing=()
+  local wrong_type=()
+  local file
+
+  for file in "${REQUIRED_FILES[@]}"; do
+    if [ -d "$file" ]; then
+      wrong_type+=("$file is a directory")
+    elif [ ! -f "$file" ]; then
+      missing+=("$file")
+    fi
+  done
+
+  if [ ${#missing[@]} -eq 0 ] && [ ${#wrong_type[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  echo "ERROR: this CT-Ops bundle is incomplete or corrupt." >&2
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "Missing required files:" >&2
+    for file in "${missing[@]}"; do echo "  - $file"; done >&2
+  fi
+  if [ ${#wrong_type[@]} -gt 0 ]; then
+    echo "Invalid paths:" >&2
+    for file in "${wrong_type[@]}"; do echo "  - $file"; done >&2
+  fi
+  echo "" >&2
+  echo "Re-download the release bundle and unpack it into a clean directory." >&2
+  exit 1
 }
 
 show_version() {
@@ -212,6 +247,21 @@ gen_cert() {
   echo "Wrote ${out_dir}/server.{crt,key} (CN=${cn}, SANs: ${san})"
 }
 
+fix_ingest_tls_permissions() {
+  local cert_dir="$SCRIPT_DIR/deploy/dev-tls"
+  [ -f "$cert_dir/server.key" ] || return 0
+  [ -f "$cert_dir/server.crt" ] || return 0
+
+  # The ingest image runs as uid/gid 1001. These files are bind-mounted
+  # read-only, so make the key readable before Docker starts the container.
+  if chown 1001:1001 "$cert_dir/server.key" "$cert_dir/server.crt" 2>/dev/null; then
+    chmod 600 "$cert_dir/server.key"
+  else
+    chmod 644 "$cert_dir/server.key"
+  fi
+  chmod 644 "$cert_dir/server.crt"
+}
+
 ensure_tls_certs() {
   # Ingest mTLS cert — consumed by the gRPC listener on :9443.
   if [ ! -f "$SCRIPT_DIR/deploy/dev-tls/server.crt" ] || [ ! -f "$SCRIPT_DIR/deploy/dev-tls/server.key" ]; then
@@ -228,6 +278,8 @@ ensure_tls_certs() {
     echo "Replace deploy/tls/server.crt and deploy/tls/server.key with your own"
     echo "certificate at any time to remove the browser warning."
   fi
+
+  fix_ingest_tls_permissions
 }
 
 # check_ports_free fails fast when :80 or :443 are already bound on the host,
@@ -274,20 +326,32 @@ warn_legacy_env() {
 }
 
 start_stack() {
+  check_bundle_files
   require_docker
   check_env
   warn_legacy_env
   check_ports_free
   ensure_tls_certs
 
-  echo "Pulling latest images from GHCR..."
-  if ! docker compose pull db web ingest nginx; then
-    echo "" >&2
-    echo "ERROR: failed to pull one or more images from GHCR." >&2
-    echo "  - Check your network access to ghcr.io" >&2
-    echo "  - If you pinned WEB_IMAGE/INGEST_IMAGE in .env, verify the tag exists" >&2
-    echo "  - For air-gapped installs, load images with: docker load < ct-ops.tar.gz" >&2
-    exit 1
+  if [ -f "images.tar.gz" ]; then
+    echo "Loading bundled Docker images (offline mode)..."
+    if ! docker load -i images.tar.gz; then
+      echo "ERROR: failed to load images from images.tar.gz" >&2
+      echo "  - The archive may be corrupted; rebuild the air-gap bundle" >&2
+      echo "  - Verify free disk space with: df -h" >&2
+      exit 1
+    fi
+  else
+    echo "Pulling latest images from GHCR..."
+    if ! docker compose pull db web migrate ingest nginx tls-init; then
+      echo "" >&2
+      echo "ERROR: failed to pull one or more images from GHCR." >&2
+      echo "  - Check your network access to ghcr.io" >&2
+      echo "  - If you pinned WEB_IMAGE/INGEST_IMAGE in .env, verify the tag exists" >&2
+      echo "  - For air-gapped installs, run ./build-offline-installer.sh on a" >&2
+      echo "    connected host and ship the resulting *-airgap.zip to this host" >&2
+      exit 1
+    fi
   fi
 
   docker compose down --remove-orphans >/dev/null 2>&1 || true

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -24,8 +24,8 @@ services:
       dockerfile: apps/web/Dockerfile
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     ports:
       # Loopback-only — browser traffic flows in via the nginx container on :443.
       # Keeping :3000 on 127.0.0.1 lets operators tunnel for debugging without
@@ -56,6 +56,19 @@ services:
       # bundle route can embed it in agent downloads.
       - ./deploy/tls:/var/lib/ct-ops/server-tls:ro
 
+  migrate:
+    image: ${WEB_IMAGE:-ghcr.io/carrtech-dev/ct-ops/web:latest}
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-ctops}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-ctops}
+    command: ["node", "migrate.js"]
+
   ingest:
     image: ${INGEST_IMAGE:-ghcr.io/carrtech-dev/ct-ops/ingest:latest}
     build:
@@ -63,8 +76,8 @@ services:
       dockerfile: apps/ingest/Dockerfile
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     ports:
       - "9443:9443"   # gRPC (mTLS) — agents connect here directly, bypassing nginx.
       # Loopback-only — nginx reaches :8080 over the docker network; there is
@@ -116,7 +129,7 @@ services:
       web:
         condition: service_started
       ingest:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "${NGINX_HTTPS_PORT:-443}:443"
       - "${NGINX_HTTP_PORT:-80}:80"


### PR DESCRIPTION
## Summary

Fixes the customer installer path so a freshly downloaded release bundle can boot without manual repairs.

## Changes

- Include `deploy/nginx/nginx.conf` in the staged customer release bundle.
- Add customer bundle preflight checks so missing bind-mounted files fail before Docker creates bad directories.
- Fix ingest TLS key permissions for the non-root ingest container user.
- Add a one-shot `migrate` service and gate web/ingest/nginx startup on the right readiness conditions.
- Add a checked-in air-gap bundle helper and a CI bundle-shape check.
- Build the missing Windows ARM64 agent binary and avoid misleading GitHub release warnings when baked binaries are present.
- Document custom HTTPS ports and VM/LXC/Incus port forwarding requirements.

## Validation

- `bash -n deploy/customer-bundle/start.sh`
- `bash -n deploy/customer-bundle/build-offline-installer.sh`
- `git diff --check`
- staged customer bundle smoke check with `docker compose config --quiet`
- verified staged zip contains `deploy/nginx/nginx.conf`
- `pnpm --filter web lint` passed with existing warnings only
- `pnpm --filter @ct-ops/docs build`
