### PR TITLE
fix(agent): validate config file ownership and mode

### DIFF
--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/BurntSushi/toml"
 )
@@ -40,6 +41,9 @@ func Load(path string) (*Config, error) {
 	cfg := defaults()
 
 	if _, err := os.Stat(path); err == nil {
+		if err := validateFileSecurity(path); err != nil {
+			return nil, err
+		}
 		if _, err := toml.DecodeFile(path, cfg); err != nil {
 			return nil, fmt.Errorf("parsing config %s: %w", path, err)
 		}
@@ -47,6 +51,33 @@ func Load(path string) (*Config, error) {
 
 	applyEnv(cfg)
 	return cfg, nil
+}
+
+func validateFileSecurity(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat config %s: %w", path, err)
+	}
+
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("config %s must not grant group/other access (mode %04o)", path, info.Mode().Perm())
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+
+	euid := uint32(os.Geteuid())
+	if stat.Uid != euid {
+		expectedOwner := "root"
+		if euid != 0 {
+			expectedOwner = fmt.Sprintf("uid %d", euid)
+		}
+		return fmt.Errorf("config %s must be owned by %s (found uid %d)", path, expectedOwner, stat.Uid)
+	}
+
+	return nil
 }
 
 func defaults() *Config {

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/BurntSushi/toml"
 )
@@ -63,18 +62,8 @@ func validateFileSecurity(path string) error {
 		return fmt.Errorf("config %s must not grant group/other access (mode %04o)", path, info.Mode().Perm())
 	}
 
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return nil
-	}
-
-	euid := uint32(os.Geteuid())
-	if stat.Uid != euid {
-		expectedOwner := "root"
-		if euid != 0 {
-			expectedOwner = fmt.Sprintf("uid %d", euid)
-		}
-		return fmt.Errorf("config %s must be owned by %s (found uid %d)", path, expectedOwner, stat.Uid)
+	if err := validateConfigOwner(path, info); err != nil {
+		return err
 	}
 
 	return nil

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRejectsGroupReadableConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte("[agent]\norg_token = \"secret\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected insecure permissions to fail")
+	}
+	if !strings.Contains(err.Error(), "must not grant group/other access") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadReadsSecureConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte("[ingest]\naddress = \"ingest.example:9443\"\n\n[agent]\norg_token = \"secret\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Ingest.Address != "ingest.example:9443" {
+		t.Fatalf("unexpected ingest address: %q", cfg.Ingest.Address)
+	}
+	if cfg.Agent.OrgToken != "secret" {
+		t.Fatalf("unexpected org token: %q", cfg.Agent.OrgToken)
+	}
+}

--- a/agent/internal/config/config_unix.go
+++ b/agent/internal/config/config_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func validateConfigOwner(path string, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+
+	euid := uint32(os.Geteuid())
+	if stat.Uid == euid {
+		return nil
+	}
+
+	expectedOwner := "root"
+	if euid != 0 {
+		expectedOwner = fmt.Sprintf("uid %d", euid)
+	}
+
+	return fmt.Errorf("config %s must be owned by %s (found uid %d)", path, expectedOwner, stat.Uid)
+}

--- a/agent/internal/config/config_windows.go
+++ b/agent/internal/config/config_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package config
+
+import "os"
+
+func validateConfigOwner(_ string, _ os.FileInfo) error {
+	return nil
+}

--- a/agent/internal/install/install.go
+++ b/agent/internal/install/install.go
@@ -36,20 +36,23 @@ func Run(orgToken, ingestAddress string, tlsSkipVerify bool, tags []string) erro
 // any explicitly provided flag values on top. This preserves fields like
 // ca_cert_file and tls_skip_verify across reinstalls.
 // orgToken is always applied. ingestAddress and tlsSkipVerify are only applied if non-zero.
-func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string, tlsSkipVerify bool, tags []string) *agentconfig.Config {
-	cfg, err := agentconfig.Load(cfgPath)
-	if err != nil {
-		// File missing or unparseable — start from scratch with caller-supplied defaults.
-		cfg = &agentconfig.Config{
-			Ingest: agentconfig.IngestConfig{
-				Address: "localhost:9443",
-			},
-			Agent: agentconfig.AgentConfig{
-				DataDir:               defaultDataDir,
-				HeartbeatIntervalSecs: 30,
-			},
+func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string, tlsSkipVerify bool, tags []string) (*agentconfig.Config, error) {
+	cfg := &agentconfig.Config{
+		Ingest: agentconfig.IngestConfig{
+			Address: "localhost:9443",
+		},
+		Agent: agentconfig.AgentConfig{
+			DataDir:               defaultDataDir,
+			HeartbeatIntervalSecs: 30,
+		},
+	}
+
+	if _, err := os.Stat(cfgPath); err == nil {
+		loaded, err := agentconfig.Load(cfgPath)
+		if err != nil {
+			return nil, err
 		}
-	} else {
+		cfg = loaded
 		slog.Info("existing config found, preserving settings", "path", cfgPath)
 		backupConfig(cfgPath)
 	}
@@ -65,7 +68,7 @@ func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string, tlsSki
 		cfg.Agent.Tags = tags
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 // backupConfig copies cfgPath to cfgPath.<timestamp>.bak so the user can recover it.
@@ -103,7 +106,10 @@ func installLinux(orgToken, ingestAddress string, tlsSkipVerify bool, tags []str
 	if err := mkdirs("/etc/ct-ops", dataDir); err != nil {
 		return fmt.Errorf("creating directories: %w", err)
 	}
-	cfg := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	cfg, err := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	if err != nil {
+		return fmt.Errorf("loading existing config: %w", err)
+	}
 	if err := writeConfig(cfgPath, cfg); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
@@ -161,7 +167,10 @@ func installDarwin(orgToken, ingestAddress string, tlsSkipVerify bool, tags []st
 	if err := mkdirs("/etc/ct-ops", dataDir, "/var/log"); err != nil {
 		return fmt.Errorf("creating directories: %w", err)
 	}
-	cfg := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	cfg, err := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	if err != nil {
+		return fmt.Errorf("loading existing config: %w", err)
+	}
 	if err := writeConfig(cfgPath, cfg); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
@@ -235,7 +244,10 @@ func installWindows(orgToken, ingestAddress string, tlsSkipVerify bool, tags []s
 	if err := copyBinary(dest); err != nil {
 		return fmt.Errorf("copying binary: %w", err)
 	}
-	cfg := mergeConfig(cfgFile, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	cfg, err := mergeConfig(cfgFile, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	if err != nil {
+		return fmt.Errorf("loading existing config: %w", err)
+	}
 	if err := writeConfig(cfgFile, cfg); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}


### PR DESCRIPTION
## Summary
- validate agent config file mode before parsing and refuse group/other-readable configs
- require Unix config ownership to match the effective user, which enforces root-owned configs for the installed service while preserving non-root dev runs
- stop reinstall flows from silently overwriting an existing insecure config, and add focused loader tests

## Testing
- go test ./internal/config
- go test ./internal/install ./cmd/agent
- go test ./...

Fixes #319
