### PR TITLE
fix: block private notification test targets

### DIFF
--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { createHmac } from 'crypto'
 import nodemailer from 'nodemailer'
 import { createRateLimiter } from '@/lib/rate-limit'
+import { assertPublicHost, assertPublicUrl } from '@/lib/net/ssrf-guard'
 
 const testNotificationLimiter = createRateLimiter(60_000, 5)
 import { db } from '@/lib/db'
@@ -710,6 +711,7 @@ export async function sendTestNotification(
 
   if (existing.type === 'webhook') {
     const cfg = existing.config as WebhookChannelConfig
+    await assertPublicUrl(cfg.url)
     const payload = JSON.stringify({
       event: 'alert.test',
       severity: 'info',
@@ -745,6 +747,7 @@ export async function sendTestNotification(
     }
   } else if (existing.type === 'smtp') {
     const cfg = normaliseSmtpConfig(existing.config)
+    await assertPublicHost(cfg.host)
     const transporter = nodemailer.createTransport({
       host: cfg.host,
       port: cfg.port,
@@ -767,6 +770,7 @@ export async function sendTestNotification(
     }
   } else if (existing.type === 'slack') {
     const cfg = existing.config as SlackChannelConfig
+    await assertPublicUrl(cfg.webhookUrl)
     const payload = JSON.stringify({
       blocks: [
         {

--- a/apps/web/lib/net/ssrf-guard.test.mjs
+++ b/apps/web/lib/net/ssrf-guard.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { assertPublicHost, assertPublicUrl, isPrivateIp } from './ssrf-guard.ts'
+
+test('isPrivateIp flags private and reserved IPv4 ranges', () => {
+  assert.equal(isPrivateIp('127.0.0.1'), true)
+  assert.equal(isPrivateIp('10.0.0.8'), true)
+  assert.equal(isPrivateIp('172.16.1.5'), true)
+  assert.equal(isPrivateIp('192.168.1.10'), true)
+  assert.equal(isPrivateIp('169.254.10.20'), true)
+  assert.equal(isPrivateIp('100.64.0.1'), true)
+  assert.equal(isPrivateIp('8.8.8.8'), false)
+})
+
+test('isPrivateIp flags private and reserved IPv6 ranges', () => {
+  assert.equal(isPrivateIp('::1'), true)
+  assert.equal(isPrivateIp('::'), true)
+  assert.equal(isPrivateIp('fc00::1'), true)
+  assert.equal(isPrivateIp('fd12::1'), true)
+  assert.equal(isPrivateIp('fe80::1'), true)
+  assert.equal(isPrivateIp('2001:4860:4860::8888'), false)
+})
+
+test('assertPublicHost rejects private and reserved literal addresses', async () => {
+  await assert.rejects(() => assertPublicHost('127.0.0.1'), /private or reserved address/)
+  await assert.rejects(() => assertPublicHost('::1'), /private or reserved address/)
+  await assert.doesNotReject(() => assertPublicHost('8.8.8.8'))
+})
+
+test('assertPublicUrl rejects webhook targets on blocked addresses', async () => {
+  await assert.rejects(
+    () => assertPublicUrl('https://127.0.0.1/webhook'),
+    /private or reserved address/,
+  )
+  await assert.rejects(
+    () => assertPublicUrl('https://[::1]/webhook'),
+    /private or reserved address/,
+  )
+  await assert.doesNotReject(() => assertPublicUrl('https://8.8.8.8/webhook'))
+})

--- a/apps/web/lib/net/ssrf-guard.ts
+++ b/apps/web/lib/net/ssrf-guard.ts
@@ -1,7 +1,7 @@
 import * as dns from 'dns'
 import * as net from 'net'
 
-function isPrivateIp(ip: string): boolean {
+export function isPrivateIp(ip: string): boolean {
   if (net.isIPv4(ip)) {
     const parts = ip.split('.').map(Number)
     const [a = 0, b = 0] = parts
@@ -39,11 +39,13 @@ function isPrivateIp(ip: string): boolean {
  * prevent DNS-rebinding between the check and the actual connection.
  */
 export async function assertPublicHost(hostname: string): Promise<string> {
+  const normalizedHostname =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
   let resolvedIp: string
-  if (net.isIPv4(hostname) || net.isIPv6(hostname)) {
-    resolvedIp = hostname
+  if (net.isIPv4(normalizedHostname) || net.isIPv6(normalizedHostname)) {
+    resolvedIp = normalizedHostname
   } else {
-    const { address } = await dns.promises.lookup(hostname)
+    const { address } = await dns.promises.lookup(normalizedHostname)
     resolvedIp = address
   }
   if (isPrivateIp(resolvedIp)) {
@@ -53,4 +55,10 @@ export async function assertPublicHost(hostname: string): Promise<string> {
     )
   }
   return resolvedIp
+}
+
+export async function assertPublicUrl(url: string): Promise<URL> {
+  const parsed = new URL(url)
+  await assertPublicHost(parsed.hostname)
+  return parsed
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "type-check": "tsc --noEmit",
+    "test:unit": "node --experimental-strip-types --test \"lib/**/*.test.mjs\"",
     "build": "node scripts/validate-migrations.js && next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- block notification test sends to webhook, Slack, and SMTP targets that resolve to private or reserved addresses
- reuse the shared SSRF guard for URL and host validation, including bracketed IPv6 literals
- add executable guard coverage under the web app's Node test harness

## Root cause
`sendTestNotification` trusted stored destination hosts and opened outbound connections from the server without checking whether the target resolved to an internal or reserved address.

## Validation
- `npm run test:unit -- ssrf-guard.test.mjs`
- `npm run type-check`

Closes #279.
