### PR TITLE
fix(agent): send JWT on initial heartbeat

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -233,9 +233,10 @@ func (r *Runner) runStream(ctx context.Context) error {
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
 
-	// Collect metrics and send first heartbeat immediately.
+	// Collect metrics and send first heartbeat immediately. The first message
+	// authenticates the stream, so agent_id carries the JWT for that one send.
 	r.refreshMetrics()
-	if err := r.sendHeartbeat(stream); err != nil {
+	if err := r.sendHeartbeatWithAgentID(stream, r.jwtToken); err != nil {
 		return err
 	}
 
@@ -575,9 +576,13 @@ func (r *Runner) refreshMetrics() {
 }
 
 func (r *Runner) sendHeartbeat(stream agentv1.IngestService_HeartbeatClient) error {
+	return r.sendHeartbeatWithAgentID(stream, r.agentID)
+}
+
+func (r *Runner) sendHeartbeatWithAgentID(stream agentv1.IngestService_HeartbeatClient, agentIDField string) error {
 	m := r.cachedMetrics
 	req := &agentv1.HeartbeatRequest{
-		AgentId:                     r.agentID,
+		AgentId:                     agentIDField,
 		CpuPercent:                  m.cpu,
 		MemoryPercent:               m.memory,
 		DiskPercent:                 m.disk,


### PR DESCRIPTION
## Summary

- Send the agent JWT in the first heartbeat message for each stream.
- Keep subsequent heartbeat messages using the real agent ID after the stream is authenticated.

## Root Cause

Recent ingest security hardening removed the fallback that accepted a plain agent ID in the first heartbeat message. The released agent still sent `agentID` instead of `jwtToken`, so active agents could register successfully but every heartbeat stream was rejected with `Unauthenticated: invalid or missing JWT`.

## Impact

This restores compatibility with the stricter heartbeat authentication contract and should allow agents to resume telemetry, host vitals, and status updates after registration.

## Validation

- `go test ./agent/internal/heartbeat ./agent/internal/loadtest ./apps/ingest/internal/handlers`
