### PR TITLE
fix(security): lock down certificate checker SSRF surface

### DIFF
--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -58,6 +58,7 @@ import {
 } from '@/components/ui/table'
 import type { ParsedCertificate, CertCheckerResponse } from '@/app/api/tools/certificate-checker/route'
 import { trackCertificateFromUrl, trackCertificateFromUpload } from '@/lib/actions/certificates'
+import { getAllowedCertificateCheckerPorts } from '@/lib/net/certificate-checker-policy'
 
 // ─── Utility helpers ─────────────────────────────────────────────────────────
 
@@ -771,6 +772,7 @@ function UploadTab({ onResult }: { onResult: (cert: ParsedCertificate, source: T
 // ─── URL tab ──────────────────────────────────────────────────────────────────
 
 function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: TrackSource, keyMatch?: boolean) => void }) {
+  const allowedPorts = getAllowedCertificateCheckerPorts().join(', ')
   const [url, setUrl] = useState('')
   const [port, setPort] = useState('443')
   const [servername, setServername] = useState('')
@@ -831,6 +833,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
             value={port}
             onChange={(e) => setPort(e.target.value)}
           />
+          <p className="text-xs text-muted-foreground">Allowed TLS ports: {allowedPorts}</p>
         </div>
         <div className="space-y-1.5">
           <Label htmlFor="cert-sni">SNI Override <span className="text-muted-foreground font-normal">(optional)</span></Label>

--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import * as crypto from 'crypto'
 import * as forge from 'node-forge'
 import { z } from 'zod'
+import { auth } from '@/lib/auth'
 import {
   type ParsedCertificate,
   checkKeyMatch,
@@ -10,6 +11,7 @@ import {
   pemToForgeCert,
   resolveUrlTarget,
 } from '@/lib/certificates/fetch'
+import { assertAllowedCertificateCheckerPort } from '@/lib/net/certificate-checker-policy'
 import { assertPublicHost } from '@/lib/net/ssrf-guard'
 
 export type { ParsedCertificate, ParsedSAN, ChainEntry } from '@/lib/certificates/fetch'
@@ -56,6 +58,11 @@ const BodySchema = z.discriminatedUnion('action', [
 ])
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  const session = await auth.api.getSession({ headers: req.headers })
+  if (!session) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' } satisfies CertCheckerResponse, { status: 401 })
+  }
+
   let body: unknown
   try {
     body = await req.json()
@@ -81,7 +88,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
 
     if (data.action === 'fetch-url') {
-      const { host } = resolveUrlTarget(data.url, data.port)
+      const { host, port } = resolveUrlTarget(data.url, data.port)
+      assertAllowedCertificateCheckerPort(port)
       await assertPublicHost(host)
       const { certificate } = await fetchCertificateFromUrl(data.url, data.port, data.servername)
       const keyMatch = data.keyPem ? checkKeyMatch(data.keyPem, certificate.pem) : undefined

--- a/apps/web/lib/net/certificate-checker-policy.test.mjs
+++ b/apps/web/lib/net/certificate-checker-policy.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  assertAllowedCertificateCheckerPort,
+  getAllowedCertificateCheckerPorts,
+} from './certificate-checker-policy.ts'
+
+test('allows the documented certificate-checker ports', () => {
+  for (const port of getAllowedCertificateCheckerPorts()) {
+    assert.doesNotThrow(() => assertAllowedCertificateCheckerPort(port))
+  }
+})
+
+test('rejects non-TLS and internal-service ports', () => {
+  for (const port of [22, 80, 5432, 2375, 3306]) {
+    assert.throws(
+      () => assertAllowedCertificateCheckerPort(port),
+      /Blocked: port .* is not allowed/,
+    )
+  }
+})

--- a/apps/web/lib/net/certificate-checker-policy.ts
+++ b/apps/web/lib/net/certificate-checker-policy.ts
@@ -1,0 +1,27 @@
+const ALLOWED_CERTIFICATE_CHECKER_PORTS = [
+  443,
+  465,
+  587,
+  636,
+  853,
+  993,
+  995,
+  8443,
+  9443,
+] as const
+
+const allowedPortSet = new Set<number>(ALLOWED_CERTIFICATE_CHECKER_PORTS)
+
+export function getAllowedCertificateCheckerPorts(): readonly number[] {
+  return ALLOWED_CERTIFICATE_CHECKER_PORTS
+}
+
+export function assertAllowedCertificateCheckerPort(port: number): void {
+  if (allowedPortSet.has(port)) {
+    return
+  }
+
+  throw new Error(
+    `Blocked: port ${port} is not allowed. Use one of: ${ALLOWED_CERTIFICATE_CHECKER_PORTS.join(', ')}`,
+  )
+}


### PR DESCRIPTION
## Summary
- require an authenticated session for the certificate checker API route
- block `fetch-url` requests to non-approved TLS ports before any outbound connection is attempted
- surface the allowed port list in the UI and add a targeted policy test

## Testing
- `node --test --experimental-strip-types apps/web/lib/net/certificate-checker-policy.test.mjs`
- `pnpm --dir apps/web run type-check`

Closes #278.
