### PR TITLE
fix(release): export customer bundle image refs

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -179,6 +179,7 @@ jobs:
             INGEST_IMAGE_REF="$(docker buildx imagetools inspect ghcr.io/carrtech-dev/ct-ops/ingest:latest --format '{{json .Manifest.Digest}}' | tr -d '"')"
             INGEST_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/ingest@${INGEST_IMAGE_REF}"
           fi
+          export WEB_IMAGE_REF INGEST_IMAGE_REF
           mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Stage customer bundle
         run: |
           set -euo pipefail
+          WEB_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/web@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+          INGEST_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/ingest@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          export WEB_IMAGE_REF INGEST_IMAGE_REF
           mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml dist/ct-ops/docker-compose.yml
           cp .env.example dist/ct-ops/.env.example
@@ -30,6 +33,8 @@ jobs:
           cp deploy/customer-bundle/build-offline-installer.sh dist/ct-ops/build-offline-installer.sh
           cp deploy/nginx/nginx.conf dist/ct-ops/deploy/nginx/nginx.conf
           echo "test" > dist/ct-ops/VERSION
+          perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml
+          perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m' dist/ct-ops/.env.example
           chmod +x dist/ct-ops/start.sh dist/ct-ops/build-offline-installer.sh
 
       - name: Validate scripts and required files
@@ -53,4 +58,16 @@ jobs:
         env:
           BETTER_AUTH_SECRET: build-time-placeholder
           POSTGRES_PASSWORD: build-time-placeholder
-        run: docker compose config --quiet
+        run: |
+          set -euo pipefail
+          refs="$(docker compose config --images)"
+          echo "$refs"
+          while IFS= read -r ref; do
+            case "$ref" in
+              *@sha256:*) ;;
+              *)
+                echo "ERROR: unpinned image reference in bundled compose: $ref" >&2
+                exit 1
+                ;;
+            esac
+          done <<< "$refs"


### PR DESCRIPTION
## Summary
- export the computed web and ingest image refs before the release workflow rewrites the customer bundle compose file
- make the PR-time customer bundle check run the same digest-ref replacement path
- verify every resolved bundled compose image remains pinned to a sha256 digest

## Root cause
The release workflow assigned `WEB_IMAGE_REF` and `INGEST_IMAGE_REF` as shell variables, but the `perl` replacements read them from `$ENV{...}`. Without exporting them, the generated compose file could receive blank `image:` values and fail validation with `services.ingest.image must be a string`.

## Testing
- `git diff --check origin/main..HEAD`
- `bash -n install.sh`
- `bash -n deploy/scripts/test-install.sh`
- staged the customer bundle locally and ran `docker compose config --images` with the digest-pin validation loop
