### PR TITLE
fix(agent): constrain custom script tasks

### DIFF
--- a/agent/internal/tasks/patch.go
+++ b/agent/internal/tasks/patch.go
@@ -157,7 +157,7 @@ func buildPatchCommand(pm, mode string) (*exec.Cmd, error) {
 // the write-end of the pipe to signal EOF to the scanner, then wait for it to
 // flush any remaining lines before returning.
 func runCommandStreaming(ctx context.Context, cmd *exec.Cmd, progressFn func(chunk string)) (exitCode int, rawOutput string, err error) {
-	cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+	cmd.Env = append(os.Environ(), append(cmd.Env, "DEBIAN_FRONTEND=noninteractive")...)
 
 	pr, pw := io.Pipe()
 	cmd.Stdout = pw
@@ -201,9 +201,7 @@ func runCommandStreaming(ctx context.Context, cmd *exec.Cmd, progressFn func(chu
 	go func() {
 		select {
 		case <-ctx.Done():
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
+			killCommand(cmd)
 		case <-scanDone:
 			// Completed normally — nothing to kill.
 		}

--- a/agent/internal/tasks/process_kill_unix.go
+++ b/agent/internal/tasks/process_kill_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package tasks
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func killCommand(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err == nil && pgid > 0 {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/agent/internal/tasks/process_kill_windows.go
+++ b/agent/internal/tasks/process_kill_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tasks
+
+import "os/exec"
+
+func killCommand(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/agent/internal/tasks/script.go
+++ b/agent/internal/tasks/script.go
@@ -16,6 +16,17 @@ func init() {
 	Register("custom_script", RunCustomScript)
 }
 
+const (
+	defaultScriptTimeout = 10 * time.Minute
+	maxScriptTimeout     = time.Hour
+)
+
+var allowedScriptInterpreters = map[string]struct{}{
+	"sh":      {},
+	"bash":    {},
+	"python3": {},
+}
+
 // scriptConfig is the JSON structure stored in task_runs.config for custom_script tasks.
 type scriptConfig struct {
 	Script         string `json:"script"`          // script body to execute
@@ -41,17 +52,14 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 	if cfg.Interpreter == "" {
 		cfg.Interpreter = "sh"
 	}
-
-	// Apply an explicit timeout if requested, capped at 1 hour.
-	if cfg.TimeoutSeconds > 0 {
-		timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
-		if timeout > time.Hour {
-			timeout = time.Hour
-		}
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
+	if _, ok := allowedScriptInterpreters[cfg.Interpreter]; !ok {
+		return errorResult(fmt.Sprintf("interpreter %q is not permitted", cfg.Interpreter))
 	}
+
+	timeout := effectiveScriptTimeout(cfg.TimeoutSeconds)
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	// Verify the interpreter is available before writing the temp file.
 	if _, err := exec.LookPath(cfg.Interpreter); err != nil {
@@ -77,9 +85,12 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 		return errorResult(fmt.Sprintf("failed to set script permissions: %v", err))
 	}
 
-	progressFn(fmt.Sprintf("Running script with interpreter: %s\n\n", cfg.Interpreter))
+	progressFn(fmt.Sprintf("Running script with interpreter: %s (timeout: %s)\n\n", cfg.Interpreter, timeout))
 
-	cmd := exec.CommandContext(ctx, cfg.Interpreter, tmpPath)
+	cmd, err := buildScriptCommand(ctx, cfg.Interpreter, tmpPath, timeout)
+	if err != nil {
+		return errorResult(err.Error())
+	}
 	exitCode, _, runErr := runCommandStreaming(ctx, cmd, progressFn)
 
 	if runErr != nil {
@@ -92,7 +103,7 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 		if errors.Is(runErr, context.DeadlineExceeded) {
 			return &agentv1.AgentTaskResult{
 				ExitCode: int32(exitCode),
-				Error:    fmt.Sprintf("task timed out (exceeded %d seconds)", cfg.TimeoutSeconds),
+				Error:    fmt.Sprintf("task timed out (exceeded %s)", timeout),
 			}
 		}
 		if exitCode == -1 {
@@ -108,4 +119,15 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 		ExitCode:   int32(exitCode),
 		ResultJson: string(resultJSON),
 	}
+}
+
+func effectiveScriptTimeout(timeoutSeconds int) time.Duration {
+	if timeoutSeconds <= 0 {
+		return defaultScriptTimeout
+	}
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	if timeout > maxScriptTimeout {
+		return maxScriptTimeout
+	}
+	return timeout
 }

--- a/agent/internal/tasks/script_limits_unix.go
+++ b/agent/internal/tasks/script_limits_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const (
+	scriptMemoryLimitKB   = 1_048_576
+	scriptMaxFileBlocks   = 20_480
+	scriptMaxProcesses    = 32
+	scriptMaxOpenFiles    = 128
+	scriptTimeoutHeadroom = 5 * time.Second
+)
+
+func buildScriptCommand(ctx context.Context, interpreter, scriptPath string, timeout time.Duration) (*exec.Cmd, error) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		return nil, fmt.Errorf("required bootstrap shell %q not found on this host: %v", "sh", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", `
+ulimit -t "$CT_OPS_SCRIPT_CPU_SECONDS"
+ulimit -f "$CT_OPS_SCRIPT_FILE_BLOCKS"
+ulimit -u "$CT_OPS_SCRIPT_MAX_PROCS"
+ulimit -n "$CT_OPS_SCRIPT_MAX_NOFILE"
+ulimit -v "$CT_OPS_SCRIPT_MEMORY_KB" 2>/dev/null || true
+exec "$1" "$2"
+`, "sh", interpreter, scriptPath)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = append(cmd.Env,
+		"CT_OPS_SCRIPT_CPU_SECONDS="+strconv.Itoa(int((timeout+scriptTimeoutHeadroom)/time.Second)),
+		"CT_OPS_SCRIPT_FILE_BLOCKS="+strconv.Itoa(scriptMaxFileBlocks),
+		"CT_OPS_SCRIPT_MAX_PROCS="+strconv.Itoa(scriptMaxProcesses),
+		"CT_OPS_SCRIPT_MAX_NOFILE="+strconv.Itoa(scriptMaxOpenFiles),
+		"CT_OPS_SCRIPT_MEMORY_KB="+strconv.Itoa(scriptMemoryLimitKB),
+	)
+	return cmd, nil
+}

--- a/agent/internal/tasks/script_limits_windows.go
+++ b/agent/internal/tasks/script_limits_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+func buildScriptCommand(_ context.Context, _, _ string, _ time.Duration) (*exec.Cmd, error) {
+	return nil, fmt.Errorf("custom_script tasks are disabled on Windows until sandboxing is implemented")
+}

--- a/agent/internal/tasks/script_test.go
+++ b/agent/internal/tasks/script_test.go
@@ -1,0 +1,29 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEffectiveScriptTimeoutDefaultsAndCaps(t *testing.T) {
+	if got := effectiveScriptTimeout(0); got != defaultScriptTimeout {
+		t.Fatalf("effectiveScriptTimeout(0) = %s, want %s", got, defaultScriptTimeout)
+	}
+	if got := effectiveScriptTimeout(int((2 * time.Hour) / time.Second)); got != maxScriptTimeout {
+		t.Fatalf("effectiveScriptTimeout(2h) = %s, want %s", got, maxScriptTimeout)
+	}
+	if got := effectiveScriptTimeout(90); got != 90*time.Second {
+		t.Fatalf("effectiveScriptTimeout(90) = %s, want %s", got, 90*time.Second)
+	}
+}
+
+func TestRunCustomScriptRejectsUnsupportedInterpreter(t *testing.T) {
+	result := RunCustomScript(t.Context(), `{"script":"echo hi","interpreter":"perl"}`, func(string) {})
+	if result.Error == "" {
+		t.Fatal("expected unsupported interpreter error")
+	}
+	if !strings.Contains(result.Error, "not permitted") {
+		t.Fatalf("unexpected error: %q", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce a real default timeout for custom script tasks and cap requested timeouts
- restrict custom scripts to approved interpreters and run them through a shell wrapper with Unix ulimit guardrails
- kill the whole process group on cancellation and add focused task-runner tests

## Testing
- go test ./internal/tasks/...
- go test ./...

Closes #306