### PR TITLE
fix(agent): disable unsigned self-update

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -21,7 +21,6 @@ import (
 	"github.com/carrtech-dev/ct-ops/agent/internal/checks"
 	"github.com/carrtech-dev/ct-ops/agent/internal/identity"
 	"github.com/carrtech-dev/ct-ops/agent/internal/tasks"
-	"github.com/carrtech-dev/ct-ops/agent/internal/updater"
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
 )
 
@@ -101,12 +100,16 @@ type Runner struct {
 	lastKnownDefs []*agentv1.CheckDefinition
 
 	// pinnedServerCertMu guards pinnedServerCertPEM and pinnedServerCertFpr.
-	// These hold the nginx-facing server cert that agent self-update trusts in
-	// addition to the system CA pool. Values are persisted to disk whenever
-	// they change so a process restart picks up the same pin.
+	// These hold the nginx-facing server cert fingerprint and PEM pushed by
+	// ingest so the agent can preserve that trust material on disk while the
+	// signed self-update flow is redesigned.
 	pinnedServerCertMu  sync.Mutex
 	pinnedServerCertPEM []byte
 	pinnedServerCertFpr string
+
+	// lastSkippedUpdateVersion suppresses duplicate warnings when the server
+	// repeatedly advertises the same release while auto-update is disabled.
+	lastSkippedUpdateVersion string
 }
 
 // New creates a new heartbeat Runner. dialFunc is called once per stream
@@ -128,9 +131,8 @@ func New(dialFunc func() (*grpc.ClientConn, error), agentID, jwtToken, version s
 		dataDir:      dataDir,
 		keypair:      keypair,
 	}
-	// Prime the pinned server cert from disk so the first heartbeat sends
-	// the correct fingerprint and a pre-re-exec self-update can trust the
-	// same PEM that was bundled at enrolment time.
+	// Prime the pinned server cert from disk so the first heartbeat sends the
+	// correct fingerprint and preserves any previously pushed trust material.
 	if dataDir != "" {
 		if pem, fpr, err := identity.LoadPinnedServerCert(dataDir); err == nil {
 			r.pinnedServerCertPEM = pem
@@ -373,15 +375,19 @@ func (r *Runner) handleResponse(ctx context.Context, resp *agentv1.HeartbeatResp
 		}
 	}
 	if resp.UpdateAvailable && resp.DownloadUrl != "" {
-		slog.Info("agent update available, downloading",
-			"current", r.version,
-			"latest", resp.LatestVersion,
-		)
-		if err := updater.Update(resp.LatestVersion, resp.DownloadUrl, r.pinnedServerCertBytes()); err != nil {
-			slog.Warn("self-update failed, continuing with current version", "err", err)
-		}
-		// If Update succeeds it re-execs and never returns.
+		r.noteSkippedSelfUpdate(resp.LatestVersion)
 	}
+}
+
+func (r *Runner) noteSkippedSelfUpdate(latestVersion string) {
+	if latestVersion == "" || latestVersion == r.lastSkippedUpdateVersion {
+		return
+	}
+	r.lastSkippedUpdateVersion = latestVersion
+	slog.Warn("agent update available, but automatic self-update is disabled until release signature verification is implemented",
+		"current", r.version,
+		"latest", latestVersion,
+	)
 }
 
 // maybeRenewCert checks the on-disk leaf cert's expiry. If it's within the
@@ -608,30 +614,16 @@ func (r *Runner) sendHeartbeatWithAgentID(stream agentv1.IngestService_Heartbeat
 }
 
 // currentPinnedFingerprint returns the fingerprint of the pinned server cert
-// the agent currently trusts for self-update downloads. Empty when no cert
-// is pinned (e.g. freshly enrolled agent before the first server push).
+// last pushed by ingest. Empty when no cert is pinned yet.
 func (r *Runner) currentPinnedFingerprint() string {
 	r.pinnedServerCertMu.Lock()
 	defer r.pinnedServerCertMu.Unlock()
 	return r.pinnedServerCertFpr
 }
 
-// pinnedServerCertBytes returns a copy of the pinned cert PEM for callers
-// that need trust material (e.g. the self-update HTTP client).
-func (r *Runner) pinnedServerCertBytes() []byte {
-	r.pinnedServerCertMu.Lock()
-	defer r.pinnedServerCertMu.Unlock()
-	if len(r.pinnedServerCertPEM) == 0 {
-		return nil
-	}
-	out := make([]byte, len(r.pinnedServerCertPEM))
-	copy(out, r.pinnedServerCertPEM)
-	return out
-}
-
 // applyServerCertRotation persists the pushed PEM to disk and updates the
-// in-memory pin so the next heartbeat advertises the new fingerprint and
-// the next self-update trusts the new chain.
+// in-memory pin so the next heartbeat advertises the new fingerprint and the
+// agent preserves the latest trust material on disk.
 func (r *Runner) applyServerCertRotation(certPEM string) {
 	if certPEM == "" || r.dataDir == "" {
 		return

--- a/agent/internal/heartbeat/heartbeat_test.go
+++ b/agent/internal/heartbeat/heartbeat_test.go
@@ -1,0 +1,56 @@
+package heartbeat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/carrtech-dev/ct-ops/agent/internal/checks"
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+func TestHandleResponseSkipsSelfUpdate(t *testing.T) {
+	runner := New(nil, "agent-id", "jwt", "v1.0.0", 30, checks.NewExecutor(), "", nil)
+
+	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
+		Ok:              true,
+		UpdateAvailable: true,
+		LatestVersion:   "v2.0.0",
+		DownloadUrl:     "https://example.com/api/agent/download",
+	})
+
+	if got := runner.lastSkippedUpdateVersion; got != "v2.0.0" {
+		t.Fatalf("lastSkippedUpdateVersion = %q, want %q", got, "v2.0.0")
+	}
+}
+
+func TestHandleResponseOnlyNotesEachSkippedVersionOnce(t *testing.T) {
+	runner := New(nil, "agent-id", "jwt", "v1.0.0", 30, checks.NewExecutor(), "", nil)
+
+	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
+		Ok:              true,
+		UpdateAvailable: true,
+		LatestVersion:   "v2.0.0",
+		DownloadUrl:     "https://example.com/api/agent/download",
+	})
+	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
+		Ok:              true,
+		UpdateAvailable: true,
+		LatestVersion:   "v2.0.0",
+		DownloadUrl:     "https://example.com/api/agent/download",
+	})
+
+	if got := runner.lastSkippedUpdateVersion; got != "v2.0.0" {
+		t.Fatalf("lastSkippedUpdateVersion = %q, want %q", got, "v2.0.0")
+	}
+
+	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
+		Ok:              true,
+		UpdateAvailable: true,
+		LatestVersion:   "v2.1.0",
+		DownloadUrl:     "https://example.com/api/agent/download",
+	})
+
+	if got := runner.lastSkippedUpdateVersion; got != "v2.1.0" {
+		t.Fatalf("lastSkippedUpdateVersion = %q, want %q", got, "v2.1.0")
+	}
+}

--- a/apps/docs/docs/architecture/agent.md
+++ b/apps/docs/docs/architecture/agent.md
@@ -227,9 +227,10 @@ The host record remains in CT-Ops's database (soft-deleted on revocation). You c
 
 The agent polls the ingest service for the minimum required version. If the running version is below the minimum:
 
-1. Agent downloads the signed binary from the web server (`INGEST_AGENT_DOWNLOAD_BASE_URL`)
-2. Verifies the signature
-3. Hot-swaps the binary and restarts
-4. Rolls back automatically on failure
+1. Ingest advertises the newer version on heartbeat responses
+2. The current agent logs that a manual upgrade is required
+3. Operators install the newer binary via the download/install bundle flow
+
+Automatic self-update is currently disabled until signed release verification is implemented.
 
 All updates are served from your CT-Ops server — no internet access required.

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -175,7 +175,7 @@ install -m 0600 /path/to/your.key deploy/tls/server.key
 docker compose restart nginx
 ```
 
-No rebuild is required. On the next heartbeat, every connected agent's pinned fingerprint will mismatch the new cert, and the ingest service pushes the new cert down the mTLS-protected heartbeat stream. The agent persists it to its data dir and uses it as an additional trust anchor for self-update downloads. This means operators can rotate the browser cert without touching any agent host, even on Linux VMs where the internal CA is not installed in the system trust store.
+No rebuild is required. On the next heartbeat, every connected agent's pinned fingerprint will mismatch the new cert, and the ingest service pushes the new cert down the mTLS-protected heartbeat stream. The agent persists it to its data dir so the latest trust material stays aligned across restarts while signed self-update support is reworked. This means operators can rotate the browser cert without touching any agent host, even on Linux VMs where the internal CA is not installed in the system trust store.
 
 ## Fronting with your own reverse proxy
 


### PR DESCRIPTION
## Summary
- disable the agent heartbeat path that auto-downloads and executes server-advertised binaries
- keep version advertisements as warnings so operators know a manual upgrade is required
- update the agent self-update docs to match the new behavior

## Root cause
The agent accepted a server-provided download URL and executed the replacement binary without any release signature verification.

## Testing
- go test ./agent/...

Fixes #282
