### PR TITLE
fix(web): require org auth for server actions

### DIFF
--- a/apps/web/lib/actions/action-auth-core.ts
+++ b/apps/web/lib/actions/action-auth-core.ts
@@ -1,0 +1,15 @@
+export type OrgScopedUser = {
+  organisationId: string | null
+  isActive: boolean
+  deletedAt: Date | null
+}
+
+export function assertOrgAccess(user: OrgScopedUser, orgId: string): void {
+  if (!user.isActive || user.deletedAt) {
+    throw new Error('forbidden: inactive user')
+  }
+
+  if (user.organisationId !== orgId) {
+    throw new Error('forbidden: organisation mismatch')
+  }
+}

--- a/apps/web/lib/actions/action-auth.test.mjs
+++ b/apps/web/lib/actions/action-auth.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { assertOrgAccess } from './action-auth-core.ts'
+
+test('assertOrgAccess rejects inactive users', () => {
+  assert.throws(
+    () => assertOrgAccess({ organisationId: 'org-1', isActive: false, deletedAt: null }, 'org-1'),
+    /forbidden: inactive user/,
+  )
+})
+
+test('assertOrgAccess rejects deleted users', () => {
+  assert.throws(
+    () => assertOrgAccess({ organisationId: 'org-1', isActive: true, deletedAt: new Date() }, 'org-1'),
+    /forbidden: inactive user/,
+  )
+})
+
+test('assertOrgAccess rejects cross-org access', () => {
+  assert.throws(
+    () => assertOrgAccess({ organisationId: 'org-1', isActive: true, deletedAt: null }, 'org-2'),
+    /forbidden: organisation mismatch/,
+  )
+})
+
+test('assertOrgAccess allows active users in their own organisation', () => {
+  assert.doesNotThrow(
+    () => assertOrgAccess({ organisationId: 'org-1', isActive: true, deletedAt: null }, 'org-1'),
+  )
+})

--- a/apps/web/lib/actions/action-auth.ts
+++ b/apps/web/lib/actions/action-auth.ts
@@ -1,0 +1,8 @@
+import { getRequiredSession, type RequiredSession } from '@/lib/auth/session'
+import { assertOrgAccess } from '@/lib/actions/action-auth-core'
+
+export async function requireOrgAccess(orgId: string): Promise<RequiredSession> {
+  const session = await getRequiredSession()
+  assertOrgAccess(session.user, orgId)
+  return session
+}

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import {
@@ -65,6 +67,7 @@ const createEnrolmentTokenSchema = z.object({
 })
 
 export async function listPendingAgents(orgId: string): Promise<Agent[]> {
+  await requireOrgAccess(orgId)
   return db.query.agents.findMany({
     where: and(
       eq(agents.organisationId, orgId),
@@ -79,6 +82,7 @@ export async function approveAgent(
   agentId: string,
   actorId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const agent = await db.query.agents.findFirst({
       where: and(eq(agents.id, agentId), eq(agents.organisationId, orgId)),
@@ -210,6 +214,7 @@ export async function rejectAgent(
   agentId: string,
   actorId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const agent = await db.query.agents.findFirst({
       where: and(eq(agents.id, agentId), eq(agents.organisationId, orgId)),
@@ -251,6 +256,7 @@ export async function rejectAgent(
 export type HostWithAgent = Host & { agent: Agent | null }
 
 export async function listHosts(orgId: string): Promise<HostWithAgent[]> {
+  await requireOrgAccess(orgId)
   const rows = await db
     .select()
     .from(hosts)
@@ -303,6 +309,7 @@ export async function listHostsPaginated(
   orgId: string,
   params: HostListParams = {},
 ): Promise<HostListResult> {
+  await requireOrgAccess(orgId)
   const limit = Math.max(1, Math.min(params.limit ?? 50, HOST_PAGE_MAX))
   const offset = Math.max(0, params.offset ?? 0)
   const sortBy: HostSortField = params.sortBy ?? 'hostname'
@@ -388,6 +395,7 @@ export interface HostInventoryStats {
 }
 
 export async function getHostInventoryStats(orgId: string): Promise<HostInventoryStats> {
+  await requireOrgAccess(orgId)
   const baseWhere = and(eq(hosts.organisationId, orgId), isNull(hosts.deletedAt))
   const threshold = HOST_HIGH_USAGE_THRESHOLD
   const staleCutoff = new Date(Date.now() - HOST_STALE_MINUTES * 60 * 1000)
@@ -458,6 +466,7 @@ export async function getHostInventoryStats(orgId: string): Promise<HostInventor
 }
 
 export async function listDistinctHostOses(orgId: string): Promise<string[]> {
+  await requireOrgAccess(orgId)
   const rows = await db
     .selectDistinct({ os: hosts.os })
     .from(hosts)
@@ -478,6 +487,7 @@ export async function createEnrolmentToken(
     tags?: Array<{ key: string; value: string }>
   },
 ): Promise<{ token: string; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (!createEnrolmentTokenLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before creating another enrolment token.' }
   }
@@ -535,6 +545,7 @@ export type EnrolmentTokenSafe = Omit<AgentEnrolmentToken, 'token' | 'tokenHash'
 }
 
 export async function listEnrolmentTokens(orgId: string): Promise<EnrolmentTokenSafe[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.agentEnrolmentTokens.findMany({
     where: and(
       eq(agentEnrolmentTokens.organisationId, orgId),
@@ -551,6 +562,7 @@ export async function revokeEnrolmentToken(
   orgId: string,
   tokenId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await db
       .update(agentEnrolmentTokens)
@@ -641,6 +653,7 @@ export async function getHostMetrics(
   hostId: string,
   query: MetricsQuery,
 ): Promise<HostMetric[]> {
+  await requireOrgAccess(orgId)
   const { from, to, fromISO, toISO } = resolveTimeBounds(query)
   const bucketMode = computeBucketMode(to.getTime() - from.getTime())
 
@@ -764,6 +777,7 @@ export async function getAgentOfflinePeriods(
   agentId: string,
   query: MetricsQuery,
 ): Promise<OfflinePeriod[]> {
+  await requireOrgAccess(orgId)
   const { from, to } = resolveTimeBounds(query)
   const windowStart = from.getTime()
   // Look back one extra hour before the window to capture an offline event that
@@ -812,6 +826,7 @@ export async function getHeartbeatHistory(
   hostId: string,
   query: MetricsQuery,
 ): Promise<HeartbeatPoint[]> {
+  await requireOrgAccess(orgId)
   const { from, to, fromISO, toISO } = resolveTimeBounds(query)
   const bucketMode = computeBucketMode(to.getTime() - from.getTime())
 
@@ -898,6 +913,7 @@ export async function getHeartbeatHistory(
 }
 
 export async function getHost(orgId: string, hostId: string): Promise<HostWithAgent | null> {
+  await requireOrgAccess(orgId)
   const rows = await db
     .select()
     .from(hosts)
@@ -923,6 +939,7 @@ export async function deleteHost(
   orgId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     // Capture the result of the "not found" check that happens inside the
     // transaction so we can surface it as an error after the transaction closes.
@@ -1162,6 +1179,7 @@ export async function uninstallAndDeleteHost(
   | { success: true }
   | { error: string; taskRunId?: string; agentOffline?: boolean }
 > {
+  await requireOrgAccess(orgId)
   try {
     const host = await db.query.hosts.findFirst({
       where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)),

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { createHmac } from 'crypto'
 import nodemailer from 'nodemailer'
@@ -126,6 +128,7 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
 // ─── Alert Rules ──────────────────────────────────────────────────────────────
 
 export async function getAlertRules(orgId: string, hostId?: string): Promise<AlertRule[]> {
+  await requireOrgAccess(orgId)
   return db.query.alertRules.findMany({
     where: and(
       eq(alertRules.organisationId, orgId),
@@ -138,6 +141,7 @@ export async function getAlertRules(orgId: string, hostId?: string): Promise<Ale
 }
 
 export async function getGlobalAlertDefaults(orgId: string): Promise<AlertRule[]> {
+  await requireOrgAccess(orgId)
   return db.query.alertRules.findMany({
     where: and(
       eq(alertRules.organisationId, orgId),
@@ -158,6 +162,7 @@ export async function createGlobalAlertDefault(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = createGlobalAlertDefaultSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -189,6 +194,7 @@ export async function deleteGlobalAlertDefault(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.alertRules.findFirst({
     where: and(
       eq(alertRules.id, ruleId),
@@ -211,6 +217,7 @@ export async function applyGlobalDefaultsToHost(
   orgId: string,
   hostId: string,
 ): Promise<void> {
+  await requireOrgAccess(orgId)
   const defaults = await getGlobalAlertDefaults(orgId)
   if (defaults.length === 0) return
 
@@ -232,6 +239,7 @@ export async function createAlertRule(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = createAlertRuleSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -263,6 +271,7 @@ export async function updateAlertRule(
   ruleId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = updateAlertRuleSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -296,6 +305,7 @@ export async function deleteAlertRule(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.alertRules.findFirst({
     where: and(
       eq(alertRules.id, ruleId),
@@ -329,6 +339,7 @@ export async function getAlertInstances(
   orgId: string,
   filters: AlertHistoryFilters = {},
 ): Promise<AlertInstanceWithRule[]> {
+  await requireOrgAccess(orgId)
   const limit = filters.limit ?? 50
   const offset = filters.offset ?? 0
 
@@ -378,6 +389,7 @@ export async function getAlertInstanceCount(
   orgId: string,
   filters: Omit<AlertHistoryFilters, 'limit' | 'offset'> = {},
 ): Promise<number> {
+  await requireOrgAccess(orgId)
   const rows = await db
     .select({ total: count() })
     .from(alertInstances)
@@ -401,6 +413,7 @@ export async function acknowledgeAlert(
   instanceId: string,
   userId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.alertInstances.findFirst({
     where: and(
       eq(alertInstances.id, instanceId),
@@ -426,6 +439,7 @@ export async function getActiveAlertCountsForHosts(
   orgId: string,
   hostIds: string[],
 ): Promise<Record<string, number>> {
+  await requireOrgAccess(orgId)
   if (hostIds.length === 0) return {}
 
   const rows = await db
@@ -478,6 +492,7 @@ function normaliseSmtpConfig(raw: unknown): SmtpChannelConfig {
 }
 
 export async function getNotificationChannels(orgId: string): Promise<NotificationChannelSafe[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.notificationChannels.findMany({
     where: and(
       eq(notificationChannels.organisationId, orgId),
@@ -536,6 +551,7 @@ export async function createNotificationChannel(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = createNotificationChannelSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -564,6 +580,7 @@ export async function deleteNotificationChannel(
   orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
       eq(notificationChannels.id, channelId),
@@ -622,6 +639,7 @@ export async function updateNotificationChannel(
   channelId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
       eq(notificationChannels.id, channelId),
@@ -697,6 +715,7 @@ export async function sendTestNotification(
   orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (!testNotificationLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before sending another test notification.' }
   }
@@ -838,6 +857,7 @@ const createSilenceSchema = z.object({
 })
 
 export async function getSilences(orgId: string): Promise<AlertSilenceWithHost[]> {
+  await requireOrgAccess(orgId)
   const rows = await db
     .select({
       id: alertSilences.id,
@@ -871,6 +891,7 @@ export async function getActiveSilencesForHost(
   orgId: string,
   hostId: string,
 ): Promise<AlertSilence[]> {
+  await requireOrgAccess(orgId)
   const now = new Date()
   return db.query.alertSilences.findMany({
     where: and(
@@ -890,6 +911,7 @@ export async function createSilence(
   userId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = createSilenceSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -921,6 +943,7 @@ export async function deleteSilence(
   orgId: string,
   silenceId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.alertSilences.findFirst({
     where: and(
       eq(alertSilences.id, silenceId),

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { certificates, certificateEvents } from '@/lib/db/schema'
@@ -44,6 +46,7 @@ export async function getCertificates(
   orgId: string,
   filters: CertificateListFilters = {},
 ): Promise<Certificate[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
   const {
     status,
@@ -84,6 +87,7 @@ export async function getCertificate(
   orgId: string,
   certId: string,
 ): Promise<{ certificate: Certificate; events: CertificateEvent[] } | null> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
   const certificate = await db.query.certificates.findFirst({
     where: and(
@@ -106,6 +110,7 @@ export async function getCertificate(
 }
 
 export async function getCertificateCounts(orgId: string): Promise<CertificateCounts> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
   const rows = await db
     .select({
@@ -131,6 +136,7 @@ export async function deleteCertificate(
   orgId: string,
   certId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) {
     return { error: 'Organisation mismatch' }
@@ -235,6 +241,7 @@ export async function trackCertificateFromUrl(
   orgId: string,
   input: unknown,
 ): Promise<TrackCertificateResult> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) {
@@ -324,6 +331,7 @@ export async function trackCertificateFromUpload(
   orgId: string,
   input: unknown,
 ): Promise<TrackCertificateResult> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) {

--- a/apps/web/lib/actions/checks.ts
+++ b/apps/web/lib/actions/checks.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { checks, checkResults } from '@/lib/db/schema'
@@ -72,6 +74,7 @@ const updateCheckSchema = z.object({
 })
 
 export async function getChecksWithHistory(orgId: string, hostId: string): Promise<CheckWithHistory[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.checks.findMany({
     where: and(
       eq(checks.organisationId, orgId),
@@ -97,6 +100,7 @@ export async function createCheck(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = createCheckSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -128,6 +132,7 @@ export async function updateCheck(
   checkId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = updateCheckSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -161,6 +166,7 @@ export async function deleteCheckHistory(
   orgId: string,
   checkId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.checks.findFirst({
     where: and(
       eq(checks.id, checkId),
@@ -179,6 +185,7 @@ export async function deleteCheck(
   orgId: string,
   checkId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.checks.findFirst({
     where: and(
       eq(checks.id, checkId),

--- a/apps/web/lib/actions/domain-accounts.ts
+++ b/apps/web/lib/actions/domain-accounts.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { domainAccounts } from '@/lib/db/schema'
@@ -49,6 +51,7 @@ export async function getDomainAccounts(
   orgId: string,
   filters: DomainAccountListFilters = {},
 ): Promise<DomainAccount[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const {
     status,
@@ -89,6 +92,7 @@ export async function getDomainAccount(
   orgId: string,
   accountId: string,
 ): Promise<DomainAccount | null> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const result = await db.query.domainAccounts.findFirst({
     where: and(
@@ -103,6 +107,7 @@ export async function getDomainAccount(
 export async function getDomainAccountCounts(
   orgId: string,
 ): Promise<DomainAccountCounts> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const statusRows = await db
     .select({
@@ -138,6 +143,7 @@ export async function createDomainAccount(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const parsed = createDomainAccountSchema.safeParse(input)
   if (!parsed.success) {
@@ -175,6 +181,7 @@ export async function updateDomainAccount(
   accountId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const parsed = updateDomainAccountSchema.safeParse(input)
   if (!parsed.success) {
@@ -212,6 +219,7 @@ export async function deleteDomainAccount(
   orgId: string,
   accountId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const existing = await db.query.domainAccounts.findFirst({
     where: and(

--- a/apps/web/lib/actions/host-groups.ts
+++ b/apps/web/lib/actions/host-groups.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { hostGroups, hostGroupMembers, hosts } from '@/lib/db/schema'
@@ -21,6 +23,7 @@ export async function createGroup(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; group: HostGroup } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = groupSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -48,6 +51,7 @@ export async function updateGroup(
   groupId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = groupSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -71,6 +75,7 @@ export async function deleteGroup(
   orgId: string,
   groupId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     // Soft-delete the group
     const result = await db
@@ -95,6 +100,7 @@ export async function deleteGroup(
 }
 
 export async function listGroups(orgId: string): Promise<HostGroupWithCount[]> {
+  await requireOrgAccess(orgId)
   const groups = await db.query.hostGroups.findMany({
     where: and(eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)),
     orderBy: (g, { asc }) => [asc(g.name)],
@@ -116,6 +122,7 @@ export async function listGroups(orgId: string): Promise<HostGroupWithCount[]> {
 }
 
 export async function getGroup(orgId: string, groupId: string): Promise<HostGroupWithMembers | null> {
+  await requireOrgAccess(orgId)
   const group = await db.query.hostGroups.findFirst({
     where: and(eq(hostGroups.id, groupId), eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)),
   })
@@ -132,6 +139,7 @@ export async function addHostToGroup(
   groupId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     // Check if already a member (including soft-deleted — restore if so)
     const existing = await db.query.hostGroupMembers.findFirst({
@@ -169,6 +177,7 @@ export async function removeHostFromGroup(
   groupId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const result = await db
       .update(hostGroupMembers)
@@ -192,6 +201,7 @@ export async function removeHostFromGroup(
 }
 
 export async function listHostsInGroup(orgId: string, groupId: string): Promise<Host[]> {
+  await requireOrgAccess(orgId)
   const members = await db.query.hostGroupMembers.findMany({
     where: and(
       eq(hostGroupMembers.groupId, groupId),
@@ -213,6 +223,7 @@ export async function listHostsInGroup(orgId: string, groupId: string): Promise<
 }
 
 export async function listGroupsForHost(orgId: string, hostId: string): Promise<HostGroup[]> {
+  await requireOrgAccess(orgId)
   const members = await db.query.hostGroupMembers.findMany({
     where: and(
       eq(hostGroupMembers.hostId, hostId),

--- a/apps/web/lib/actions/host-settings.ts
+++ b/apps/web/lib/actions/host-settings.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { hosts, organisations, checks } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
@@ -12,6 +14,7 @@ export async function getHostCollectionSettings(
   orgId: string,
   hostId: string,
 ): Promise<HostCollectionSettings> {
+  await requireOrgAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
     columns: { metadata: true },
@@ -30,6 +33,7 @@ export async function updateHostCollectionSettings(
   hostId: string,
   settings: HostCollectionSettings,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const host = await db.query.hosts.findFirst({
       where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
@@ -61,6 +65,7 @@ export async function updateHostCollectionSettings(
 export async function getOrgDefaultCollectionSettings(
   orgId: string,
 ): Promise<HostCollectionSettings> {
+  await requireOrgAccess(orgId)
   const org = await db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
@@ -78,6 +83,7 @@ export async function updateOrgDefaultCollectionSettings(
   orgId: string,
   settings: HostCollectionSettings,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const org = await db.query.organisations.findFirst({
       where: eq(organisations.id, orgId),

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { ldapConfigurations } from '@/lib/db/schema'
@@ -65,6 +67,7 @@ const updateLdapConfigSchema = z.object({
 export async function getLdapConfigurations(
   orgId: string,
 ): Promise<LdapConfiguration[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.ldapConfigurations.findMany({
     where: and(
       eq(ldapConfigurations.organisationId, orgId),
@@ -79,6 +82,7 @@ export async function getLdapConfiguration(
   orgId: string,
   configId: string,
 ): Promise<LdapConfiguration | null> {
+  await requireOrgAccess(orgId)
   const result = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),
@@ -93,6 +97,7 @@ export async function createLdapConfiguration(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = createLdapConfigSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -136,6 +141,7 @@ export async function updateLdapConfiguration(
   configId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = updateLdapConfigSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -184,6 +190,7 @@ export async function deleteLdapConfiguration(
   orgId: string,
   configId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const existing = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),
@@ -205,6 +212,7 @@ export async function testLdapConnection(
   orgId: string,
   configId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const config = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),
@@ -250,6 +258,7 @@ export async function searchLdapDirectory(
   configId: string,
   query: string,
 ): Promise<{ success: true; users: LdapUserResult[] } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (!query.trim()) return { success: true, users: [] }
 
   const config = await db.query.ldapConfigurations.findFirst({
@@ -279,6 +288,7 @@ export type LookupConfigOption = {
 export async function getLookupConfigOptions(
   orgId: string,
 ): Promise<LookupConfigOption[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.ldapConfigurations.findMany({
     where: and(
       eq(ldapConfigurations.organisationId, orgId),
@@ -300,6 +310,7 @@ export async function lookupDirectoryUser(
   configId: string,
   dn: string,
 ): Promise<{ success: true; user: LdapUserDetailResult } | { error: string }> {
+  await requireOrgAccess(orgId)
   const config = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -3,6 +3,7 @@ import { cache } from 'react'
 import { db } from '@/lib/db'
 import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { requireOrgAccess } from '@/lib/actions/action-auth'
 import { validateLicenceKey } from '@/lib/licence'
 import {
   hasFeature,
@@ -73,10 +74,12 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
 })
 
 export async function getEffectiveLicence(orgId: string): Promise<EffectiveLicence> {
+  await requireOrgAccess(orgId)
   return loadEffectiveLicence(orgId)
 }
 
 export async function hasLicenceFeature(orgId: string, feature: Feature): Promise<boolean> {
+  await requireOrgAccess(orgId)
   const licence = await loadEffectiveLicence(orgId)
   if (hasFeature(licence.tier, feature)) return true
   if (licence.features.includes(feature)) return true
@@ -84,6 +87,7 @@ export async function hasLicenceFeature(orgId: string, feature: Feature): Promis
 }
 
 export async function requireFeature(orgId: string, feature: Feature): Promise<void> {
+  await requireOrgAccess(orgId)
   const licence = await loadEffectiveLicence(orgId)
   if (hasFeature(licence.tier, feature)) return
   if (licence.features.includes(feature)) return
@@ -95,6 +99,7 @@ export async function requireFeature(orgId: string, feature: Feature): Promise<v
 }
 
 export async function clampRetentionDays(orgId: string, days: number): Promise<number> {
+  await requireOrgAccess(orgId)
   const extended = await hasLicenceFeature(orgId, 'metricRetentionExtended')
   if (extended) return days
   return Math.min(days, COMMUNITY_MAX_RETENTION_DAYS)

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { networks, hostNetworkMemberships, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, sql } from 'drizzle-orm'
@@ -25,6 +27,7 @@ const networkSchema = z.object({
 // ── Network CRUD ──────────────────────────────────────────────────────────────
 
 export async function listNetworks(orgId: string): Promise<NetworkWithCount[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.networks.findMany({
     where: and(eq(networks.organisationId, orgId), isNull(networks.deletedAt)),
     orderBy: (n, { asc }) => [asc(n.name)],
@@ -48,6 +51,7 @@ export async function getNetwork(
   orgId: string,
   networkId: string,
 ): Promise<(Network & { members: Host[] }) | null> {
+  await requireOrgAccess(orgId)
   const network = await db.query.networks.findFirst({
     where: and(eq(networks.id, networkId), eq(networks.organisationId, orgId), isNull(networks.deletedAt)),
   })
@@ -61,6 +65,7 @@ export async function createNetwork(
   orgId: string,
   data: { name: string; cidr: string; description?: string },
 ): Promise<{ success: true; network: Network } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -95,6 +100,7 @@ export async function updateNetwork(
   networkId: string,
   data: { name: string; cidr: string; description?: string },
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -129,6 +135,7 @@ export async function deleteNetwork(
   orgId: string,
   networkId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -169,6 +176,7 @@ export async function addHostToNetwork(
   networkId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!MEMBERSHIP_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -211,6 +219,7 @@ export async function removeHostFromNetwork(
   networkId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!MEMBERSHIP_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -239,6 +248,7 @@ export async function removeHostFromNetwork(
 }
 
 export async function listHostsInNetwork(orgId: string, networkId: string): Promise<Host[]> {
+  await requireOrgAccess(orgId)
   const members = await db.query.hostNetworkMemberships.findMany({
     where: and(
       eq(hostNetworkMemberships.networkId, networkId),
@@ -268,6 +278,7 @@ export async function listMembershipsForNetwork(
   orgId: string,
   networkId: string,
 ): Promise<NetworkMembershipEntry[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.hostNetworkMemberships.findMany({
     where: and(
       eq(hostNetworkMemberships.networkId, networkId),
@@ -282,6 +293,7 @@ export async function listMembershipsForNetwork(
 export type NetworkWithHosts = Network & { hosts: Host[] }
 
 export async function listNetworksWithHosts(orgId: string): Promise<NetworkWithHosts[]> {
+  await requireOrgAccess(orgId)
   const networkRows = await db.query.networks.findMany({
     where: and(eq(networks.organisationId, orgId), isNull(networks.deletedAt)),
     orderBy: (n, { asc }) => [asc(n.name)],
@@ -318,6 +330,7 @@ export async function listNetworksWithHosts(orgId: string): Promise<NetworkWithH
 }
 
 export async function listNetworksForHost(orgId: string, hostId: string): Promise<NetworkWithMembership[]> {
+  await requireOrgAccess(orgId)
   const members = await db.query.hostNetworkMemberships.findMany({
     where: and(
       eq(hostNetworkMemberships.hostId, hostId),

--- a/apps/web/lib/actions/notes-resolver.ts
+++ b/apps/web/lib/actions/notes-resolver.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { sql } from 'drizzle-orm'
 import { getRequiredSession } from '@/lib/auth/session'
@@ -37,6 +39,7 @@ export async function resolveNotesForHost(
   hostId: string,
   opts: { includePrivate?: boolean; categories?: NoteCategory[] } = {},
 ): Promise<ResolvedNote[]> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return []
 

--- a/apps/web/lib/actions/notes.ts
+++ b/apps/web/lib/actions/notes.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import {
   notes,
@@ -105,6 +107,7 @@ export async function listNotesForHost(
   hostId: string,
   filter?: { categories?: NoteCategory[]; includePrivate?: boolean },
 ): Promise<ResolvedNote[]> {
+  await requireOrgAccess(orgId)
   return resolveNotesForHost(orgId, hostId, filter)
 }
 
@@ -116,6 +119,7 @@ export async function listNotes(
     mineOnly?: boolean
   } = {},
 ): Promise<Note[]> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return []
 
@@ -151,6 +155,7 @@ export async function listNotes(
 // truly malformed input — the ILIKE fallback means a user's search box always
 // returns something sensible even if they paste an unbalanced quote.
 export async function searchNotes(orgId: string, q: string): Promise<Note[]> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return []
   const trimmed = q.trim()
@@ -195,6 +200,7 @@ export async function getNote(
   orgId: string,
   noteId: string,
 ): Promise<{ note: Note; targets: NoteTarget[] } | null> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return null
 
@@ -221,6 +227,7 @@ export async function createNote(
   orgId: string,
   input: z.input<typeof createNoteSchema>,
 ): Promise<{ success: true; note: Note } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
   if (!canCreateNote(session.user)) {
@@ -285,6 +292,7 @@ export async function updateNote(
   noteId: string,
   input: z.input<typeof updateNoteSchema>,
 ): Promise<{ success: true; note: Note } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
 
@@ -367,6 +375,7 @@ export async function deleteNote(
   orgId: string,
   noteId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
 
@@ -403,6 +412,7 @@ export async function setNoteTargets(
   noteId: string,
   targets: z.input<typeof targetSchema>[],
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
 
@@ -463,6 +473,7 @@ export async function toggleNotePin(
   noteTargetId: string,
   pinned: boolean,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
 
@@ -533,6 +544,7 @@ export async function toggleNotePrivate(
   noteId: string,
   isPrivate: boolean,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
 
@@ -568,6 +580,7 @@ export async function addNoteReaction(
   noteId: string,
   reaction: NoteReactionType,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
   if (!NOTE_REACTIONS.includes(reaction)) return { error: 'Invalid reaction' }
@@ -609,6 +622,7 @@ export async function removeNoteReaction(
   noteId: string,
   reaction: NoteReactionType,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Not found' }
 
@@ -634,6 +648,7 @@ export async function listNoteReactions(
   orgId: string,
   noteId: string,
 ): Promise<NoteReaction[]> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return []
 
@@ -648,6 +663,7 @@ export async function listNoteRevisions(
   orgId: string,
   noteId: string,
 ): Promise<NoteRevision[]> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return []
 

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { organisations } from '@/lib/db/schema'
@@ -25,6 +27,7 @@ export interface OrgNotificationSettingsFull {
 export async function getOrgNotificationSettings(
   orgId: string,
 ): Promise<OrgNotificationSettingsFull> {
+  await requireOrgAccess(orgId)
   const org = await db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
@@ -42,6 +45,7 @@ export async function updateOrgNotificationSettings(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
 
   if (!ADMIN_ROLES.includes(session.user.role)) {

--- a/apps/web/lib/actions/notifications.ts
+++ b/apps/web/lib/actions/notifications.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { notifications } from '@/lib/db/schema'
 import { eq, and, desc, count, inArray, gte, sql, isNull } from 'drizzle-orm'
@@ -11,6 +13,7 @@ export async function getNotifications(
   limit = 20,
   offset = 0,
 ): Promise<Notification[]> {
+  await requireOrgAccess(orgId)
   return db.query.notifications.findMany({
     where: and(
       eq(notifications.organisationId, orgId),
@@ -24,6 +27,7 @@ export async function getNotifications(
 }
 
 export async function getUnreadCount(orgId: string, userId: string): Promise<number> {
+  await requireOrgAccess(orgId)
   const [result] = await db
     .select({ value: count() })
     .from(notifications)
@@ -43,6 +47,7 @@ export async function markAsRead(
   userId: string,
   notificationId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await db
       .update(notifications)
@@ -65,6 +70,7 @@ export async function markAllAsRead(
   orgId: string,
   userId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await db
       .update(notifications)
@@ -88,6 +94,7 @@ export async function deleteNotification(
   userId: string,
   notificationId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await db
       .update(notifications)
@@ -111,6 +118,7 @@ export async function deleteNotifications(
   userId: string,
   ids: string[],
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (ids.length === 0) return { success: true }
   try {
     await db
@@ -136,6 +144,7 @@ export async function markBatchReadStatus(
   ids: string[],
   read: boolean,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (ids.length === 0) return { success: true }
   try {
     await db
@@ -165,6 +174,7 @@ export async function getNotificationStats(
   userId: string,
   hostId?: string,
 ): Promise<NotificationSeverityStat[]> {
+  await requireOrgAccess(orgId)
   const results = await db
     .select({
       severity: notifications.severity,
@@ -209,6 +219,7 @@ export async function getNotificationsOverTime(
   range: TrendRange = '30d',
   hostId?: string,
 ): Promise<NotificationTimeSeriesPoint[]> {
+  await requireOrgAccess(orgId)
   // Intentionally does NOT filter on deletedAt so that deleting notifications
   // from the inbox does not affect the historical trend.
   const config = TREND_RANGE_CONFIG[range]

--- a/apps/web/lib/actions/service-accounts.ts
+++ b/apps/web/lib/actions/service-accounts.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { serviceAccounts, sshKeys, identityEvents, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm'
@@ -47,6 +49,7 @@ export async function getServiceAccounts(
   orgId: string,
   filters: ServiceAccountListFilters = {},
 ): Promise<ServiceAccountWithHost[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const {
     accountType,
@@ -135,6 +138,7 @@ export async function getServiceAccount(
   events: IdentityEvent[]
   host: Host | null
 } | null> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const account = await db.query.serviceAccounts.findFirst({
     where: and(
@@ -175,6 +179,7 @@ export async function getServiceAccount(
 export async function getServiceAccountCounts(
   orgId: string,
 ): Promise<ServiceAccountCounts> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'serviceAccountTracker')
   const [typeRows, statusRows] = await Promise.all([
     db
@@ -223,6 +228,7 @@ export async function getSshKeysByFingerprint(
   orgId: string,
   fingerprint: string,
 ): Promise<(SshKey & { hostHostname?: string })[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'sshKeyInventory')
   const keys = await db.query.sshKeys.findMany({
     where: and(

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { createId } from '@paralleldrive/cuid2'
 import { db } from '@/lib/db'
@@ -20,6 +22,7 @@ export async function updateOrgName(
   orgId: string,
   name: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -51,6 +54,7 @@ export async function updateMetricRetention(
   orgId: string,
   days: number,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -105,6 +109,7 @@ export async function saveLicenceKey(
   orgId: string,
   key: string,
 ): Promise<{ success: true; tier: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -139,6 +144,7 @@ export async function saveLicenceKey(
 export async function generateActivationToken(
   orgId: string,
 ): Promise<{ success: true; token: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import {
@@ -42,6 +44,7 @@ const softwareInventorySettingsSchema = z.object({
 export async function getSoftwareInventorySettings(
   orgId: string,
 ): Promise<SoftwareInventorySettings> {
+  await requireOrgAccess(orgId)
   const org = await db.query.organisations.findFirst({
     where: and(eq(organisations.id, orgId), isNull(organisations.deletedAt)),
     columns: { metadata: true },
@@ -58,6 +61,7 @@ export async function updateSoftwareInventorySettings(
   orgId: string,
   settings: SoftwareInventorySettings,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -94,6 +98,7 @@ export async function triggerSoftwareScan(
   orgId: string,
   hostId: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -155,6 +160,7 @@ export async function getHostSoftwareInventory(
   hostId: string,
   includeRemoved = false,
 ): Promise<HostSoftwareInventory> {
+  await requireOrgAccess(orgId)
   const [packages, scans, settings, activeTaskRows, failedTaskRows] = await Promise.all([
     db.query.softwarePackages.findMany({
       where: and(
@@ -242,6 +248,7 @@ export async function searchPackageNames(
   orgId: string,
   q: string,
 ): Promise<PackageNameSuggestion[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   if (!q || q.length < 2 || q.length > 100) return []
 
@@ -305,6 +312,7 @@ export async function getSoftwareReport(
   orgId: string,
   filters: SoftwareReportFilters = {},
 ): Promise<SoftwareReportResult> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   if (!softwareReportLimiter.check(orgId)) {
     throw new Error('Too many requests — please wait before generating another report.')
@@ -442,6 +450,7 @@ export async function getNewPackages(
   orgId: string,
   windowDays: 7 | 30 = 7,
 ): Promise<NewPackageRow[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - windowDays)
@@ -494,6 +503,7 @@ export interface DriftRow {
 }
 
 export async function getPackageDrift(orgId: string): Promise<DriftRow[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const rows = await db
     .select({
@@ -584,6 +594,7 @@ export async function getPackageDetails(
   packageName: string,
   osFamily?: string,
 ): Promise<PackageDetailsResult> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const packages = await db
     .select({
@@ -657,6 +668,7 @@ export async function getPackageVersions(
   orgId: string,
   packageName: string,
 ): Promise<string[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const rows = await db
     .select({ version: softwarePackages.version })
@@ -688,6 +700,7 @@ export async function compareHosts(
   hostIdA: string,
   hostIdB: string,
 ): Promise<HostCompareResult> {
+  await requireOrgAccess(orgId)
   const [pkgsA, pkgsB] = await Promise.all([
     db.query.softwarePackages.findMany({
       where: and(
@@ -750,6 +763,7 @@ const saveReportSchema = z.object({
 })
 
 export async function listSavedReports(orgId: string): Promise<SavedSoftwareReport[]> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const session = await getRequiredSession()
   return db.query.savedSoftwareReports.findMany({
@@ -767,6 +781,7 @@ export async function saveSoftwareReport(
   name: string,
   filters: SoftwareReportFilters,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const session = await getRequiredSession()
   const parsed = saveReportSchema.safeParse({ name, filters })
@@ -795,6 +810,7 @@ export async function deleteSavedReport(
   orgId: string,
   reportId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
   const session = await getRequiredSession()
   try {

--- a/apps/web/lib/actions/tag-rules.ts
+++ b/apps/web/lib/actions/tag-rules.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { tagRules, hosts } from '@/lib/db/schema'
@@ -39,6 +41,7 @@ export async function previewHostFilter(
   orgId: string,
   filter: HostFilter,
 ): Promise<HostFilterResult[]> {
+  await requireOrgAccess(orgId)
   const parsed = hostFilterSchema.safeParse(filter)
   if (!parsed.success) return []
   if (isEmptyFilter(parsed.data)) return []
@@ -69,6 +72,7 @@ export async function bulkAssignTags(
   filter: HostFilter,
   pairs: TagPair[],
 ): Promise<{ success: true; applied: number } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const parsedFilter = hostFilterSchema.safeParse(filter)
     if (!parsedFilter.success) return { error: 'Invalid filter' }
@@ -90,6 +94,7 @@ export async function bulkAssignTags(
 }
 
 export async function listTagRules(orgId: string): Promise<TagRule[]> {
+  await requireOrgAccess(orgId)
   return db.query.tagRules.findMany({
     where: and(eq(tagRules.organisationId, orgId), isNull(tagRules.deletedAt)),
     orderBy: (r, { desc }) => [desc(r.createdAt)],
@@ -100,6 +105,7 @@ export async function createTagRule(
   orgId: string,
   input: { name: string; filter: HostFilter; tags: TagPair[]; enabled?: boolean },
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const parsed = createRuleSchema.safeParse(input)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -127,6 +133,7 @@ export async function updateTagRule(
   ruleId: string,
   input: Partial<{ name: string; filter: HostFilter; tags: TagPair[]; enabled: boolean }>,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const existing = await db.query.tagRules.findFirst({
       where: and(
@@ -167,6 +174,7 @@ export async function deleteTagRule(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await db
       .update(tagRules)
@@ -186,6 +194,7 @@ export async function runTagRule(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true; applied: number } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const rule = await db.query.tagRules.findFirst({
       where: and(
@@ -211,6 +220,7 @@ export async function runMatchingTagRules(
   orgId: string,
   hostId: string,
 ): Promise<void> {
+  await requireOrgAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })

--- a/apps/web/lib/actions/tags.ts
+++ b/apps/web/lib/actions/tags.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { tags, resourceTags, organisations } from '@/lib/db/schema'
@@ -43,6 +45,7 @@ export async function searchTags(
   query: string,
   opts?: { key?: string; limit?: number },
 ): Promise<Tag[]> {
+  await requireOrgAccess(orgId)
   const q = (query ?? '').trim()
   const limit = Math.min(Math.max(opts?.limit ?? 10, 1), 50)
 
@@ -122,6 +125,7 @@ export async function assignTagsToResource(
   resourceId: string,
   pairs: TagPair[],
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const parsed = z.array(tagPairSchema).safeParse(pairs)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid tags' }
@@ -158,6 +162,7 @@ export async function removeTagFromResource(
   orgId: string,
   resourceTagId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const row = await db.query.resourceTags.findFirst({
       where: and(eq(resourceTags.id, resourceTagId), eq(resourceTags.organisationId, orgId)),
@@ -186,6 +191,7 @@ export async function replaceResourceTags(
   resourceId: string,
   pairs: TagPair[],
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const parsed = z.array(tagPairSchema).safeParse(pairs)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid tags' }
@@ -263,6 +269,7 @@ export async function listResourceTags(
   resourceType: string,
   resourceId: string,
 ): Promise<TagAssignment[]> {
+  await requireOrgAccess(orgId)
   const rows = await db
     .select({
       resourceTagId: resourceTags.id,
@@ -284,6 +291,7 @@ export async function listResourceTags(
 }
 
 export async function getOrgDefaultTags(orgId: string): Promise<TagPair[]> {
+  await requireOrgAccess(orgId)
   const org = await db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
@@ -296,6 +304,7 @@ export async function updateOrgDefaultTags(
   orgId: string,
   pairs: TagPair[],
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const parsed = z.array(tagPairSchema).safeParse(pairs)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid tags' }

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import {
   taskRuns,
@@ -98,6 +100,7 @@ export async function getTaskRun(
   orgId: string,
   taskRunId: string,
 ): Promise<TaskRunWithHosts | null> {
+  await requireOrgAccess(orgId)
   const run = await db.query.taskRuns.findFirst({
     where: and(
       eq(taskRuns.id, taskRunId),
@@ -148,6 +151,7 @@ export async function listTaskRunsForHost(
   hostId: string,
   taskType?: string,
 ): Promise<TaskRunWithHosts[]> {
+  await requireOrgAccess(orgId)
   // Find task_run_hosts rows for this host
   const hostRunRows = await db.query.taskRunHosts.findMany({
     where: and(
@@ -187,6 +191,7 @@ export async function listAutomatedRunsForHost(
   hostId: string,
   taskType?: string,
 ): Promise<TaskRunWithHosts[]> {
+  await requireOrgAccess(orgId)
   const hostRunRows = await db.query.taskRunHosts.findMany({
     where: and(
       eq(taskRunHosts.hostId, hostId),
@@ -224,6 +229,7 @@ export async function listTaskRunsForGroup(
   groupId: string,
   taskType?: string,
 ): Promise<TaskRunWithHosts[]> {
+  await requireOrgAccess(orgId)
   const runs = await db.query.taskRuns.findMany({
     where: and(
       eq(taskRuns.organisationId, orgId),
@@ -253,6 +259,7 @@ export async function cancelTaskRun(
   orgId: string,
   taskRunId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     return await db.transaction(async (tx) => {
       // Verify ownership and that the run is still active.
@@ -338,6 +345,7 @@ export async function triggerCustomScriptRun(
   interpreter: 'sh' | 'bash' | 'python3',
   timeoutSeconds?: number,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
     return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
   }
@@ -364,6 +372,7 @@ export async function triggerGroupCustomScriptRun(
   maxParallel: number,
   timeoutSeconds?: number,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
     return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
   }
@@ -395,6 +404,7 @@ export async function triggerServiceAction(
   serviceName: string,
   action: 'start' | 'stop' | 'restart' | 'status',
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })
@@ -421,6 +431,7 @@ export async function triggerGroupServiceAction(
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
+  await requireOrgAccess(orgId)
   const members = await db.query.hostGroupMembers.findMany({
     where: and(
       eq(hostGroupMembers.groupId, groupId),
@@ -491,6 +502,7 @@ export async function triggerAgentUninstall(
   userId: string,
   hostId: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })
@@ -511,6 +523,7 @@ export async function deleteTaskRuns(
   orgId: string,
   taskRunIds: string[],
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   if (taskRunIds.length === 0) return { success: true }
   try {
     const now = new Date()
@@ -555,6 +568,7 @@ export async function triggerPatchRun(
   hostId: string,
   mode: 'security' | 'all',
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(
       eq(hosts.id, hostId),
@@ -585,6 +599,7 @@ export async function triggerGroupPatchRun(
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
+  await requireOrgAccess(orgId)
   // Fetch all members of the group
   const members = await db.query.hostGroupMembers.findMany({
     where: and(

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { taskSchedules, taskRuns, hostGroups, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, desc, inArray } from 'drizzle-orm'
@@ -108,6 +110,7 @@ async function verifyTargetExists(
 // ── Read queries ──────────────────────────────────────────────────────────────
 
 export async function listSchedules(orgId: string): Promise<ScheduleWithTargetName[]> {
+  await requireOrgAccess(orgId)
   const rows = await db.query.taskSchedules.findMany({
     where: and(eq(taskSchedules.organisationId, orgId), isNull(taskSchedules.deletedAt)),
     orderBy: [desc(taskSchedules.createdAt)],
@@ -155,6 +158,7 @@ export async function getSchedule(
   orgId: string,
   id: string,
 ): Promise<{ schedule: TaskSchedule; recentRuns: Awaited<ReturnType<typeof recentRunsForSchedule>> } | null> {
+  await requireOrgAccess(orgId)
   const schedule = await db.query.taskSchedules.findFirst({
     where: and(
       eq(taskSchedules.id, id),
@@ -186,6 +190,7 @@ export async function createSchedule(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
   if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
@@ -239,6 +244,7 @@ export async function updateSchedule(
   id: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
   if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
@@ -301,6 +307,7 @@ export async function setScheduleEnabled(
   id: string,
   enabled: boolean,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
   if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
@@ -340,6 +347,7 @@ export async function deleteSchedule(
   orgId: string,
   id: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
   if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
@@ -371,6 +379,7 @@ export async function runScheduleNow(
   orgId: string,
   id: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
   if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { db } from '@/lib/db'
 import { organisations, hosts, terminalSessions } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
@@ -27,6 +29,7 @@ export async function checkTerminalAccess(
   orgId: string,
   hostId: string,
 ): Promise<TerminalAccessResult | TerminalAccessDenied> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   const { user } = session
 
@@ -82,6 +85,7 @@ export async function createTerminalSession(
   hostId: string,
   username?: string,
 ): Promise<{ sessionId: string; ingestWsUrl: string; websocketToken: string } | { error: string }> {
+  await requireOrgAccess(orgId)
   const access = await checkTerminalAccess(orgId, hostId)
   if (!access.allowed) {
     return { error: access.reason }
@@ -155,6 +159,7 @@ export interface OrgTerminalSettings {
 export async function getOrgTerminalSettings(
   orgId: string,
 ): Promise<OrgTerminalSettings> {
+  await requireOrgAccess(orgId)
   const org = await db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
@@ -171,6 +176,7 @@ export async function updateOrgTerminalSettings(
   orgId: string,
   settings: OrgTerminalSettings,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }
@@ -214,6 +220,7 @@ export async function getHostTerminalSettings(
   orgId: string,
   hostId: string,
 ): Promise<HostTerminalSettings> {
+  await requireOrgAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
     columns: { metadata: true },
@@ -230,6 +237,7 @@ export async function updateHostTerminalSettings(
   hostId: string,
   settings: HostTerminalSettings,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) {
     return { error: 'You do not have permission to perform this action' }

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { requireOrgAccess } from '@/lib/actions/action-auth'
+
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { users, invitations } from '@/lib/db/schema'
@@ -44,6 +46,7 @@ async function requireOrgAdmin(orgId: string): Promise<RequiredSession> {
 export async function getOrgUsers(
   orgId: string,
 ): Promise<{ members: User[]; pendingInvites: Invitation[] }> {
+  await requireOrgAccess(orgId)
   await requireOrgSession(orgId)
 
   const [members, pendingInvites] = await Promise.all([
@@ -66,6 +69,7 @@ export async function inviteUser(
   orgId: string,
   input: { email: string; role: string },
 ): Promise<{ inviteLink: string } | { restored: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = inviteSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -144,6 +148,7 @@ export async function updateUserRole(
   targetUserId: string,
   role: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   const parsed = updateRoleSchema.safeParse({ role })
   if (!parsed.success) {
     return { error: 'Invalid role' }
@@ -181,6 +186,7 @@ export async function deactivateUser(
   orgId: string,
   targetUserId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const session = await requireOrgAdmin(orgId)
 
@@ -216,6 +222,7 @@ export async function reactivateUser(
   orgId: string,
   targetUserId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await requireOrgAdmin(orgId)
 
@@ -235,6 +242,7 @@ export async function removeUser(
   orgId: string,
   targetUserId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     const session = await requireOrgAdmin(orgId)
 
@@ -270,6 +278,7 @@ export async function cancelInvite(
   orgId: string,
   inviteId: string,
 ): Promise<{ success: true } | { error: string }> {
+  await requireOrgAccess(orgId)
   try {
     await requireOrgAdmin(orgId)
 


### PR DESCRIPTION
## Summary
- add a shared `requireOrgAccess()` guard for org-scoped server actions
- apply the guard across the exported `apps/web/lib/actions/*` entrypoints that accept caller-supplied `orgId`
- cover the core org-access checks with a focused unit test

## Testing
- `pnpm --filter web type-check`
- `pnpm --filter web exec node --experimental-strip-types --test lib/actions/action-auth.test.mjs`

Closes #280.
