### PR TITLE
fix(agent): preserve inherited script timeouts

### DIFF
--- a/agent/internal/tasks/script.go
+++ b/agent/internal/tasks/script.go
@@ -17,8 +17,7 @@ func init() {
 }
 
 const (
-	defaultScriptTimeout = 10 * time.Minute
-	maxScriptTimeout     = time.Hour
+	maxScriptTimeout = time.Hour
 )
 
 var allowedScriptInterpreters = map[string]struct{}{
@@ -56,10 +55,12 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 		return errorResult(fmt.Sprintf("interpreter %q is not permitted", cfg.Interpreter))
 	}
 
-	timeout := effectiveScriptTimeout(cfg.TimeoutSeconds)
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, timeout)
-	defer cancel()
+	timeout, hasTimeout := effectiveScriptTimeout(cfg.TimeoutSeconds)
+	if hasTimeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	// Verify the interpreter is available before writing the temp file.
 	if _, err := exec.LookPath(cfg.Interpreter); err != nil {
@@ -85,9 +86,13 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 		return errorResult(fmt.Sprintf("failed to set script permissions: %v", err))
 	}
 
-	progressFn(fmt.Sprintf("Running script with interpreter: %s (timeout: %s)\n\n", cfg.Interpreter, timeout))
+	timeoutLabel := "inherited"
+	if hasTimeout {
+		timeoutLabel = timeout.String()
+	}
+	progressFn(fmt.Sprintf("Running script with interpreter: %s (timeout: %s)\n\n", cfg.Interpreter, timeoutLabel))
 
-	cmd, err := buildScriptCommand(ctx, cfg.Interpreter, tmpPath, timeout)
+	cmd, err := buildScriptCommand(ctx, cfg.Interpreter, tmpPath, timeout, hasTimeout)
 	if err != nil {
 		return errorResult(err.Error())
 	}
@@ -121,13 +126,13 @@ func RunCustomScript(ctx context.Context, configJSON string, progressFn func(chu
 	}
 }
 
-func effectiveScriptTimeout(timeoutSeconds int) time.Duration {
+func effectiveScriptTimeout(timeoutSeconds int) (time.Duration, bool) {
 	if timeoutSeconds <= 0 {
-		return defaultScriptTimeout
+		return 0, false
 	}
 	timeout := time.Duration(timeoutSeconds) * time.Second
 	if timeout > maxScriptTimeout {
-		return maxScriptTimeout
+		return maxScriptTimeout, true
 	}
-	return timeout
+	return timeout, true
 }

--- a/agent/internal/tasks/script_limits_unix.go
+++ b/agent/internal/tasks/script_limits_unix.go
@@ -19,13 +19,18 @@ const (
 	scriptTimeoutHeadroom = 5 * time.Second
 )
 
-func buildScriptCommand(ctx context.Context, interpreter, scriptPath string, timeout time.Duration) (*exec.Cmd, error) {
+func buildScriptCommand(ctx context.Context, interpreter, scriptPath string, timeout time.Duration, hasTimeout bool) (*exec.Cmd, error) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		return nil, fmt.Errorf("required bootstrap shell %q not found on this host: %v", "sh", err)
 	}
 
+	cpuLimitSnippet := ""
+	if hasTimeout {
+		cpuLimitSnippet = `ulimit -t "$CT_OPS_SCRIPT_CPU_SECONDS"`
+	}
+
 	cmd := exec.CommandContext(ctx, "sh", "-c", `
-ulimit -t "$CT_OPS_SCRIPT_CPU_SECONDS"
+`+cpuLimitSnippet+`
 ulimit -f "$CT_OPS_SCRIPT_FILE_BLOCKS"
 ulimit -u "$CT_OPS_SCRIPT_MAX_PROCS"
 ulimit -n "$CT_OPS_SCRIPT_MAX_NOFILE"
@@ -33,8 +38,12 @@ ulimit -v "$CT_OPS_SCRIPT_MEMORY_KB" 2>/dev/null || true
 exec "$1" "$2"
 `, "sh", interpreter, scriptPath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if hasTimeout {
+		cmd.Env = append(cmd.Env,
+			"CT_OPS_SCRIPT_CPU_SECONDS="+strconv.Itoa(int((timeout+scriptTimeoutHeadroom)/time.Second)),
+		)
+	}
 	cmd.Env = append(cmd.Env,
-		"CT_OPS_SCRIPT_CPU_SECONDS="+strconv.Itoa(int((timeout+scriptTimeoutHeadroom)/time.Second)),
 		"CT_OPS_SCRIPT_FILE_BLOCKS="+strconv.Itoa(scriptMaxFileBlocks),
 		"CT_OPS_SCRIPT_MAX_PROCS="+strconv.Itoa(scriptMaxProcesses),
 		"CT_OPS_SCRIPT_MAX_NOFILE="+strconv.Itoa(scriptMaxOpenFiles),

--- a/agent/internal/tasks/script_limits_windows.go
+++ b/agent/internal/tasks/script_limits_windows.go
@@ -9,6 +9,6 @@ import (
 	"time"
 )
 
-func buildScriptCommand(_ context.Context, _, _ string, _ time.Duration) (*exec.Cmd, error) {
+func buildScriptCommand(_ context.Context, _, _ string, _ time.Duration, _ bool) (*exec.Cmd, error) {
 	return nil, fmt.Errorf("custom_script tasks are disabled on Windows until sandboxing is implemented")
 }

--- a/agent/internal/tasks/script_test.go
+++ b/agent/internal/tasks/script_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestEffectiveScriptTimeoutDefaultsAndCaps(t *testing.T) {
-	if got := effectiveScriptTimeout(0); got != defaultScriptTimeout {
-		t.Fatalf("effectiveScriptTimeout(0) = %s, want %s", got, defaultScriptTimeout)
+	if got, ok := effectiveScriptTimeout(0); ok || got != 0 {
+		t.Fatalf("effectiveScriptTimeout(0) = (%s, %t), want (0s, false)", got, ok)
 	}
-	if got := effectiveScriptTimeout(int((2 * time.Hour) / time.Second)); got != maxScriptTimeout {
-		t.Fatalf("effectiveScriptTimeout(2h) = %s, want %s", got, maxScriptTimeout)
+	if got, ok := effectiveScriptTimeout(int((2 * time.Hour) / time.Second)); !ok || got != maxScriptTimeout {
+		t.Fatalf("effectiveScriptTimeout(2h) = (%s, %t), want (%s, true)", got, ok, maxScriptTimeout)
 	}
-	if got := effectiveScriptTimeout(90); got != 90*time.Second {
-		t.Fatalf("effectiveScriptTimeout(90) = %s, want %s", got, 90*time.Second)
+	if got, ok := effectiveScriptTimeout(90); !ok || got != 90*time.Second {
+		t.Fatalf("effectiveScriptTimeout(90) = (%s, %t), want (%s, true)", got, ok, 90*time.Second)
 	}
 }
 
@@ -25,5 +25,15 @@ func TestRunCustomScriptRejectsUnsupportedInterpreter(t *testing.T) {
 	}
 	if !strings.Contains(result.Error, "not permitted") {
 		t.Fatalf("unexpected error: %q", result.Error)
+	}
+}
+
+func TestRunCustomScriptWithoutTimeoutKeepsInheritedDeadline(t *testing.T) {
+	result := RunCustomScript(t.Context(), `{"script":"echo hi","interpreter":"sh"}`, func(string) {})
+	if result.Error != "" {
+		t.Fatalf("unexpected error: %q", result.Error)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("unexpected exit code: %d", result.ExitCode)
 	}
 }


### PR DESCRIPTION
## Summary
- restore the pre-#604 behavior when `custom_script` omits `timeout_seconds`
- keep the new interpreter allowlist and explicit timeout cap for opted-in limits
- cover the blank-timeout path with a regression test

## Evidence
Commit `5580168a84d788392cc6baf3faa0a8bdeb9bac4e` changed `RunCustomScript` to always wrap the task context with `defaultScriptTimeout = 10 * time.Minute`, while the web actions still omit `timeout_seconds` by default in `apps/web/lib/actions/task-runs.ts` and existing task configs rely on that omission. Before #604, `agent/internal/tasks/script.go` only applied `context.WithTimeout` when `timeout_seconds > 0`.

## Testing
- `go test ./agent/internal/tasks/...`
- `git diff --check`
