### PR TITLE
fix(auth): require email verification for local sign-ups

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,6 +30,19 @@ BETTER_AUTH_URL=http://localhost:3000
 # Example: BETTER_AUTH_TRUSTED_ORIGINS=https://tunnel.example.com
 BETTER_AUTH_TRUSTED_ORIGINS=
 
+# --- Auth email verification ---
+# CT-Ops requires email verification for local email/password accounts.
+# In production, configure a real SMTP relay and sender address.
+# In local development you can leave these blank; CT-Ops logs verification
+# links to the server console instead.
+# AUTH_EMAIL_SMTP_HOST=smtp.example.com
+# AUTH_EMAIL_SMTP_PORT=587
+# AUTH_EMAIL_SMTP_SECURE=false
+# AUTH_EMAIL_SMTP_USER=
+# AUTH_EMAIL_SMTP_PASSWORD=
+# AUTH_EMAIL_FROM=no-reply@example.com
+# AUTH_EMAIL_FROM_NAME=CT-Ops
+
 # --- LDAP (optional) ---
 # LDAP can also be configured via the Settings > LDAP / Directory UI.
 # Environment variables here act as a fallback when no DB-stored config exists.

--- a/apps/web/app/(auth)/check-email/page.tsx
+++ b/apps/web/app/(auth)/check-email/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+
+export const metadata: Metadata = {
+  title: 'Check your email',
+}
+
+type CheckEmailPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function CheckEmailPage({ searchParams }: CheckEmailPageProps) {
+  const params = await searchParams
+  const email = readParam(params.email)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Check your email</CardTitle>
+        <CardDescription>
+          We sent a verification link{email ? ` to ${email}` : ''}. You need to verify your
+          address before CT-Ops will sign you in.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        After you open the link, CT-Ops will continue to the next step automatically.
+      </CardContent>
+      <CardFooter>
+        <Link href="/login" className="text-sm text-foreground underline underline-offset-4">
+          Back to sign in
+        </Link>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/app/(auth)/register/register-form.tsx
+++ b/apps/web/app/(auth)/register/register-form.tsx
@@ -19,7 +19,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { signUp } from '@/lib/auth/client'
-import { getInviteByToken, acceptInvite } from '@/lib/actions/auth'
+import { getInviteByToken } from '@/lib/actions/auth'
 
 const registerSchema = z
   .object({
@@ -64,10 +64,14 @@ export function RegisterForm() {
 
   async function onSubmit(values: RegisterValues) {
     setServerError(null)
+    const callbackURL = inviteToken
+      ? `/accept-invite?token=${encodeURIComponent(inviteToken)}`
+      : '/onboarding'
     const result = await signUp.email({
       name: values.name,
       email: values.email,
       password: values.password,
+      callbackURL,
     })
 
     if (result.error) {
@@ -75,15 +79,7 @@ export function RegisterForm() {
       return
     }
 
-    if (inviteToken) {
-      const userId = (result.data as { user?: { id?: string } } | null)?.user?.id
-      if (userId) {
-        await acceptInvite(inviteToken, userId)
-      }
-      router.push('/dashboard')
-    } else {
-      router.push('/onboarding')
-    }
+    router.push(`/check-email?email=${encodeURIComponent(values.email)}`)
   }
 
   return (

--- a/apps/web/app/accept-invite/page.tsx
+++ b/apps/web/app/accept-invite/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation'
+import { getRequiredSession } from '@/lib/auth/session'
+import { acceptInvite } from '@/lib/actions/auth'
+
+type AcceptInvitePageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function AcceptInvitePage({ searchParams }: AcceptInvitePageProps) {
+  const params = await searchParams
+  const token = readParam(params.token)
+  if (!token) redirect('/login?error=missing_invite_token')
+
+  const session = await getRequiredSession()
+  const result = await acceptInvite(token, session.user.id)
+  if ('error' in result) {
+    redirect(`/login?error=${encodeURIComponent(result.error)}`)
+  }
+
+  redirect('/dashboard')
+}

--- a/apps/web/app/verify-email/page.tsx
+++ b/apps/web/app/verify-email/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from 'next/navigation'
+
+type VerifyEmailPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function VerifyEmailPage({ searchParams }: VerifyEmailPageProps) {
+  const params = await searchParams
+  const token = readParam(params.token)
+  const callbackURL = readParam(params.callbackURL) ?? '/login?verified=1'
+
+  if (!token) {
+    redirect('/login?error=missing_verification_token')
+  }
+
+  const target = new URL('/api/auth/verify-email', process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000')
+  target.searchParams.set('token', token)
+  target.searchParams.set('callbackURL', callbackURL)
+  redirect(target.toString())
+}

--- a/apps/web/lib/auth/email.ts
+++ b/apps/web/lib/auth/email.ts
@@ -1,0 +1,96 @@
+import { appendFile, mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import nodemailer from 'nodemailer'
+
+type AuthEmailInput = {
+  to: string
+  subject: string
+  text: string
+  html: string
+  metadata?: Record<string, string>
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value == null) return fallback
+  return value === '1' || value.toLowerCase() === 'true'
+}
+
+async function captureEmail(input: AuthEmailInput): Promise<void> {
+  const file = process.env['AUTH_EMAIL_CAPTURE_FILE']
+  if (!file) return
+
+  await mkdir(path.dirname(file), { recursive: true })
+  await appendFile(file, `${JSON.stringify(input)}
+`, 'utf8')
+}
+
+export async function sendAuthEmail(input: AuthEmailInput): Promise<void> {
+  const host = process.env['AUTH_EMAIL_SMTP_HOST']
+  const port = Number(process.env['AUTH_EMAIL_SMTP_PORT'] ?? '587')
+  const secure = parseBoolean(process.env['AUTH_EMAIL_SMTP_SECURE'], port === 465)
+  const user = process.env['AUTH_EMAIL_SMTP_USER']
+  const password = process.env['AUTH_EMAIL_SMTP_PASSWORD']
+  const fromAddress = process.env['AUTH_EMAIL_FROM']
+  const fromName = process.env['AUTH_EMAIL_FROM_NAME'] ?? 'CT-Ops'
+
+  if (host && fromAddress) {
+    const transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure,
+      ...(user ? { auth: { user, pass: password ?? '' } } : {}),
+    })
+
+    await transporter.sendMail({
+      from: fromName ? `"${fromName}" <${fromAddress}>` : fromAddress,
+      to: input.to,
+      subject: input.subject,
+      text: input.text,
+      html: input.html,
+    })
+
+    await captureEmail(input)
+    return
+  }
+
+  if (process.env['NODE_ENV'] === 'production') {
+    throw new Error(
+      'AUTH_EMAIL_SMTP_HOST and AUTH_EMAIL_FROM must be configured when email verification is enabled.',
+    )
+  }
+
+  console.log('[auth-email]', JSON.stringify(input))
+  await captureEmail(input)
+}
+
+export async function sendVerificationEmail(input: {
+  email: string
+  name: string
+  verificationUrl: string
+}): Promise<void> {
+  const subject = 'Verify your CT-Ops email address'
+  const text = [
+    `Hi ${input.name || 'there'},`,
+    '',
+    'Verify your email address to finish setting up your CT-Ops account:',
+    input.verificationUrl,
+    '',
+    'If you did not create this account, you can ignore this email.',
+  ].join('\n')
+
+  const html = [
+    `<p>Hi ${input.name || 'there'},</p>`,
+    '<p>Verify your email address to finish setting up your CT-Ops account:</p>',
+    `<p><a href="${input.verificationUrl}">Verify email address</a></p>`,
+    `<p>If the button does not work, use this link:<br /><a href="${input.verificationUrl}">${input.verificationUrl}</a></p>`,
+    '<p>If you did not create this account, you can ignore this email.</p>',
+  ].join('')
+
+  await sendAuthEmail({
+    to: input.email,
+    subject,
+    text,
+    html,
+    metadata: { verificationUrl: input.verificationUrl },
+  })
+}

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor } from 'better-auth/plugins'
 import { db } from '@/lib/db'
 import * as schema from '@/lib/db/schema'
+import { sendVerificationEmail } from './email'
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -16,9 +17,19 @@ export const auth = betterAuth({
   }),
   emailAndPassword: {
     enabled: true,
-    requireEmailVerification: false,
+    requireEmailVerification: true,
     minPasswordLength: 12,
     maxPasswordLength: 128,
+  },
+  emailVerification: {
+    autoSignInAfterVerification: true,
+    sendVerificationEmail: async ({ user, url }) => {
+      await sendVerificationEmail({
+        email: user.email,
+        name: user.name,
+        verificationUrl: url,
+      })
+    },
   },
   plugins: [
     twoFactor({

--- a/apps/web/tests/e2e/auth/register.spec.ts
+++ b/apps/web/tests/e2e/auth/register.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '../fixtures/test'
+import { waitForVerificationUrl } from '../fixtures/email'
+
+test('email sign-up requires verification before dashboard access', async ({ page }) => {
+  const email = `verify-${Date.now()}@example.com`
+  const password = 'TestPassword123!'
+
+  await page.goto('/register')
+  await page.getByLabel('Full name').fill('Verification Test User')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel(/^Password$/).fill(password)
+  await page.getByLabel(/^Confirm password$/).fill(password)
+  await page.getByRole('button', { name: 'Create account' }).click()
+
+  await page.waitForURL('**/check-email*')
+  await expect(page.getByText(`We sent a verification link to ${email}.`)).toBeVisible()
+
+  await page.goto('/dashboard')
+  await page.waitForURL('**/login')
+
+  const verificationUrl = await waitForVerificationUrl(email)
+  await page.goto(verificationUrl)
+
+  await page.waitForURL('**/onboarding')
+  await expect(page.getByText('Create your organisation')).toBeVisible()
+})

--- a/apps/web/tests/e2e/fixtures/email.ts
+++ b/apps/web/tests/e2e/fixtures/email.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises'
+
+type CapturedEmail = {
+  to: string
+  subject: string
+  text: string
+  html: string
+  metadata?: Record<string, string>
+}
+
+function getCaptureFile(): string {
+  const file = process.env['AUTH_EMAIL_CAPTURE_FILE']
+  if (!file) {
+    throw new Error('AUTH_EMAIL_CAPTURE_FILE is not set')
+  }
+  return file
+}
+
+export async function waitForVerificationUrl(to: string, timeoutMs = 10_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  const file = getCaptureFile()
+
+  while (Date.now() < deadline) {
+    try {
+      const raw = await readFile(file, 'utf8')
+      const messages = raw
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as CapturedEmail)
+
+      const match = [...messages].reverse().find((message) => message.to === to)
+      const verificationUrl = match?.metadata?.verificationUrl
+      if (verificationUrl) return verificationUrl
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+
+  throw new Error(`Timed out waiting for verification email for ${to}`)
+}

--- a/apps/web/tests/e2e/runner.mjs
+++ b/apps/web/tests/e2e/runner.mjs
@@ -9,6 +9,7 @@
 // with a missing env var. This wrapper inverts the order.
 
 import { spawn } from 'node:child_process'
+import { mkdir, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { GenericContainer, Wait } from 'testcontainers'
@@ -20,6 +21,7 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 const webDir = path.resolve(here, '..', '..')
 const port = Number(process.env.E2E_PORT ?? 3100)
 const appUrl = `http://localhost:${port}`
+const authEmailCaptureFile = path.join(webDir, 'tests', 'e2e', '.tmp', 'auth-emails.ndjson')
 
 async function main() {
   console.log('[e2e] starting TimescaleDB container (tmpfs)')
@@ -45,6 +47,10 @@ async function main() {
     process.env.BETTER_AUTH_URL = appUrl
     process.env.BETTER_AUTH_TRUSTED_ORIGINS = appUrl
     process.env.E2E_PORT = String(port)
+    process.env.AUTH_EMAIL_CAPTURE_FILE = authEmailCaptureFile
+
+    await mkdir(path.dirname(authEmailCaptureFile), { recursive: true })
+    await rm(authEmailCaptureFile, { force: true })
 
     console.log('[e2e] running migrations')
     const migrationClient = postgres(databaseUrl, { prepare: false, max: 1 })


### PR DESCRIPTION
## Summary
- require Better Auth email verification for local email/password sign-ups
- add the verification mailer, check-email page, and post-verification invite/onboarding flow
- cover the registration flow with a Playwright E2E that proves dashboard access is blocked until verification

## Testing
- pnpm type-check
- pnpm lint
- E2E_PORT=3110 pnpm test:e2e -- tests/e2e/auth/register.spec.ts

Fixes #275