### PR TITLE
fix(auth): require BETTER_AUTH env configuration

### DIFF
--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -6,6 +6,7 @@ import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
 import { randomBytes } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
+import { getBetterAuthSecret } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
 
 // Produce a signed cookie value in exactly the format Hono's serializeSigned uses:
@@ -187,7 +188,7 @@ export async function POST(request: NextRequest) {
         userAgent: request.headers.get('user-agent') ?? null,
       })
 
-      const authSecret = process.env['BETTER_AUTH_SECRET'] ?? ''
+      const authSecret = getBetterAuthSecret()
       const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
 
       const response = NextResponse.json({

--- a/apps/web/app/verify-email/page.tsx
+++ b/apps/web/app/verify-email/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import { getBetterAuthUrl } from '@/lib/auth/env'
 
 type VerifyEmailPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>
@@ -18,7 +19,7 @@ export default async function VerifyEmailPage({ searchParams }: VerifyEmailPageP
     redirect('/login?error=missing_verification_token')
   }
 
-  const target = new URL('/api/auth/verify-email', process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000')
+  const target = new URL('/api/auth/verify-email', getBetterAuthUrl())
   target.searchParams.set('token', token)
   target.searchParams.set('callbackURL', callbackURL)
   redirect(target.toString())

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,3 +1,5 @@
+import { assertProductionAuthEnv } from '@/lib/auth/env'
+
 /**
  * Next.js instrumentation hook — runs once when the server starts.
  *
@@ -19,19 +21,7 @@ export async function register() {
   // Better Auth accepts an empty secret and falls back silently, which would
   // allow session cookies to be signed with an empty key.
   if (process.env.NODE_ENV === 'production') {
-    const secret = process.env.BETTER_AUTH_SECRET
-    if (!secret || secret.length < 32) {
-      throw new Error(
-        'BETTER_AUTH_SECRET must be set to a random string of at least 32 characters in production. ' +
-          'Generate one with: openssl rand -base64 32',
-      )
-    }
-    if (!process.env.BETTER_AUTH_URL || process.env.BETTER_AUTH_URL === 'http://localhost:3000') {
-      throw new Error(
-        'BETTER_AUTH_URL must be set to the public URL of this deployment in production ' +
-          '(e.g. https://ct-ops.corp.example.com).',
-      )
-    }
+    assertProductionAuthEnv()
     if (!process.env.LDAP_ENCRYPTION_KEY) {
       // Not a hard failure — LDAP may not be used — but warn loudly so operators know
       // to set this before configuring LDAP. Without it, BETTER_AUTH_SECRET is used as

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -6,6 +6,7 @@ import { users, organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { headers, cookies } from 'next/headers'
 import type { OrgMetadata } from '@/lib/db/schema/organisations'
+import { getBetterAuthOrigin } from '@/lib/auth/env'
 
 const updateNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -146,7 +147,7 @@ export async function updatePassword(
   try {
     const reqHeaders = await headers()
     const cookie = reqHeaders.get('cookie') ?? ''
-    const baseUrl = process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000'
+    const baseUrl = getBetterAuthOrigin()
 
     const response = await fetch(`${baseUrl}/api/auth/change-password`, {
       method: 'POST',

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/db'
 import { users, invitations } from '@/lib/db/schema'
 import { eq, and, isNull, isNotNull, gt } from 'drizzle-orm'
 import type { User, Invitation } from '@/lib/db/schema'
+import { getBetterAuthOrigin } from '@/lib/auth/env'
 import { getRequiredSession, type RequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
 
@@ -135,7 +136,7 @@ export async function inviteUser(
 
     if (!invite) return { error: 'Failed to create invitation' }
 
-    const baseUrl = process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000'
+    const baseUrl = getBetterAuthOrigin()
     return { inviteLink: `${baseUrl}/register?invite=${invite.token}` }
   } catch (err) {
     console.error('Failed to invite user:', err)

--- a/apps/web/lib/auth/env.js
+++ b/apps/web/lib/auth/env.js
@@ -1,0 +1,1 @@
+export * from './env.ts'

--- a/apps/web/lib/auth/env.js
+++ b/apps/web/lib/auth/env.js
@@ -1,1 +1,0 @@
-export * from './env.ts'

--- a/apps/web/lib/auth/env.test.mjs
+++ b/apps/web/lib/auth/env.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  assertProductionAuthEnv,
+  getBetterAuthOrigin,
+  getBetterAuthSecret,
+  getBetterAuthUrl,
+} from './env.ts'
+
+test('getBetterAuthSecret rejects missing values', () => {
+  assert.throws(() => getBetterAuthSecret({}), /BETTER_AUTH_SECRET must be set/)
+})
+
+test('getBetterAuthUrl rejects missing or invalid values', () => {
+  assert.throws(() => getBetterAuthUrl({}), /BETTER_AUTH_URL must be set/)
+  assert.throws(
+    () => getBetterAuthUrl({ BETTER_AUTH_URL: 'not-a-url' }),
+    /BETTER_AUTH_URL must be a valid absolute URL/,
+  )
+})
+
+test('getBetterAuthOrigin normalises BETTER_AUTH_URL to an origin', () => {
+  assert.equal(
+    getBetterAuthOrigin({ BETTER_AUTH_URL: 'https://ct-ops.example.com/login?next=%2Fdashboard' }),
+    'https://ct-ops.example.com',
+  )
+})
+
+test('assertProductionAuthEnv rejects short secrets and localhost URLs', () => {
+  assert.throws(
+    () =>
+      assertProductionAuthEnv({
+        BETTER_AUTH_SECRET: 'too-short',
+        BETTER_AUTH_URL: 'https://ct-ops.example.com',
+      }),
+    /BETTER_AUTH_SECRET must be set to a random string of at least 32 characters in production/,
+  )
+
+  assert.throws(
+    () =>
+      assertProductionAuthEnv({
+        BETTER_AUTH_SECRET: '01234567890123456789012345678901',
+        BETTER_AUTH_URL: 'http://localhost:3000',
+      }),
+    /BETTER_AUTH_URL must be set to the public URL of this deployment in production/,
+  )
+})

--- a/apps/web/lib/auth/env.ts
+++ b/apps/web/lib/auth/env.ts
@@ -1,0 +1,45 @@
+type EnvLike = Record<string, string | undefined>
+
+function readRequiredEnv(env: EnvLike, name: 'BETTER_AUTH_SECRET' | 'BETTER_AUTH_URL'): string {
+  const value = env[name]?.trim()
+  if (!value) {
+    throw new Error(`${name} must be set`)
+  }
+  return value
+}
+
+export function getBetterAuthSecret(env: EnvLike = process.env): string {
+  return readRequiredEnv(env, 'BETTER_AUTH_SECRET')
+}
+
+export function getBetterAuthUrl(env: EnvLike = process.env): string {
+  const value = readRequiredEnv(env, 'BETTER_AUTH_URL')
+
+  try {
+    return new URL(value).toString()
+  } catch {
+    throw new Error('BETTER_AUTH_URL must be a valid absolute URL')
+  }
+}
+
+export function getBetterAuthOrigin(env: EnvLike = process.env): string {
+  return new URL(getBetterAuthUrl(env)).origin
+}
+
+export function assertProductionAuthEnv(env: EnvLike = process.env): void {
+  const secret = getBetterAuthSecret(env)
+  if (secret.length < 32) {
+    throw new Error(
+      'BETTER_AUTH_SECRET must be set to a random string of at least 32 characters in production. ' +
+        'Generate one with: openssl rand -base64 32',
+    )
+  }
+
+  const url = new URL(getBetterAuthUrl(env))
+  if (url.origin === 'http://localhost:3000' || url.hostname === 'localhost' || url.hostname === '127.0.0.1') {
+    throw new Error(
+      'BETTER_AUTH_URL must be set to the public URL of this deployment in production ' +
+        '(e.g. https://ct-ops.corp.example.com).',
+    )
+  }
+}

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -5,6 +5,7 @@ import { twoFactor } from 'better-auth/plugins'
 import { db } from '@/lib/db'
 import * as schema from '@/lib/db/schema'
 import { sendVerificationEmail } from './email'
+import { getBetterAuthOrigin, getBetterAuthSecret, getBetterAuthUrl } from './env'
 import { passwordLoginAttemptGuard } from './login-attempts'
 
 const LOGIN_THROTTLED_MESSAGE = 'Too many login attempts — please wait before trying again.'
@@ -70,15 +71,15 @@ export const auth = betterAuth({
   },
   trustedOrigins: Array.from(
     new Set([
-      process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000',
+      getBetterAuthOrigin(),
       ...(process.env['BETTER_AUTH_TRUSTED_ORIGINS']
         ?.split(',')
         .map((o) => o.trim())
         .filter(Boolean) ?? []),
     ]),
   ),
-  secret: process.env['BETTER_AUTH_SECRET'] ?? '',
-  baseURL: process.env['BETTER_AUTH_URL'] ?? 'http://localhost:3000',
+  secret: getBetterAuthSecret(),
+  baseURL: getBetterAuthUrl(),
 })
 
 export type Auth = typeof auth

--- a/apps/web/lib/security/trusted-origins.test.mjs
+++ b/apps/web/lib/security/trusted-origins.test.mjs
@@ -21,6 +21,10 @@ test('getTrustedOrigins normalises BETTER_AUTH_URL and additional origins', () =
   ])
 })
 
+test('getTrustedOrigins rejects missing BETTER_AUTH_URL instead of silently using localhost', () => {
+  assert.throws(() => getTrustedOrigins({}), /BETTER_AUTH_URL must be set/)
+})
+
 test('getTrustedOriginHosts keeps the host:port values expected by Next serverActions.allowedOrigins', () => {
   const env = {
     BETTER_AUTH_URL: 'https://ct-ops.example.com',

--- a/apps/web/lib/security/trusted-origins.ts
+++ b/apps/web/lib/security/trusted-origins.ts
@@ -1,4 +1,4 @@
-const DEFAULT_AUTH_URL = 'http://localhost:3000'
+import { getBetterAuthUrl } from '../auth/env.ts'
 
 type EnvLike = Record<string, string | undefined>
 
@@ -12,7 +12,7 @@ function normaliseOrigin(value: string): string | null {
 
 export function getTrustedOrigins(env: EnvLike = process.env): string[] {
   const configured = [
-    env['BETTER_AUTH_URL'] ?? DEFAULT_AUTH_URL,
+    getBetterAuthUrl(env),
     ...(env['BETTER_AUTH_TRUSTED_ORIGINS']
       ?.split(',')
       .map((value) => value.trim())

--- a/apps/web/lib/security/trusted-origins.ts
+++ b/apps/web/lib/security/trusted-origins.ts
@@ -1,4 +1,4 @@
-import { getBetterAuthUrl } from '../auth/env.ts'
+import { getBetterAuthUrl } from '../auth/env.js'
 
 type EnvLike = Record<string, string | undefined>
 

--- a/apps/web/lib/security/trusted-origins.ts
+++ b/apps/web/lib/security/trusted-origins.ts
@@ -1,5 +1,3 @@
-import { getBetterAuthUrl } from '../auth/env.js'
-
 type EnvLike = Record<string, string | undefined>
 
 function normaliseOrigin(value: string): string | null {
@@ -10,9 +8,22 @@ function normaliseOrigin(value: string): string | null {
   }
 }
 
+function getConfiguredAuthUrl(env: EnvLike): string {
+  const value = env['BETTER_AUTH_URL']?.trim()
+  if (!value) {
+    throw new Error('BETTER_AUTH_URL must be set')
+  }
+
+  try {
+    return new URL(value).toString()
+  } catch {
+    throw new Error('BETTER_AUTH_URL must be a valid absolute URL')
+  }
+}
+
 export function getTrustedOrigins(env: EnvLike = process.env): string[] {
   const configured = [
-    getBetterAuthUrl(env),
+    getConfiguredAuthUrl(env),
     ...(env['BETTER_AUTH_TRUSTED_ORIGINS']
       ?.split(',')
       .map((value) => value.trim())


### PR DESCRIPTION
## Summary
- remove silent BETTER_AUTH_SECRET and BETTER_AUTH_URL fallbacks from auth/session entry points
- add a shared auth env helper so startup-critical paths require explicit BETTER_AUTH configuration
- cover the new validation with focused unit tests and make trusted origin parsing fail fast instead of defaulting to localhost

## Testing
- `node --experimental-strip-types --test lib/auth/env.test.mjs`
- `node --experimental-strip-types --test lib/security/trusted-origins.test.mjs`
- `pnpm --filter web test:unit` *(blocked in this worktree: missing installed dependencies; unrelated existing `node-forge` resolution failure also surfaced in `lib/certificates/fetch.test.mjs`)*
- `pnpm --filter web type-check` *(blocked in this worktree: dependencies not installed, `tsc` unavailable)*

Closes #312