### PR TITLE
feat(web): add GitLab air-gap bundler

### DIFF
--- a/apps/web/app/(dashboard)/bundlers/bundlers-client.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundlers-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { GitLabBundler } from './gitlab-bundler'
 import { JenkinsBundler } from './jenkins-bundler'
 
 export function BundlersClient() {
@@ -8,9 +9,13 @@ export function BundlersClient() {
     <Tabs defaultValue="jenkins" className="w-full">
       <TabsList>
         <TabsTrigger value="jenkins">Jenkins</TabsTrigger>
+        <TabsTrigger value="gitlab">GitLab</TabsTrigger>
       </TabsList>
       <TabsContent value="jenkins" className="mt-4">
         <JenkinsBundler />
+      </TabsContent>
+      <TabsContent value="gitlab" className="mt-4">
+        <GitLabBundler />
       </TabsContent>
     </Tabs>
   )

--- a/apps/web/app/(dashboard)/bundlers/gitlab-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/gitlab-bundler.tsx
@@ -1,0 +1,476 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import JSZip from 'jszip'
+import {
+  AlertTriangle,
+  Archive,
+  CheckCircle2,
+  Download,
+  Loader2,
+  Package,
+  Search,
+} from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { GitLabBundleStep, GitLabBundlerResponse } from '@/app/api/tools/gitlab-bundler/route'
+
+const OS_OPTIONS = [
+  { value: 'ubuntu-noble', label: 'Ubuntu 24.04 Noble', kind: 'deb', arches: ['amd64', 'arm64'] },
+  { value: 'ubuntu-jammy', label: 'Ubuntu 22.04 Jammy', kind: 'deb', arches: ['amd64', 'arm64'] },
+  { value: 'ubuntu-focal', label: 'Ubuntu 20.04 Focal', kind: 'deb', arches: ['amd64', 'arm64'] },
+  { value: 'debian-bookworm', label: 'Debian 12 Bookworm', kind: 'deb', arches: ['amd64', 'arm64'] },
+  { value: 'debian-bullseye', label: 'Debian 11 Bullseye', kind: 'deb', arches: ['amd64', 'arm64'] },
+  { value: 'el-9', label: 'RHEL/Rocky/Alma 9', kind: 'rpm', arches: ['x86_64', 'aarch64'] },
+  { value: 'el-8', label: 'RHEL/Rocky/Alma 8', kind: 'rpm', arches: ['x86_64', 'aarch64'] },
+] as const
+
+type OsOption = (typeof OS_OPTIONS)[number]
+
+type Report = Extract<GitLabBundlerResponse, { ok: true }> & {
+  downloaded: Record<string, boolean>
+}
+
+async function postJson<T>(body: unknown): Promise<T> {
+  const res = await fetch('/api/tools/gitlab-bundler', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return (await res.json()) as T
+}
+
+async function fetchWithProgress(
+  step: GitLabBundleStep,
+  report: Report,
+  onProgress: (loaded: number, total: number | null) => void,
+): Promise<Uint8Array> {
+  const qs = new URLSearchParams({
+    edition: report.edition,
+    packageTarget: report.packageTarget.key,
+    arch: report.packageTarget.arch,
+    version: step.version,
+  })
+  const res = await fetch(`/api/tools/gitlab-bundler?${qs.toString()}`, { cache: 'no-store' })
+  if (!res.ok || !res.body) throw new Error(`Download failed (${res.status})`)
+
+  const totalHeader = res.headers.get('content-length')
+  const total = totalHeader ? parseInt(totalHeader, 10) : null
+  const reader = res.body.getReader()
+  const chunks: Uint8Array[] = []
+  let loaded = 0
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+    chunks.push(value)
+    loaded += value.byteLength
+    onProgress(loaded, total)
+  }
+
+  const out = new Uint8Array(loaded)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
+}
+
+function humanBytes(bytes: number | null): string {
+  if (bytes == null) return 'Unknown'
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MB`
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${bytes} B`
+}
+
+function safeVersion(value: string): boolean {
+  return /^\d+\.\d+(\.\d+)?$/.test(value)
+}
+
+export function GitLabBundler() {
+  const [currentVersion, setCurrentVersion] = useState('')
+  const [targetVersion, setTargetVersion] = useState('')
+  const [edition, setEdition] = useState<'ee' | 'ce'>('ee')
+  const [packageTarget, setPackageTarget] = useState<OsOption['value']>('ubuntu-jammy')
+  const selectedOs = OS_OPTIONS.find((option) => option.value === packageTarget) ?? OS_OPTIONS[1]!
+  const [arch, setArch] = useState<string>(selectedOs.arches[0])
+  const [resolving, setResolving] = useState(false)
+  const [resolveError, setResolveError] = useState<string | null>(null)
+  const [report, setReport] = useState<Report | null>(null)
+  const [downloading, setDownloading] = useState(false)
+  const [downloadError, setDownloadError] = useState<string | null>(null)
+  const [currentFile, setCurrentFile] = useState<string | null>(null)
+  const [currentLoaded, setCurrentLoaded] = useState(0)
+  const [currentTotal, setCurrentTotal] = useState<number | null>(null)
+  const [doneCount, setDoneCount] = useState(0)
+  const [downloadTotal, setDownloadTotal] = useState(0)
+
+  const availableSteps = useMemo(
+    () => report?.steps.filter((step) => step.status === 'available' && step.filename) ?? [],
+    [report],
+  )
+
+  const downloadPct = useMemo(() => {
+    if (!downloading || downloadTotal === 0) return 0
+    const perFile = currentTotal && currentTotal > 0 ? currentLoaded / currentTotal : 0
+    return Math.min(100, ((doneCount + perFile) / downloadTotal) * 100)
+  }, [currentLoaded, currentTotal, doneCount, downloadTotal, downloading])
+
+  function onOsChange(next: string) {
+    const option = OS_OPTIONS.find((entry) => entry.value === next)
+    if (!option) return
+    setPackageTarget(option.value)
+    setArch(option.arches[0])
+  }
+
+  async function resolve() {
+    setResolveError(null)
+    setDownloadError(null)
+    setReport(null)
+    if (!safeVersion(currentVersion.trim())) {
+      setResolveError('Enter a valid current GitLab version, e.g. 16.11.10')
+      return
+    }
+    if (!safeVersion(targetVersion.trim())) {
+      setResolveError('Enter a valid target GitLab version, e.g. 18.6.6')
+      return
+    }
+
+    setResolving(true)
+    try {
+      const data = await postJson<GitLabBundlerResponse>({
+        action: 'resolve',
+        currentVersion: currentVersion.trim(),
+        targetVersion: targetVersion.trim(),
+        edition,
+        packageTarget,
+        arch,
+      })
+      if (!data.ok) {
+        setResolveError(data.error)
+        return
+      }
+      setReport({ ...data, downloaded: {} })
+    } catch (err) {
+      setResolveError(err instanceof Error ? err.message : 'Failed to resolve GitLab upgrade path')
+    } finally {
+      setResolving(false)
+    }
+  }
+
+  async function downloadSteps(steps: GitLabBundleStep[], label: string) {
+    if (!report || steps.length === 0) return
+    setDownloadError(null)
+    setDownloading(true)
+    setDoneCount(0)
+    setDownloadTotal(steps.length)
+    setCurrentFile(null)
+    setCurrentLoaded(0)
+    setCurrentTotal(null)
+
+    try {
+      const zip = new JSZip()
+      const packages = zip.folder('packages')!
+      const downloaded: Record<string, boolean> = { ...report.downloaded }
+
+      for (const step of steps) {
+        if (!step.filename) continue
+        setCurrentFile(step.filename)
+        setCurrentLoaded(0)
+        setCurrentTotal(step.sizeBytes)
+        const bytes = await fetchWithProgress(step, report, (loaded, total) => {
+          setCurrentLoaded(loaded)
+          setCurrentTotal(total ?? step.sizeBytes)
+        })
+        packages.file(step.filename, bytes)
+        downloaded[step.id] = true
+        setReport({ ...report, downloaded })
+        setDoneCount((count) => count + 1)
+      }
+
+      zip.file(
+        'bundle-manifest.json',
+        JSON.stringify(
+          {
+            generatedAt: report.generatedAt,
+            currentVersion: report.currentVersion,
+            targetVersion: report.targetVersion,
+            edition: report.edition,
+            packageTarget: report.packageTarget,
+            sources: report.sources,
+            steps: report.steps,
+            included: steps.map((step) => step.id),
+          },
+          null,
+          2,
+        ),
+      )
+      zip.file(
+        'README.txt',
+        [
+          'GitLab air-gap package bundle',
+          '',
+          `Current version: ${report.currentVersion}`,
+          `Target version: ${report.targetVersion}`,
+          `Edition: GitLab ${report.edition.toUpperCase()}`,
+          `Package target: ${report.packageTarget.label} ${report.packageTarget.arch}`,
+          '',
+          'Install each package in ascending version order and allow GitLab background migrations to finish between required stops.',
+          'Review GitLab upgrade notes before applying packages.',
+        ].join('\n'),
+      )
+
+      const blob = await zip.generateAsync({ type: 'blob' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `gitlab-${report.edition}-${report.currentVersion}-to-${report.targetVersion}-${label}.zip`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setDownloadError(err instanceof Error ? err.message : 'Download failed')
+    } finally {
+      setDownloading(false)
+      setCurrentFile(null)
+    }
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Package className="size-4" /> GitLab packages
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="gitlab-current">Current GitLab version</Label>
+                <Input
+                  id="gitlab-current"
+                  placeholder="e.g. 16.11.10"
+                  value={currentVersion}
+                  onChange={(event) => setCurrentVersion(event.target.value)}
+                  disabled={resolving || downloading}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="gitlab-target">Target GitLab version</Label>
+                <Input
+                  id="gitlab-target"
+                  placeholder="e.g. 18.6.6"
+                  value={targetVersion}
+                  onChange={(event) => setTargetVersion(event.target.value)}
+                  disabled={resolving || downloading}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="space-y-1.5">
+                <Label>Edition</Label>
+                <Select value={edition} onValueChange={(value) => setEdition(value as 'ee' | 'ce')} disabled={resolving || downloading}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ee">Enterprise Edition (EE)</SelectItem>
+                    <SelectItem value="ce">Community Edition (CE)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>OS package target</Label>
+                <Select value={packageTarget} onValueChange={onOsChange} disabled={resolving || downloading}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {OS_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Architecture</Label>
+                <Select value={arch} onValueChange={setArch} disabled={resolving || downloading}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {selectedOs.arches.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={resolve} disabled={resolving || downloading}>
+                {resolving ? <Loader2 className="size-4 animate-spin" /> : <Search className="size-4" />}
+                Find upgrade packages
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => downloadSteps(availableSteps, 'all')}
+                disabled={!report || availableSteps.length === 0 || downloading || resolving}
+              >
+                {downloading ? <Loader2 className="size-4 animate-spin" /> : <Archive className="size-4" />}
+                Download all
+              </Button>
+            </div>
+
+            {resolveError && (
+              <Alert variant="destructive">
+                <AlertTriangle className="size-4" />
+                <AlertTitle>Unable to resolve GitLab packages</AlertTitle>
+                <AlertDescription>{resolveError}</AlertDescription>
+              </Alert>
+            )}
+            {downloadError && (
+              <Alert variant="destructive">
+                <AlertTriangle className="size-4" />
+                <AlertTitle>Download failed</AlertTitle>
+                <AlertDescription>{downloadError}</AlertDescription>
+              </Alert>
+            )}
+            {downloading && (
+              <Alert>
+                <Loader2 className="size-4 animate-spin" />
+                <AlertTitle>Building zip</AlertTitle>
+                <AlertDescription>
+                  {currentFile ? `${currentFile} (${downloadPct.toFixed(0)}%)` : 'Preparing download...'}{' '}
+                  {currentTotal ? `${humanBytes(currentLoaded)} of ${humanBytes(currentTotal)}` : humanBytes(currentLoaded)}
+                </AlertDescription>
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+
+        {report && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between gap-3">
+                <span>Resolved upgrade sequence</span>
+                <Badge variant="secondary">{report.steps.length} package{report.steps.length === 1 ? '' : 's'}</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Step</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Package</TableHead>
+                    <TableHead>Size</TableHead>
+                    <TableHead className="text-right">Download</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {report.steps.map((step, index) => (
+                    <TableRow key={step.id}>
+                      <TableCell className="align-top">
+                        <div className="flex flex-col gap-1">
+                          <span className="font-medium">{index + 1}</span>
+                          <Badge variant={step.role === 'target' ? 'default' : 'secondary'} className="w-fit">
+                            {step.role === 'target' ? 'Target' : 'Required stop'}
+                          </Badge>
+                          {step.conditional && (
+                            <Badge variant="outline" className="w-fit">
+                              Conditional
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <div className="font-medium">{step.version}</div>
+                        {step.sourceVersion !== step.version && (
+                          <div className="text-xs text-muted-foreground">Latest {step.majorMinor} patch</div>
+                        )}
+                        {step.note && <div className="mt-1 max-w-xl text-xs text-muted-foreground">{step.note}</div>}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        {step.filename ? (
+                          <span className="font-mono text-xs">{step.filename}</span>
+                        ) : (
+                          <span className="text-sm text-destructive">{step.reason}</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="align-top">{step.sizeLabel ?? humanBytes(step.sizeBytes)}</TableCell>
+                      <TableCell className="align-top text-right">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => downloadSteps([step], step.version)}
+                          disabled={downloading || resolving || step.status !== 'available'}
+                        >
+                          {report.downloaded[step.id] ? <CheckCircle2 className="size-4" /> : <Download className="size-4" />}
+                          <span className="sr-only">Download {step.version}</span>
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle className="text-base">Resolution details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
+          <p>
+            The resolver reads GitLab&apos;s current upgrade-path document, applies required stops between the current and target
+            versions, then searches the selected package repository for the latest available patch package in each required minor.
+          </p>
+          <p>
+            For GitLab 17.5 and later, GitLab documents required stops at x.2, x.5, x.8, and x.11. Conditional stops from older
+            release lines are shown with a badge.
+          </p>
+          {report && (
+            <div className="rounded-md border bg-muted/30 p-3">
+              <div className="font-medium text-foreground">{report.packageTarget.label}</div>
+              <div>{report.edition.toUpperCase()} / {report.packageTarget.arch} / {report.packageTarget.kind.toUpperCase()}</div>
+              <div className="mt-2 break-all text-xs">{report.sources.packages}</div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/app/api/tools/gitlab-bundler/route.ts
+++ b/apps/web/app/api/tools/gitlab-bundler/route.ts
@@ -1,0 +1,482 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { compareVersions } from '@/lib/version-compare'
+
+export const runtime = 'nodejs'
+
+const UPGRADE_PATH_SOURCE =
+  'https://gitlab.com/gitlab-org/gitlab/-/raw/master/doc/update/upgrade_paths.md'
+
+const PackageTargetSchema = z.enum([
+  'ubuntu-noble',
+  'ubuntu-jammy',
+  'ubuntu-focal',
+  'debian-bookworm',
+  'debian-bullseye',
+  'el-9',
+  'el-8',
+])
+
+const EditionSchema = z.enum(['ee', 'ce'])
+const VersionSchema = z.string().regex(/^\d+\.\d+(\.\d+)?$/, 'Expected version like 17.11.7')
+
+const ResolveSchema = z.object({
+  action: z.literal('resolve'),
+  currentVersion: VersionSchema,
+  targetVersion: VersionSchema,
+  edition: EditionSchema,
+  packageTarget: PackageTargetSchema,
+  arch: z.enum(['amd64', 'arm64', 'x86_64', 'aarch64']),
+})
+
+const BodySchema = z.discriminatedUnion('action', [ResolveSchema])
+
+const QuerySchema = z.object({
+  edition: EditionSchema,
+  packageTarget: PackageTargetSchema,
+  arch: z.enum(['amd64', 'arm64', 'x86_64', 'aarch64']),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/),
+})
+
+type PackageTarget = z.infer<typeof PackageTargetSchema>
+type Edition = z.infer<typeof EditionSchema>
+
+type PackageRepoTarget = {
+  kind: 'deb' | 'rpm'
+  distro: string
+  release: string
+  label: string
+  arches: readonly string[]
+}
+
+const PACKAGE_TARGETS: Record<PackageTarget, PackageRepoTarget> = {
+  'ubuntu-noble': {
+    kind: 'deb',
+    distro: 'ubuntu',
+    release: 'noble',
+    label: 'Ubuntu 24.04 Noble',
+    arches: ['amd64', 'arm64'],
+  },
+  'ubuntu-jammy': {
+    kind: 'deb',
+    distro: 'ubuntu',
+    release: 'jammy',
+    label: 'Ubuntu 22.04 Jammy',
+    arches: ['amd64', 'arm64'],
+  },
+  'ubuntu-focal': {
+    kind: 'deb',
+    distro: 'ubuntu',
+    release: 'focal',
+    label: 'Ubuntu 20.04 Focal',
+    arches: ['amd64', 'arm64'],
+  },
+  'debian-bookworm': {
+    kind: 'deb',
+    distro: 'debian',
+    release: 'bookworm',
+    label: 'Debian 12 Bookworm',
+    arches: ['amd64', 'arm64'],
+  },
+  'debian-bullseye': {
+    kind: 'deb',
+    distro: 'debian',
+    release: 'bullseye',
+    label: 'Debian 11 Bullseye',
+    arches: ['amd64', 'arm64'],
+  },
+  'el-9': {
+    kind: 'rpm',
+    distro: 'el',
+    release: '9',
+    label: 'RHEL/Rocky/Alma 9',
+    arches: ['x86_64', 'aarch64'],
+  },
+  'el-8': {
+    kind: 'rpm',
+    distro: 'el',
+    release: '8',
+    label: 'RHEL/Rocky/Alma 8',
+    arches: ['x86_64', 'aarch64'],
+  },
+}
+
+export type GitLabBundleStep = {
+  id: string
+  role: 'required-stop' | 'target'
+  version: string
+  majorMinor: string
+  sourceVersion: string
+  conditional: boolean
+  note: string | null
+  packageName: string
+  filename: string | null
+  url: string | null
+  sizeBytes: number | null
+  sizeLabel: string | null
+  status: 'available' | 'not-found'
+  reason?: string
+}
+
+export type GitLabBundlerResponse =
+  | {
+      ok: true
+      currentVersion: string
+      targetVersion: string
+      edition: Edition
+      packageTarget: {
+        key: PackageTarget
+        label: string
+        arch: string
+        kind: 'deb' | 'rpm'
+      }
+      generatedAt: string
+      sources: {
+        upgradePath: string
+        packages: string
+      }
+      steps: GitLabBundleStep[]
+    }
+  | { ok: false; error: string }
+
+type RequiredStop = {
+  version: string
+  note: string | null
+  conditional: boolean
+}
+
+type PackageCandidate = {
+  version: string
+  filename: string
+  url: string
+  sizeBytes: number | null
+  sizeLabel: string | null
+}
+
+function packageNameFor(edition: Edition): string {
+  return `gitlab-${edition}`
+}
+
+function majorMinor(version: string): string {
+  const [major, minor] = version.split('.')
+  return `${major}.${minor}`
+}
+
+function fullVersion(version: string): string {
+  const parts = version.split('.')
+  return parts.length === 2 ? `${version}.0` : version
+}
+
+function stripMarkdown(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/<([^>]+)>/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function parseRequiredStops(markdown: string, currentVersion: string, targetVersion: string): RequiredStop[] {
+  const stops = new Map<string, RequiredStop>()
+
+  for (const section of markdown.split(/^### /m)) {
+    const heading = section.match(/^Required GitLab (\d+) upgrade stops/)
+    if (!heading) continue
+    const major = Number(heading[1])
+
+    const minorLine = section.split('\n').find((line) => line.includes('occur at versions'))
+    if (minorLine) {
+      for (const match of minorLine.matchAll(/`(\d+\.\d+)`/g)) {
+        const version = `${match[1]}.0`
+        stops.set(version, {
+          version,
+          note: `Required GitLab ${match[1]} upgrade stop. Use the latest available patch release for this minor version.`,
+          conditional: false,
+        })
+      }
+    }
+
+    for (const line of section.split('\n')) {
+      const row = line.match(/^\|\s*(\d+\.\d+\.\d+)\s*\|\s*(.*?)\s*\|$/)
+      if (!row) continue
+      const note = stripMarkdown(row[2] ?? '')
+      stops.set(row[1]!, {
+        version: row[1]!,
+        note: note || null,
+        conditional: /required only/i.test(note),
+      })
+    }
+
+    // GitLab documents the x.2/x.5/x.8/x.11 cadence for 17.5 and later. Use
+    // that rule for newer major versions even before a per-version section is
+    // added to the docs page.
+    if (major >= 18) {
+      for (const minor of [2, 5, 8, 11]) {
+        const version = `${major}.${minor}.0`
+        if (!stops.has(version)) {
+          stops.set(version, {
+            version,
+            note: `Required GitLab ${major}.${minor} upgrade stop from GitLab's x.2/x.5/x.8/x.11 cadence. Use the latest available patch release for this minor version.`,
+            conditional: false,
+          })
+        }
+      }
+    }
+  }
+
+  const current = fullVersion(currentVersion)
+  const target = fullVersion(targetVersion)
+  const targetMajor = Number(target.split('.')[0])
+  const maxMajor = Number.isFinite(targetMajor) ? targetMajor : 18
+
+  for (let major = 19; major <= maxMajor; major++) {
+    for (const minor of [2, 5, 8, 11]) {
+      const version = `${major}.${minor}.0`
+      if (!stops.has(version)) {
+        stops.set(version, {
+          version,
+          note: `Required GitLab ${major}.${minor} upgrade stop from GitLab's x.2/x.5/x.8/x.11 cadence. Use the latest available patch release for this minor version.`,
+          conditional: false,
+        })
+      }
+    }
+  }
+
+  const targetMm = majorMinor(target)
+  return Array.from(stops.values())
+    .filter((stop) => {
+      if (majorMinor(stop.version) === targetMm) return false
+      return compareVersions(stop.version, current) > 0 && compareVersions(stop.version, target) < 0
+    })
+    .sort((a, b) => compareVersions(a.version, b.version))
+}
+
+function basePackageUrl(edition: Edition, target: PackageRepoTarget, arch: string): string {
+  const name = packageNameFor(edition)
+  if (target.kind === 'deb') {
+    return `https://packages.gitlab.com/gitlab/${name}/${target.distro}/${target.release}/pool/main/g/${name}/`
+  }
+  return `https://packages.gitlab.com/gitlab/${name}/${target.distro}/${target.release}/${arch}/Packages/g/`
+}
+
+function packageFilename(edition: Edition, target: PackageRepoTarget, arch: string, version: string): string {
+  const name = packageNameFor(edition)
+  if (target.kind === 'deb') return `${name}_${version}-${edition}.0_${arch}.deb`
+  return `${name}-${version}-${edition}.0.${target.distro}${target.release}.${arch}.rpm`
+}
+
+function parseSizeLabel(label: string): number | null {
+  const match = label.trim().match(/^([\d.]+)\s*([KMGT]?B)$/i)
+  if (!match) return null
+  const value = Number(match[1])
+  if (!Number.isFinite(value)) return null
+  const unit = match[2]!.toUpperCase()
+  const multiplier =
+    unit === 'TB' ? 1024 ** 4 :
+    unit === 'GB' ? 1024 ** 3 :
+    unit === 'MB' ? 1024 ** 2 :
+    unit === 'KB' ? 1024 :
+    1
+  return Math.round(value * multiplier)
+}
+
+async function fetchPackageCandidates(
+  edition: Edition,
+  packageTarget: PackageTarget,
+  arch: string,
+): Promise<{ candidates: PackageCandidate[]; repoUrl: string }> {
+  const target = PACKAGE_TARGETS[packageTarget]
+  if (!target.arches.includes(arch)) {
+    throw new Error(`${target.label} does not publish ${arch} packages`)
+  }
+
+  const repoUrl = basePackageUrl(edition, target, arch)
+  const res = await fetch(repoUrl, { cache: 'no-store' })
+  if (!res.ok) throw new Error(`Unable to fetch GitLab package index (${res.status})`)
+  const html = await res.text()
+  const name = packageNameFor(edition)
+  const candidates: PackageCandidate[] = []
+
+  for (const line of html.split('\n')) {
+    const filePattern =
+      target.kind === 'deb'
+        ? new RegExp(`href="(${name}_(\\d+\\.\\d+\\.\\d+)-${edition}\\.0_${arch}\\.deb)"`)
+        : new RegExp(`href="(${name}-(\\d+\\.\\d+\\.\\d+)-${edition}\\.0\\.${target.distro}${target.release}\\.${arch}\\.rpm)"`)
+    const match = line.match(filePattern)
+    if (!match) continue
+    const sizeMatch = line.match(/>\s*(\d{2}-[A-Za-z]{3}-\d{4}\s+\d{2}:\d{2})\s+([\d.]+\s*[KMGT]?B)\s*$/)
+    const sizeLabel = sizeMatch?.[2]?.trim() ?? null
+    candidates.push({
+      filename: match[1]!,
+      version: match[2]!,
+      url: `${repoUrl}${match[1]!}`,
+      sizeBytes: sizeLabel ? parseSizeLabel(sizeLabel) : null,
+      sizeLabel,
+    })
+  }
+
+  return { candidates, repoUrl }
+}
+
+function findPackage(candidates: PackageCandidate[], version: string, allowLatestPatch: boolean): PackageCandidate | null {
+  const normalized = fullVersion(version)
+  if (!allowLatestPatch) {
+    return candidates.find((candidate) => candidate.version === normalized) ?? null
+  }
+  const mm = majorMinor(normalized)
+  const matching = candidates
+    .filter((candidate) => majorMinor(candidate.version) === mm)
+    .sort((a, b) => compareVersions(a.version, b.version))
+  return matching.at(-1) ?? null
+}
+
+function createStep(
+  params: {
+    role: 'required-stop' | 'target'
+    sourceVersion: string
+    note: string | null
+    conditional: boolean
+    packageName: string
+    candidate: PackageCandidate | null
+  },
+): GitLabBundleStep {
+  const version = params.candidate?.version ?? fullVersion(params.sourceVersion)
+  return {
+    id: `${params.role}-${version}`,
+    role: params.role,
+    version,
+    majorMinor: majorMinor(version),
+    sourceVersion: params.sourceVersion,
+    conditional: params.conditional,
+    note: params.note,
+    packageName: params.packageName,
+    filename: params.candidate?.filename ?? null,
+    url: params.candidate?.url ?? null,
+    sizeBytes: params.candidate?.sizeBytes ?? null,
+    sizeLabel: params.candidate?.sizeLabel ?? null,
+    status: params.candidate ? 'available' : 'not-found',
+    reason: params.candidate
+      ? undefined
+      : `No ${params.packageName} package found for ${params.sourceVersion}`,
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse<GitLabBundlerResponse>> {
+  try {
+    const raw = await req.json()
+    const parsed = BodySchema.safeParse(raw)
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: parsed.error.issues[0]?.message ?? 'Invalid request' }, { status: 400 })
+    }
+
+    const body = parsed.data
+    const current = fullVersion(body.currentVersion)
+    const target = fullVersion(body.targetVersion)
+    if (compareVersions(current, target) >= 0) {
+      return NextResponse.json({ ok: false, error: 'Target version must be newer than the current version' }, { status: 400 })
+    }
+
+    const targetDef = PACKAGE_TARGETS[body.packageTarget]
+    if (!targetDef.arches.includes(body.arch)) {
+      return NextResponse.json(
+        { ok: false, error: `${targetDef.label} does not publish ${body.arch} packages` },
+        { status: 400 },
+      )
+    }
+
+    const [upgradePathRes, packageData] = await Promise.all([
+      fetch(UPGRADE_PATH_SOURCE, { cache: 'no-store' }),
+      fetchPackageCandidates(body.edition, body.packageTarget, body.arch),
+    ])
+    if (!upgradePathRes.ok) {
+      return NextResponse.json({ ok: false, error: `Unable to fetch GitLab upgrade path docs (${upgradePathRes.status})` }, { status: 502 })
+    }
+    const markdown = await upgradePathRes.text()
+    const stops = parseRequiredStops(markdown, current, target)
+    const packageName = packageNameFor(body.edition)
+
+    const steps = stops.map((stop) =>
+      createStep({
+        role: 'required-stop',
+        sourceVersion: stop.version,
+        note: stop.note,
+        conditional: stop.conditional,
+        packageName,
+        candidate: findPackage(packageData.candidates, stop.version, true),
+      }),
+    )
+
+    const targetCandidate = findPackage(
+      packageData.candidates,
+      target,
+      body.targetVersion.split('.').length === 2,
+    )
+    steps.push(
+      createStep({
+        role: 'target',
+        sourceVersion: target,
+        note: majorMinor(target) === majorMinor(targetCandidate?.version ?? target)
+          ? 'Target version selected by the user.'
+          : null,
+        conditional: false,
+        packageName,
+        candidate: targetCandidate,
+      }),
+    )
+
+    const deduped = Array.from(
+      steps.reduce((acc, step) => acc.set(step.majorMinor, step), new Map<string, GitLabBundleStep>()).values(),
+    ).sort((a, b) => compareVersions(a.version, b.version))
+
+    return NextResponse.json({
+      ok: true,
+      currentVersion: current,
+      targetVersion: targetCandidate?.version ?? target,
+      edition: body.edition,
+      packageTarget: {
+        key: body.packageTarget,
+        label: targetDef.label,
+        arch: body.arch,
+        kind: targetDef.kind,
+      },
+      generatedAt: new Date().toISOString(),
+      sources: {
+        upgradePath: UPGRADE_PATH_SOURCE,
+        packages: packageData.repoUrl,
+      },
+      steps: deduped,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to resolve GitLab packages'
+    return NextResponse.json({ ok: false, error: message }, { status: 502 })
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse | Response> {
+  const params = Object.fromEntries(req.nextUrl.searchParams.entries())
+  const parsed = QuerySchema.safeParse(params)
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'Invalid or missing parameters' }, { status: 400 })
+  }
+
+  const target = PACKAGE_TARGETS[parsed.data.packageTarget]
+  if (!target.arches.includes(parsed.data.arch)) {
+    return NextResponse.json({ ok: false, error: 'Unsupported architecture for package target' }, { status: 400 })
+  }
+
+  const filename = packageFilename(parsed.data.edition, target, parsed.data.arch, parsed.data.version)
+  const url = `${basePackageUrl(parsed.data.edition, target, parsed.data.arch)}${filename}`
+  const upstream = await fetch(url, { cache: 'no-store', redirect: 'follow' })
+  if (!upstream.ok || !upstream.body) {
+    return NextResponse.json({ ok: false, error: `Upstream returned ${upstream.status}` }, { status: 502 })
+  }
+
+  const headers = new Headers()
+  headers.set('content-type', upstream.headers.get('content-type') ?? 'application/octet-stream')
+  headers.set('content-disposition', `attachment; filename="${filename}"`)
+  headers.set('cache-control', 'no-store')
+  const cl = upstream.headers.get('content-length') ?? upstream.headers.get('x-pulp-artifact-size')
+  if (cl) headers.set('content-length', cl)
+
+  return new Response(upstream.body, { status: 200, headers })
+}


### PR DESCRIPTION
## Summary

Adds a GitLab air-gap bundler alongside the existing Jenkins bundler.

- Adds a GitLab tab to the Air-gap Bundlers screen.
- Lets users enter current and target GitLab versions, select CE/EE, OS package target, and architecture.
- Resolves required GitLab upgrade stops from GitLab's current upgrade-path documentation.
- Looks up matching GitLab package files from packages.gitlab.com and supports per-step or download-all zip bundles with a manifest and README.
- Adds a server-side package download proxy that accepts validated package identifiers instead of arbitrary URLs.

## Validation

- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings only)
- Tested `/api/tools/gitlab-bundler` locally for Ubuntu Jammy DEB and EL9 RPM package resolution.
