### PR TITLE
fix(web): validate signed licence revocation bundles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ AGENT_DOWNLOAD_BASE_URL=https://localhost
 # between environments. Rotating this invalidates all active sessions.
 BETTER_AUTH_SECRET=
 
+# === Licensing ===
+
+# Signed revocation bundle for paid licence JWTs. Leave unset to use the
+# default carrtech.dev endpoint. Set to an empty string only for fully
+# air-gapped installs that accept expiry-only licence revocation.
+# LICENCE_REVOCATION_URL=
+
 # === Terminal ===
 
 # 🔒 WebSocket URL of the ingest service for browser terminal connections.

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -29,6 +29,7 @@ CT-Ops validates licence JWTs using an RSA public key. The production public key
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `LICENCE_PUBLIC_KEY` | — 🔒 | *(baked-in prod key)* | PEM-encoded RSA public key used to verify licence JWTs. **Do not set this in normal deployments.** Reserved for emergency key rotation and internal QA/staging environments using a non-production keypair. In production, the dev key is explicitly rejected even if supplied here. |
+| `LICENCE_REVOCATION_URL` | `https://licence.carrtech.dev/.well-known/ct-ops-licence-revocations.jwt` | same | Signed JWT bundle listing revoked licence ids (`jti`). Connected installs refresh it opportunistically; offline installs fall back to expiry-only validation until the endpoint is reachable again. Set to an empty string to disable remote revocation checks. |
 
 ### Example `.env.local` (development)
 

--- a/apps/docs/docs/licensing.md
+++ b/apps/docs/docs/licensing.md
@@ -94,6 +94,8 @@ Licences are time-limited via the `exp` claim. When a licence expires, CT-Ops si
 
 Connected installs may opportunistically check a signed revocation list published by the issuance service. Air-gapped installs rely exclusively on the `exp` claim — licence terms are therefore sized short enough (typically one year) for revocation-by-expiry to be acceptable.
 
+When `LICENCE_REVOCATION_URL` is unset, CT-Ops defaults to `https://licence.carrtech.dev/.well-known/ct-ops-licence-revocations.jwt` and refreshes that signed bundle periodically. If the install is offline or the endpoint is unreachable, the last known list is reused; if no list has ever been fetched, validation falls back to the JWT `exp` claim only.
+
 ### Seat limits
 
 If a licence includes a `maxHosts` cap, agent approval is blocked once that count is reached. Remove or archive decommissioned hosts to free up seats.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -30,6 +30,12 @@ BETTER_AUTH_URL=http://localhost:3000
 # Example: BETTER_AUTH_TRUSTED_ORIGINS=https://tunnel.example.com
 BETTER_AUTH_TRUSTED_ORIGINS=
 
+# --- Licensing ---
+# Signed revocation bundle for paid licence JWTs. Leave unset to use the
+# default carrtech.dev endpoint. Set to an empty string only for fully
+# air-gapped local development where expiry-only validation is acceptable.
+# LICENCE_REVOCATION_URL=
+
 # --- Auth email verification ---
 # CT-Ops requires email verification for local email/password accounts.
 # In production, configure a real SMTP relay and sender address.

--- a/apps/web/lib/licence.test.mjs
+++ b/apps/web/lib/licence.test.mjs
@@ -1,0 +1,136 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { exportPKCS8, exportSPKI, generateKeyPair, importPKCS8, SignJWT } from 'jose'
+
+import {
+  resetLicenceValidationStateForTests,
+  validateLicenceKey,
+} from './licence.ts'
+
+const realFetch = globalThis.fetch
+const realNodeEnv = process.env.NODE_ENV
+const realPublicKey = process.env.LICENCE_PUBLIC_KEY
+const realRevocationUrl = process.env.LICENCE_REVOCATION_URL
+
+async function createKeyPair() {
+  const { privateKey, publicKey } = await generateKeyPair('RS256', { extractable: true })
+  return {
+    privateKeyPem: await exportPKCS8(privateKey),
+    publicKeyPem: await exportSPKI(publicKey),
+  }
+}
+
+async function signJwt(privateKeyPem, audience, claims = {}) {
+  const privateKey = await importPKCS8(privateKeyPem, 'RS256')
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
+    .setIssuer('licence.carrtech.dev')
+    .setAudience(audience)
+    .setIssuedAt()
+    .setNotBefore(0)
+    .setExpirationTime('1 hour')
+    .sign(privateKey)
+}
+
+async function signLicence(privateKeyPem, claims = {}) {
+  return signJwt(privateKeyPem, 'install.carrtech.dev', {
+    tier: 'enterprise',
+    features: ['whiteLabel'],
+    customer: {
+      name: 'Example Corp',
+      email: 'ops@example.com',
+    },
+    sub: 'org_123',
+    jti: 'lic_123',
+    ...claims,
+  })
+}
+
+async function signRevocationBundle(privateKeyPem, revoked = []) {
+  return signJwt(privateKeyPem, 'install.carrtech.dev/licence-revocations', { revoked })
+}
+
+test.afterEach(() => {
+  resetLicenceValidationStateForTests()
+  globalThis.fetch = realFetch
+
+  if (realNodeEnv === undefined) {
+    delete process.env.NODE_ENV
+  } else {
+    process.env.NODE_ENV = realNodeEnv
+  }
+
+  if (realPublicKey === undefined) {
+    delete process.env.LICENCE_PUBLIC_KEY
+  } else {
+    process.env.LICENCE_PUBLIC_KEY = realPublicKey
+  }
+
+  if (realRevocationUrl === undefined) {
+    delete process.env.LICENCE_REVOCATION_URL
+  } else {
+    process.env.LICENCE_REVOCATION_URL = realRevocationUrl
+  }
+})
+
+test('validateLicenceKey accepts a signed licence when the revocation list is unreachable', async () => {
+  const keys = await createKeyPair()
+  process.env.NODE_ENV = 'production'
+  process.env.LICENCE_PUBLIC_KEY = keys.publicKeyPem
+  process.env.LICENCE_REVOCATION_URL = 'https://licence.example.test/.well-known/ct-ops-licence-revocations.jwt'
+  globalThis.fetch = async () => {
+    throw new Error('network offline')
+  }
+
+  const key = await signLicence(keys.privateKeyPem)
+  const result = await validateLicenceKey(key)
+
+  assert.equal(result.valid, true)
+})
+
+test('validateLicenceKey rejects a licence whose jti is present in the signed revocation bundle', async () => {
+  const keys = await createKeyPair()
+  process.env.NODE_ENV = 'production'
+  process.env.LICENCE_PUBLIC_KEY = keys.publicKeyPem
+  process.env.LICENCE_REVOCATION_URL = 'https://licence.example.test/.well-known/ct-ops-licence-revocations.jwt'
+  globalThis.fetch = async () =>
+    new Response(await signRevocationBundle(keys.privateKeyPem, ['lic_revoked']), {
+      status: 200,
+      headers: { 'content-type': 'application/jwt' },
+    })
+
+  const key = await signLicence(keys.privateKeyPem, { jti: 'lic_revoked' })
+  const result = await validateLicenceKey(key)
+
+  assert.deepEqual(result, {
+    valid: false,
+    error: 'Licence key has been revoked',
+  })
+})
+
+test('validateLicenceKey caches the revocation bundle between validations', async () => {
+  const keys = await createKeyPair()
+  process.env.NODE_ENV = 'production'
+  process.env.LICENCE_PUBLIC_KEY = keys.publicKeyPem
+  process.env.LICENCE_REVOCATION_URL = 'https://licence.example.test/.well-known/ct-ops-licence-revocations.jwt'
+
+  let fetchCalls = 0
+  globalThis.fetch = async () => {
+    fetchCalls += 1
+    return new Response(await signRevocationBundle(keys.privateKeyPem, []), {
+      status: 200,
+      headers: { 'content-type': 'application/jwt' },
+    })
+  }
+
+  const firstKey = await signLicence(keys.privateKeyPem, { jti: 'lic_one' })
+  const secondKey = await signLicence(keys.privateKeyPem, { jti: 'lic_two' })
+
+  const first = await validateLicenceKey(firstKey)
+  const second = await validateLicenceKey(secondKey)
+
+  assert.equal(first.valid, true)
+  assert.equal(second.valid, true)
+  assert.equal(fetchCalls, 1)
+})

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -56,6 +56,11 @@ export function resolveLicencePublicKeyPem(): string {
 
 const LICENCE_ISSUER = 'licence.carrtech.dev'
 const LICENCE_AUDIENCE = 'install.carrtech.dev'
+const LICENCE_REVOCATION_AUDIENCE = 'install.carrtech.dev/licence-revocations'
+const DEFAULT_REVOCATION_URL = `https://${LICENCE_ISSUER}/.well-known/ct-ops-licence-revocations.jwt`
+const REVOCATION_REFRESH_MS = 15 * 60 * 1000
+const REVOCATION_RETRY_MS = 5 * 60 * 1000
+const REVOCATION_FETCH_TIMEOUT_MS = 2_000
 
 export type PaidTier = Exclude<LicenceTier, 'community'>
 
@@ -82,6 +87,21 @@ export type LicenceValidationResult =
   | { valid: true; payload: LicencePayload }
   | { valid: false; error: string }
 
+type RevocationBundlePayload = {
+  iss: string
+  aud: string
+  exp: number
+  revoked: string[]
+}
+
+type CachedRevocationBundle = {
+  revoked: Set<string>
+  refreshAfter: number
+}
+
+let revocationCache: CachedRevocationBundle | null = null
+let revocationInflight: Promise<CachedRevocationBundle | null> | null = null
+
 function isPaidTier(v: unknown): v is PaidTier {
   return v === 'pro' || v === 'enterprise'
 }
@@ -94,6 +114,129 @@ function isCustomer(v: unknown): v is LicenceCustomer {
   if (!v || typeof v !== 'object') return false
   const c = v as Record<string, unknown>
   return typeof c.name === 'string' && typeof c.email === 'string'
+}
+
+function resolveRevocationUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  const configured = env.LICENCE_REVOCATION_URL?.trim()
+  if (configured === '') {
+    return null
+  }
+  if (configured) {
+    return configured
+  }
+  return env.NODE_ENV === 'production' ? DEFAULT_REVOCATION_URL : null
+}
+
+function isRevocationBundlePayload(payload: unknown): payload is RevocationBundlePayload {
+  if (!payload || typeof payload !== 'object') {
+    return false
+  }
+
+  const bundle = payload as Record<string, unknown>
+  return (
+    bundle.iss === LICENCE_ISSUER &&
+    bundle.aud === LICENCE_REVOCATION_AUDIENCE &&
+    typeof bundle.exp === 'number' &&
+    isStringArray(bundle.revoked)
+  )
+}
+
+async function fetchRevocationBundle(now: number): Promise<CachedRevocationBundle | null> {
+  const revocationUrl = resolveRevocationUrl()
+  if (!revocationUrl) {
+    return null
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REVOCATION_FETCH_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(revocationUrl, {
+      method: 'GET',
+      cache: 'no-store',
+      headers: {
+        accept: 'application/jwt, text/plain;q=0.9',
+      },
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Revocation list request failed with status ${response.status}`)
+    }
+
+    const bundleToken = (await response.text()).trim()
+    if (!bundleToken) {
+      throw new Error('Revocation list response was empty')
+    }
+
+    const publicKey = await importSPKI(resolveLicencePublicKeyPem(), 'RS256')
+    const { payload } = await jwtVerify(bundleToken, publicKey, {
+      algorithms: ['RS256'],
+      issuer: LICENCE_ISSUER,
+      audience: LICENCE_REVOCATION_AUDIENCE,
+      typ: 'JWT',
+    })
+
+    if (!isRevocationBundlePayload(payload)) {
+      throw new Error('Revocation list payload is invalid')
+    }
+
+    return {
+      revoked: new Set(payload.revoked),
+      refreshAfter: Math.min(now + REVOCATION_REFRESH_MS, payload.exp * 1000),
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function loadRevocationBundle(now = Date.now()): Promise<CachedRevocationBundle | null> {
+  if (revocationCache && revocationCache.refreshAfter > now) {
+    return revocationCache
+  }
+
+  if (!revocationInflight) {
+    revocationInflight = fetchRevocationBundle(now)
+      .then((bundle) => {
+        revocationCache = bundle
+          ? bundle
+          : {
+              revoked: new Set(),
+              refreshAfter: now + REVOCATION_RETRY_MS,
+            }
+        return revocationCache
+      })
+      .catch(() => {
+        if (revocationCache) {
+          revocationCache = {
+            ...revocationCache,
+            refreshAfter: now + REVOCATION_RETRY_MS,
+          }
+          return revocationCache
+        }
+
+        revocationCache = {
+          revoked: new Set(),
+          refreshAfter: now + REVOCATION_RETRY_MS,
+        }
+        return revocationCache
+      })
+      .finally(() => {
+        revocationInflight = null
+      })
+  }
+
+  return revocationInflight
+}
+
+async function isLicenceRevoked(jti: string): Promise<boolean> {
+  const bundle = await loadRevocationBundle()
+  return bundle?.revoked.has(jti) ?? false
+}
+
+export function resetLicenceValidationStateForTests(): void {
+  revocationCache = null
+  revocationInflight = null
 }
 
 export async function validateLicenceKey(key: string): Promise<LicenceValidationResult> {
@@ -131,6 +274,10 @@ export async function validateLicenceKey(key: string): Promise<LicenceValidation
 
     const rawMaxHosts = payload['maxHosts']
     const maxHosts = typeof rawMaxHosts === 'number' && rawMaxHosts > 0 ? rawMaxHosts : undefined
+
+    if (await isLicenceRevoked(payload.jti)) {
+      return { valid: false, error: 'Licence key has been revoked' }
+    }
 
     return {
       valid: true,


### PR DESCRIPTION
## Summary
- validate paid licence JWTs against a signed revocation bundle when the server is online
- cache the fetched bundle with offline/stale fallback so feature checks keep working during transient outages
- document `LICENCE_REVOCATION_URL` and add unit coverage for revoked, offline, and cached validation flows

## Testing
- `node --experimental-strip-types --test lib/licence.test.mjs`
- `npm run type-check`
- `npm run test:unit` *(still has the pre-existing `lib/db/schema/metadata-validation.test.mjs` failure caused by an extensionless import in `lib/db/schema/hosts.ts`)*

Closes #328.
