### PR TITLE
test(web): add auth and settings e2e coverage

### DIFF
--- a/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
+++ b/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '../fixtures/test'
+
+test('authenticated user visiting login is redirected to the dashboard', async ({ authenticatedPage: page }) => {
+  await page.goto('/login')
+
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+})

--- a/apps/web/tests/e2e/fixtures/auth.ts
+++ b/apps/web/tests/e2e/fixtures/auth.ts
@@ -9,16 +9,8 @@ export const STORAGE_STATE_PATH = path.resolve(
   'user.json',
 )
 
-let cachedPromise: Promise<string> | null = null
-
 export async function getStorageStatePath(baseURL: string): Promise<string> {
-  if (!cachedPromise) {
-    cachedPromise = signInAndCacheStorageState(baseURL).catch((err) => {
-      cachedPromise = null
-      throw err
-    })
-  }
-  return cachedPromise
+  return signInAndCacheStorageState(baseURL)
 }
 
 async function signInAndCacheStorageState(baseURL: string): Promise<string> {

--- a/apps/web/tests/e2e/fixtures/test.ts
+++ b/apps/web/tests/e2e/fixtures/test.ts
@@ -1,6 +1,7 @@
 import { test as base, expect, type Page } from '@playwright/test'
 import { truncateAppTables } from './db'
 import { getStorageStatePath } from './auth'
+import { seedOrgAndUser } from './seed'
 
 type Fixtures = {
   autoTruncate: void
@@ -16,8 +17,9 @@ export const test = base.extend<Fixtures>({
     { auto: true },
   ],
 
-  authenticatedPage: async ({ browser, baseURL }, use) => {
+  authenticatedPage: async ({ browser, baseURL, request }, use) => {
     if (!baseURL) throw new Error('baseURL must be configured')
+    await seedOrgAndUser(request)
     const storageState = await getStorageStatePath(baseURL)
     const context = await browser.newContext({ storageState })
     const page = await context.newPage()

--- a/apps/web/tests/e2e/settings/activation-token.spec.ts
+++ b/apps/web/tests/e2e/settings/activation-token.spec.ts
@@ -10,4 +10,8 @@ test('admin can generate an activation token from settings', async ({ authentica
   await expect(activationToken).toBeVisible()
   await expect(activationToken).not.toBeEmpty()
   await expect(page.getByTestId('activation-token-generate')).toHaveText('Generate a new token')
+
+  const firstToken = await activationToken.textContent()
+  await page.getByTestId('activation-token-generate').click()
+  await expect(activationToken).not.toHaveText(firstToken ?? '')
 })


### PR DESCRIPTION
## Summary
- add E2E coverage for authenticated users being redirected away from `/login`
- expand the activation token settings test to verify regeneration replaces the token
- fix the authenticated Playwright fixture to reseed/sign in per test instead of reusing truncated sessions

## Testing
- `pnpm exec node tests/e2e/runner.mjs tests/e2e/auth/authenticated-redirects.spec.ts tests/e2e/settings/activation-token.spec.ts`

## Notes
- Filed [#609](https://github.com/carrtech-dev/ct-ops/issues/609) for the separate organisation-name settings regression found while expanding coverage.
