### PR TITLE
fix(security): validate JSONB metadata at runtime

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -56,6 +56,7 @@ import type { HostWithAgent, MetricsPreset, MetricsQuery, HeartbeatPoint } from 
 import { useHostStream } from '@/hooks/use-host-stream'
 import { useChartZoom } from '@/hooks/use-chart-zoom'
 import type { DiskInfo, NetworkInterface } from '@/lib/db/schema'
+import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { ChecksTab } from './checks-tab'
 import { AlertsTab } from './alerts-tab'
 import { HostNotificationCharts } from './host-notification-charts'
@@ -436,8 +437,9 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
 
   if (!host) return null
 
-  const disks: DiskInfo[] = host.metadata?.disks ?? []
-  const networkInterfaces: NetworkInterface[] = host.metadata?.network_interfaces ?? []
+  const hostMetadata = parseHostMetadata(host.metadata)
+  const disks: DiskInfo[] = hostMetadata.disks
+  const networkInterfaces: NetworkInterface[] = hostMetadata.network_interfaces
 
   const cpuColor =
     (host.cpuPercent ?? 0) > 90

--- a/apps/web/app/api/agent/bundle/route.ts
+++ b/apps/web/app/api/agent/bundle/route.ts
@@ -4,7 +4,7 @@ import { and, eq, isNull } from 'drizzle-orm'
 import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema/auth'
-import { agentEnrolmentTokens } from '@/lib/db/schema/agents'
+import { agentEnrolmentTokens, parseAgentEnrolmentTokenMetadata } from '@/lib/db/schema/agents'
 import {
   SUPPORTED_OS,
   SUPPORTED_ARCH,
@@ -134,7 +134,7 @@ export async function POST(request: NextRequest) {
     if (parsed.data.skipVerify === undefined) {
       effectiveSkipVerify = existing.skipVerify
     }
-    const tokenMetaTags = existing.metadata?.tags ?? []
+    const tokenMetaTags = parseAgentEnrolmentTokenMetadata(existing.metadata).tags ?? []
     if (bundleTags.length === 0 && tokenMetaTags.length > 0) {
       bundleTags = [...tokenMetaTags]
     }

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -42,6 +42,7 @@ import { triggerAgentUninstall, getTaskRun } from '@/lib/actions/task-runs'
 import { assignTagsToResource, getOrgDefaultTags, mergeTagLayers } from '@/lib/actions/tags'
 import { runMatchingTagRules } from '@/lib/actions/tag-rules'
 import type { HostMetadata, TagPair } from '@/lib/db/schema'
+import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getRequiredSession } from '@/lib/auth/session'
 import {
@@ -149,7 +150,7 @@ export async function approveAgent(
       // the (token → CLI) merge on the ingest side; here we layer org defaults
       // underneath (weakest), then run any saved tag_rules last.
       const defaults = await getOrgDefaultCollectionSettings(orgId)
-      const currentMetadata = (host.metadata ?? { disks: [], network_interfaces: [] }) as HostMetadata
+      const currentMetadata = parseHostMetadata(host.metadata)
       const pendingTags: TagPair[] = currentMetadata.pendingTags ?? []
       const orgDefaultTags = await getOrgDefaultTags(orgId)
       const finalTags = await mergeTagLayers(orgDefaultTags, pendingTags)

--- a/apps/web/lib/actions/host-settings.ts
+++ b/apps/web/lib/actions/host-settings.ts
@@ -5,9 +5,10 @@ import { requireOrgAccess } from '@/lib/actions/action-auth'
 import { db } from '@/lib/db'
 import { hosts, organisations, checks } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
-import type { HostCollectionSettings, HostMetadata } from '@/lib/db/schema'
-import type { OrgMetadata } from '@/lib/db/schema'
+import type { HostCollectionSettings } from '@/lib/db/schema'
 import { DEFAULT_COLLECTION_SETTINGS } from '@/lib/db/schema'
+import { parseHostMetadata } from '@/lib/db/schema/hosts'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 import { createCheck, updateCheck } from '@/lib/actions/checks'
 
 export async function getHostCollectionSettings(
@@ -20,8 +21,9 @@ export async function getHostCollectionSettings(
     columns: { metadata: true },
   })
 
-  if (host?.metadata?.collectionSettings) {
-    return host.metadata.collectionSettings
+  const metadata = parseHostMetadata(host?.metadata)
+  if (metadata.collectionSettings) {
+    return metadata.collectionSettings
   }
 
   // Fall back to org defaults
@@ -41,8 +43,8 @@ export async function updateHostCollectionSettings(
     })
     if (!host) return { error: 'Host not found' }
 
-    const currentMetadata = (host.metadata ?? { disks: [], network_interfaces: [] }) as HostMetadata
-    const updatedMetadata: HostMetadata = {
+    const currentMetadata = parseHostMetadata(host.metadata)
+    const updatedMetadata = {
       ...currentMetadata,
       collectionSettings: settings,
     }
@@ -71,7 +73,7 @@ export async function getOrgDefaultCollectionSettings(
     columns: { metadata: true },
   })
 
-  const meta = org?.metadata as OrgMetadata | null
+  const meta = parseOrgMetadata(org?.metadata)
   if (meta?.defaultCollectionSettings) {
     return meta.defaultCollectionSettings
   }
@@ -91,8 +93,8 @@ export async function updateOrgDefaultCollectionSettings(
     })
     if (!org) return { error: 'Organisation not found' }
 
-    const currentMetadata = (org.metadata ?? {}) as OrgMetadata
-    const updatedMetadata: OrgMetadata = {
+    const currentMetadata = parseOrgMetadata(org.metadata)
+    const updatedMetadata = {
       ...currentMetadata,
       defaultCollectionSettings: settings,
     }

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -6,7 +6,8 @@ import { z } from 'zod'
 import { db } from '@/lib/db'
 import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
-import type { OrgMetadata, OrgNotificationSettings } from '@/lib/db/schema/organisations'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
+import type { OrgNotificationSettings } from '@/lib/db/schema/organisations'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES, DEFAULT_NOTIFICATION_ROLES } from '@/lib/auth/roles'
 
@@ -32,7 +33,7 @@ export async function getOrgNotificationSettings(
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
   })
-  const meta = (org?.metadata ?? {}) as OrgMetadata
+  const meta = parseOrgMetadata(org?.metadata)
   const ns = meta.notificationSettings ?? {}
   return {
     inAppEnabled: ns.inAppEnabled !== false,
@@ -69,8 +70,8 @@ export async function updateOrgNotificationSettings(
   })
   if (!org) return { error: 'Organisation not found' }
 
-  const currentMetadata = (org.metadata ?? {}) as OrgMetadata
-  const updatedMetadata: OrgMetadata = {
+  const currentMetadata = parseOrgMetadata(org.metadata)
+  const updatedMetadata = {
     ...currentMetadata,
     notificationSettings: {
       inAppEnabled,

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -5,8 +5,8 @@ import { db } from '@/lib/db'
 import { users, organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { headers, cookies } from 'next/headers'
-import type { OrgMetadata } from '@/lib/db/schema/organisations'
 import { getBetterAuthOrigin } from '@/lib/auth/env'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 
 const updateNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -112,7 +112,7 @@ export async function updateNotificationPreference(
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
   })
-  const meta = (org?.metadata ?? {}) as OrgMetadata
+  const meta = parseOrgMetadata(org?.metadata)
   const allowOptOut = meta.notificationSettings?.allowUserOptOut !== false
 
   if (!allowOptOut && !enabled) {

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -28,6 +28,7 @@ import { escapeLikePattern } from '@/lib/utils'
 import { compareVersions } from '@/lib/version-compare'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { createRateLimiter } from '@/lib/rate-limit'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 
 const triggerScanLimiter = createRateLimiter(60_000, 5)
 const softwareReportLimiter = createRateLimiter(60_000, 10)
@@ -49,12 +50,11 @@ export async function getSoftwareInventorySettings(
     where: and(eq(organisations.id, orgId), isNull(organisations.deletedAt)),
     columns: { metadata: true },
   })
-  return (
-    org?.metadata?.softwareInventorySettings ?? {
-      enabled: false,
-      intervalHours: 24,
-    }
-  )
+  const metadata = parseOrgMetadata(org?.metadata)
+  return metadata.softwareInventorySettings ?? {
+    enabled: false,
+    intervalHours: 24,
+  }
 }
 
 export async function updateSoftwareInventorySettings(
@@ -77,7 +77,7 @@ export async function updateSoftwareInventorySettings(
       where: eq(organisations.id, orgId),
       columns: { metadata: true },
     })
-    const currentMetadata = org?.metadata ?? {}
+    const currentMetadata = parseOrgMetadata(org?.metadata)
     await db
       .update(organisations)
       .set({

--- a/apps/web/lib/actions/tags.ts
+++ b/apps/web/lib/actions/tags.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/db'
 import { tags, resourceTags, organisations } from '@/lib/db/schema'
 import type { Tag, TagPair, OrgMetadata } from '@/lib/db/schema'
 import { and, eq, sql, inArray, desc, asc } from 'drizzle-orm'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 
 export type TagAssignment = {
   resourceTagId: string
@@ -296,7 +297,7 @@ export async function getOrgDefaultTags(orgId: string): Promise<TagPair[]> {
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
   })
-  const meta = org?.metadata as OrgMetadata | null
+  const meta = parseOrgMetadata(org?.metadata)
   return meta?.defaultTags ?? []
 }
 
@@ -316,7 +317,7 @@ export async function updateOrgDefaultTags(
     })
     if (!org) return { error: 'Organisation not found' }
 
-    const currentMetadata = (org.metadata ?? {}) as OrgMetadata
+    const currentMetadata = parseOrgMetadata(org.metadata)
     const updatedMetadata: OrgMetadata = {
       ...currentMetadata,
       defaultTags: deduped,

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -8,7 +8,8 @@ import { eq, and, isNull } from 'drizzle-orm'
 import { createId } from '@paralleldrive/cuid2'
 import { createHash, randomBytes } from 'node:crypto'
 import { getRequiredSession } from '@/lib/auth/session'
-import type { OrgMetadata, HostMetadata } from '@/lib/db/schema'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
+import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 export interface TerminalAccessResult {
@@ -43,7 +44,7 @@ export async function checkTerminalAccess(
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
   })
-  const orgMeta = (org?.metadata ?? {}) as OrgMetadata
+  const orgMeta = parseOrgMetadata(org?.metadata)
   if (orgMeta.terminalEnabled === false) {
     return { allowed: false, reason: 'Terminal access is disabled for this organisation' }
   }
@@ -56,7 +57,7 @@ export async function checkTerminalAccess(
   if (!host) {
     return { allowed: false, reason: 'Host not found' }
   }
-  const hostMeta = (host.metadata ?? { disks: [], network_interfaces: [] }) as HostMetadata
+  const hostMeta = parseHostMetadata(host.metadata)
   if (hostMeta.terminalEnabled === false) {
     return { allowed: false, reason: 'Terminal access is disabled for this host' }
   }
@@ -164,7 +165,7 @@ export async function getOrgTerminalSettings(
     where: eq(organisations.id, orgId),
     columns: { metadata: true },
   })
-  const meta = (org?.metadata ?? {}) as OrgMetadata
+  const meta = parseOrgMetadata(org?.metadata)
   return {
     terminalEnabled: meta.terminalEnabled !== false,
     terminalLoggingEnabled: meta.terminalLoggingEnabled === true,
@@ -189,8 +190,8 @@ export async function updateOrgTerminalSettings(
     })
     if (!org) return { error: 'Organisation not found' }
 
-    const currentMetadata = (org.metadata ?? {}) as OrgMetadata
-    const updatedMetadata: OrgMetadata = {
+    const currentMetadata = parseOrgMetadata(org.metadata)
+    const updatedMetadata = {
       ...currentMetadata,
       terminalEnabled: settings.terminalEnabled,
       terminalLoggingEnabled: settings.terminalLoggingEnabled,
@@ -225,7 +226,7 @@ export async function getHostTerminalSettings(
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
     columns: { metadata: true },
   })
-  const meta = (host?.metadata ?? { disks: [], network_interfaces: [] }) as HostMetadata
+  const meta = parseHostMetadata(host?.metadata)
   return {
     terminalEnabled: meta.terminalEnabled !== false,
     terminalAllowedUsers: meta.terminalAllowedUsers ?? [],
@@ -250,8 +251,8 @@ export async function updateHostTerminalSettings(
     })
     if (!host) return { error: 'Host not found' }
 
-    const currentMetadata = (host.metadata ?? { disks: [], network_interfaces: [] }) as HostMetadata
-    const updatedMetadata: HostMetadata = {
+    const currentMetadata = parseHostMetadata(host.metadata)
+    const updatedMetadata = {
       ...currentMetadata,
       terminalEnabled: settings.terminalEnabled,
       terminalAllowedUsers: settings.terminalAllowedUsers,

--- a/apps/web/lib/db/schema/agents.ts
+++ b/apps/web/lib/db/schema/agents.ts
@@ -1,5 +1,6 @@
 import { pgTable, text, timestamp, jsonb, boolean, integer } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
+import { z } from 'zod'
 import { organisations } from './organisations'
 import { users } from './auth'
 
@@ -8,6 +9,26 @@ export interface AgentEnrolmentTokenMetadata {
   source?: string
   os?: string
   arch?: string
+}
+
+const tagPairSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+}).strip()
+
+export const agentEnrolmentTokenMetadataSchema = z.object({
+  tags: z.array(tagPairSchema).catch([]).optional(),
+  source: z.string().optional().catch(undefined),
+  os: z.string().optional().catch(undefined),
+  arch: z.string().optional().catch(undefined),
+}).strip()
+
+export function parseAgentEnrolmentTokenMetadata(input: unknown): AgentEnrolmentTokenMetadata {
+  const parsed = agentEnrolmentTokenMetadataSchema.safeParse(input)
+  if (!parsed.success) {
+    return {}
+  }
+  return parsed.data
 }
 
 export const agentEnrolmentTokens = pgTable('agent_enrolment_tokens', {

--- a/apps/web/lib/db/schema/hosts.ts
+++ b/apps/web/lib/db/schema/hosts.ts
@@ -1,5 +1,6 @@
 import { pgTable, text, timestamp, jsonb, integer, real } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
+import { z } from 'zod'
 import { organisations } from './organisations'
 import { agents } from './agents'
 
@@ -36,6 +37,63 @@ export const DEFAULT_COLLECTION_SETTINGS: HostCollectionSettings = {
   memory: true,
   disk: true,
   localUsers: false,
+}
+
+const diskInfoSchema = z.object({
+  mount_point: z.string(),
+  device: z.string(),
+  fs_type: z.string(),
+  total_bytes: z.number(),
+  used_bytes: z.number(),
+  free_bytes: z.number(),
+  percent_used: z.number(),
+}).strip()
+
+const networkInterfaceSchema = z.object({
+  name: z.string(),
+  ip_addresses: z.array(z.string()).catch([]),
+  mac_address: z.string(),
+  is_up: z.boolean(),
+}).strip()
+
+const tagPairSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+}).strip()
+
+export const hostCollectionSettingsSchema = z.object({
+  cpu: z.boolean().catch(DEFAULT_COLLECTION_SETTINGS.cpu),
+  memory: z.boolean().catch(DEFAULT_COLLECTION_SETTINGS.memory),
+  disk: z.boolean().catch(DEFAULT_COLLECTION_SETTINGS.disk),
+  localUsers: z.boolean().catch(DEFAULT_COLLECTION_SETTINGS.localUsers),
+  localUserConfig: z.object({
+    mode: z.enum(['all', 'selected']).catch('all'),
+    selectedUsernames: z.array(z.string()).catch([]).optional(),
+  }).strip().optional().catch(undefined),
+}).strip()
+
+export const hostMetadataSchema = z.object({
+  disks: z.array(diskInfoSchema).catch([]).default([]),
+  network_interfaces: z.array(networkInterfaceSchema).catch([]).default([]),
+  collectionSettings: hostCollectionSettingsSchema.optional().catch(undefined),
+  terminalEnabled: z.boolean().optional().catch(undefined),
+  terminalAllowedUsers: z.array(z.string()).catch([]).optional(),
+  sshHostKeySha256: z.string().optional().catch(undefined),
+  lastSoftwareScanAt: z.string().optional().catch(undefined),
+  pendingTags: z.array(tagPairSchema).catch([]).optional(),
+}).strip()
+
+const defaultHostMetadata: HostMetadata = {
+  disks: [],
+  network_interfaces: [],
+}
+
+export function parseHostMetadata(input: unknown): HostMetadata {
+  const parsed = hostMetadataSchema.safeParse(input)
+  if (!parsed.success) {
+    return { ...defaultHostMetadata }
+  }
+  return parsed.data
 }
 
 // Operational thresholds shared between host stats queries (server) and the

--- a/apps/web/lib/db/schema/metadata-validation.test.mjs
+++ b/apps/web/lib/db/schema/metadata-validation.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import hostsModule from './hosts.ts'
+import organisationsModule from './organisations.ts'
+
+const { parseHostMetadata } = hostsModule
+const { parseOrgMetadata } = organisationsModule
+
+test('parseHostMetadata strips unknown fields and falls back on malformed values', () => {
+  const parsed = parseHostMetadata({
+    disks: [
+      {
+        mount_point: '/',
+        device: '/dev/vda1',
+        fs_type: 'ext4',
+        total_bytes: 100,
+        used_bytes: 50,
+        free_bytes: 50,
+        percent_used: 50,
+        unexpected: 'drop-me',
+      },
+    ],
+    network_interfaces: 'not-an-array',
+    terminalAllowedUsers: [123, 'user-2'],
+    collectionSettings: {
+      cpu: 'yes',
+      memory: false,
+      disk: true,
+      localUsers: true,
+      localUserConfig: {
+        mode: 'selected',
+        selectedUsernames: ['alice'],
+        extra: true,
+      },
+    },
+    injected: { admin: true },
+  })
+
+  assert.deepEqual(parsed.disks, [{
+    mount_point: '/',
+    device: '/dev/vda1',
+    fs_type: 'ext4',
+    total_bytes: 100,
+    used_bytes: 50,
+    free_bytes: 50,
+    percent_used: 50,
+  }])
+  assert.deepEqual(parsed.network_interfaces, [])
+  assert.deepEqual(parsed.terminalAllowedUsers, [])
+  assert.deepEqual(parsed.collectionSettings, {
+    cpu: true,
+    memory: false,
+    disk: true,
+    localUsers: true,
+    localUserConfig: {
+      mode: 'selected',
+      selectedUsernames: ['alice'],
+    },
+  })
+  assert.equal('injected' in parsed, false)
+})
+
+test('parseOrgMetadata preserves valid settings and drops malformed nested metadata', () => {
+  const parsed = parseOrgMetadata({
+    defaultTags: [
+      { key: 'env', value: 'prod', extra: 'drop-me' },
+      { key: 42, value: 'bad' },
+    ],
+    notificationSettings: {
+      inAppEnabled: true,
+      inAppRoles: 'super_admin',
+      allowUserOptOut: false,
+    },
+    softwareInventorySettings: {
+      enabled: true,
+      intervalHours: 24,
+      includeSnapFlatpak: 'yes',
+    },
+  })
+
+  assert.deepEqual(parsed.defaultTags, [])
+  assert.deepEqual(parsed.notificationSettings, {
+    inAppEnabled: true,
+    inAppRoles: ['super_admin', 'org_admin', 'engineer'],
+    allowUserOptOut: false,
+  })
+  assert.deepEqual(parsed.softwareInventorySettings, {
+    enabled: true,
+    intervalHours: 24,
+    includeSnapFlatpak: undefined,
+  })
+})

--- a/apps/web/lib/db/schema/organisations.ts
+++ b/apps/web/lib/db/schema/organisations.ts
@@ -1,5 +1,7 @@
 import { pgTable, text, timestamp, jsonb, integer } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
+import { z } from 'zod'
+import { DEFAULT_NOTIFICATION_ROLES } from '../../auth/roles'
 import type { HostCollectionSettings } from './hosts'
 
 export interface OrgNotificationSettings {
@@ -23,6 +25,53 @@ export interface OrgMetadata {
   terminalDirectAccess?: boolean
   notificationSettings?: OrgNotificationSettings
   softwareInventorySettings?: SoftwareInventorySettings
+}
+
+const tagPairSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+}).strip()
+
+const hostCollectionSettingsSchema = z.object({
+  cpu: z.boolean().catch(true),
+  memory: z.boolean().catch(true),
+  disk: z.boolean().catch(true),
+  localUsers: z.boolean().catch(false),
+  localUserConfig: z.object({
+    mode: z.enum(['all', 'selected']).catch('all'),
+    selectedUsernames: z.array(z.string()).catch([]).optional(),
+  }).strip().optional().catch(undefined),
+}).strip()
+
+const orgNotificationSettingsSchema = z.object({
+  inAppEnabled: z.boolean().optional().catch(undefined),
+  inAppRoles: z.array(z.string()).catch([...DEFAULT_NOTIFICATION_ROLES]).optional(),
+  allowUserOptOut: z.boolean().optional().catch(undefined),
+}).strip()
+
+const softwareInventorySettingsSchema = z.object({
+  enabled: z.boolean(),
+  intervalHours: z.number().int(),
+  includeSnapFlatpak: z.boolean().optional().catch(undefined),
+  includeWindowsStore: z.boolean().optional().catch(undefined),
+}).strip()
+
+export const orgMetadataSchema = z.object({
+  defaultCollectionSettings: hostCollectionSettingsSchema.optional().catch(undefined),
+  defaultTags: z.array(tagPairSchema).catch([]).optional(),
+  terminalEnabled: z.boolean().optional().catch(undefined),
+  terminalLoggingEnabled: z.boolean().optional().catch(undefined),
+  terminalDirectAccess: z.boolean().optional().catch(undefined),
+  notificationSettings: orgNotificationSettingsSchema.optional().catch(undefined),
+  softwareInventorySettings: softwareInventorySettingsSchema.optional().catch(undefined),
+}).strip()
+
+export function parseOrgMetadata(input: unknown): OrgMetadata {
+  const parsed = orgMetadataSchema.safeParse(input)
+  if (!parsed.success) {
+    return {}
+  }
+  return parsed.data
 }
 
 export const organisations = pgTable('organisations', {


### PR DESCRIPTION
## Summary
- add shared Zod parsers for host, organisation, and enrolment-token JSONB metadata
- validate/sanitise metadata at existing read and write boundaries instead of trusting type casts
- cover malformed metadata fallback behaviour with targeted parser tests

## Testing
- `pnpm dlx tsx --test /Volumes/MacBookStorage-Dev/dev/carrtech/.worktrees/ct-ops-issue-323/apps/web/lib/db/schema/metadata-validation.test.mjs`
- `pnpm --dir apps/web exec tsc --noEmit`

Closes #323.
