### PR TITLE
fix(web): remove root startup from web image

### DIFF
--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -17,7 +17,7 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `CT_OPS_LOADTEST_ADMIN_KEY` | — 🔒 | — | Bearer credential for `/api/admin/hosts/bulk-delete`. Endpoint returns 503 when unset. Set only on environments running load tests |
 | `NEXT_PUBLIC_APP_URL` | — | — | Exposed to the browser — used for constructing absolute links |
 | `NODE_ENV` | — | `development` | Set to `production` in production |
-| `AGENT_DIST_DIR` | — | `/var/lib/ct-ops/agent-dist` | Directory where compiled agent binaries are stored for download |
+| `AGENT_DIST_DIR` | — | `/var/lib/ct-ops/agent-dist` | Directory where compiled agent binaries are stored for download. If you override or mount it, ensure it is writable by uid/gid `1001` (`nextjs:nodejs`) |
 | `AGENT_DOWNLOAD_BASE_URL` | — | `https://localhost` | Public URL agents use to download new binaries. Must be reachable from every agent host |
 | `INGEST_WS_URL` | — | *(empty)* | WebSocket URL of the ingest service. Empty = same-origin via the bundled nginx (recommended). Set to an absolute `wss://` URL only to bypass the bundled proxy |
 | `WEB_TLS_CERT` | — | `/var/lib/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. The enrolment bundle route reads this file and embeds it so agents can verify the HTTPS download URL |

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -81,8 +81,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN apk add --no-cache su-exec && \
-    addgroup --system --gid 1001 nodejs && \
+RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # In a pnpm monorepo, Next.js standalone mirrors the full workspace structure.
@@ -118,9 +117,10 @@ COPY --chown=nextjs:nodejs apps/web/lib/db/migrations ./apps/web/lib/db/migratio
 COPY --from=deps --chown=nextjs:nodejs /migrate-deps/drizzle-orm ./node_modules/drizzle-orm
 COPY --from=deps --chown=nextjs:nodejs /migrate-deps/postgres ./node_modules/postgres
 
-# Entrypoint: runs as root, fixes agent-dist volume ownership, then drops to nextjs
+# Entrypoint: runs entirely as nextjs. Any external AGENT_DIST_DIR mount must
+# already be writable by uid/gid 1001.
 COPY apps/web/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && chown nextjs:nodejs /entrypoint.sh
 
 EXPOSE 3000
 
@@ -129,4 +129,5 @@ ENV HOSTNAME="0.0.0.0"
 
 # server.js is at /app/apps/web/server.js after the standalone copy
 WORKDIR /app/apps/web
+USER nextjs:nodejs
 CMD ["/entrypoint.sh"]

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -8,10 +8,15 @@ set -e
 : "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
 : "${BETTER_AUTH_URL:?BETTER_AUTH_URL must be set}"
 
-# Ensure the agent-dist volume mount is writable by the nextjs user.
-# Docker named volumes are created as root; this fixes ownership on each start.
-if [ -d "/var/lib/ct-ops/agent-dist" ]; then
-  chown -R nextjs:nodejs /var/lib/ct-ops/agent-dist
+AGENT_DIST_DIR="${AGENT_DIST_DIR:-./data/agent-dist}"
+
+# The web container no longer starts as root. If operators mount a custom
+# agent bundle directory, it must already be writable by uid/gid 1001.
+mkdir -p "$AGENT_DIST_DIR"
+if [ ! -w "$AGENT_DIST_DIR" ]; then
+  echo "AGENT_DIST_DIR is not writable: $AGENT_DIST_DIR" >&2
+  echo "Pre-create the directory or volume with uid/gid 1001 (nextjs:nodejs)." >&2
+  exit 1
 fi
 
-exec su-exec nextjs sh -c "node migrate.js && node server.js"
+exec sh -c "node migrate.js && node server.js"

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -24,6 +24,8 @@ services:
       dockerfile: apps/web/Dockerfile
     restart: unless-stopped
     depends_on:
+      agent-dist-init:
+        condition: service_completed_successfully
       migrate:
         condition: service_completed_successfully
     ports:
@@ -55,6 +57,20 @@ services:
       # Read-only mount of the nginx-facing server cert so the enrolment
       # bundle route can embed it in agent downloads.
       - ./deploy/tls:/var/lib/ct-ops/server-tls:ro
+
+  agent-dist-init:
+    image: busybox:1.36
+    restart: "no"
+    user: "0:0"
+    volumes:
+      - agent_dist:/var/lib/ct-ops/agent-dist
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mkdir -p /var/lib/ct-ops/agent-dist
+        chown 1001:1001 /var/lib/ct-ops/agent-dist
 
   migrate:
     image: ${WEB_IMAGE:-ghcr.io/carrtech-dev/ct-ops/web:latest}


### PR DESCRIPTION
## Summary
- run the web image entirely as `nextjs:nodejs` instead of starting as root and dropping privileges at runtime
- fail fast when `AGENT_DIST_DIR` is not writable, instead of recursively `chown`ing it from the web entrypoint
- add a one-shot compose init service that prepares the shared `agent_dist` volume for uid/gid 1001

## Testing
- `sh -n apps/web/entrypoint.sh`
- `POSTGRES_PASSWORD=test BETTER_AUTH_SECRET=01234567890123456789012345678901 docker compose -f docker-compose.single.yml config`
- `docker build -f apps/web/Dockerfile -t ct-ops-web-issue-302 .`

Closes #302