### PR TITLE
feat(web): transfer bundler archives to hosts

### DIFF
--- a/apps/web/app/(dashboard)/bundlers/bundle-transfer-dialog.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundle-transfer-dialog.tsx
@@ -1,0 +1,329 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ArrowLeft,
+  CheckCircle2,
+  KeyRound,
+  Loader2,
+  Search,
+  Send,
+  Server,
+  WifiOff,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { listHosts, type HostWithAgent } from '@/lib/actions/agents'
+
+export type BuiltBundle = {
+  blob: Blob
+  fileName: string
+}
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  orgId: string
+  buildBundle: () => Promise<BuiltBundle>
+}
+
+type Step = 'details' | 'password'
+
+export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle }: Props) {
+  const [hosts, setHosts] = useState<HostWithAgent[]>([])
+  const [loadingHosts, setLoadingHosts] = useState(false)
+  const [search, setSearch] = useState('')
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(null)
+  const [username, setUsername] = useState('')
+  const [directory, setDirectory] = useState('/tmp')
+  const [password, setPassword] = useState('')
+  const [step, setStep] = useState<Step>('details')
+  const [transferring, setTransferring] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<{ path: string; host: string } | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setLoadingHosts(true)
+    setError(null)
+    listHosts(orgId)
+      .then((rows) => {
+        if (!cancelled) setHosts(rows)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load hosts')
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingHosts(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, orgId])
+
+  const filteredHosts = useMemo(() => {
+    const q = search.toLowerCase().trim()
+    const rows = [...hosts].sort((a, b) => {
+      if (a.status === b.status) {
+        return (a.displayName ?? a.hostname).localeCompare(b.displayName ?? b.hostname, undefined, { sensitivity: 'base' })
+      }
+      return a.status === 'online' ? -1 : 1
+    })
+    if (!q) return rows
+    return rows.filter((host) => {
+      const label = host.displayName ?? host.hostname
+      return (
+        label.toLowerCase().includes(q) ||
+        host.hostname.toLowerCase().includes(q) ||
+        (host.ipAddresses ?? []).some((ip) => ip.includes(q))
+      )
+    })
+  }, [hosts, search])
+
+  const selectedHost = hosts.find((host) => host.id === selectedHostId) ?? null
+  const canContinue = !!selectedHostId && username.trim().length > 0 && directory.trim().startsWith('/')
+
+  function reset() {
+    setSearch('')
+    setSelectedHostId(null)
+    setUsername('')
+    setDirectory('/tmp')
+    setPassword('')
+    setStep('details')
+    setTransferring(false)
+    setError(null)
+    setSuccess(null)
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (transferring) return
+    if (!nextOpen) reset()
+    onOpenChange(nextOpen)
+  }
+
+  function continueToPassword() {
+    setError(null)
+    if (!selectedHostId) {
+      setError('Select a host')
+      return
+    }
+    if (!username.trim()) {
+      setError('Enter a username')
+      return
+    }
+    if (!directory.trim().startsWith('/')) {
+      setError('Enter an absolute directory path')
+      return
+    }
+    setStep('password')
+  }
+
+  async function transfer() {
+    if (!selectedHost || !password) return
+    setTransferring(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const bundle = await buildBundle()
+      const form = new FormData()
+      form.set('hostId', selectedHost.id)
+      form.set('username', username.trim())
+      form.set('password', password)
+      form.set('directory', directory.trim())
+      form.set('fileName', bundle.fileName)
+      form.set('bundle', bundle.blob, bundle.fileName)
+
+      const res = await fetch('/api/tools/bundle-transfer', {
+        method: 'POST',
+        body: form,
+      })
+      const data = (await res.json().catch(() => null)) as { ok?: boolean; error?: string; path?: string; host?: string } | null
+      if (!res.ok || !data?.ok) {
+        throw new Error(data?.error ?? `Transfer failed (${res.status})`)
+      }
+      setPassword('')
+      setSuccess({ path: data.path ?? `${directory.trim()}/${bundle.fileName}`, host: data.host ?? selectedHost.hostname })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Transfer failed')
+    } finally {
+      setTransferring(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Send className="size-4" />
+            Transfer bundle
+          </DialogTitle>
+          <DialogDescription>
+            {step === 'details'
+              ? 'Select the destination host, username, and directory.'
+              : `Enter the SSH password for ${username.trim()}${selectedHost ? ` on ${selectedHost.displayName ?? selectedHost.hostname}` : ''}.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'details' ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Host</Label>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search hosts by name or IP"
+                  className="pl-9"
+                  autoFocus
+                />
+              </div>
+              <div className="max-h-56 overflow-y-auto rounded-md border">
+                {loadingHosts ? (
+                  <div className="flex items-center justify-center py-8">
+                    <Loader2 className="size-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : filteredHosts.length === 0 ? (
+                  <div className="py-8 text-center text-sm text-muted-foreground">
+                    {search ? 'No hosts match your search' : 'No hosts available'}
+                  </div>
+                ) : (
+                  filteredHosts.map((host) => {
+                    const active = host.id === selectedHostId
+                    return (
+                      <button
+                        key={host.id}
+                        type="button"
+                        onClick={() => {
+                          setSelectedHostId(host.id)
+                          setError(null)
+                        }}
+                        className={`flex w-full items-center gap-3 border-b px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-muted/50 ${
+                          active ? 'bg-muted' : ''
+                        }`}
+                      >
+                        {host.status === 'online' ? (
+                          <Server className="size-4 shrink-0 text-muted-foreground" />
+                        ) : (
+                          <WifiOff className="size-4 shrink-0 text-muted-foreground" />
+                        )}
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium">{host.displayName ?? host.hostname}</span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {host.displayName && host.displayName !== host.hostname ? host.hostname : host.ipAddresses?.[0] ?? 'No IP recorded'}
+                          </span>
+                        </span>
+                        <Badge variant={host.status === 'online' ? 'default' : 'secondary'}>{host.status}</Badge>
+                      </button>
+                    )
+                  })
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="bundle-transfer-username">Username</Label>
+                <Input
+                  id="bundle-transfer-username"
+                  value={username}
+                  onChange={(event) => {
+                    setUsername(event.target.value)
+                    setError(null)
+                  }}
+                  placeholder="e.g. deploy"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="bundle-transfer-path">Directory</Label>
+                <Input
+                  id="bundle-transfer-path"
+                  value={directory}
+                  onChange={(event) => {
+                    setDirectory(event.target.value)
+                    setError(null)
+                  }}
+                  placeholder="/tmp"
+                />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="rounded-md border bg-muted/30 p-3 text-sm">
+              <div className="font-medium">{selectedHost?.displayName ?? selectedHost?.hostname}</div>
+              <div className="break-all text-muted-foreground">
+                {username.trim()}:{directory.trim()}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="bundle-transfer-password" className="flex items-center gap-1.5">
+                <KeyRound className="size-3.5" />
+                Password
+              </Label>
+              <Input
+                id="bundle-transfer-password"
+                type="password"
+                value={password}
+                onChange={(event) => {
+                  setPassword(event.target.value)
+                  setError(null)
+                }}
+                autoFocus
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && password && !transferring) void transfer()
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="flex items-start gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-200">
+            <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
+            <span>
+              Transferred to <span className="font-medium">{success.host}</span>
+              <span className="block break-all font-mono text-xs">{success.path}</span>
+            </span>
+          </div>
+        )}
+
+        <DialogFooter>
+          {step === 'password' && (
+            <Button type="button" variant="outline" onClick={() => setStep('details')} disabled={transferring} className="mr-auto">
+              <ArrowLeft className="size-4" />
+              Back
+            </Button>
+          )}
+          {step === 'details' ? (
+            <Button type="button" onClick={continueToPassword} disabled={!canContinue}>
+              Continue
+            </Button>
+          ) : (
+            <Button type="button" onClick={transfer} disabled={!password || transferring}>
+              {transferring ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+              Transfer
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/app/(dashboard)/bundlers/bundlers-client.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundlers-client.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { GitLabBundler } from './gitlab-bundler'
 import { JenkinsBundler } from './jenkins-bundler'
 
-export function BundlersClient() {
+export function BundlersClient({ orgId }: { orgId: string }) {
   return (
     <Tabs defaultValue="jenkins" className="w-full">
       <TabsList>
@@ -12,10 +12,10 @@ export function BundlersClient() {
         <TabsTrigger value="gitlab">GitLab</TabsTrigger>
       </TabsList>
       <TabsContent value="jenkins" className="mt-4">
-        <JenkinsBundler />
+        <JenkinsBundler orgId={orgId} />
       </TabsContent>
       <TabsContent value="gitlab" className="mt-4">
-        <GitLabBundler />
+        <GitLabBundler orgId={orgId} />
       </TabsContent>
     </Tabs>
   )

--- a/apps/web/app/(dashboard)/bundlers/gitlab-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/gitlab-bundler.tsx
@@ -11,6 +11,7 @@ import {
   Package,
   RefreshCw,
   Search,
+  Send,
 } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -34,6 +35,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import type { GitLabBundleStep, GitLabBundlerResponse, GitLabLatestVersionResponse } from '@/app/api/tools/gitlab-bundler/route'
+import { BundleTransferDialog, type BuiltBundle } from './bundle-transfer-dialog'
 
 const OS_OPTIONS = [
   { value: 'ubuntu-noble', label: 'Ubuntu 24.04 Noble', kind: 'deb', arches: ['amd64', 'arm64'] },
@@ -110,7 +112,18 @@ function safeVersion(value: string): boolean {
   return /^\d+\.\d+(\.\d+)?$/.test(value)
 }
 
-export function GitLabBundler() {
+function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = fileName
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
+export function GitLabBundler({ orgId }: { orgId: string }) {
   const [currentVersion, setCurrentVersion] = useState('')
   const [targetVersion, setTargetVersion] = useState('')
   const [edition, setEdition] = useState<'ee' | 'ce'>('ee')
@@ -128,6 +141,7 @@ export function GitLabBundler() {
   const [currentTotal, setCurrentTotal] = useState<number | null>(null)
   const [doneCount, setDoneCount] = useState(0)
   const [downloadTotal, setDownloadTotal] = useState(0)
+  const [transferOpen, setTransferOpen] = useState(false)
 
   const availableSteps = useMemo(
     () => report?.steps.filter((step) => step.status === 'available' && step.filename) ?? [],
@@ -206,8 +220,8 @@ export function GitLabBundler() {
     }
   }
 
-  async function downloadSteps(steps: GitLabBundleStep[], label: string) {
-    if (!report || steps.length === 0) return
+  async function buildStepsBundle(steps: GitLabBundleStep[], label: string): Promise<BuiltBundle> {
+    if (!report || steps.length === 0) throw new Error('No packages available to bundle')
     setDownloadError(null)
     setDownloading(true)
     setDoneCount(0)
@@ -269,19 +283,26 @@ export function GitLabBundler() {
       )
 
       const blob = await zip.generateAsync({ type: 'blob' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `gitlab-${report.edition}-${report.currentVersion}-to-${report.targetVersion}-${label}.zip`
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      URL.revokeObjectURL(url)
+      return {
+        blob,
+        fileName: `gitlab-${report.edition}-${report.currentVersion}-to-${report.targetVersion}-${label}.zip`,
+      }
     } catch (err) {
-      setDownloadError(err instanceof Error ? err.message : 'Download failed')
+      const message = err instanceof Error ? err.message : 'Download failed'
+      setDownloadError(message)
+      throw new Error(message)
     } finally {
       setDownloading(false)
       setCurrentFile(null)
+    }
+  }
+
+  async function downloadSteps(steps: GitLabBundleStep[], label: string) {
+    try {
+      const bundle = await buildStepsBundle(steps, label)
+      downloadBlob(bundle.blob, bundle.fileName)
+    } catch {
+      // buildStepsBundle already surfaced the error in the bundler panel.
     }
   }
 
@@ -386,6 +407,14 @@ export function GitLabBundler() {
               >
                 {downloading ? <Loader2 className="size-4 animate-spin" /> : <Archive className="size-4" />}
                 Download all
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setTransferOpen(true)}
+                disabled={!report || availableSteps.length === 0 || downloading || resolving}
+              >
+                <Send className="size-4" />
+                Transfer all
               </Button>
             </div>
 
@@ -508,6 +537,12 @@ export function GitLabBundler() {
           )}
         </CardContent>
       </Card>
+      <BundleTransferDialog
+        open={transferOpen}
+        onOpenChange={setTransferOpen}
+        orgId={orgId}
+        buildBundle={() => buildStepsBundle(availableSteps, 'all')}
+      />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   Package,
   RefreshCw,
+  Send,
   Sparkles,
   Upload,
   XCircle,
@@ -38,6 +39,7 @@ import type {
   ResolvedPluginNode,
   ResolveResponse,
 } from '@/app/api/tools/jenkins-bundler/route'
+import { BundleTransferDialog, type BuiltBundle } from './bundle-transfer-dialog'
 
 type PluginRow = ResolvedPlugin & {
   downloaded: boolean
@@ -163,6 +165,17 @@ function sortPluginNodes(nodes: ResolvedPluginNode[]): ResolvedPluginNode[] {
   }))
 }
 
+function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = fileName
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
 // Bash script bundled into the offline-script zip. Reads manifest.tsv and
 // downloads each entry, then zips them up so the final archive matches what
 // the in-browser "Download bundle" button would produce.
@@ -266,7 +279,7 @@ Jenkins.instance.pluginManager.plugins
   .each { println it }
 `
 
-export function JenkinsBundler() {
+export function JenkinsBundler({ orgId }: { orgId: string }) {
   const [coreVersion, setCoreVersion] = useState('')
   const [javaVersion, setJavaVersion] = useState<string>('')
   const [pluginsText, setPluginsText] = useState('')
@@ -283,6 +296,7 @@ export function JenkinsBundler() {
   const [currentTotal, setCurrentTotal] = useState<number | null>(null)
   const [doneCount, setDoneCount] = useState(0)
   const [scriptBundling, setScriptBundling] = useState(false)
+  const [transferOpen, setTransferOpen] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   function toggleExpanded(key: string) {
@@ -397,8 +411,8 @@ export function JenkinsBundler() {
     }
   }
 
-  async function downloadBundle() {
-    if (!report) return
+  async function buildJenkinsBundle(): Promise<BuiltBundle> {
+    if (!report) throw new Error('Resolve a bundle before transferring')
     setDownloadError(null)
     setDownloading(true)
     setDoneCount(0)
@@ -580,21 +594,28 @@ export function JenkinsBundler() {
       zip.file('bundle-manifest.json', JSON.stringify(manifest, null, 2))
 
       const blob = await zip.generateAsync({ type: 'blob' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `jenkins-${report.core.version}-bundle.zip`
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      URL.revokeObjectURL(url)
 
       commitDownloadState()
+      return {
+        blob,
+        fileName: `jenkins-${report.core.version}-bundle.zip`,
+      }
     } catch (e) {
-      setDownloadError(e instanceof Error ? e.message : 'Download failed')
+      const message = e instanceof Error ? e.message : 'Download failed'
+      setDownloadError(message)
+      throw new Error(message)
     } finally {
       setDownloading(false)
       setCurrentFile(null)
+    }
+  }
+
+  async function downloadBundle() {
+    try {
+      const bundle = await buildJenkinsBundle()
+      downloadBlob(bundle.blob, bundle.fileName)
+    } catch {
+      // buildJenkinsBundle already surfaced the error in the bundler panel.
     }
   }
 
@@ -810,6 +831,15 @@ export function JenkinsBundler() {
               </Button>
               <Button
                 type="button"
+                onClick={() => setTransferOpen(true)}
+                disabled={!report || downloading || scriptBundling || totalToDownload === 0}
+                variant="outline"
+              >
+                <Send className="mr-1.5 size-4" />
+                Transfer bundle
+              </Button>
+              <Button
+                type="button"
                 onClick={downloadScriptBundle}
                 disabled={!report || downloading || scriptBundling || totalToDownload === 0}
                 variant="outline"
@@ -888,6 +918,12 @@ export function JenkinsBundler() {
       <div className="space-y-6">
         <HelpCard />
       </div>
+      <BundleTransferDialog
+        open={transferOpen}
+        onOpenChange={setTransferOpen}
+        orgId={orgId}
+        buildBundle={buildJenkinsBundle}
+      />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/bundlers/page.tsx
+++ b/apps/web/app/(dashboard)/bundlers/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from 'next'
+import { getRequiredSession } from '@/lib/auth/session'
 import { BundlersClient } from './bundlers-client'
 
 export const metadata: Metadata = {
   title: 'Air-gap Bundlers',
 }
 
-export default function BundlersPage() {
+export default async function BundlersPage() {
+  const session = await getRequiredSession()
+  const orgId = session.user.organisationId!
+
   return (
     <div className="space-y-6">
       <div>
@@ -14,7 +18,7 @@ export default function BundlersPage() {
           Build self-contained bundles of upstream software for installation into air-gapped networks.
         </p>
       </div>
-      <BundlersClient />
+      <BundlersClient orgId={orgId} />
     </div>
   )
 }

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -1,0 +1,217 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Client, type SFTPWrapper } from 'ssh2'
+import { z } from 'zod'
+import { and, eq, isNull } from 'drizzle-orm'
+import { auth } from '@/lib/auth'
+import { db } from '@/lib/db'
+import { hosts, users } from '@/lib/db/schema'
+import path from 'node:path'
+
+export const runtime = 'nodejs'
+
+const TransferFieldsSchema = z.object({
+  hostId: z.string().min(1),
+  username: z.string().min(1).max(128).regex(/^[^\s:]+$/, 'Username cannot contain whitespace or ":"'),
+  password: z.string().min(1).max(4096),
+  directory: z
+    .string()
+    .min(1)
+    .max(4096)
+    .refine((value) => !value.includes('\0'), 'Directory path is invalid')
+    .refine((value) => value.trim().startsWith('/'), 'Enter an absolute directory path'),
+  fileName: z
+    .string()
+    .min(1)
+    .max(200)
+    .regex(/^[A-Za-z0-9._-]+\.zip$/, 'Bundle filename must be a zip filename'),
+})
+
+function formValue(form: FormData, key: string): string {
+  const value = form.get(key)
+  return typeof value === 'string' ? value : ''
+}
+
+function getFormFile(form: FormData): File | null {
+  const value = form.get('bundle')
+  if (value && typeof value === 'object' && 'arrayBuffer' in value && 'size' in value) {
+    return value as File
+  }
+  return null
+}
+
+function connectSsh(options: { host: string; username: string; password: string }): Promise<Client> {
+  return new Promise((resolve, reject) => {
+    const client = new Client()
+    const cleanup = () => {
+      client.off('ready', onReady)
+      client.off('error', onError)
+    }
+    const onReady = () => {
+      cleanup()
+      resolve(client)
+    }
+    const onError = (err: Error) => {
+      cleanup()
+      reject(err)
+    }
+    client.once('ready', onReady)
+    client.once('error', onError)
+    client.connect({
+      host: options.host,
+      port: 22,
+      username: options.username,
+      password: options.password,
+      readyTimeout: 30_000,
+      keepaliveInterval: 10_000,
+    })
+  })
+}
+
+function openSftp(client: Client): Promise<SFTPWrapper> {
+  return new Promise((resolve, reject) => {
+    client.sftp((err, sftp) => {
+      if (err) reject(err)
+      else resolve(sftp)
+    })
+  })
+}
+
+function isMissingSftpError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | { code?: number } | null)?.code
+  return code === 'ENOENT' || code === 2
+}
+
+function stat(sftp: SFTPWrapper, remotePath: string): Promise<{ isDirectory: () => boolean } | null> {
+  return new Promise((resolve, reject) => {
+    sftp.stat(remotePath, (err, stats) => {
+      if (!err) {
+        resolve(stats)
+        return
+      }
+      if (isMissingSftpError(err)) {
+        resolve(null)
+        return
+      }
+      reject(err)
+    })
+  })
+}
+
+function mkdir(sftp: SFTPWrapper, remotePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.mkdir(remotePath, async (err) => {
+      if (!err) {
+        resolve()
+        return
+      }
+      try {
+        const stats = await stat(sftp, remotePath)
+        if (stats?.isDirectory()) resolve()
+        else reject(err)
+      } catch {
+        reject(err)
+      }
+    })
+  })
+}
+
+async function ensureRemoteDirectory(sftp: SFTPWrapper, directory: string) {
+  const normalized = path.posix.normalize(directory)
+  const parts = normalized.split('/').filter(Boolean)
+  let current = normalized.startsWith('/') ? '/' : ''
+
+  for (const part of parts) {
+    current = current === '/' ? `/${part}` : path.posix.join(current, part)
+    const stats = await stat(sftp, current)
+    if (!stats) await mkdir(sftp, current)
+    else if (!stats.isDirectory()) throw new Error(`${current} exists but is not a directory`)
+  }
+}
+
+function writeFile(sftp: SFTPWrapper, remotePath: string, data: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sftp.writeFile(remotePath, data, (err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
+  }
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, session.user.id),
+  })
+  if (!user?.organisationId) {
+    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
+  }
+
+  const form = await request.formData().catch(() => null)
+  if (!form) {
+    return NextResponse.json({ error: 'Invalid transfer request' }, { status: 400 })
+  }
+
+  const bundle = getFormFile(form)
+  if (!bundle || bundle.size === 0) {
+    return NextResponse.json({ error: 'Bundle zip is required' }, { status: 400 })
+  }
+
+  const parsed = TransferFieldsSchema.safeParse({
+    hostId: formValue(form, 'hostId'),
+    username: formValue(form, 'username').trim(),
+    password: formValue(form, 'password'),
+    directory: formValue(form, 'directory').trim(),
+    fileName: formValue(form, 'fileName').trim(),
+  })
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? 'Invalid transfer request' },
+      { status: 400 },
+    )
+  }
+
+  const host = await db.query.hosts.findFirst({
+    where: and(
+      eq(hosts.id, parsed.data.hostId),
+      eq(hosts.organisationId, user.organisationId),
+      isNull(hosts.deletedAt),
+    ),
+  })
+  if (!host) {
+    return NextResponse.json({ error: 'Host not found' }, { status: 404 })
+  }
+
+  const connectHost = host.hostname
+  const directory = path.posix.normalize(parsed.data.directory)
+  const remotePath = path.posix.join(directory, parsed.data.fileName)
+  let client: Client | null = null
+
+  try {
+    const data = Buffer.from(await bundle.arrayBuffer())
+    client = await connectSsh({
+      host: connectHost,
+      username: parsed.data.username,
+      password: parsed.data.password,
+    })
+    const sftp = await openSftp(client)
+    await ensureRemoteDirectory(sftp, directory)
+    await writeFile(sftp, remotePath, data)
+
+    return NextResponse.json({
+      ok: true,
+      host: connectHost,
+      path: remotePath,
+      bytes: data.byteLength,
+    })
+  } catch (err) {
+    console.error('Bundle transfer failed:', err)
+    const message = err instanceof Error && err.message ? err.message : 'Transfer failed'
+    return NextResponse.json({ error: message }, { status: 502 })
+  } finally {
+    client?.end()
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "remark-gfm": "^4.0.1",
     "semver": "^7.7.4",
     "shadcn": "^4.3.0",
+    "ssh2": "^1.17.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"
@@ -69,6 +70,7 @@
     "@types/nodemailer": "^8.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/ssh2": "^1.15.5",
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       shadcn:
         specifier: ^4.3.0
         version: 4.3.0(@types/node@20.19.37)(typescript@5.9.3)
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -307,6 +310,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2


### PR DESCRIPTION
## Summary
- add a shared transfer dialog for GitLab and Jenkins bundler archives
- start server-side transfer jobs instead of uploading generated zip files through nginx
- show visible bundle-file download progress followed by host-transfer status on the bundlers page
- add an authenticated SFTP upload endpoint that validates selected hosts by organisation

## Impact
Operators can transfer large air-gap bundles directly to a selected CT-Ops host without hitting reverse-proxy request body limits. The password is used only for the transfer request and is not stored.

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint
- pnpm install --lockfile-only --frozen-lockfile