### PR TITLE
fix(release): verify installer bundle checksums

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -565,9 +565,12 @@ jobs:
           TAG="${{ needs.release-please.outputs.web_tag_name }}"
           VERSION="${TAG#web/}"
           echo "versioned=ct-ops-single-${VERSION}.zip" >> "$GITHUB_OUTPUT"
+          echo "versioned_checksum=ct-ops-single-${VERSION}.zip.sha256" >> "$GITHUB_OUTPUT"
           echo "compose_versioned=docker-compose.single-${VERSION}.yml" >> "$GITHUB_OUTPUT"
           cp dist/ct-ops/docker-compose.yml "docker-compose.single-${VERSION}.yml"
           cp dist/ct-ops/docker-compose.yml docker-compose.single.yml
+          sha256sum "ct-ops-single-${VERSION}.zip" > "ct-ops-single-${VERSION}.zip.sha256"
+          sha256sum ct-ops-single.zip > ct-ops-single.zip.sha256
 
       - name: Verify bundled compose pins image digests
         run: |
@@ -592,7 +595,9 @@ jobs:
           tag_name: ${{ needs.release-please.outputs.web_tag_name }}
           files: |
             ${{ steps.bundle.outputs.versioned }}
+            ${{ steps.bundle.outputs.versioned_checksum }}
             ct-ops-single.zip
+            ct-ops-single.zip.sha256
             ${{ steps.bundle.outputs.compose_versioned }}
             docker-compose.single.yml
             ct-ops-web.spdx.json

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -6,9 +6,11 @@ on:
       - ".github/workflows/agent-release.yml"
       - ".github/workflows/customer-bundle-check.yml"
       - "deploy/customer-bundle/**"
+      - "deploy/scripts/test-install.sh"
       - "deploy/nginx/nginx.conf"
       - "docker-compose.single.yml"
       - ".env.example"
+      - "install.sh"
   workflow_dispatch:
 
 jobs:
@@ -39,6 +41,12 @@ jobs:
           test -f .env.example
           bash -n start.sh
           bash -n build-offline-installer.sh
+
+      - name: Validate installer script
+        run: |
+          set -euo pipefail
+          bash -n install.sh
+          bash deploy/scripts/test-install.sh
 
       - name: Render compose config
         working-directory: dist/ct-ops

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ CT-Ops is an open-source monitoring and operations platform designed to run **en
 
 ```bash
 # Download and unpack the latest release
+# The installer verifies the published SHA-256 checksum before unpacking.
 curl -fsSL https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/install.sh | bash
 
 cd ct-ops

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ That's it. No local Go, Node.js, or pnpm required.
 
 ## Option A — Pre-built images from GHCR
 
-The fastest way to get CT-Ops running. One command downloads a small bundle (compose file, `start.sh`, `.env.example`) from the latest GitHub release:
+The fastest way to get CT-Ops running. One command downloads a small bundle (compose file, `start.sh`, `.env.example`) from the latest GitHub release and verifies the published SHA-256 checksum before unpacking:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/install.sh | bash

--- a/deploy/scripts/test-install.sh
+++ b/deploy/scripts/test-install.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+INSTALLER="${REPO_ROOT}/install.sh"
+
+make_mock_bin() {
+  local dir="$1"
+
+  cat > "${dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  cat > "${dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$out" || -z "$url" ]]; then
+  echo "mock curl expected -o <file> <url>" >&2
+  exit 2
+fi
+
+if [[ "$url" == *.sha256 ]]; then
+  printf '%s  ct-ops-single.zip\n' "${MOCK_CHECKSUM}" > "$out"
+else
+  printf '%s' "${MOCK_PAYLOAD}" > "$out"
+fi
+EOF
+
+  cat > "${dir}/unzip" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${UNZIP_SHOULD_FAIL:-0}" = "1" ]; then
+  echo "unzip should not have been called" >&2
+  exit 99
+fi
+
+mkdir -p ct-ops
+exit 0
+EOF
+
+  chmod +x "${dir}/docker" "${dir}/curl" "${dir}/unzip"
+}
+
+run_match_case() {
+  local workspace="$1"
+  local mockbin="${workspace}/mockbin"
+  mkdir -p "$workspace" "$mockbin"
+  make_mock_bin "$mockbin"
+
+  export MOCK_PAYLOAD="verified bundle payload"
+  export MOCK_CHECKSUM
+  MOCK_CHECKSUM="$(printf '%s' "$MOCK_PAYLOAD" | openssl dgst -sha256 | awk '{print $NF}')"
+
+  (
+    cd "$workspace"
+    PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" bash "$INSTALLER"
+  )
+
+  test -d "${workspace}/ct-ops"
+}
+
+run_mismatch_case() {
+  local workspace="$1"
+  local mockbin="${workspace}/mockbin"
+  mkdir -p "$workspace" "$mockbin"
+  make_mock_bin "$mockbin"
+
+  export MOCK_PAYLOAD="tampered bundle payload"
+  export MOCK_CHECKSUM="deadbeef"
+  export UNZIP_SHOULD_FAIL="1"
+
+  set +e
+  local output
+  output="$(
+    cd "$workspace" &&
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" bash "$INSTALLER" 2>&1
+  )"
+  local status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "expected checksum mismatch failure" >&2
+    exit 1
+  fi
+
+  if [[ "$output" != *"bundle checksum mismatch"* ]]; then
+    echo "expected checksum mismatch message, got:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  test ! -d "${workspace}/ct-ops"
+  unset UNZIP_SHOULD_FAIL
+}
+
+main() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "'"$tmpdir"'"' EXIT
+
+  run_match_case "${tmpdir}/match"
+  run_mismatch_case "${tmpdir}/mismatch"
+  echo "install.sh checksum verification tests passed"
+}
+
+main "$@"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ That's it. No local Go, Node.js, or pnpm required.
 
 ## Option A — Pre-built images from GHCR
 
-The fastest way to get CT-Ops running. One command downloads a small bundle (compose file, `start.sh`, `.env.example`, README) from the latest GitHub release and unpacks it into `./ct-ops`:
+The fastest way to get CT-Ops running. One command downloads a small bundle (compose file, `start.sh`, `.env.example`, README) from the latest GitHub release, verifies the published SHA-256 checksum, and unpacks it into `./ct-ops`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/install.sh | bash

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,8 @@
 #
 #   curl -fsSL https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/install.sh | bash
 #
+# The installer verifies the published SHA-256 checksum before unpacking.
+#
 # Optional: pin a specific version.
 #
 #   curl -fsSL https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/install.sh \
@@ -38,16 +40,36 @@ fi
 
 if [ -n "${CT_OPS_VERSION:-}" ]; then
   URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/web/${CT_OPS_VERSION}/ct-ops-single-${CT_OPS_VERSION}.zip"
+  CHECKSUM_URL="${URL}.sha256"
   echo "Downloading ct-ops ${CT_OPS_VERSION}..."
 else
   URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download/ct-ops-single.zip"
+  CHECKSUM_URL="${URL}.sha256"
   echo "Downloading the latest ct-ops release..."
 fi
 
 TMP=$(mktemp -t ct-ops.XXXXXX.zip)
-trap 'rm -f "$TMP"' EXIT
+CHECKSUM_TMP=$(mktemp -t ct-ops.XXXXXX.sha256)
+trap 'rm -f "$TMP" "$CHECKSUM_TMP"' EXIT
 
 curl -fsSL -o "$TMP" "$URL"
+curl -fsSL -o "$CHECKSUM_TMP" "$CHECKSUM_URL"
+
+EXPECTED_CHECKSUM="$(awk 'NF { print $1; exit }' "$CHECKSUM_TMP" | tr '[:upper:]' '[:lower:]')"
+ACTUAL_CHECKSUM="$(openssl dgst -sha256 "$TMP" | awk '{print $NF}' | tr '[:upper:]' '[:lower:]')"
+
+if [ -z "$EXPECTED_CHECKSUM" ]; then
+  echo "ERROR: failed to read bundle checksum from ${CHECKSUM_URL}" >&2
+  exit 1
+fi
+
+if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+  echo "ERROR: bundle checksum mismatch." >&2
+  echo "Expected: $EXPECTED_CHECKSUM" >&2
+  echo "Actual:   $ACTUAL_CHECKSUM" >&2
+  exit 1
+fi
+
 unzip -q "$TMP" -d .
 
 echo ""


### PR DESCRIPTION
## Summary
- add SHA-256 verification to the one-line release installer before unzip
- publish checksum assets alongside the customer bundle release zip
- add a mocked installer regression test and document the verified install flow

## Testing
- bash deploy/scripts/test-install.sh
- bash -n install.sh
- bash -n deploy/scripts/test-install.sh

Closes #304