### PR TITLE
fix(auth): add per-account login lockout (H-01)

### DIFF
--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -6,6 +6,7 @@ import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
 import { randomBytes } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
+import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
 
 // Produce a signed cookie value in exactly the format Hono's serializeSigned uses:
 // encodeURIComponent(`${value}.${btoa(HMAC-SHA256(value, secret))}`).
@@ -41,168 +42,179 @@ export async function POST(request: NextRequest) {
   const requestStart = Date.now()
 
   try {
-  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-    ?? request.headers.get('x-real-ip')
-    ?? 'unknown'
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? request.headers.get('x-real-ip')
+      ?? 'unknown'
 
-  if (!ldapRateLimit.check(ip)) {
-    return NextResponse.json(
-      { error: 'Too many login attempts — please wait before trying again.' },
-      { status: 429 },
-    )
-  }
-
-  const body = await request.json()
-  const { username, password } = body as { username?: string; password?: string }
-
-  if (!username || !password) {
-    return NextResponse.json({ error: 'Username and password are required' }, { status: 400 })
-  }
-
-  // Find all enabled LDAP configs that allow login
-  const configs = await db.query.ldapConfigurations.findMany({
-    where: and(
-      eq(ldapConfigurations.enabled, true),
-      eq(ldapConfigurations.allowLogin, true),
-      isNull(ldapConfigurations.deletedAt),
-    ),
-  })
-
-  if (configs.length === 0) {
-    return NextResponse.json({ error: 'LDAP login is not configured' }, { status: 400 })
-  }
-
-  // Try each config until one succeeds
-  const errors: string[] = []
-  for (const config of configs) {
-    const result = await authenticateUser(config, username, password)
-    if ('error' in result) {
-      console.error(`[LDAP] Auth failed for config "${config.name}" (${config.host}): ${result.error}`)
-      errors.push(`${config.name}: ${result.error}`)
-      continue
+    if (!ldapRateLimit.check(ip)) {
+      return NextResponse.json(
+        { error: 'Too many login attempts — please wait before trying again.' },
+        { status: 429 },
+      )
     }
 
-    const ldapUser = result.user
-    const ldapDn = ldapUser.dn
+    const body = await request.json()
+    const { username, password } = body as { username?: string; password?: string }
 
-    // Find existing account linked to this LDAP DN for this LDAP config's org.
-    let userId: string
-    const [linkedAccount] = await db
-      .select({ user: users })
-      .from(accounts)
-      .innerJoin(users, eq(accounts.userId, users.id))
-      .where(
-        and(
-          eq(accounts.providerId, 'ldap'),
-          eq(accounts.accountId, ldapDn),
-          eq(users.organisationId, config.organisationId),
-          isNull(users.deletedAt),
-        ),
+    if (!username || !password) {
+      return NextResponse.json({ error: 'Username and password are required' }, { status: 400 })
+    }
+
+    const accountStatus = passwordLoginAttemptGuard.check(username)
+    if (!accountStatus.allowed) {
+      return NextResponse.json(
+        { error: 'Too many login attempts — please wait before trying again.' },
+        { status: 429 },
       )
-      .limit(1)
-    const linkedUser = linkedAccount?.user ?? null
+    }
 
-    if (linkedUser) {
-      userId = linkedUser.id
+    // Find all enabled LDAP configs that allow login
+    const configs = await db.query.ldapConfigurations.findMany({
+      where: and(
+        eq(ldapConfigurations.enabled, true),
+        eq(ldapConfigurations.allowLogin, true),
+        isNull(ldapConfigurations.deletedAt),
+      ),
+    })
 
-      // Update user info from LDAP
-      await db
-        .update(users)
-        .set({
-          name: ldapUser.displayName ?? ldapUser.username,
-          ...(ldapUser.email ? { email: ldapUser.email } : {}),
-          updatedAt: new Date(),
-        })
-        .where(eq(users.id, userId))
-    } else {
-      // Check if a user with this email already exists in this LDAP config's org.
-      const existingUser = ldapUser.email
-        ? await db.query.users.findFirst({
-            where: and(
-              eq(users.email, ldapUser.email),
-              eq(users.organisationId, config.organisationId),
-              isNull(users.deletedAt),
-            ),
+    if (configs.length === 0) {
+      return NextResponse.json({ error: 'LDAP login is not configured' }, { status: 400 })
+    }
+
+    // Try each config until one succeeds
+    const errors: string[] = []
+    for (const config of configs) {
+      const result = await authenticateUser(config, username, password)
+      if ('error' in result) {
+        console.error(`[LDAP] Auth failed for config "${config.name}" (${config.host}): ${result.error}`)
+        errors.push(`${config.name}: ${result.error}`)
+        continue
+      }
+
+      const ldapUser = result.user
+      const ldapDn = ldapUser.dn
+
+      // Find existing account linked to this LDAP DN for this LDAP config's org.
+      let userId: string
+      const [linkedAccount] = await db
+        .select({ user: users })
+        .from(accounts)
+        .innerJoin(users, eq(accounts.userId, users.id))
+        .where(
+          and(
+            eq(accounts.providerId, 'ldap'),
+            eq(accounts.accountId, ldapDn),
+            eq(users.organisationId, config.organisationId),
+            isNull(users.deletedAt),
+          ),
+        )
+        .limit(1)
+      const linkedUser = linkedAccount?.user ?? null
+
+      if (linkedUser) {
+        userId = linkedUser.id
+
+        // Update user info from LDAP
+        await db
+          .update(users)
+          .set({
+            name: ldapUser.displayName ?? ldapUser.username,
+            ...(ldapUser.email ? { email: ldapUser.email } : {}),
+            updatedAt: new Date(),
           })
-        : null
-
-      if (existingUser) {
-        userId = existingUser.id
+          .where(eq(users.id, userId))
       } else {
-        // Create new user
-        userId = createId()
-        const email = ldapUser.email || `${ldapUser.username}@ldap.local`
+        // Check if a user with this email already exists in this LDAP config's org.
+        const existingUser = ldapUser.email
+          ? await db.query.users.findFirst({
+              where: and(
+                eq(users.email, ldapUser.email),
+                eq(users.organisationId, config.organisationId),
+                isNull(users.deletedAt),
+              ),
+            })
+          : null
 
-        // Find the org from the LDAP config
-        await db.insert(users).values({
-          id: userId,
-          name: ldapUser.displayName ?? ldapUser.username,
-          email,
-          emailVerified: true,
-          organisationId: config.organisationId,
-          role: 'pending',
+        if (existingUser) {
+          userId = existingUser.id
+        } else {
+          // Create new user
+          userId = createId()
+          const email = ldapUser.email || `${ldapUser.username}@ldap.local`
+
+          // Find the org from the LDAP config
+          await db.insert(users).values({
+            id: userId,
+            name: ldapUser.displayName ?? ldapUser.username,
+            email,
+            emailVerified: true,
+            organisationId: config.organisationId,
+            role: 'pending',
+          })
+        }
+
+        // Create account link
+        await db.insert(accounts).values({
+          accountId: ldapDn,
+          providerId: 'ldap',
+          userId,
         })
       }
 
-      // Create account link
-      await db.insert(accounts).values({
-        accountId: ldapDn,
-        providerId: 'ldap',
-        userId,
+      // Verify user is active
+      const user = await db.query.users.findFirst({
+        where: eq(users.id, userId),
       })
-    }
+      if (!user || !user.isActive || user.deletedAt) {
+        // Log internally but return the same generic error to avoid leaking account existence.
+        console.warn(`[LDAP] Login rejected — account inactive or deleted: userId=${userId}`)
+        passwordLoginAttemptGuard.recordFailure(username)
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
+        )
+      }
 
-    // Verify user is active
-    const user = await db.query.users.findFirst({
-      where: eq(users.id, userId),
-    })
-    if (!user || !user.isActive || user.deletedAt) {
-      // Log internally but return the same generic error to avoid leaking account existence.
-      console.warn(`[LDAP] Login rejected — account inactive or deleted: userId=${userId}`)
-      return withAuthDelay(
-        requestStart,
-        NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
+      // Create session
+      const sessionToken = randomBytes(32).toString('hex')
+      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days
+
+      await db.insert(sessions).values({
+        token: sessionToken,
+        userId,
+        expiresAt,
+        ipAddress: request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? null,
+        userAgent: request.headers.get('user-agent') ?? null,
+      })
+
+      const authSecret = process.env['BETTER_AUTH_SECRET'] ?? ''
+      const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
+
+      const response = NextResponse.json({
+        success: true,
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+        },
+      })
+
+      // Set the cookie with an already-encoded value (Next.js would double-encode otherwise).
+      response.headers.append(
+        'Set-Cookie',
+        `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
       )
+
+      passwordLoginAttemptGuard.reset(username)
+      return withAuthDelay(requestStart, response)
     }
 
-    // Create session
-    const sessionToken = randomBytes(32).toString('hex')
-    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days
-
-    await db.insert(sessions).values({
-      token: sessionToken,
-      userId,
-      expiresAt,
-      ipAddress: request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? null,
-      userAgent: request.headers.get('user-agent') ?? null,
-    })
-
-    const authSecret = process.env['BETTER_AUTH_SECRET'] ?? ''
-    const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
-
-    const response = NextResponse.json({
-      success: true,
-      user: {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-      },
-    })
-
-    // Set the cookie with an already-encoded value (Next.js would double-encode otherwise).
-    response.headers.append(
-      'Set-Cookie',
-      `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
+    console.error(`[LDAP] All configs failed for user "${username}":`, errors)
+    passwordLoginAttemptGuard.recordFailure(username)
+    return withAuthDelay(
+      requestStart,
+      NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
     )
-
-    return withAuthDelay(requestStart, response)
-  }
-
-  console.error(`[LDAP] All configs failed for user "${username}":`, errors)
-  return withAuthDelay(
-    requestStart,
-    NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
-  )
   } catch (err) {
     console.error('[LDAP] Unexpected error during login:', err)
     return withAuthDelay(

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -1,9 +1,13 @@
 import { betterAuth } from 'better-auth'
+import { APIError, createAuthMiddleware } from 'better-auth/api'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor } from 'better-auth/plugins'
 import { db } from '@/lib/db'
 import * as schema from '@/lib/db/schema'
 import { sendVerificationEmail } from './email'
+import { passwordLoginAttemptGuard } from './login-attempts'
+
+const LOGIN_THROTTLED_MESSAGE = 'Too many login attempts — please wait before trying again.'
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -40,6 +44,30 @@ export const auth = betterAuth({
       },
     }),
   ],
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== '/sign-in/email') return
+
+      const email = typeof ctx.body?.email === 'string' ? ctx.body.email : ''
+      const status = passwordLoginAttemptGuard.check(email)
+      if (status.allowed) return
+
+      throw new APIError('TOO_MANY_REQUESTS', {
+        message: LOGIN_THROTTLED_MESSAGE,
+      })
+    }),
+    after: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== '/sign-in/email') return
+      if (typeof ctx.body?.email !== 'string' || typeof ctx.body?.password !== 'string') return
+
+      if (ctx.context.newSession) {
+        passwordLoginAttemptGuard.reset(ctx.body.email)
+        return
+      }
+
+      passwordLoginAttemptGuard.recordFailure(ctx.body.email)
+    }),
+  },
   trustedOrigins: Array.from(
     new Set([
       process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000',

--- a/apps/web/lib/auth/login-attempts.test.mjs
+++ b/apps/web/lib/auth/login-attempts.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createLoginAttemptGuard } from './login-attempts.ts'
+
+test('login attempt guard allows attempts before the threshold', () => {
+  const guard = createLoginAttemptGuard({
+    windowMs: 60_000,
+    maxFailures: 3,
+    baseLockoutMs: 10_000,
+    maxLockoutMs: 60_000,
+  })
+
+  assert.deepEqual(guard.check('User@Example.com', 0), { allowed: true, retryAfterMs: 0 })
+  assert.deepEqual(guard.recordFailure('User@Example.com', 1_000), { allowed: true, retryAfterMs: 0 })
+  assert.deepEqual(guard.recordFailure('user@example.com', 2_000), { allowed: true, retryAfterMs: 0 })
+  assert.deepEqual(guard.check('user@example.com', 2_500), { allowed: true, retryAfterMs: 0 })
+})
+
+test('login attempt guard locks after the configured threshold and escalates later lockouts', () => {
+  const guard = createLoginAttemptGuard({
+    windowMs: 60_000,
+    maxFailures: 3,
+    baseLockoutMs: 10_000,
+    maxLockoutMs: 60_000,
+  })
+
+  guard.recordFailure('user@example.com', 1_000)
+  guard.recordFailure('user@example.com', 2_000)
+  assert.deepEqual(guard.recordFailure('user@example.com', 3_000), {
+    allowed: false,
+    retryAfterMs: 10_000,
+  })
+  assert.deepEqual(guard.check('user@example.com', 5_000), {
+    allowed: false,
+    retryAfterMs: 8_000,
+  })
+
+  guard.recordFailure('user@example.com', 14_000)
+  guard.recordFailure('user@example.com', 15_000)
+  assert.deepEqual(guard.recordFailure('user@example.com', 16_000), {
+    allowed: false,
+    retryAfterMs: 20_000,
+  })
+})
+
+test('login attempt guard resets state after a successful sign-in', () => {
+  const guard = createLoginAttemptGuard({
+    windowMs: 60_000,
+    maxFailures: 2,
+    baseLockoutMs: 10_000,
+    maxLockoutMs: 60_000,
+  })
+
+  guard.recordFailure('user@example.com', 1_000)
+  guard.reset('user@example.com')
+
+  assert.deepEqual(guard.check('user@example.com', 2_000), { allowed: true, retryAfterMs: 0 })
+  assert.deepEqual(guard.recordFailure('user@example.com', 3_000), { allowed: true, retryAfterMs: 0 })
+})
+
+test('login attempt guard forgets failures outside the sliding window', () => {
+  const guard = createLoginAttemptGuard({
+    windowMs: 5_000,
+    maxFailures: 2,
+    baseLockoutMs: 10_000,
+    maxLockoutMs: 60_000,
+  })
+
+  guard.recordFailure('user@example.com', 1_000)
+  assert.deepEqual(guard.recordFailure('user@example.com', 7_000), { allowed: true, retryAfterMs: 0 })
+  assert.deepEqual(guard.check('user@example.com', 7_100), { allowed: true, retryAfterMs: 0 })
+})

--- a/apps/web/lib/auth/login-attempts.ts
+++ b/apps/web/lib/auth/login-attempts.ts
@@ -1,0 +1,110 @@
+export interface LoginAttemptGuardOptions {
+  windowMs: number
+  maxFailures: number
+  baseLockoutMs: number
+  maxLockoutMs: number
+}
+
+export interface LoginAttemptStatus {
+  allowed: boolean
+  retryAfterMs: number
+}
+
+interface AttemptState {
+  failures: number[]
+  lockoutLevel: number
+  lockedUntil: number
+}
+
+function pruneFailures(failures: number[], windowMs: number, now: number): number[] {
+  const cutoff = now - windowMs
+  return failures.filter((timestamp) => timestamp > cutoff)
+}
+
+function normalizeIdentifier(identifier: string): string {
+  return identifier.trim().toLowerCase()
+}
+
+export function createLoginAttemptGuard(options: LoginAttemptGuardOptions) {
+  const state = new Map<string, AttemptState>()
+
+  function getState(rawIdentifier: string, now = Date.now()): [string, AttemptState] | null {
+    const identifier = normalizeIdentifier(rawIdentifier)
+    if (!identifier) return null
+
+    const existing = state.get(identifier)
+    const next: AttemptState = existing
+      ? {
+          failures: pruneFailures(existing.failures, options.windowMs, now),
+          lockoutLevel: existing.lockoutLevel,
+          lockedUntil: existing.lockedUntil,
+        }
+      : {
+          failures: [],
+          lockoutLevel: 0,
+          lockedUntil: 0,
+        }
+
+    state.set(identifier, next)
+    return [identifier, next]
+  }
+
+  return {
+    check(identifier: string, now = Date.now()): LoginAttemptStatus {
+      const entry = getState(identifier, now)
+      if (!entry) return { allowed: true, retryAfterMs: 0 }
+
+      const [, current] = entry
+      if (current.lockedUntil > now) {
+        return {
+          allowed: false,
+          retryAfterMs: current.lockedUntil - now,
+        }
+      }
+
+      if (current.lockedUntil !== 0) {
+        current.lockedUntil = 0
+      }
+
+      return { allowed: true, retryAfterMs: 0 }
+    },
+
+    recordFailure(identifier: string, now = Date.now()): LoginAttemptStatus {
+      const entry = getState(identifier, now)
+      if (!entry) return { allowed: true, retryAfterMs: 0 }
+
+      const [, current] = entry
+      current.failures.push(now)
+
+      if (current.failures.length < options.maxFailures) {
+        return { allowed: true, retryAfterMs: 0 }
+      }
+
+      current.failures = []
+      current.lockoutLevel += 1
+      const lockoutMs = Math.min(
+        options.baseLockoutMs * 2 ** (current.lockoutLevel - 1),
+        options.maxLockoutMs,
+      )
+      current.lockedUntil = now + lockoutMs
+
+      return {
+        allowed: false,
+        retryAfterMs: lockoutMs,
+      }
+    },
+
+    reset(identifier: string): void {
+      const normalized = normalizeIdentifier(identifier)
+      if (!normalized) return
+      state.delete(normalized)
+    },
+  }
+}
+
+export const passwordLoginAttemptGuard = createLoginAttemptGuard({
+  windowMs: 15 * 60_000,
+  maxFailures: 5,
+  baseLockoutMs: 5 * 60_000,
+  maxLockoutMs: 60 * 60_000,
+})


### PR DESCRIPTION
## Summary
- add a shared per-account login attempt guard with escalating lockouts
- enforce the guard on Better Auth email/password sign-in and LDAP sign-in
- add focused unit coverage for the guard logic

## Testing
- node --experimental-strip-types --test lib/auth/login-attempts.test.mjs
- ./apps/web/node_modules/.bin/tsc --noEmit -p apps/web/tsconfig.json

Closes #285