### PR TITLE
fix(web): transfer bundles via agent connection

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,26 @@
 **Phase 5 — Tooling (in progress)**
 
 ## Current Status
-🟢 Phase 5 progressing — two new Tooling utilities shipped (Directory User Lookup for live LDAP/AD queries, SSL Certificate Checker for parse/fetch/validate/convert of X.509 certs); offline agent install bundle (zip) for air-gapped enrolment; ingest-side host deduplication by hostname / IP overlap; repo/image rename to `carrtech-dev` and enrolment-URL env-var plumbing; plus the established VuePress docs, networks (CIDR + graph view), and split-pane terminal workspace.
+🟢 Phase 5 progressing — two new Tooling utilities shipped (Directory User Lookup for live LDAP/AD queries, SSL Certificate Checker for parse/fetch/validate/convert of X.509 certs); offline agent install bundle (zip) for air-gapped enrolment; GitLab/Jenkins bundle transfer now routes through the existing agent task connection instead of direct SSH; ingest-side host deduplication by hostname / IP overlap; repo/image rename to `carrtech-dev` and enrolment-URL env-var plumbing; plus the established VuePress docs, networks (CIDR + graph view), and split-pane terminal workspace.
 
 ---
 
 ## What Has Been Built
+
+### Session 54 — Bundler transfer via agent task channel
+
+**GitLab/Jenkins bundle transfer** (`apps/web/app/api/tools/bundle-transfer/route.ts`, `apps/web/app/(dashboard)/bundlers/`)
+- Removed the direct SSH/SFTP transfer path from the web container; transfers now prepare the zip server-side and dispatch a `custom_script` task to the selected online host.
+- The host receives the task through the existing agent heartbeat/task channel, creates the destination directory, downloads the prepared zip with a short-lived per-job token, and writes it to the requested path.
+- Transfer modal is now single-step: select host, optional owner, and destination directory. No SSH password is requested or sent from the browser.
+- Status panel keeps the existing download phase and then shows the separate host transfer phase while the agent task is pending/running/completed/failed.
+- Removed the direct `ssh2` dependency from the web package; remaining `ssh2` lockfile entries are transitive dev dependencies of `testcontainers`.
+
+**Build state**
+- `pnpm --filter web type-check` — zero errors ✅
+- `pnpm --filter web lint -- app/api/tools/bundle-transfer/route.ts 'app/(dashboard)/bundlers/bundle-transfer-dialog.tsx' 'app/(dashboard)/bundlers/bundle-transfer-status.tsx'` — zero errors ✅
+
+---
 
 ### Session 53 — SSL Certificate Checker tool
 

--- a/apps/web/app/(dashboard)/bundlers/bundle-transfer-dialog.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundle-transfer-dialog.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import {
-  ArrowLeft,
-  KeyRound,
   Loader2,
   Search,
   Send,
@@ -40,6 +38,7 @@ export type TransferJobStatus = {
   currentFile: string | null
   currentLoaded: number
   currentTotal: number | null
+  taskRunId: string | null
   error: string | null
 }
 
@@ -51,8 +50,6 @@ type Props = {
   onTransferStarted: (job: TransferJobStatus) => void
 }
 
-type Step = 'details' | 'password'
-
 export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, onTransferStarted }: Props) {
   const [hosts, setHosts] = useState<HostWithAgent[]>([])
   const [loadingHosts, setLoadingHosts] = useState(false)
@@ -60,8 +57,6 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
   const [selectedHostId, setSelectedHostId] = useState<string | null>(null)
   const [username, setUsername] = useState('')
   const [directory, setDirectory] = useState('/tmp')
-  const [password, setPassword] = useState('')
-  const [step, setStep] = useState<Step>('details')
   const [transferring, setTransferring] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -105,15 +100,13 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
   }, [hosts, search])
 
   const selectedHost = hosts.find((host) => host.id === selectedHostId) ?? null
-  const canContinue = !!selectedHostId && username.trim().length > 0 && directory.trim().startsWith('/')
+  const canTransfer = !!selectedHostId && directory.trim().startsWith('/')
 
   function reset() {
     setSearch('')
     setSelectedHostId(null)
     setUsername('')
     setDirectory('/tmp')
-    setPassword('')
-    setStep('details')
     setTransferring(false)
     setError(null)
   }
@@ -124,25 +117,12 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
     onOpenChange(nextOpen)
   }
 
-  function continueToPassword() {
-    setError(null)
-    if (!selectedHostId) {
-      setError('Select a host')
-      return
-    }
-    if (!username.trim()) {
-      setError('Enter a username')
-      return
-    }
+  async function transfer() {
+    if (!selectedHost) return
     if (!directory.trim().startsWith('/')) {
       setError('Enter an absolute directory path')
       return
     }
-    setStep('password')
-  }
-
-  async function transfer() {
-    if (!selectedHost || !password) return
     setTransferring(true)
     setError(null)
     try {
@@ -153,7 +133,6 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
         body: JSON.stringify({
           hostId: selectedHost.id,
           username: username.trim(),
-          password,
           directory: directory.trim(),
           fileName: bundle.fileName,
           bundle: bundle.payload,
@@ -165,7 +144,6 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
       }
       if (!data.job) throw new Error('Transfer job was not created')
       onTransferStarted(data.job)
-      setPassword('')
       reset()
       onOpenChange(false)
     } catch (err) {
@@ -184,125 +162,105 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
             Transfer bundle
           </DialogTitle>
           <DialogDescription>
-            {step === 'details'
-              ? 'Select the destination host, username, and directory.'
-              : `Enter the SSH password for ${username.trim()}${selectedHost ? ` on ${selectedHost.displayName ?? selectedHost.hostname}` : ''}.`}
+            Select the destination host and directory. The transfer runs through the CT-Ops agent connection.
           </DialogDescription>
         </DialogHeader>
 
-        {step === 'details' ? (
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label>Host</Label>
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  placeholder="Search hosts by name or IP"
-                  className="pl-9"
-                  autoFocus
-                />
-              </div>
-              <div className="max-h-56 overflow-y-auto rounded-md border">
-                {loadingHosts ? (
-                  <div className="flex items-center justify-center py-8">
-                    <Loader2 className="size-5 animate-spin text-muted-foreground" />
-                  </div>
-                ) : filteredHosts.length === 0 ? (
-                  <div className="py-8 text-center text-sm text-muted-foreground">
-                    {search ? 'No hosts match your search' : 'No hosts available'}
-                  </div>
-                ) : (
-                  filteredHosts.map((host) => {
-                    const active = host.id === selectedHostId
-                    return (
-                      <button
-                        key={host.id}
-                        type="button"
-                        onClick={() => {
-                          setSelectedHostId(host.id)
-                          setError(null)
-                        }}
-                        className={`flex w-full items-center gap-3 border-b px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-muted/50 ${
-                          active ? 'bg-muted' : ''
-                        }`}
-                      >
-                        {host.status === 'online' ? (
-                          <Server className="size-4 shrink-0 text-muted-foreground" />
-                        ) : (
-                          <WifiOff className="size-4 shrink-0 text-muted-foreground" />
-                        )}
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate text-sm font-medium">{host.displayName ?? host.hostname}</span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {host.displayName && host.displayName !== host.hostname ? host.hostname : host.ipAddresses?.[0] ?? 'No IP recorded'}
-                          </span>
-                        </span>
-                        <Badge variant={host.status === 'online' ? 'default' : 'secondary'}>{host.status}</Badge>
-                      </button>
-                    )
-                  })
-                )}
-              </div>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Host</Label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search hosts by name or IP"
+                className="pl-9"
+                autoFocus
+              />
             </div>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="bundle-transfer-username">Username</Label>
-                <Input
-                  id="bundle-transfer-username"
-                  value={username}
-                  onChange={(event) => {
-                    setUsername(event.target.value)
-                    setError(null)
-                  }}
-                  placeholder="e.g. deploy"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="bundle-transfer-path">Directory</Label>
-                <Input
-                  id="bundle-transfer-path"
-                  value={directory}
-                  onChange={(event) => {
-                    setDirectory(event.target.value)
-                    setError(null)
-                  }}
-                  placeholder="/tmp"
-                />
-              </div>
+            <div className="max-h-56 overflow-y-auto rounded-md border">
+              {loadingHosts ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="size-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : filteredHosts.length === 0 ? (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  {search ? 'No hosts match your search' : 'No hosts available'}
+                </div>
+              ) : (
+                filteredHosts.map((host) => {
+                  const active = host.id === selectedHostId
+                  return (
+                    <button
+                      key={host.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedHostId(host.id)
+                        setError(null)
+                      }}
+                      className={`flex w-full items-center gap-3 border-b px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-muted/50 ${
+                        active ? 'bg-muted' : ''
+                      }`}
+                    >
+                      {host.status === 'online' ? (
+                        <Server className="size-4 shrink-0 text-muted-foreground" />
+                      ) : (
+                        <WifiOff className="size-4 shrink-0 text-muted-foreground" />
+                      )}
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium">{host.displayName ?? host.hostname}</span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {host.displayName && host.displayName !== host.hostname ? host.hostname : host.ipAddresses?.[0] ?? 'No IP recorded'}
+                        </span>
+                      </span>
+                      <Badge variant={host.status === 'online' ? 'default' : 'secondary'}>{host.status}</Badge>
+                    </button>
+                  )
+                })
+              )}
             </div>
           </div>
-        ) : (
-          <div className="space-y-4">
-            <div className="rounded-md border bg-muted/30 p-3 text-sm">
-              <div className="font-medium">{selectedHost?.displayName ?? selectedHost?.hostname}</div>
-              <div className="break-all text-muted-foreground">
-                {username.trim()}:{directory.trim()}
-              </div>
-            </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="bundle-transfer-password" className="flex items-center gap-1.5">
-                <KeyRound className="size-3.5" />
-                Password
-              </Label>
+              <Label htmlFor="bundle-transfer-username">Owner (optional)</Label>
               <Input
-                id="bundle-transfer-password"
-                type="password"
-                value={password}
+                id="bundle-transfer-username"
+                value={username}
                 onChange={(event) => {
-                  setPassword(event.target.value)
+                  setUsername(event.target.value)
                   setError(null)
                 }}
-                autoFocus
+                placeholder="e.g. deploy"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="bundle-transfer-path">Directory</Label>
+              <Input
+                id="bundle-transfer-path"
+                value={directory}
+                onChange={(event) => {
+                  setDirectory(event.target.value)
+                  setError(null)
+                }}
+                placeholder="/tmp"
                 onKeyDown={(event) => {
-                  if (event.key === 'Enter' && password && !transferring) void transfer()
+                  if (event.key === 'Enter' && canTransfer && !transferring) void transfer()
                 }}
               />
             </div>
           </div>
-        )}
+
+          {selectedHost && (
+            <div className="rounded-md border bg-muted/30 p-3 text-sm">
+              <div className="font-medium">{selectedHost.displayName ?? selectedHost.hostname}</div>
+              <div className="break-all text-muted-foreground">
+                {directory.trim()}
+              </div>
+            </div>
+          )}
+        </div>
 
         {error && (
           <div className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -310,22 +268,10 @@ export function BundleTransferDialog({ open, onOpenChange, orgId, buildBundle, o
           </div>
         )}
         <DialogFooter>
-          {step === 'password' && (
-            <Button type="button" variant="outline" onClick={() => setStep('details')} disabled={transferring} className="mr-auto">
-              <ArrowLeft className="size-4" />
-              Back
-            </Button>
-          )}
-          {step === 'details' ? (
-            <Button type="button" onClick={continueToPassword} disabled={!canContinue}>
-              Continue
-            </Button>
-          ) : (
-            <Button type="button" onClick={transfer} disabled={!password || transferring}>
-              {transferring ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
-              Transfer
-            </Button>
-          )}
+          <Button type="button" onClick={transfer} disabled={!canTransfer || transferring}>
+            {transferring ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+            Transfer now
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/web/app/(dashboard)/bundlers/bundle-transfer-status.tsx
+++ b/apps/web/app/(dashboard)/bundlers/bundle-transfer-status.tsx
@@ -114,6 +114,9 @@ export function BundleTransferStatus({
           </div>
           <div className="rounded-md border bg-muted/30 p-3 text-xs">
             <div className="break-all font-mono">{job.path}</div>
+            {job.currentFile && transferring && (
+              <div className="mt-2 text-muted-foreground">{job.currentFile}</div>
+            )}
             <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
               <div
                 className="h-full bg-emerald-600 transition-[width] duration-150"

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -1,19 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import archiver from 'archiver'
-import { Client, type SFTPWrapper } from 'ssh2'
 import { z } from 'zod'
 import { and, eq, isNull } from 'drizzle-orm'
 import { Readable } from 'node:stream'
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
 import { pipeline } from 'node:stream/promises'
-import { createWriteStream } from 'node:fs'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { createReadStream, createWriteStream } from 'node:fs'
+import { mkdtemp, rm, stat as fsStat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { randomUUID } from 'node:crypto'
+import { randomBytes, randomUUID } from 'node:crypto'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { hosts, users } from '@/lib/db/schema'
+import { hosts, taskRunHosts, taskRuns, users } from '@/lib/db/schema'
 import { resolveWarUrl } from '@/lib/jenkins/update-center'
 
 export const runtime = 'nodejs'
@@ -113,8 +112,13 @@ const JenkinsBundleSchema = z.object({
 
 const TransferRequestSchema = z.object({
   hostId: z.string().min(1),
-  username: z.string().min(1).max(128).regex(/^[^\s:]+$/, 'Username cannot contain whitespace or ":"'),
-  password: z.string().min(1).max(4096),
+  username: z
+    .string()
+    .trim()
+    .max(128)
+    .regex(/^[^\s:]*$/, 'Username cannot contain whitespace or ":"')
+    .optional()
+    .default(''),
   directory: z
     .string()
     .min(1)
@@ -157,12 +161,35 @@ type TransferJob = {
   currentFile: string | null
   currentLoaded: number
   currentTotal: number | null
+  tempDir: string | null
+  archivePath: string | null
+  downloadToken: string | null
+  taskRunId: string | null
   error: string | null
   createdAt: number
   updatedAt: number
 }
 
 const transferJobs = new Map<string, TransferJob>()
+
+function publicJob(job: TransferJob) {
+  return {
+    id: job.id,
+    phase: job.phase,
+    fileName: job.fileName,
+    host: job.host,
+    path: job.path,
+    filesTotal: job.filesTotal,
+    filesDone: job.filesDone,
+    currentFile: job.currentFile,
+    currentLoaded: job.currentLoaded,
+    currentTotal: job.currentTotal,
+    taskRunId: job.taskRunId,
+    error: job.error,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  }
+}
 
 function publishJob(job: TransferJob, patch: Partial<Omit<TransferJob, 'id' | 'userId' | 'organisationId' | 'createdAt'>>) {
   Object.assign(job, patch, { updatedAt: Date.now() })
@@ -171,7 +198,11 @@ function publishJob(job: TransferJob, patch: Partial<Omit<TransferJob, 'id' | 'u
 function cleanupOldJobs() {
   const cutoff = Date.now() - 60 * 60 * 1000
   for (const [id, job] of transferJobs.entries()) {
-    if (job.updatedAt < cutoff) transferJobs.delete(id)
+    if (job.updatedAt < cutoff) {
+      const tempDir = job.tempDir
+      transferJobs.delete(id)
+      if (tempDir) void rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
+    }
   }
 }
 
@@ -202,96 +233,6 @@ function gitLabPackageFilename(
   const name = gitLabPackageName(edition)
   if (target.kind === 'deb') return `${name}_${version}-${edition}.0_${arch}.deb`
   return `${name}-${version}-${edition}.0.${target.distro}${target.release}.${arch}.rpm`
-}
-
-function connectSsh(options: { host: string; username: string; password: string }): Promise<Client> {
-  return new Promise((resolve, reject) => {
-    const client = new Client()
-    const cleanup = () => {
-      client.off('ready', onReady)
-      client.off('error', onError)
-    }
-    const onReady = () => {
-      cleanup()
-      resolve(client)
-    }
-    const onError = (err: Error) => {
-      cleanup()
-      reject(err)
-    }
-    client.once('ready', onReady)
-    client.once('error', onError)
-    client.connect({
-      host: options.host,
-      port: 22,
-      username: options.username,
-      password: options.password,
-      readyTimeout: 30_000,
-      keepaliveInterval: 10_000,
-    })
-  })
-}
-
-function openSftp(client: Client): Promise<SFTPWrapper> {
-  return new Promise((resolve, reject) => {
-    client.sftp((err: Error | undefined, sftp: SFTPWrapper | undefined) => {
-      if (err) reject(err)
-      else if (sftp) resolve(sftp)
-      else reject(new Error('Failed to open SFTP session'))
-    })
-  })
-}
-
-function isMissingSftpError(err: unknown): boolean {
-  const code = (err as NodeJS.ErrnoException | { code?: number } | null)?.code
-  return code === 'ENOENT' || code === 2
-}
-
-function stat(sftp: SFTPWrapper, remotePath: string): Promise<{ isDirectory: () => boolean } | null> {
-  return new Promise((resolve, reject) => {
-    sftp.stat(remotePath, (err: Error | undefined, stats: { isDirectory: () => boolean } | undefined) => {
-      if (!err) {
-        resolve(stats ?? null)
-        return
-      }
-      if (isMissingSftpError(err)) {
-        resolve(null)
-        return
-      }
-      reject(err)
-    })
-  })
-}
-
-function mkdir(sftp: SFTPWrapper, remotePath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.mkdir(remotePath, async (err: Error | null | undefined) => {
-      if (!err) {
-        resolve()
-        return
-      }
-      try {
-        const stats = await stat(sftp, remotePath)
-        if (stats?.isDirectory()) resolve()
-        else reject(err)
-      } catch {
-        reject(err)
-      }
-    })
-  })
-}
-
-async function ensureRemoteDirectory(sftp: SFTPWrapper, directory: string) {
-  const normalized = path.posix.normalize(directory)
-  const parts = normalized.split('/').filter(Boolean)
-  let current = normalized.startsWith('/') ? '/' : ''
-
-  for (const part of parts) {
-    current = current === '/' ? `/${part}` : path.posix.join(current, part)
-    const stats = await stat(sftp, current)
-    if (!stats) await mkdir(sftp, current)
-    else if (!stats.isDirectory()) throw new Error(`${current} exists but is not a directory`)
-  }
 }
 
 function buildGitLabArchive(bundle: z.infer<typeof GitLabBundleSchema>): ArchiveSpec {
@@ -422,9 +363,8 @@ async function downloadEntryToTemp(entry: ArchiveEntry, localPath: string, job: 
   await pipeline(source, createWriteStream(localPath))
 }
 
-async function streamLocalArchiveToSftp(params: {
-  sftp: SFTPWrapper
-  remotePath: string
+async function writeLocalArchive(params: {
+  archivePath: string
   entries: LocalArchiveEntry[]
   manifest: unknown
   readme?: string
@@ -432,7 +372,7 @@ async function streamLocalArchiveToSftp(params: {
 }) {
   await new Promise<void>(async (resolve, reject) => {
     const archive = archiver('zip', { zlib: { level: 0 } })
-    const out = params.sftp.createWriteStream(params.remotePath)
+    const out = createWriteStream(params.archivePath)
     let settled = false
     const settle = (err?: Error) => {
       if (settled) return
@@ -468,10 +408,152 @@ async function streamLocalArchiveToSftp(params: {
   })
 }
 
-async function runTransferJob(job: TransferJob, request: TransferRequest) {
-  const directory = path.posix.normalize(request.directory)
-  const remotePath = path.posix.join(directory, request.fileName)
-  let client: Client | null = null
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function buildHostDownloadScript(params: {
+  downloadUrl: string
+  directory: string
+  fileName: string
+  owner: string
+}) {
+  const destination = path.posix.join(params.directory, params.fileName)
+  return [
+    'set -eu',
+    `DEST_DIR=${shellQuote(params.directory)}`,
+    `DEST_FILE=${shellQuote(params.fileName)}`,
+    `DEST_PATH=${shellQuote(destination)}`,
+    `DOWNLOAD_URL=${shellQuote(params.downloadUrl)}`,
+    `OWNER=${shellQuote(params.owner)}`,
+    'TMP_PATH="${DEST_DIR}/.${DEST_FILE}.ct-ops-transfer.$$"',
+    'cleanup() { rm -f "$TMP_PATH"; }',
+    'trap cleanup INT TERM EXIT',
+    'mkdir -p "$DEST_DIR"',
+    'echo "Downloading bundle to ${DEST_PATH}"',
+    'if command -v curl >/dev/null 2>&1; then',
+    '  curl -fLk --retry 3 --connect-timeout 20 --output "$TMP_PATH" "$DOWNLOAD_URL"',
+    'elif command -v wget >/dev/null 2>&1; then',
+    '  wget --no-check-certificate --tries=3 --timeout=20 -O "$TMP_PATH" "$DOWNLOAD_URL"',
+    'else',
+    '  echo "Neither curl nor wget is installed on this host" >&2',
+    '  exit 127',
+    'fi',
+    'mv -f "$TMP_PATH" "$DEST_PATH"',
+    'trap - INT TERM EXIT',
+    'if [ -n "$OWNER" ] && command -v chown >/dev/null 2>&1 && id "$OWNER" >/dev/null 2>&1; then',
+    '  chown "$OWNER" "$DEST_PATH" || true',
+    'fi',
+    'echo "Bundle transferred to ${DEST_PATH}"',
+  ].join('\n')
+}
+
+async function createBundleTransferTask(job: TransferJob, request: TransferRequest, downloadUrl: string) {
+  const script = buildHostDownloadScript({
+    downloadUrl,
+    directory: path.posix.normalize(request.directory),
+    fileName: request.fileName,
+    owner: request.username.trim(),
+  })
+
+  return db.transaction(async (tx) => {
+    const [run] = await tx
+      .insert(taskRuns)
+      .values({
+        organisationId: job.organisationId,
+        triggeredBy: job.userId,
+        targetType: 'host',
+        targetId: request.hostId,
+        taskType: 'custom_script',
+        config: {
+          script,
+          interpreter: 'sh',
+          timeout_seconds: 3600,
+        },
+        maxParallel: 1,
+        metadata: {
+          source: 'bundle-transfer',
+          bundleTransferJobId: job.id,
+          destinationPath: job.path,
+        },
+      })
+      .returning({ id: taskRuns.id })
+
+    if (!run) throw new Error('Failed to create host transfer task')
+
+    await tx.insert(taskRunHosts).values({
+      organisationId: job.organisationId,
+      taskRunId: run.id,
+      hostId: request.hostId,
+      status: 'pending',
+      metadata: {
+        source: 'bundle-transfer',
+        bundleTransferJobId: job.id,
+      },
+    })
+
+    return run.id
+  })
+}
+
+function getTransferErrorFromOutput(output: string | null, fallback: string) {
+  const lines = (output ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  return lines.slice(-6).join('\n') || fallback
+}
+
+async function refreshTransferTaskStatus(job: TransferJob) {
+  if (!job.taskRunId || job.phase !== 'transferring') return
+
+  const hostRow = await db.query.taskRunHosts.findFirst({
+    where: and(
+      eq(taskRunHosts.taskRunId, job.taskRunId),
+      eq(taskRunHosts.organisationId, job.organisationId),
+      isNull(taskRunHosts.deletedAt),
+    ),
+  })
+  if (!hostRow) {
+    publishJob(job, { phase: 'failed', error: 'Host transfer task was not found' })
+    return
+  }
+
+  if (hostRow.status === 'pending') {
+    publishJob(job, { currentFile: 'Waiting for the agent to pick up the transfer task' })
+    return
+  }
+  if (hostRow.status === 'running' || hostRow.status === 'cancelling') {
+    publishJob(job, { currentFile: 'Agent is transferring the bundle to the host' })
+    return
+  }
+  if (hostRow.status === 'success') {
+    const tempDir = job.tempDir
+    publishJob(job, {
+      phase: 'completed',
+      currentFile: job.fileName,
+      currentLoaded: 0,
+      currentTotal: null,
+      tempDir: null,
+      archivePath: null,
+      downloadToken: null,
+    })
+    if (tempDir) void rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
+    return
+  }
+
+  const tempDir = job.tempDir
+  publishJob(job, {
+    phase: 'failed',
+    error: hostRow.skipReason ?? getTransferErrorFromOutput(hostRow.rawOutput, `Host transfer task ${hostRow.status}`),
+    tempDir: null,
+    archivePath: null,
+    downloadToken: null,
+  })
+  if (tempDir) void rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
+}
+
+async function runTransferJob(job: TransferJob, request: TransferRequest, baseUrl: string) {
   let tempDir: string | null = null
 
   try {
@@ -489,6 +571,7 @@ async function runTransferJob(job: TransferJob, request: TransferRequest) {
     })
 
     tempDir = await mkdtemp(path.join(tmpdir(), 'ct-ops-bundle-transfer-'))
+    publishJob(job, { tempDir })
     const localEntries: LocalArchiveEntry[] = []
 
     for (const [index, entry] of archive.entries.entries()) {
@@ -514,38 +597,46 @@ async function runTransferJob(job: TransferJob, request: TransferRequest) {
       currentTotal: null,
     })
 
-    client = await connectSsh({
-      host: job.host,
-      username: request.username,
-      password: request.password,
-    })
-    const sftp = await openSftp(client)
-    await ensureRemoteDirectory(sftp, directory)
-    await streamLocalArchiveToSftp({
-      sftp,
-      remotePath,
+    const archivePath = path.join(tempDir, request.fileName)
+    await writeLocalArchive({
+      archivePath,
       entries: localEntries,
       manifest: archive.manifest,
       readme: archive.readme,
       job,
     })
 
+    const downloadToken = randomBytes(32).toString('base64url')
+    const downloadUrl = new URL('/api/tools/bundle-transfer', baseUrl)
+    downloadUrl.searchParams.set('download', '1')
+    downloadUrl.searchParams.set('jobId', job.id)
+    downloadUrl.searchParams.set('token', downloadToken)
+
     publishJob(job, {
-      phase: 'completed',
-      filesDone: archive.entries.length,
-      currentFile: request.fileName,
+      archivePath,
+      downloadToken,
+      currentFile: 'Waiting for the agent to pick up the transfer task',
       currentLoaded: 0,
       currentTotal: null,
     })
+
+    const taskRunId = await createBundleTransferTask(job, request, downloadUrl.toString())
+    publishJob(job, { taskRunId })
+
+    await refreshTransferTaskStatus(job)
   } catch (err) {
     console.error('Bundle transfer failed:', err)
+    const cleanupDir = job.tempDir
     publishJob(job, {
       phase: 'failed',
       error: err instanceof Error && err.message ? err.message : 'Transfer failed',
+      tempDir: null,
+      archivePath: null,
+      downloadToken: null,
     })
+    if (cleanupDir) void rm(cleanupDir, { recursive: true, force: true }).catch(() => undefined)
   } finally {
-    client?.end()
-    if (tempDir) {
+    if (tempDir && !job.tempDir) {
       await rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
     }
   }
@@ -558,6 +649,46 @@ async function getAuthorisedUser(request: NextRequest) {
     where: eq(users.id, session.user.id),
   })
   return user?.organisationId ? user : null
+}
+
+function getRequestOrigin(request: NextRequest) {
+  const configuredBaseUrl = process.env.AGENT_DOWNLOAD_BASE_URL?.trim()
+  if (configuredBaseUrl) return configuredBaseUrl.replace(/\/+$/, '')
+  const origin = request.headers.get('origin')
+  if (origin) return origin
+  const forwardedProto = request.headers.get('x-forwarded-proto')
+  const forwardedHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host')
+  if (forwardedProto && forwardedHost) return `${forwardedProto.split(',')[0]}://${forwardedHost.split(',')[0]}`
+  return request.nextUrl.origin
+}
+
+async function serveBundleDownload(request: NextRequest) {
+  cleanupOldJobs()
+  const jobId = request.nextUrl.searchParams.get('jobId')
+  const token = request.nextUrl.searchParams.get('token')
+  if (!jobId || !token) {
+    return NextResponse.json({ error: 'Missing download token' }, { status: 400 })
+  }
+
+  const job = transferJobs.get(jobId)
+  if (!job || job.downloadToken !== token || !job.archivePath || job.phase !== 'transferring') {
+    return NextResponse.json({ error: 'Bundle download not found' }, { status: 404 })
+  }
+
+  const stats = await fsStat(job.archivePath).catch(() => null)
+  if (!stats?.isFile()) {
+    return NextResponse.json({ error: 'Bundle archive is unavailable' }, { status: 410 })
+  }
+
+  const stream = Readable.toWeb(createReadStream(job.archivePath)) as unknown as ReadableStream<Uint8Array>
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="${job.fileName.replace(/"/g, '')}"`,
+      'Content-Length': String(stats.size),
+      'Cache-Control': 'no-store',
+    },
+  })
 }
 
 export async function POST(request: NextRequest) {
@@ -586,6 +717,9 @@ export async function POST(request: NextRequest) {
   if (!host) {
     return NextResponse.json({ error: 'Host not found' }, { status: 404 })
   }
+  if (!host.agentId || host.status !== 'online') {
+    return NextResponse.json({ error: 'Host must be online with an active agent before a bundle can be transferred' }, { status: 409 })
+  }
 
   const directory = path.posix.normalize(parsed.data.directory)
   const remotePath = path.posix.join(directory, parsed.data.fileName)
@@ -602,21 +736,29 @@ export async function POST(request: NextRequest) {
     currentFile: null,
     currentLoaded: 0,
     currentTotal: null,
+    tempDir: null,
+    archivePath: null,
+    downloadToken: null,
+    taskRunId: null,
     error: null,
     createdAt: Date.now(),
     updatedAt: Date.now(),
   }
   transferJobs.set(job.id, job)
-  void runTransferJob(job, parsed.data)
+  void runTransferJob(job, parsed.data, getRequestOrigin(request))
 
   return NextResponse.json({
     ok: true,
     jobId: job.id,
-    job,
+    job: publicJob(job),
   })
 }
 
 export async function GET(request: NextRequest) {
+  if (request.nextUrl.searchParams.get('download') === '1') {
+    return serveBundleDownload(request)
+  }
+
   cleanupOldJobs()
   const user = await getAuthorisedUser(request)
   if (!user?.organisationId) {
@@ -630,5 +772,6 @@ export async function GET(request: NextRequest) {
   if (!job || job.userId !== user.id || job.organisationId !== user.organisationId) {
     return NextResponse.json({ error: 'Transfer job not found' }, { status: 404 })
   }
-  return NextResponse.json({ ok: true, job })
+  await refreshTransferTaskStatus(job)
+  return NextResponse.json({ ok: true, job: publicJob(job) })
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,7 +59,6 @@
     "remark-gfm": "^4.0.1",
     "semver": "^7.7.4",
     "shadcn": "^4.3.0",
-    "ssh2": "^1.17.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"
@@ -72,7 +71,6 @@
     "@types/nodemailer": "^8.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/ssh2": "^1.15.5",
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,9 +282,6 @@ importers:
       shadcn:
         specifier: ^4.3.0
         version: 4.3.0(@types/node@20.19.37)(typescript@5.9.3)
-      ssh2:
-        specifier: ^1.17.0
-        version: 1.17.0
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -316,9 +313,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
-      '@types/ssh2':
-        specifier: ^1.15.5
-        version: 1.15.5
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2


### PR DESCRIPTION
## Summary
- route GitLab/Jenkins bundle transfers through the existing agent task channel instead of direct SSH/SFTP from the web container
- prepare the zip server-side, expose it through a short-lived per-job token, and dispatch a host-side `custom_script` task to write it to the requested directory
- simplify the transfer modal to host, optional owner, and destination directory; remove SSH password collection and direct `ssh2` web dependency

## Root Cause
The v0.70.2 transfer path attempted to resolve and SSH to the host from the web container. Hosts such as `ct-agent-alma` are known to CT-Ops through the agent connection, but are not necessarily resolvable or reachable from the web container DNS/network path.

## Validation
- `pnpm --filter web type-check`
- `pnpm --filter web lint -- app/api/tools/bundle-transfer/route.ts 'app/(dashboard)/bundlers/bundle-transfer-dialog.tsx' 'app/(dashboard)/bundlers/bundle-transfer-status.tsx'`
- `pnpm install --frozen-lockfile --offline`
