### PR TITLE
fix(auth): scope LDAP login links to organisation

### DIFF
--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -85,18 +85,25 @@ export async function POST(request: NextRequest) {
     const ldapUser = result.user
     const ldapDn = ldapUser.dn
 
-    // Find existing account linked to this LDAP DN
-    const existingAccount = await db.query.accounts.findFirst({
-      where: and(
-        eq(accounts.providerId, 'ldap'),
-        eq(accounts.accountId, ldapDn),
-      ),
-    })
-
+    // Find existing account linked to this LDAP DN for this LDAP config's org.
     let userId: string
+    const [linkedAccount] = await db
+      .select({ user: users })
+      .from(accounts)
+      .innerJoin(users, eq(accounts.userId, users.id))
+      .where(
+        and(
+          eq(accounts.providerId, 'ldap'),
+          eq(accounts.accountId, ldapDn),
+          eq(users.organisationId, config.organisationId),
+          isNull(users.deletedAt),
+        ),
+      )
+      .limit(1)
+    const linkedUser = linkedAccount?.user ?? null
 
-    if (existingAccount) {
-      userId = existingAccount.userId
+    if (linkedUser) {
+      userId = linkedUser.id
 
       // Update user info from LDAP
       await db
@@ -108,10 +115,14 @@ export async function POST(request: NextRequest) {
         })
         .where(eq(users.id, userId))
     } else {
-      // Check if a user with this email already exists (merge case)
+      // Check if a user with this email already exists in this LDAP config's org.
       const existingUser = ldapUser.email
         ? await db.query.users.findFirst({
-            where: eq(users.email, ldapUser.email),
+            where: and(
+              eq(users.email, ldapUser.email),
+              eq(users.organisationId, config.organisationId),
+              isNull(users.deletedAt),
+            ),
           })
         : null
 


### PR DESCRIPTION
Closes #273.\n\nScopes LDAP account linking and email-based merges to the LDAP configuration organisation, and ignores deleted users, preventing a successful LDAP login in one organisation from linking to or updating a user in another organisation.\n\nValidation run by automation:\n- pnpm --filter web type-check\n- pnpm --filter web exec eslint app/api/auth/ldap/route.ts