### PR TITLE
fix(release): ship digest-pinned compose bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,7 @@ POSTGRES_PASSWORD=
 # POSTGRES_DB=ctops
 
 # === Optional image overrides (advanced) ===
-# Pin to a specific image tag instead of :latest.
-# WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web:sha-abc1234
-# INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest:sha-abc1234
+# The release bundle stamps these to digest-pinned refs by default.
+# Override only when you intentionally want a different published image.
+# WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:...
+# INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:...

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -148,8 +148,11 @@ jobs:
   # `push: tags` would never fire because release-please uses GITHUB_TOKEN).
   bundle-web:
     name: Customer bundle (web)
-    needs: release-please
-    if: needs.release-please.outputs.web_release_created == 'true'
+    needs:
+      - release-please
+      - build-web-image
+      - build-ingest-image
+    if: always() && needs.release-please.outputs.web_release_created == 'true'
     runs-on: self-hosted
     steps:
       - name: Reset workspace ownership
@@ -166,12 +169,25 @@ jobs:
           set -euo pipefail
           TAG="${{ needs.release-please.outputs.web_tag_name }}"
           VERSION="${TAG#web/}"
+          WEB_IMAGE_REF="${{ needs.build-web-image.outputs.image_ref }}"
+          if [ -z "${WEB_IMAGE_REF}" ]; then
+            echo "ERROR: missing web image digest output from build-web-image" >&2
+            exit 1
+          fi
+          INGEST_IMAGE_REF="${{ needs.build-ingest-image.outputs.image_ref }}"
+          if [ -z "${INGEST_IMAGE_REF}" ]; then
+            INGEST_IMAGE_REF="$(docker buildx imagetools inspect ghcr.io/carrtech-dev/ct-ops/ingest:latest --format '{{json .Manifest.Digest}}' | tr -d '"')"
+            INGEST_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/ingest@${INGEST_IMAGE_REF}"
+          fi
           mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example
           cp deploy/customer-bundle/README.md dist/ct-ops/README.md
           cp deploy/nginx/nginx.conf          dist/ct-ops/deploy/nginx/nginx.conf
           echo "$VERSION" > dist/ct-ops/VERSION
+
+          perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml
+          perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m' dist/ct-ops/.env.example
 
           # The customer start.sh is generated here rather than checked into
           # the repo so the only source of truth lives next to the workflow
@@ -549,6 +565,26 @@ jobs:
           TAG="${{ needs.release-please.outputs.web_tag_name }}"
           VERSION="${TAG#web/}"
           echo "versioned=ct-ops-single-${VERSION}.zip" >> "$GITHUB_OUTPUT"
+          echo "compose_versioned=docker-compose.single-${VERSION}.yml" >> "$GITHUB_OUTPUT"
+          cp dist/ct-ops/docker-compose.yml "docker-compose.single-${VERSION}.yml"
+          cp dist/ct-ops/docker-compose.yml docker-compose.single.yml
+
+      - name: Verify bundled compose pins image digests
+        run: |
+          set -euo pipefail
+          export BETTER_AUTH_SECRET=verify-placeholder
+          export POSTGRES_PASSWORD=verify-placeholder
+          refs="$(docker compose -f dist/ct-ops/docker-compose.yml --env-file dist/ct-ops/.env.example config --images)"
+          echo "$refs"
+          while IFS= read -r ref; do
+            case "$ref" in
+              *@sha256:*) ;;
+              *)
+                echo "ERROR: unpinned image reference in bundled compose: $ref" >&2
+                exit 1
+                ;;
+            esac
+          done <<< "$refs"
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
@@ -557,6 +593,8 @@ jobs:
           files: |
             ${{ steps.bundle.outputs.versioned }}
             ct-ops-single.zip
+            ${{ steps.bundle.outputs.compose_versioned }}
+            docker-compose.single.yml
             ct-ops-web.spdx.json
 
       - name: Clean up runner disk

--- a/.github/workflows/docker-publish-ingest.yml
+++ b/.github/workflows/docker-publish-ingest.yml
@@ -21,6 +21,10 @@ on:
         description: Release tag (e.g. ingest/v0.1.0). Used as the checkout ref and stripped of its `ingest/` prefix to tag the image.
         required: true
         type: string
+    outputs:
+      image_ref:
+        description: Digest-pinned multi-arch ingest image reference.
+        value: ${{ jobs.merge-ingest.outputs.image_ref }}
   workflow_dispatch:
     inputs:
       tag_name:
@@ -147,6 +151,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image_ref: ${{ steps.final-image.outputs.ref }}
 
     steps:
       - name: Log in to GHCR
@@ -188,3 +194,10 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}/ingest@sha256:%s ' *)
+
+      - name: Capture manifest digest
+        id: final-image
+        run: |
+          set -euo pipefail
+          digest="$(docker buildx imagetools inspect "${{ env.IMAGE_PREFIX }}/ingest:${{ steps.version.outputs.value }}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          echo "ref=${{ env.IMAGE_PREFIX }}/ingest@${digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -24,6 +24,10 @@ on:
         description: Release tag (e.g. web/v0.64.1). Used as the checkout ref and stripped of its `web/` prefix to tag the image.
         required: true
         type: string
+    outputs:
+      image_ref:
+        description: Digest-pinned multi-arch web image reference.
+        value: ${{ jobs.merge-web.outputs.image_ref }}
   workflow_dispatch:
     inputs:
       tag_name:
@@ -151,6 +155,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image_ref: ${{ steps.final-image.outputs.ref }}
 
     steps:
       - name: Log in to GHCR
@@ -192,3 +198,10 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_PREFIX }}/web@sha256:%s ' *)
+
+      - name: Capture manifest digest
+        id: final-image
+        run: |
+          set -euo pipefail
+          digest="$(docker buildx imagetools inspect "${{ env.IMAGE_PREFIX }}/web:${{ steps.version.outputs.value }}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          echo "ref=${{ env.IMAGE_PREFIX }}/web@${digest}" >> "$GITHUB_OUTPUT"

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -1,6 +1,6 @@
 # Docker Compose Deployment
 
-The recommended way to run CT-Ops in production is via `docker-compose.single.yml`. This deploys the full stack (web, ingest, database) on a single host using pre-built images from GHCR.
+The recommended way to run CT-Ops in production is via `docker-compose.single.yml`. This deploys the full stack (web, ingest, database) on a single host using digest-pinned images from GHCR.
 
 ---
 
@@ -102,10 +102,10 @@ The one-shot `migrate` container applies database migrations before web and inge
 
 | Service | Image | Host ports | Description |
 |---|---|---|---|
-| `nginx` | `nginx:1.27-alpine` | **443**, **80** | TLS terminator for browser traffic |
-| `db` | `timescale/timescaledb:latest-pg16` | 127.0.0.1:5432 | PostgreSQL + TimescaleDB |
-| `web` | `ghcr.io/carrtech-dev/ct-ops/web:latest` | 127.0.0.1:3000 | Next.js web app (reached via nginx) |
-| `ingest` | `ghcr.io/carrtech-dev/ct-ops/ingest:latest` | **9443**, 127.0.0.1:8080 | Agent gRPC (:9443 direct, bypasses nginx) + JWKS on loopback |
+| `nginx` | `nginx@sha256:...` | **443**, **80** | TLS terminator for browser traffic |
+| `db` | `timescale/timescaledb@sha256:...` | 127.0.0.1:5432 | PostgreSQL + TimescaleDB |
+| `web` | `ghcr.io/carrtech-dev/ct-ops/web@sha256:...` | 127.0.0.1:3000 | Next.js web app (reached via nginx) |
+| `ingest` | `ghcr.io/carrtech-dev/ct-ops/ingest@sha256:...` | **9443**, 127.0.0.1:8080 | Agent gRPC (:9443 direct, bypasses nginx) + JWKS on loopback |
 
 Only `443`, `80`, and `9443` are published on all host interfaces:
 
@@ -123,14 +123,14 @@ their own network, not just from the container host.
 
 ## Updating
 
-To update to the latest image versions:
+To update to newer image versions:
 
 ```bash
 docker compose -f docker-compose.single.yml pull
 docker compose -f docker-compose.single.yml up -d
 ```
 
-Migrations run automatically on container start.
+Migrations run automatically on container start. Release bundles ship with digest-pinned `WEB_IMAGE` and `INGEST_IMAGE` values in `.env.example`; when a new CT-Ops release is published, update both values to the new release digests before pulling.
 
 ---
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -95,7 +95,9 @@ RUN mkdir -p apps/web/.next && chown nextjs:nodejs apps/web/.next
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 
-# Release-please manifest — read at runtime to determine the required agent version
+# Release-please manifest — read at runtime to determine the required agent
+# version. Customer release bundles now pin the published web image by digest,
+# so the image itself must carry the manifest that identifies that release.
 COPY --from=builder --chown=nextjs:nodejs /app/.release-please-manifest.json /app/.release-please-manifest.json
 
 # Agent binaries — built fresh in the agent-builder stage so every web image is

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: timescale/timescaledb:latest-pg16
+    image: timescale/timescaledb@sha256:95a7997408e3295935e4afe8af8c09aae22bd51732131d1e7351c63d6198a71c
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-ctops}
@@ -59,7 +59,7 @@ services:
       - ./deploy/tls:/var/lib/ct-ops/server-tls:ro
 
   agent-dist-init:
-    image: busybox:1.36
+    image: busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
     restart: "no"
     user: "0:0"
     volumes:
@@ -137,7 +137,7 @@ services:
       retries: 5
 
   nginx:
-    image: nginx:1.27-alpine
+    image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
     restart: unless-stopped
     depends_on:
       tls-init:
@@ -165,7 +165,7 @@ services:
   # nginx starts only after a successful exit (depends_on above). When
   # start.sh has already populated deploy/tls/ this is a no-op.
   tls-init:
-    image: nginx:1.27-alpine
+    image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
     restart: "no"
     user: "0:0"
     volumes:


### PR DESCRIPTION
## Summary
- pin third-party images in `docker-compose.single.yml` by digest
- stamp digest-pinned `WEB_IMAGE` and `INGEST_IMAGE` refs into the web release bundle and standalone release compose asset
- verify in CI that the bundled compose resolves only `@sha256` image references

## Testing
- `docker compose -f docker-compose.single.yml config --images`
- simulated the `bundle-web` rewrite locally and verified every resolved image ref is digest-pinned

Closes #303.
