### PR TITLE
fix(agent): enforce enrolment token expiry and usage caps

### DIFF
--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -43,6 +43,10 @@ import {
 import type { AgentEnrolmentToken } from '@/lib/db/schema'
 import type { EnrolmentTokenSafe } from '@/lib/actions/agents'
 import { TagEditor, type EditorTag } from '@/components/shared/tag-editor'
+import {
+  DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
+  DEFAULT_ENROLMENT_TOKEN_MAX_USES,
+} from '@/lib/agent/enrolment-token-policy'
 
 const createTokenSchema = z.object({
   label: z.string().min(1, 'Label is required').max(100),
@@ -133,7 +137,13 @@ export function AgentsSettingsClient({
     formState: { errors },
   } = useForm<CreateTokenForm>({
     resolver: zodResolver(createTokenSchema),
-    defaultValues: { label: '', autoApprove: false, skipVerify: true },
+    defaultValues: {
+      label: '',
+      autoApprove: false,
+      skipVerify: true,
+      maxUses: String(DEFAULT_ENROLMENT_TOKEN_MAX_USES),
+      expiresInDays: String(DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS),
+    },
   })
 
   const autoApprove = watch('autoApprove')
@@ -430,22 +440,20 @@ export function AgentsSettingsClient({
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="maxUses">Max uses (optional)</Label>
+                  <Label htmlFor="maxUses">Max uses</Label>
                   <Input
                     id="maxUses"
                     type="number"
                     min="1"
-                    placeholder="Unlimited"
                     {...register('maxUses')}
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="expiresInDays">Expires in days (optional)</Label>
+                  <Label htmlFor="expiresInDays">Expires in days</Label>
                   <Input
                     id="expiresInDays"
                     type="number"
                     min="1"
-                    placeholder="Never"
                     {...register('expiresInDays')}
                   />
                 </div>

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -44,6 +44,12 @@ import { runMatchingTagRules } from '@/lib/actions/tag-rules'
 import type { HostMetadata, TagPair } from '@/lib/db/schema'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getRequiredSession } from '@/lib/auth/session'
+import {
+  calculateEnrolmentTokenExpiry,
+  DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
+  DEFAULT_ENROLMENT_TOKEN_MAX_USES,
+  normaliseEnrolmentTokenLimits,
+} from '@/lib/agent/enrolment-token-policy'
 import { createHash } from 'crypto'
 import { createId } from '@paralleldrive/cuid2'
 
@@ -59,8 +65,8 @@ const createEnrolmentTokenSchema = z.object({
   label: z.string().min(1, 'Label is required').max(100),
   autoApprove: z.boolean().default(false),
   skipVerify: z.boolean().default(false),
-  maxUses: z.number().int().positive().optional(),
-  expiresInDays: z.number().int().positive().optional(),
+  maxUses: z.number().int().positive().default(DEFAULT_ENROLMENT_TOKEN_MAX_USES),
+  expiresInDays: z.number().int().positive().max(365).default(DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS),
   tags: z
     .array(z.object({ key: z.string().min(1).max(100), value: z.string().min(1).max(500) }))
     .default([]),
@@ -506,11 +512,8 @@ export async function createEnrolmentToken(
   }
 
   try {
-    let expiresAt: Date | undefined
-    if (parsed.data.expiresInDays) {
-      expiresAt = new Date()
-      expiresAt.setDate(expiresAt.getDate() + parsed.data.expiresInDays)
-    }
+    const limits = normaliseEnrolmentTokenLimits(parsed.data)
+    const expiresAt = calculateEnrolmentTokenExpiry(limits.expiresInDays)
 
     // Generate the token explicitly so we can hash it before insertion.
     // The plaintext is returned to the caller once; subsequent list queries omit it.
@@ -523,8 +526,8 @@ export async function createEnrolmentToken(
         createdById: userId,
         autoApprove: parsed.data.autoApprove,
         skipVerify: parsed.data.skipVerify,
-        maxUses: parsed.data.maxUses ?? null,
-        expiresAt: expiresAt ?? null,
+        maxUses: limits.maxUses,
+        expiresAt,
         metadata: parsed.data.tags.length > 0 ? { tags: parsed.data.tags } : null,
         token,
         tokenHash: hashToken(token),

--- a/apps/web/lib/agent/enrolment-token-policy.test.mjs
+++ b/apps/web/lib/agent/enrolment-token-policy.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
+  DEFAULT_ENROLMENT_TOKEN_MAX_USES,
+  calculateEnrolmentTokenExpiry,
+  normaliseEnrolmentTokenLimits,
+} from './enrolment-token-policy.ts'
+
+test('normaliseEnrolmentTokenLimits applies secure defaults when limits are omitted', () => {
+  assert.deepEqual(normaliseEnrolmentTokenLimits({}), {
+    maxUses: DEFAULT_ENROLMENT_TOKEN_MAX_USES,
+    expiresInDays: DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
+  })
+})
+
+test('normaliseEnrolmentTokenLimits preserves explicit limits', () => {
+  assert.deepEqual(normaliseEnrolmentTokenLimits({ maxUses: 25, expiresInDays: 14 }), {
+    maxUses: 25,
+    expiresInDays: 14,
+  })
+})
+
+test('calculateEnrolmentTokenExpiry adds the requested number of days', () => {
+  const now = new Date('2026-04-27T12:00:00.000Z')
+  assert.equal(
+    calculateEnrolmentTokenExpiry(7, now).toISOString(),
+    '2026-05-04T12:00:00.000Z',
+  )
+})

--- a/apps/web/lib/agent/enrolment-token-policy.ts
+++ b/apps/web/lib/agent/enrolment-token-policy.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_ENROLMENT_TOKEN_MAX_USES = 1
+export const DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS = 7
+
+export const LEGACY_ENROLMENT_TOKEN_GRACE_EXPIRY_DAYS = 30
+
+export function normaliseEnrolmentTokenLimits(input: {
+  maxUses?: number | null
+  expiresInDays?: number | null
+}) {
+  return {
+    maxUses: input.maxUses ?? DEFAULT_ENROLMENT_TOKEN_MAX_USES,
+    expiresInDays: input.expiresInDays ?? DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
+  }
+}
+
+export function calculateEnrolmentTokenExpiry(expiresInDays: number, now = new Date()): Date {
+  const expiresAt = new Date(now)
+  expiresAt.setDate(expiresAt.getDate() + expiresInDays)
+  return expiresAt
+}

--- a/apps/web/lib/db/migrations/0043_enrolment_token_limits.sql
+++ b/apps/web/lib/db/migrations/0043_enrolment_token_limits.sql
@@ -1,0 +1,10 @@
+-- Backfill legacy enrolment tokens so every live token has a hard usage cap
+-- and expiry window. Existing tokens get one remaining use beyond their
+-- current counter and a 30-day grace period if they never had an expiry.
+UPDATE "agent_enrolment_tokens"
+SET
+  "max_uses" = COALESCE("max_uses", GREATEST("usage_count" + 1, 1)),
+  "expires_at" = COALESCE("expires_at", NOW() + INTERVAL '30 days'),
+  "updated_at" = NOW()
+WHERE "deleted_at" IS NULL
+  AND ("max_uses" IS NULL OR "expires_at" IS NULL);

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1777222444423,
       "tag": "0042_common_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1777280000000,
+      "tag": "0043_enrolment_token_limits",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- enforce secure defaults for all newly created enrolment tokens so max uses and expiry are always set
- backfill legacy live tokens with a hard usage cap and expiry grace window via migration 0043
- surface the required limits in the enrolment token UI and cover the policy helper with unit tests

## Testing
- node scripts/validate-migrations.js
- node --experimental-strip-types --test lib/agent/enrolment-token-policy.test.mjs
- npm run type-check could not run in this worktree because tsc is not installed in the shell environment

Closes #296
