### PR TITLE
fix(web): harden installer release checks

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -1,0 +1,32 @@
+name: Conventional PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  conventional-title:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._/-]+\))?!?: .+'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            cat >&2 <<EOF
+          PR title must be a Conventional Commit because squash merges use it
+          as the release-please input.
+
+          Current title:
+            $PR_TITLE
+
+          Expected examples:
+            fix(web): repair customer installer bundle
+            ci(release): add Docker image smoke test
+            docs(install): document custom HTTPS ports
+          EOF
+            exit 1
+          fi

--- a/.github/workflows/pr-checks-docker-images.yml
+++ b/.github/workflows/pr-checks-docker-images.yml
@@ -1,0 +1,80 @@
+name: PR Checks (Docker images)
+
+on:
+  pull_request:
+    paths:
+      - "agent/**"
+      - "apps/ingest/**"
+      - "apps/web/**"
+      - "proto/**"
+      - ".dockerignore"
+      - ".release-please-manifest.json"
+      - "docker-compose.single.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "go.work"
+      - "go.work.sum"
+      - ".github/workflows/pr-checks-docker-images.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "agent/**"
+      - "apps/ingest/**"
+      - "apps/web/**"
+      - "proto/**"
+      - ".dockerignore"
+      - ".release-please-manifest.json"
+      - "docker-compose.single.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "go.work"
+      - "go.work.sum"
+      - ".github/workflows/pr-checks-docker-images.yml"
+
+concurrency:
+  group: docker-image-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web-image:
+    name: Web Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build web image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: false
+          cache-from: type=gha,scope=pr-web-image-amd64
+          cache-to: type=gha,mode=max,scope=pr-web-image-amd64
+
+  ingest-image:
+    name: Ingest Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build ingest image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/ingest/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: false
+          cache-from: type=gha,scope=pr-ingest-image-amd64
+          cache-to: type=gha,mode=max,scope=pr-ingest-image-amd64

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -5,6 +5,8 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 
 # --- Agent binary build stage ---
 # Cross-compiles every supported agent binary so the web image is self-contained.
+# PR image checks build this stage so installer releases cannot ship with
+# missing baked agent binaries.
 # The download route falls back to these baked binaries when the operator-managed
 # volume is empty and GitHub is unreachable (air-gap installs).
 FROM golang:1.25-alpine AS agent-builder


### PR DESCRIPTION
## Summary

Adds CI guardrails so installer and image changes are validated before release, and future squash merges preserve Conventional Commit titles for release-please.

## Changes

- Add a Conventional PR title check because squash merges use the PR title as the release-please input.
- Add PR Docker image checks for the web and ingest images on linux/amd64.
- Touch the web Dockerfile with release-check documentation so this follow-up is attributed to the web package and produces a web release.

## Validation

- `git diff --check`
- YAML parse check for changed workflow files
