### PR TITLE
fix(web): stream bundle transfers server-side

### DIFF
--- a/apps/web/app/(dashboard)/bundlers/bundle-transfer-dialog.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundle-transfer-dialog.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import {
   ArrowLeft,
-  CheckCircle2,
   KeyRound,
   Loader2,
   Search,
@@ -25,21 +24,36 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { listHosts, type HostWithAgent } from '@/lib/actions/agents'
 
-export type BuiltBundle = {
-  blob: Blob
+export type TransferBundle = {
   fileName: string
+  payload: unknown
+}
+
+export type TransferJobStatus = {
+  id: string
+  phase: 'queued' | 'downloading' | 'transferring' | 'completed' | 'failed'
+  fileName: string
+  host: string
+  path: string
+  filesTotal: number
+  filesDone: number
+  currentFile: string | null
+  currentLoaded: number
+  currentTotal: number | null
+  error: string | null
 }
 
 type Props = {
   open: boolean
   onOpenChange: (open: boolean) => void
   orgId: string
-  buildBundle: () => Promise<BuiltBundle>
+  buildBundle: () => TransferBundle
+  onTransferStarted: (job: TransferJobStatus) => void
 }
 
 type Step = 'details' | 'password'
 
-export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle }: Props) {
+export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, onTransferStarted }: Props) {
   const [hosts, setHosts] = useState<HostWithAgent[]>([])
   const [loadingHosts, setLoadingHosts] = useState(false)
   const [search, setSearch] = useState('')
@@ -50,7 +64,6 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle }:
   const [step, setStep] = useState<Step>('details')
   const [transferring, setTransferring] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<{ path: string; host: string } | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -103,7 +116,6 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle }:
     setStep('details')
     setTransferring(false)
     setError(null)
-    setSuccess(null)
   }
 
   function handleOpenChange(nextOpen: boolean) {
@@ -133,27 +145,29 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle }:
     if (!selectedHost || !password) return
     setTransferring(true)
     setError(null)
-    setSuccess(null)
     try {
-      const bundle = await buildBundle()
-      const form = new FormData()
-      form.set('hostId', selectedHost.id)
-      form.set('username', username.trim())
-      form.set('password', password)
-      form.set('directory', directory.trim())
-      form.set('fileName', bundle.fileName)
-      form.set('bundle', bundle.blob, bundle.fileName)
-
+      const bundle = buildBundle()
       const res = await fetch('/api/tools/bundle-transfer', {
         method: 'POST',
-        body: form,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          hostId: selectedHost.id,
+          username: username.trim(),
+          password,
+          directory: directory.trim(),
+          fileName: bundle.fileName,
+          bundle: bundle.payload,
+        }),
       })
-      const data = (await res.json().catch(() => null)) as { ok?: boolean; error?: string; path?: string; host?: string } | null
+      const data = (await res.json().catch(() => null)) as { ok?: boolean; error?: string; job?: TransferJobStatus } | null
       if (!res.ok || !data?.ok) {
         throw new Error(data?.error ?? `Transfer failed (${res.status})`)
       }
+      if (!data.job) throw new Error('Transfer job was not created')
+      onTransferStarted(data.job)
       setPassword('')
-      setSuccess({ path: data.path ?? `${directory.trim()}/${bundle.fileName}`, host: data.host ?? selectedHost.hostname })
+      reset()
+      onOpenChange(false)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Transfer failed')
     } finally {
@@ -295,16 +309,6 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle }:
             {error}
           </div>
         )}
-        {success && (
-          <div className="flex items-start gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-200">
-            <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
-            <span>
-              Transferred to <span className="font-medium">{success.host}</span>
-              <span className="block break-all font-mono text-xs">{success.path}</span>
-            </span>
-          </div>
-        )}
-
         <DialogFooter>
           {step === 'password' && (
             <Button type="button" variant="outline" onClick={() => setStep('details')} disabled={transferring} className="mr-auto">

--- a/apps/web/app/(dashboard)/bundlers/bundle-transfer-status.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundle-transfer-status.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useEffect } from 'react'
+import { AlertTriangle, CheckCircle2, Loader2, Send } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { TransferJobStatus } from './bundle-transfer-dialog'
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null || !Number.isFinite(bytes)) return 'Unknown'
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MB`
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${bytes} B`
+}
+
+function filePct(job: TransferJobStatus): number {
+  if (!job.currentTotal || job.currentTotal <= 0) return 0
+  return Math.min(100, (job.currentLoaded / job.currentTotal) * 100)
+}
+
+function overallPct(job: TransferJobStatus): number {
+  if (job.filesTotal <= 0) return 0
+  const current = job.currentTotal && job.currentTotal > 0 ? job.currentLoaded / job.currentTotal : 0
+  return Math.min(100, ((job.filesDone + current) / job.filesTotal) * 100)
+}
+
+export function BundleTransferStatus({
+  job,
+  onJobChange,
+}: {
+  job: TransferJobStatus | null
+  onJobChange: (job: TransferJobStatus) => void
+}) {
+  useEffect(() => {
+    if (!job || job.phase === 'completed' || job.phase === 'failed') return
+
+    const timer = window.setInterval(async () => {
+      const res = await fetch(`/api/tools/bundle-transfer?jobId=${encodeURIComponent(job.id)}`, { cache: 'no-store' })
+      const data = (await res.json().catch(() => null)) as { ok?: boolean; job?: TransferJobStatus } | null
+      if (res.ok && data?.ok && data.job) onJobChange(data.job)
+    }, 1000)
+
+    return () => window.clearInterval(timer)
+  }, [job, onJobChange])
+
+  if (!job) return null
+
+  if (job.phase === 'failed') {
+    return (
+      <Alert variant="destructive">
+        <AlertTriangle className="size-4" />
+        <AlertTitle>Transfer failed</AlertTitle>
+        <AlertDescription>{job.error ?? 'The bundle could not be transferred.'}</AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (job.phase === 'completed') {
+    return (
+      <Alert>
+        <CheckCircle2 className="size-4" />
+        <AlertTitle>Transfer complete</AlertTitle>
+        <AlertDescription>
+          Bundle written to <span className="font-medium">{job.host}</span>
+          <span className="block break-all font-mono text-xs">{job.path}</span>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  const downloading = job.phase === 'queued' || job.phase === 'downloading'
+  const transferring = job.phase === 'transferring'
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Send className="size-4" />
+          Bundle transfer
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2 font-medium">
+              {downloading ? <Loader2 className="size-4 animate-spin" /> : <CheckCircle2 className="size-4 text-emerald-600" />}
+              Download bundle files
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {job.filesDone} / {job.filesTotal || '...'}
+            </span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-full bg-primary transition-[width] duration-150" style={{ width: `${overallPct(job)}%` }} />
+          </div>
+          {downloading && (
+            <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span className="truncate">{job.currentFile ?? 'Preparing downloads...'}</span>
+              <span className="shrink-0">
+                {job.currentTotal ? `${formatBytes(job.currentLoaded)} / ${formatBytes(job.currentTotal)}` : formatBytes(job.currentLoaded)}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2 font-medium">
+              {transferring ? <Loader2 className="size-4 animate-spin" /> : <span className="size-4 rounded-full border" />}
+              Transfer to host
+            </span>
+            <span className="max-w-[50%] truncate text-xs text-muted-foreground">{job.host}</span>
+          </div>
+          <div className="rounded-md border bg-muted/30 p-3 text-xs">
+            <div className="break-all font-mono">{job.path}</div>
+            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full bg-emerald-600 transition-[width] duration-150"
+                style={{ width: transferring ? `${Math.max(12, filePct(job))}%` : '0%' }}
+              />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/app/(dashboard)/bundlers/gitlab-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/gitlab-bundler.tsx
@@ -35,7 +35,8 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import type { GitLabBundleStep, GitLabBundlerResponse, GitLabLatestVersionResponse } from '@/app/api/tools/gitlab-bundler/route'
-import { BundleTransferDialog, type BuiltBundle } from './bundle-transfer-dialog'
+import { BundleTransferDialog, type TransferBundle, type TransferJobStatus } from './bundle-transfer-dialog'
+import { BundleTransferStatus } from './bundle-transfer-status'
 
 const OS_OPTIONS = [
   { value: 'ubuntu-noble', label: 'Ubuntu 24.04 Noble', kind: 'deb', arches: ['amd64', 'arm64'] },
@@ -142,6 +143,7 @@ export function GitLabBundler({ orgId }: { orgId: string }) {
   const [doneCount, setDoneCount] = useState(0)
   const [downloadTotal, setDownloadTotal] = useState(0)
   const [transferOpen, setTransferOpen] = useState(false)
+  const [transferJob, setTransferJob] = useState<TransferJobStatus | null>(null)
 
   const availableSteps = useMemo(
     () => report?.steps.filter((step) => step.status === 'available' && step.filename) ?? [],
@@ -220,7 +222,7 @@ export function GitLabBundler({ orgId }: { orgId: string }) {
     }
   }
 
-  async function buildStepsBundle(steps: GitLabBundleStep[], label: string): Promise<BuiltBundle> {
+  async function buildStepsBundle(steps: GitLabBundleStep[], label: string): Promise<{ blob: Blob; fileName: string }> {
     if (!report || steps.length === 0) throw new Error('No packages available to bundle')
     setDownloadError(null)
     setDownloading(true)
@@ -303,6 +305,36 @@ export function GitLabBundler({ orgId }: { orgId: string }) {
       downloadBlob(bundle.blob, bundle.fileName)
     } catch {
       // buildStepsBundle already surfaced the error in the bundler panel.
+    }
+  }
+
+  function buildTransferBundle(): TransferBundle {
+    if (!report || availableSteps.length === 0) throw new Error('No packages available to transfer')
+    return {
+      fileName: `gitlab-${report.edition}-${report.currentVersion}-to-${report.targetVersion}-all.zip`,
+      payload: {
+        kind: 'gitlab',
+        generatedAt: report.generatedAt,
+        currentVersion: report.currentVersion,
+        targetVersion: report.targetVersion,
+        edition: report.edition,
+        packageTarget: report.packageTarget,
+        sources: report.sources,
+        steps: availableSteps.map((step) => ({
+          id: step.id,
+          role: step.role,
+          version: step.version,
+          majorMinor: step.majorMinor,
+          sourceVersion: step.sourceVersion,
+          conditional: step.conditional,
+          note: step.note,
+          packageName: step.packageName,
+          filename: step.filename!,
+          sizeBytes: step.sizeBytes,
+          sizeLabel: step.sizeLabel,
+          status: 'available',
+        })),
+      },
     }
   }
 
@@ -513,6 +545,7 @@ export function GitLabBundler({ orgId }: { orgId: string }) {
             </CardContent>
           </Card>
         )}
+        <BundleTransferStatus job={transferJob} onJobChange={setTransferJob} />
       </div>
 
       <Card className="h-fit">
@@ -541,7 +574,8 @@ export function GitLabBundler({ orgId }: { orgId: string }) {
         open={transferOpen}
         onOpenChange={setTransferOpen}
         orgId={orgId}
-        buildBundle={() => buildStepsBundle(availableSteps, 'all')}
+        buildBundle={buildTransferBundle}
+        onTransferStarted={setTransferJob}
       />
     </div>
   )

--- a/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
+++ b/apps/web/app/(dashboard)/bundlers/jenkins-bundler.tsx
@@ -39,7 +39,8 @@ import type {
   ResolvedPluginNode,
   ResolveResponse,
 } from '@/app/api/tools/jenkins-bundler/route'
-import { BundleTransferDialog, type BuiltBundle } from './bundle-transfer-dialog'
+import { BundleTransferDialog, type TransferBundle, type TransferJobStatus } from './bundle-transfer-dialog'
+import { BundleTransferStatus } from './bundle-transfer-status'
 
 type PluginRow = ResolvedPlugin & {
   downloaded: boolean
@@ -297,6 +298,7 @@ export function JenkinsBundler({ orgId }: { orgId: string }) {
   const [doneCount, setDoneCount] = useState(0)
   const [scriptBundling, setScriptBundling] = useState(false)
   const [transferOpen, setTransferOpen] = useState(false)
+  const [transferJob, setTransferJob] = useState<TransferJobStatus | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   function toggleExpanded(key: string) {
@@ -411,7 +413,7 @@ export function JenkinsBundler({ orgId }: { orgId: string }) {
     }
   }
 
-  async function buildJenkinsBundle(): Promise<BuiltBundle> {
+  async function buildJenkinsBundle(): Promise<{ blob: Blob; fileName: string }> {
     if (!report) throw new Error('Resolve a bundle before transferring')
     setDownloadError(null)
     setDownloading(true)
@@ -616,6 +618,42 @@ export function JenkinsBundler({ orgId }: { orgId: string }) {
       downloadBlob(bundle.blob, bundle.fileName)
     } catch {
       // buildJenkinsBundle already surfaced the error in the bundler panel.
+    }
+  }
+
+  function buildTransferBundle(): TransferBundle {
+    if (!report) throw new Error('Resolve a bundle before transferring')
+    return {
+      fileName: `jenkins-${report.core.version}-bundle.zip`,
+      payload: {
+        kind: 'jenkins',
+        generatedAt: report.generatedAt,
+        core: report.core,
+        includesTransitive: report.includesTransitive,
+        plugins: report.plugins.map((plugin) => ({
+          name: plugin.name,
+          requested: plugin.requested,
+          status: plugin.status,
+          version: plugin.version,
+          requiredCore: plugin.requiredCore,
+          minimumJavaVersion: plugin.minimumJavaVersion,
+          size: plugin.size,
+          sha256: plugin.sha256,
+          reason: plugin.reason,
+        })),
+        transitivePlugins: report.transitivePlugins.map((plugin) => ({
+          name: plugin.name,
+          requested: plugin.requested,
+          status: plugin.status,
+          version: plugin.version,
+          requiredCore: plugin.requiredCore,
+          minimumJavaVersion: plugin.minimumJavaVersion,
+          size: plugin.size,
+          sha256: plugin.sha256,
+          reason: plugin.reason,
+        })),
+        dependencyTree: report.plugins,
+      },
     }
   }
 
@@ -913,6 +951,7 @@ export function JenkinsBundler({ orgId }: { orgId: string }) {
             toggleExpanded={toggleExpanded}
           />
         )}
+        <BundleTransferStatus job={transferJob} onJobChange={setTransferJob} />
       </div>
 
       <div className="space-y-6">
@@ -922,7 +961,8 @@ export function JenkinsBundler({ orgId }: { orgId: string }) {
         open={transferOpen}
         onOpenChange={setTransferOpen}
         orgId={orgId}
-        buildBundle={buildJenkinsBundle}
+        buildBundle={buildTransferBundle}
+        onTransferStarted={setTransferJob}
       />
     </div>
   )

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -1,15 +1,117 @@
 import { NextRequest, NextResponse } from 'next/server'
+import archiver from 'archiver'
 import { Client, type SFTPWrapper } from 'ssh2'
 import { z } from 'zod'
 import { and, eq, isNull } from 'drizzle-orm'
+import { Readable } from 'node:stream'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+import { pipeline } from 'node:stream/promises'
+import { createWriteStream } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { hosts, users } from '@/lib/db/schema'
-import path from 'node:path'
+import { resolveWarUrl } from '@/lib/jenkins/update-center'
 
 export const runtime = 'nodejs'
+export const maxDuration = 900
 
-const TransferFieldsSchema = z.object({
+const GitLabPackageTargetSchema = z.enum([
+  'ubuntu-noble',
+  'ubuntu-jammy',
+  'ubuntu-focal',
+  'debian-bookworm',
+  'debian-bullseye',
+  'el-9',
+  'el-8',
+])
+
+const GitLabEditionSchema = z.enum(['ee', 'ce'])
+const GitLabArchSchema = z.enum(['amd64', 'arm64', 'x86_64', 'aarch64'])
+const GitLabVersionSchema = z.string().regex(/^\d+\.\d+\.\d+$/)
+
+const GitLabTargets: Record<z.infer<typeof GitLabPackageTargetSchema>, {
+  kind: 'deb' | 'rpm'
+  distro: string
+  release: string
+  label: string
+  arches: readonly string[]
+}> = {
+  'ubuntu-noble': { kind: 'deb', distro: 'ubuntu', release: 'noble', label: 'Ubuntu 24.04 Noble', arches: ['amd64', 'arm64'] },
+  'ubuntu-jammy': { kind: 'deb', distro: 'ubuntu', release: 'jammy', label: 'Ubuntu 22.04 Jammy', arches: ['amd64', 'arm64'] },
+  'ubuntu-focal': { kind: 'deb', distro: 'ubuntu', release: 'focal', label: 'Ubuntu 20.04 Focal', arches: ['amd64', 'arm64'] },
+  'debian-bookworm': { kind: 'deb', distro: 'debian', release: 'bookworm', label: 'Debian 12 Bookworm', arches: ['amd64', 'arm64'] },
+  'debian-bullseye': { kind: 'deb', distro: 'debian', release: 'bullseye', label: 'Debian 11 Bullseye', arches: ['amd64', 'arm64'] },
+  'el-9': { kind: 'rpm', distro: 'el', release: '9', label: 'RHEL/Rocky/Alma 9', arches: ['x86_64', 'aarch64'] },
+  'el-8': { kind: 'rpm', distro: 'el', release: '8', label: 'RHEL/Rocky/Alma 8', arches: ['x86_64', 'aarch64'] },
+}
+
+const GitLabStepSchema = z.object({
+  id: z.string().min(1).max(100),
+  role: z.enum(['required-stop', 'target']),
+  version: GitLabVersionSchema,
+  majorMinor: z.string().regex(/^\d+\.\d+$/),
+  sourceVersion: GitLabVersionSchema,
+  conditional: z.boolean(),
+  note: z.string().max(1000).nullable(),
+  packageName: z.string().regex(/^gitlab-(ee|ce)$/),
+  filename: z.string().min(1).max(255),
+  sizeBytes: z.number().int().nonnegative().nullable(),
+  sizeLabel: z.string().max(50).nullable(),
+  status: z.literal('available'),
+})
+
+const GitLabBundleSchema = z.object({
+  kind: z.literal('gitlab'),
+  currentVersion: GitLabVersionSchema,
+  targetVersion: GitLabVersionSchema,
+  edition: GitLabEditionSchema,
+  packageTarget: z.object({
+    key: GitLabPackageTargetSchema,
+    label: z.string().min(1).max(100),
+    arch: GitLabArchSchema,
+    kind: z.enum(['deb', 'rpm']),
+  }),
+  generatedAt: z.string().min(1),
+  sources: z.object({
+    upgradePath: z.string().url(),
+    packages: z.string().url(),
+  }),
+  steps: z.array(GitLabStepSchema).min(1).max(50),
+})
+
+const JenkinsPluginSchema = z.object({
+  name: z.string().regex(/^[a-z0-9][a-z0-9._-]*$/i).max(100),
+  requested: z.string().max(200),
+  status: z.enum(['compatible', 'java-incompatible', 'not-found', 'core-incompatible']),
+  version: z.string().regex(/^[0-9][0-9A-Za-z.+_-]*$/).max(100).optional(),
+  requiredCore: z.string().max(50).optional(),
+  minimumJavaVersion: z.string().max(50).optional(),
+  size: z.number().int().nonnegative().optional(),
+  sha256: z.string().max(200).optional(),
+  reason: z.string().max(1000).optional(),
+})
+
+const JenkinsBundleSchema = z.object({
+  kind: z.literal('jenkins'),
+  generatedAt: z.string().min(1),
+  core: z.object({
+    version: z.string().regex(/^\d+\.\d+(\.\d+)?$/),
+    minimumJava: z.number().int().nullable(),
+    javaSource: z.enum(['updates.jenkins.io', 'unavailable']),
+    javaCompatible: z.boolean().nullable(),
+    warUrl: z.string().url().nullable(),
+  }),
+  includesTransitive: z.boolean(),
+  plugins: z.array(JenkinsPluginSchema).max(500),
+  transitivePlugins: z.array(JenkinsPluginSchema).max(1000),
+  dependencyTree: z.unknown().optional(),
+})
+
+const TransferRequestSchema = z.object({
   hostId: z.string().min(1),
   username: z.string().min(1).max(128).regex(/^[^\s:]+$/, 'Username cannot contain whitespace or ":"'),
   password: z.string().min(1).max(4096),
@@ -24,19 +126,82 @@ const TransferFieldsSchema = z.object({
     .min(1)
     .max(200)
     .regex(/^[A-Za-z0-9._-]+\.zip$/, 'Bundle filename must be a zip filename'),
+  bundle: z.discriminatedUnion('kind', [GitLabBundleSchema, JenkinsBundleSchema]),
 })
 
-function formValue(form: FormData, key: string): string {
-  const value = form.get(key)
-  return typeof value === 'string' ? value : ''
+type TransferRequest = z.infer<typeof TransferRequestSchema>
+type ArchiveEntry = {
+  name: string
+  url: string
+  sizeBytes?: number | null
 }
 
-function getFormFile(form: FormData): File | null {
-  const value = form.get('bundle')
-  if (value && typeof value === 'object' && 'arrayBuffer' in value && 'size' in value) {
-    return value as File
+type ArchiveSpec = {
+  entries: ArchiveEntry[]
+  manifest: unknown
+  readme?: string
+}
+
+type TransferJobPhase = 'queued' | 'downloading' | 'transferring' | 'completed' | 'failed'
+
+type TransferJob = {
+  id: string
+  userId: string
+  organisationId: string
+  phase: TransferJobPhase
+  fileName: string
+  host: string
+  path: string
+  filesTotal: number
+  filesDone: number
+  currentFile: string | null
+  currentLoaded: number
+  currentTotal: number | null
+  error: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+const transferJobs = new Map<string, TransferJob>()
+
+function publishJob(job: TransferJob, patch: Partial<Omit<TransferJob, 'id' | 'userId' | 'organisationId' | 'createdAt'>>) {
+  Object.assign(job, patch, { updatedAt: Date.now() })
+}
+
+function cleanupOldJobs() {
+  const cutoff = Date.now() - 60 * 60 * 1000
+  for (const [id, job] of transferJobs.entries()) {
+    if (job.updatedAt < cutoff) transferJobs.delete(id)
   }
-  return null
+}
+
+function gitLabPackageName(edition: z.infer<typeof GitLabEditionSchema>): string {
+  return `gitlab-${edition}`
+}
+
+function gitLabBasePackageUrl(
+  edition: z.infer<typeof GitLabEditionSchema>,
+  packageTarget: z.infer<typeof GitLabPackageTargetSchema>,
+  arch: string,
+): string {
+  const target = GitLabTargets[packageTarget]
+  const name = gitLabPackageName(edition)
+  if (target.kind === 'deb') {
+    return `https://packages.gitlab.com/gitlab/${name}/${target.distro}/${target.release}/pool/main/g/${name}/`
+  }
+  return `https://packages.gitlab.com/gitlab/${name}/${target.distro}/${target.release}/${arch}/Packages/g/`
+}
+
+function gitLabPackageFilename(
+  edition: z.infer<typeof GitLabEditionSchema>,
+  packageTarget: z.infer<typeof GitLabPackageTargetSchema>,
+  arch: string,
+  version: string,
+): string {
+  const target = GitLabTargets[packageTarget]
+  const name = gitLabPackageName(edition)
+  if (target.kind === 'deb') return `${name}_${version}-${edition}.0_${arch}.deb`
+  return `${name}-${version}-${edition}.0.${target.distro}${target.release}.${arch}.rpm`
 }
 
 function connectSsh(options: { host: string; username: string; password: string }): Promise<Client> {
@@ -129,45 +294,281 @@ async function ensureRemoteDirectory(sftp: SFTPWrapper, directory: string) {
   }
 }
 
-function writeFile(sftp: SFTPWrapper, remotePath: string, data: Buffer): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.writeFile(remotePath, data, (err: Error | null | undefined) => {
+function buildGitLabArchive(bundle: z.infer<typeof GitLabBundleSchema>): ArchiveSpec {
+  const target = GitLabTargets[bundle.packageTarget.key]
+  if (!target.arches.includes(bundle.packageTarget.arch)) {
+    throw new Error(`${target.label} does not publish ${bundle.packageTarget.arch} packages`)
+  }
+  if (bundle.packageTarget.kind !== target.kind || bundle.packageTarget.label !== target.label) {
+    throw new Error('GitLab package target metadata does not match the selected target')
+  }
+
+  const entries = bundle.steps.map((step) => {
+    const filename = gitLabPackageFilename(bundle.edition, bundle.packageTarget.key, bundle.packageTarget.arch, step.version)
+    if (step.filename !== filename) {
+      throw new Error(`GitLab package metadata mismatch for ${step.version}`)
+    }
+    return {
+      name: `packages/${filename}`,
+      url: `${gitLabBasePackageUrl(bundle.edition, bundle.packageTarget.key, bundle.packageTarget.arch)}${filename}`,
+      sizeBytes: step.sizeBytes,
+    }
+  })
+
+  return {
+    entries,
+    manifest: {
+      generatedAt: bundle.generatedAt,
+      currentVersion: bundle.currentVersion,
+      targetVersion: bundle.targetVersion,
+      edition: bundle.edition,
+      packageTarget: bundle.packageTarget,
+      sources: bundle.sources,
+      steps: bundle.steps,
+      included: bundle.steps.map((step) => step.id),
+    },
+    readme: [
+      'GitLab air-gap package bundle',
+      '',
+      `Current version: ${bundle.currentVersion}`,
+      `Target version: ${bundle.targetVersion}`,
+      `Edition: GitLab ${bundle.edition.toUpperCase()}`,
+      `Package target: ${bundle.packageTarget.label} ${bundle.packageTarget.arch}`,
+      '',
+      'Install each package in ascending version order and allow GitLab background migrations to finish between required stops.',
+      'Review GitLab upgrade notes before applying packages.',
+    ].join('\n'),
+  }
+}
+
+async function buildJenkinsArchive(bundle: z.infer<typeof JenkinsBundleSchema>): Promise<ArchiveSpec> {
+  const entries: ArchiveEntry[] = []
+  if (bundle.core.warUrl) {
+    const war = await resolveWarUrl(bundle.core.version)
+    if (!war) throw new Error('No Jenkins WAR published for that version')
+    entries.push({ name: 'jenkins.war', url: war })
+  }
+
+  const seen = new Set<string>()
+  const plugins = [...bundle.plugins, ...bundle.transitivePlugins]
+    .filter((plugin) => plugin.status === 'compatible' && plugin.version)
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+
+  for (const plugin of plugins) {
+    const key = plugin.name.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    entries.push({
+      name: `plugins/${plugin.name}.hpi`,
+      url: `https://updates.jenkins.io/download/plugins/${encodeURIComponent(plugin.name)}/${encodeURIComponent(plugin.version!)}/${encodeURIComponent(plugin.name)}.hpi`,
+      sizeBytes: plugin.size ?? null,
+    })
+  }
+
+  return {
+    entries,
+    manifest: {
+      generatedAt: bundle.generatedAt,
+      core: bundle.core,
+      includesTransitive: bundle.includesTransitive,
+      plugins: bundle.plugins.map((plugin) => ({
+        name: plugin.name,
+        version: plugin.version ?? null,
+        status: plugin.status,
+        reason: plugin.reason ?? null,
+        requiredCore: plugin.requiredCore ?? null,
+        minimumJavaVersion: plugin.minimumJavaVersion ?? null,
+        downloaded: plugin.status === 'compatible',
+        downloadError: null,
+        sha256: plugin.sha256 ?? null,
+      })),
+      transitivePlugins: bundle.transitivePlugins.map((plugin) => ({
+        name: plugin.name,
+        version: plugin.version ?? null,
+        status: plugin.status,
+        reason: plugin.reason ?? null,
+        requiredCore: plugin.requiredCore ?? null,
+        minimumJavaVersion: plugin.minimumJavaVersion ?? null,
+        downloaded: plugin.status === 'compatible',
+        downloadError: null,
+        sha256: plugin.sha256 ?? null,
+      })),
+      dependencyTree: bundle.dependencyTree ?? bundle.plugins,
+    },
+  }
+}
+
+type LocalArchiveEntry = ArchiveEntry & {
+  localPath: string
+}
+
+async function downloadEntryToTemp(entry: ArchiveEntry, localPath: string, job: TransferJob) {
+  const upstream = await fetch(entry.url, { cache: 'no-store', redirect: 'follow' })
+  if (!upstream.ok || !upstream.body) {
+    throw new Error(`Upstream returned ${upstream.status} for ${entry.name}`)
+  }
+  const contentLength = upstream.headers.get('content-length')
+  const total = contentLength ? Number(contentLength) : entry.sizeBytes ?? null
+  let loaded = 0
+  const source = Readable.fromWeb(upstream.body as unknown as NodeReadableStream<Uint8Array>)
+  source.on('data', (chunk: Buffer) => {
+    loaded += chunk.byteLength
+    publishJob(job, {
+      currentFile: entry.name,
+      currentLoaded: loaded,
+      currentTotal: total && Number.isFinite(total) ? total : null,
+    })
+  })
+  await pipeline(source, createWriteStream(localPath))
+}
+
+async function streamLocalArchiveToSftp(params: {
+  sftp: SFTPWrapper
+  remotePath: string
+  entries: LocalArchiveEntry[]
+  manifest: unknown
+  readme?: string
+  job: TransferJob
+}) {
+  await new Promise<void>(async (resolve, reject) => {
+    const archive = archiver('zip', { zlib: { level: 0 } })
+    const out = params.sftp.createWriteStream(params.remotePath)
+    let settled = false
+    const settle = (err?: Error) => {
+      if (settled) return
+      settled = true
       if (err) reject(err)
       else resolve()
-    })
+    }
+
+    archive.on('warning', (err) => settle(err))
+    archive.on('error', (err) => settle(err))
+    out.on('error', (err: Error) => settle(err))
+    out.on('close', () => settle())
+
+    archive.pipe(out)
+
+    try {
+      for (const entry of params.entries) {
+        publishJob(params.job, {
+          currentFile: entry.name,
+          currentLoaded: 0,
+          currentTotal: entry.sizeBytes ?? null,
+        })
+        archive.file(entry.localPath, { name: entry.name })
+      }
+      archive.append(JSON.stringify(params.manifest, null, 2), { name: 'bundle-manifest.json' })
+      if (params.readme) archive.append(params.readme, { name: 'README.txt' })
+      await archive.finalize()
+    } catch (err) {
+      archive.destroy()
+      out.destroy()
+      settle(err instanceof Error ? err : new Error('Transfer failed'))
+    }
   })
 }
 
-export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers })
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
-  }
+async function runTransferJob(job: TransferJob, request: TransferRequest) {
+  const directory = path.posix.normalize(request.directory)
+  const remotePath = path.posix.join(directory, request.fileName)
+  let client: Client | null = null
+  let tempDir: string | null = null
 
+  try {
+    const archive =
+      request.bundle.kind === 'gitlab'
+        ? buildGitLabArchive(request.bundle)
+        : await buildJenkinsArchive(request.bundle)
+
+    publishJob(job, {
+      filesTotal: archive.entries.length,
+      phase: 'downloading',
+      currentFile: null,
+      currentLoaded: 0,
+      currentTotal: null,
+    })
+
+    tempDir = await mkdtemp(path.join(tmpdir(), 'ct-ops-bundle-transfer-'))
+    const localEntries: LocalArchiveEntry[] = []
+
+    for (const [index, entry] of archive.entries.entries()) {
+      publishJob(job, {
+        filesDone: index,
+        currentFile: entry.name,
+        currentLoaded: 0,
+        currentTotal: entry.sizeBytes ?? null,
+      })
+      const localPath = path.join(tempDir, `${index}-${path.basename(entry.name)}`)
+      await downloadEntryToTemp(entry, localPath, job)
+      localEntries.push({ ...entry, localPath })
+      publishJob(job, {
+        filesDone: index + 1,
+        currentLoaded: entry.sizeBytes ?? job.currentLoaded,
+      })
+    }
+
+    publishJob(job, {
+      phase: 'transferring',
+      currentFile: request.fileName,
+      currentLoaded: 0,
+      currentTotal: null,
+    })
+
+    client = await connectSsh({
+      host: job.host,
+      username: request.username,
+      password: request.password,
+    })
+    const sftp = await openSftp(client)
+    await ensureRemoteDirectory(sftp, directory)
+    await streamLocalArchiveToSftp({
+      sftp,
+      remotePath,
+      entries: localEntries,
+      manifest: archive.manifest,
+      readme: archive.readme,
+      job,
+    })
+
+    publishJob(job, {
+      phase: 'completed',
+      filesDone: archive.entries.length,
+      currentFile: request.fileName,
+      currentLoaded: 0,
+      currentTotal: null,
+    })
+  } catch (err) {
+    console.error('Bundle transfer failed:', err)
+    publishJob(job, {
+      phase: 'failed',
+      error: err instanceof Error && err.message ? err.message : 'Transfer failed',
+    })
+  } finally {
+    client?.end()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
+    }
+  }
+}
+
+async function getAuthorisedUser(request: NextRequest) {
+  const session = await auth.api.getSession({ headers: request.headers })
+  if (!session) return null
   const user = await db.query.users.findFirst({
     where: eq(users.id, session.user.id),
   })
+  return user?.organisationId ? user : null
+}
+
+export async function POST(request: NextRequest) {
+  cleanupOldJobs()
+  const user = await getAuthorisedUser(request)
   if (!user?.organisationId) {
     return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
   }
 
-  const form = await request.formData().catch(() => null)
-  if (!form) {
-    return NextResponse.json({ error: 'Invalid transfer request' }, { status: 400 })
-  }
-
-  const bundle = getFormFile(form)
-  if (!bundle || bundle.size === 0) {
-    return NextResponse.json({ error: 'Bundle zip is required' }, { status: 400 })
-  }
-
-  const parsed = TransferFieldsSchema.safeParse({
-    hostId: formValue(form, 'hostId'),
-    username: formValue(form, 'username').trim(),
-    password: formValue(form, 'password'),
-    directory: formValue(form, 'directory').trim(),
-    fileName: formValue(form, 'fileName').trim(),
-  })
+  const body = await request.json().catch(() => null)
+  const parsed = TransferRequestSchema.safeParse(body)
   if (!parsed.success) {
     return NextResponse.json(
       { error: parsed.error.issues[0]?.message ?? 'Invalid transfer request' },
@@ -186,33 +587,48 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Host not found' }, { status: 404 })
   }
 
-  const connectHost = host.hostname
   const directory = path.posix.normalize(parsed.data.directory)
   const remotePath = path.posix.join(directory, parsed.data.fileName)
-  let client: Client | null = null
-
-  try {
-    const data = Buffer.from(await bundle.arrayBuffer())
-    client = await connectSsh({
-      host: connectHost,
-      username: parsed.data.username,
-      password: parsed.data.password,
-    })
-    const sftp = await openSftp(client)
-    await ensureRemoteDirectory(sftp, directory)
-    await writeFile(sftp, remotePath, data)
-
-    return NextResponse.json({
-      ok: true,
-      host: connectHost,
-      path: remotePath,
-      bytes: data.byteLength,
-    })
-  } catch (err) {
-    console.error('Bundle transfer failed:', err)
-    const message = err instanceof Error && err.message ? err.message : 'Transfer failed'
-    return NextResponse.json({ error: message }, { status: 502 })
-  } finally {
-    client?.end()
+  const job: TransferJob = {
+    id: randomUUID(),
+    userId: user.id,
+    organisationId: user.organisationId,
+    phase: 'queued',
+    fileName: parsed.data.fileName,
+    host: host.hostname,
+    path: remotePath,
+    filesTotal: 0,
+    filesDone: 0,
+    currentFile: null,
+    currentLoaded: 0,
+    currentTotal: null,
+    error: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
   }
+  transferJobs.set(job.id, job)
+  void runTransferJob(job, parsed.data)
+
+  return NextResponse.json({
+    ok: true,
+    jobId: job.id,
+    job,
+  })
+}
+
+export async function GET(request: NextRequest) {
+  cleanupOldJobs()
+  const user = await getAuthorisedUser(request)
+  if (!user?.organisationId) {
+    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
+  }
+  const jobId = request.nextUrl.searchParams.get('jobId')
+  if (!jobId) {
+    return NextResponse.json({ error: 'Missing jobId' }, { status: 400 })
+  }
+  const job = transferJobs.get(jobId)
+  if (!job || job.userId !== user.id || job.organisationId !== user.organisationId) {
+    return NextResponse.json({ error: 'Transfer job not found' }, { status: 404 })
+  }
+  return NextResponse.json({ ok: true, job })
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.2",
+    "archiver": "^7.0.1",
     "better-auth": "^1.6.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -66,6 +67,7 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
+    "@types/archiver": "^6.0.3",
     "@types/node": "^20",
     "@types/nodemailer": "^8.0.0",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.10.2
         version: 12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      archiver:
+        specifier: ^7.0.1
+        version: 7.0.1
       better-auth:
         specifier: ^1.6.5
         version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vue@3.5.32(typescript@5.9.3))
@@ -298,6 +301,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
+      '@types/archiver':
+        specifier: ^6.0.3
+        version: 6.0.4
       '@types/node':
         specifier: ^20
         version: 20.19.37
@@ -3074,6 +3080,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/archiver@6.0.4':
+    resolution: {integrity: sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -3189,6 +3198,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -10511,6 +10523,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/archiver@6.0.4':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -10638,6 +10654,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 20.19.37
 
   '@types/sax@1.2.7':
     dependencies:


### PR DESCRIPTION
## Summary
- replace browser zip upload transfers with server-side transfer jobs
- download upstream bundle files into temporary server storage before writing the zip over SFTP
- close the transfer dialog after job creation and show separate download and host-transfer status on the bundler page

## Why
Large GitLab bundles can exceed nginx request body limits when the browser posts the generated zip back to the web container. The new flow sends only a small JSON manifest, then performs the large download and SFTP work server-side.

## Validation
- pnpm install --lockfile-only --frozen-lockfile
- pnpm --filter web type-check
- pnpm --filter web lint