### PR TITLE
fix(web): validate trusted origins for mutations

### DIFF
--- a/apps/web/app/api/agent/bundle/route.ts
+++ b/apps/web/app/api/agent/bundle/route.ts
@@ -16,6 +16,7 @@ import {
 import { buildInstallBundle } from '@/lib/agent/bundle'
 import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
 import { readFile } from 'node:fs/promises'
+import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 
 const SERVER_TLS_CERT_PATH = process.env['INGEST_TLS_CERT'] ?? '/etc/ct-ops/tls/server.crt'
 const WEB_TLS_CERT_PATH = process.env['WEB_TLS_CERT'] ?? '/var/lib/ct-ops/server-tls/server.crt'
@@ -65,6 +66,12 @@ const requestSchema = z.object({
  * Gated on org_admin / super_admin. Scoped by organisationId.
  */
 export async function POST(request: NextRequest) {
+  try {
+    assertTrustedMutationOrigin(request.headers)
+  } catch {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const session = await auth.api.getSession({ headers: request.headers })
   if (!session) {
     return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })

--- a/apps/web/app/api/hosts/[id]/queries/route.ts
+++ b/apps/web/app/api/hosts/[id]/queries/route.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { users, hosts, agentQueries } from '@/lib/db/schema'
 import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
+import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,6 +20,12 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  try {
+    assertTrustedMutationOrigin(request.headers)
+  } catch {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -14,6 +14,7 @@ import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { hosts, taskRunHosts, taskRuns, users } from '@/lib/db/schema'
 import { resolveWarUrl } from '@/lib/jenkins/update-center'
+import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 
 export const runtime = 'nodejs'
 export const maxDuration = 900
@@ -693,6 +694,12 @@ async function serveBundleDownload(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   cleanupOldJobs()
+  try {
+    assertTrustedMutationOrigin(request.headers)
+  } catch {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const user = await getAuthorisedUser(request)
   if (!user?.organisationId) {
     return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })

--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/certificates/fetch'
 import { assertAllowedCertificateCheckerPort } from '@/lib/net/certificate-checker-policy'
 import { assertPublicHost } from '@/lib/net/ssrf-guard'
+import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 
 export type { ParsedCertificate, ParsedSAN, ChainEntry } from '@/lib/certificates/fetch'
 
@@ -58,6 +59,12 @@ const BodySchema = z.discriminatedUnion('action', [
 ])
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    assertTrustedMutationOrigin(req.headers)
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Forbidden' } satisfies CertCheckerResponse, { status: 403 })
+  }
+
   const session = await auth.api.getSession({ headers: req.headers })
   if (!session) {
     return NextResponse.json({ ok: false, error: 'Unauthorized' } satisfies CertCheckerResponse, { status: 401 })

--- a/apps/web/lib/security/trusted-origins.test.mjs
+++ b/apps/web/lib/security/trusted-origins.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  assertTrustedMutationOrigin,
+  getTrustedOriginHosts,
+  getTrustedOrigins,
+  isTrustedMutationOrigin,
+} from './trusted-origins.ts'
+
+test('getTrustedOrigins normalises BETTER_AUTH_URL and additional origins', () => {
+  const env = {
+    BETTER_AUTH_URL: 'https://ct-ops.example.com/login',
+    BETTER_AUTH_TRUSTED_ORIGINS:
+      'https://proxy.example.com, invalid-origin, https://ct-ops.example.com',
+  }
+
+  assert.deepEqual(getTrustedOrigins(env), [
+    'https://ct-ops.example.com',
+    'https://proxy.example.com',
+  ])
+})
+
+test('getTrustedOriginHosts keeps the host:port values expected by Next serverActions.allowedOrigins', () => {
+  const env = {
+    BETTER_AUTH_URL: 'https://ct-ops.example.com',
+    BETTER_AUTH_TRUSTED_ORIGINS: 'http://localhost:3001,https://proxy.example.com',
+  }
+
+  assert.deepEqual(getTrustedOriginHosts(env), [
+    'ct-ops.example.com',
+    'localhost:3001',
+    'proxy.example.com',
+  ])
+})
+
+test('isTrustedMutationOrigin accepts a trusted Origin header', () => {
+  const headers = new Headers({
+    origin: 'https://ct-ops.example.com',
+  })
+
+  assert.equal(
+    isTrustedMutationOrigin(headers, {
+      BETTER_AUTH_URL: 'https://ct-ops.example.com',
+    }),
+    true,
+  )
+})
+
+test('isTrustedMutationOrigin falls back to Referer when Origin is absent', () => {
+  const headers = new Headers({
+    referer: 'https://proxy.example.com/settings/profile',
+  })
+
+  assert.equal(
+    isTrustedMutationOrigin(headers, {
+      BETTER_AUTH_URL: 'https://ct-ops.example.com',
+      BETTER_AUTH_TRUSTED_ORIGINS: 'https://proxy.example.com',
+    }),
+    true,
+  )
+})
+
+test('assertTrustedMutationOrigin rejects missing or untrusted origins', () => {
+  assert.throws(
+    () =>
+      assertTrustedMutationOrigin(
+        new Headers(),
+        { BETTER_AUTH_URL: 'https://ct-ops.example.com' },
+      ),
+    /forbidden: invalid request origin/,
+  )
+
+  assert.throws(
+    () =>
+      assertTrustedMutationOrigin(
+        new Headers({ origin: 'https://evil.example.com' }),
+        { BETTER_AUTH_URL: 'https://ct-ops.example.com' },
+      ),
+    /forbidden: invalid request origin/,
+  )
+})

--- a/apps/web/lib/security/trusted-origins.ts
+++ b/apps/web/lib/security/trusted-origins.ts
@@ -1,0 +1,70 @@
+const DEFAULT_AUTH_URL = 'http://localhost:3000'
+
+type EnvLike = Record<string, string | undefined>
+
+function normaliseOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin
+  } catch {
+    return null
+  }
+}
+
+export function getTrustedOrigins(env: EnvLike = process.env): string[] {
+  const configured = [
+    env['BETTER_AUTH_URL'] ?? DEFAULT_AUTH_URL,
+    ...(env['BETTER_AUTH_TRUSTED_ORIGINS']
+      ?.split(',')
+      .map((value) => value.trim())
+      .filter(Boolean) ?? []),
+  ]
+
+  return Array.from(
+    new Set(
+      configured
+        .map(normaliseOrigin)
+        .filter((value): value is string => value !== null),
+    ),
+  )
+}
+
+export function getTrustedOriginHosts(env: EnvLike = process.env): string[] {
+  return Array.from(
+    new Set(
+      getTrustedOrigins(env)
+        .map((origin) => new URL(origin).host),
+    ),
+  )
+}
+
+export function isTrustedMutationOrigin(
+  headerSource: Headers | Pick<Headers, 'get'>,
+  env: EnvLike = process.env,
+): boolean {
+  const trustedOrigins = new Set(getTrustedOrigins(env))
+  const origin = headerSource.get('origin')
+  const referer = headerSource.get('referer')
+
+  if (origin) {
+    return trustedOrigins.has(origin)
+  }
+
+  if (!referer) {
+    return false
+  }
+
+  try {
+    return trustedOrigins.has(new URL(referer).origin)
+  } catch {
+    return false
+  }
+}
+
+export function assertTrustedMutationOrigin(
+  headerSource: Headers | Pick<Headers, 'get'>,
+  env: EnvLike = process.env,
+): void {
+  if (!isTrustedMutationOrigin(headerSource, env)) {
+    throw new Error('forbidden: invalid request origin')
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next'
+import { getTrustedOriginHosts } from './lib/security/trusted-origins'
 
 const securityHeaders = [
   // Prevent clickjacking
@@ -31,6 +32,11 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   poweredByHeader: false,
   reactStrictMode: true,
+  experimental: {
+    serverActions: {
+      allowedOrigins: getTrustedOriginHosts(),
+    },
+  },
 
   async headers() {
     return [


### PR DESCRIPTION
## Summary
- derive a single trusted-origin allowlist from `BETTER_AUTH_URL` and `BETTER_AUTH_TRUSTED_ORIGINS`
- wire that allowlist into Next.js `serverActions.allowedOrigins` for proxied deployments
- reject cross-origin requests on cookie-authenticated mutation routes under `/api`

## Testing
- `npm run test:unit -- lib/security/trusted-origins.test.mjs lib/actions/action-auth.test.mjs`
- `npm run type-check` *(fails locally in this worktree because `tsc` is not installed; dependencies are not present)*

Fixes #286.
