### PR TITLE
ci: pin BuildKit image for Docker builds

### DIFF
--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Extract metadata
         id: meta
@@ -163,6 +165,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Derive version
         id: version

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Extract metadata
         id: meta
@@ -167,6 +169,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Derive version
         id: version

--- a/.github/workflows/pr-checks-docker-images.yml
+++ b/.github/workflows/pr-checks-docker-images.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Build web image
         uses: docker/build-push-action@v7
@@ -67,6 +69,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Build ingest image
         uses: docker/build-push-action@v7


### PR DESCRIPTION
## Summary

Pins the BuildKit daemon image used by Docker Buildx setup in CI.

The web release image build for `web/v0.68.0` failed while booting BuildKit on the self-hosted amd64 runner because the default moving `moby/buildkit:buildx-stable-1` tag resolved to a missing content digest. Pinning `moby/buildkit:v0.29.0` avoids that moving-tag failure mode across release image builds and Docker image PR checks.

## Validation

- `git diff --check`
- Inspected failed Actions job `73067293932` from release run `24953338412`
- Will manually dispatch the web image workflow for `web/v0.68.0` from this branch to recover the missing image
