### PR TITLE
feat(notifications): purge old soft-deleted rows

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -471,6 +471,26 @@
 
 ---
 
+### Session 38 — Notification purge hygiene
+
+**Ingest** (`apps/ingest/internal/handlers/notification_purge_sweeper.go`, `apps/ingest/internal/db/queries/notifications.go`)
+- New notification purge sweeper starts with ingest, runs immediately, then repeats daily
+- Permanently deletes notifications whose `deleted_at` is older than 90 days
+- Query is covered by a focused unit test using a fake pgx executor
+
+**Database / docs**
+- Added partial `notifications_deleted_at_idx` index for efficient purge scans
+- Notification retention docs now describe the fixed 90-day soft-delete purge window
+
+**Build state**
+- `go test ./...` from `apps/ingest` — pass
+- `pnpm --filter web db:validate` — pass
+- `pnpm --filter web type-check` — pass
+- `pnpm --filter web lint` — exits 0 with existing warnings outside this change
+- `BETTER_AUTH_URL=http://localhost:3000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/ct_ops BETTER_AUTH_SECRET=<32-char-local-build-secret> pnpm --filter web build` — pass, with existing Turbopack trace warning
+
+---
+
 ### Session 37 — Remote agent uninstall on host deletion
 
 **Agent** (`agent/internal/tasks/uninstall.go`, `uninstall_unix.go`, `uninstall_windows.go`)
@@ -1636,6 +1656,7 @@ _(Built between Sessions 3 and 4; not previously documented)_
 - The `go.work.sum` file is gitignored — developers must run `go work sync` after cloning
 - CPU % on first heartbeat is always 0 — by design (two-sample baseline); accurate from second heartbeat onward
 - Metric retention `add_retention_policy` not wired dynamically ✅ Resolved — `updateMetricRetention` server action already calls `drop_retention_policy` + `add_retention_policy` via `db.execute(sql\`...\`)`
+- Soft-deleted notifications accumulate indefinitely ✅ Resolved — ingest now hard-purges notifications soft-deleted for more than 90 days
 
 ---
 
@@ -1647,20 +1668,18 @@ _None._
 
 ## What The Next Session Should Build
 
-**Session 36 — Notification UX polish and Phase 4 start**
+**Session 39 — Phase 4 Service Accounts & Identity**
 
-Notification work is feature-complete. Suggested next steps:
+Notification data hygiene is complete. Suggested next steps:
 
-1. **Notification data hygiene** — periodic hard-purge of soft-deleted notifications older than 90 days (background job or pg_cron rule) to prevent unbounded table growth
-2. **Phase 4: Service Accounts & Identity** — schema (`service_accounts` table with name, type, owner, expiry); list UI with expiry countdown badges; soft delete
-3. **SSH key inventory** — track SSH public keys linked to service accounts; fingerprint, last-used-at, expiry
-4. **Expiry tracking + alerting** — new alert condition type `service_account_expiry`; ingest evaluator + sweeper (mirrors cert_expiry pattern)
-5. **LDAP/AD integration** — community-tier LDAP sync; imports users and service accounts from directory
+1. **Phase 4: Service Accounts & Identity** — schema (`service_accounts` table with name, type, owner, expiry); list UI with expiry countdown badges; soft delete
+2. **SSH key inventory** — track SSH public keys linked to service accounts; fingerprint, last-used-at, expiry
+3. **Expiry tracking + alerting** — new alert condition type `service_account_expiry`; ingest evaluator + sweeper (mirrors cert_expiry pattern)
+4. **LDAP/AD integration** — community-tier LDAP sync; imports users and service accounts from directory
 
 **Outstanding technical debt (carry forward):**
 - mTLS client certificates deferred — TLS builder is structured for it
 - `go.work.sum` is gitignored — developers must run `go work sync` after cloning
-- Soft-deleted notifications accumulate indefinitely — purge job not yet implemented
 
 ---
 
@@ -1714,6 +1733,7 @@ Notification work is feature-complete. Suggested next steps:
 - [x] Notification severity pie chart + trend line chart on /notifications page
 - [x] Notification charts on host detail Metrics tab (host-scoped)
 - [x] Soft-delete on notifications (preserves trend history through deletions)
+- [x] Hard-purge soft-deleted notifications after 90 days
 - [x] Trend chart time-range selector (1h → 3 months, hourly/daily auto-granularity)
 - [x] Alert silencing
 - [x] Alert acknowledgement

--- a/apps/docs/docs/features/notifications.md
+++ b/apps/docs/docs/features/notifications.md
@@ -96,4 +96,4 @@ These help identify whether noise is increasing or decreasing and which rules ar
 
 ## Notification Retention
 
-Notifications are soft-deleted (marked with `deleted_at`) rather than permanently removed. A background purge job runs periodically to clean up old soft-deleted records. The retention period is configurable in **Settings → System**.
+Notifications are soft-deleted (marked with `deleted_at`) when users delete them. The ingest service permanently purges soft-deleted notifications after 90 days so notification history remains available for short-term review without unbounded table growth.

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -153,6 +153,9 @@ func main() {
 	// Start task schedule sweeper goroutine
 	go handlers.RunTaskScheduleSweeper(ctx, pool, 30*time.Second)
 
+	// Start notification purge sweeper goroutine
+	go handlers.RunNotificationPurgeSweeper(ctx, pool, 24*time.Hour)
+
 	// Start gRPC server in goroutine
 	grpcErr := make(chan error, 1)
 	go func() {

--- a/apps/ingest/internal/db/queries/notifications.go
+++ b/apps/ingest/internal/db/queries/notifications.go
@@ -1,0 +1,32 @@
+package queries
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type notificationPurgeExec interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
+
+// PurgeSoftDeletedNotifications permanently removes notifications that were
+// already soft-deleted before cutoff.
+func PurgeSoftDeletedNotifications(ctx context.Context, pool *pgxpool.Pool, cutoff time.Time) (int64, error) {
+	return purgeSoftDeletedNotifications(ctx, pool, cutoff)
+}
+
+func purgeSoftDeletedNotifications(ctx context.Context, exec notificationPurgeExec, cutoff time.Time) (int64, error) {
+	const q = `
+		DELETE FROM notifications
+		WHERE deleted_at IS NOT NULL
+		  AND deleted_at < $1
+	`
+	tag, err := exec.Exec(ctx, q, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/apps/ingest/internal/db/queries/notifications_test.go
+++ b/apps/ingest/internal/db/queries/notifications_test.go
@@ -1,0 +1,51 @@
+package queries
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakeNotificationPurgeExec struct {
+	sql  string
+	args []any
+	tag  pgconn.CommandTag
+	err  error
+}
+
+func (f *fakeNotificationPurgeExec) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.sql = sql
+	f.args = args
+	return f.tag, f.err
+}
+
+func TestPurgeSoftDeletedNotifications(t *testing.T) {
+	t.Parallel()
+
+	cutoff := time.Date(2026, 1, 27, 12, 0, 0, 0, time.UTC)
+	exec := &fakeNotificationPurgeExec{tag: pgconn.NewCommandTag("DELETE 7")}
+
+	deleted, err := purgeSoftDeletedNotifications(context.Background(), exec, cutoff)
+	if err != nil {
+		t.Fatalf("purgeSoftDeletedNotifications: %v", err)
+	}
+
+	if deleted != 7 {
+		t.Fatalf("deleted = %d, want 7", deleted)
+	}
+	if !strings.Contains(exec.sql, "DELETE FROM notifications") {
+		t.Fatalf("query did not delete notifications: %s", exec.sql)
+	}
+	if !strings.Contains(exec.sql, "deleted_at IS NOT NULL") {
+		t.Fatalf("query does not require soft-deleted rows: %s", exec.sql)
+	}
+	if !strings.Contains(exec.sql, "deleted_at < $1") {
+		t.Fatalf("query does not apply cutoff parameter: %s", exec.sql)
+	}
+	if len(exec.args) != 1 || exec.args[0] != cutoff {
+		t.Fatalf("args = %#v, want cutoff only", exec.args)
+	}
+}

--- a/apps/ingest/internal/handlers/notification_purge_sweeper.go
+++ b/apps/ingest/internal/handlers/notification_purge_sweeper.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
+)
+
+const notificationPurgeRetention = 90 * 24 * time.Hour
+
+// RunNotificationPurgeSweeper periodically hard-deletes notifications that were
+// already soft-deleted outside the retention window.
+func RunNotificationPurgeSweeper(ctx context.Context, pool *pgxpool.Pool, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	slog.Info("notification purge sweeper started", "interval", interval, "retention", notificationPurgeRetention)
+
+	runNotificationPurgeTick(ctx, pool, time.Now)
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("notification purge sweeper stopped")
+			return
+		case <-ticker.C:
+			runNotificationPurgeTick(ctx, pool, time.Now)
+		}
+	}
+}
+
+func runNotificationPurgeTick(ctx context.Context, pool *pgxpool.Pool, now func() time.Time) {
+	cutoff := now().Add(-notificationPurgeRetention)
+	deleted, err := queries.PurgeSoftDeletedNotifications(ctx, pool, cutoff)
+	if err != nil {
+		slog.Warn("notification purge sweeper: deleting old soft-deleted notifications", "err", err)
+		return
+	}
+	if deleted > 0 {
+		slog.Info("notification purge sweeper: purged notifications", "count", deleted)
+	}
+}

--- a/apps/web/lib/db/migrations/0045_notification_purge_index.sql
+++ b/apps/web/lib/db/migrations/0045_notification_purge_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "notifications_deleted_at_idx"
+  ON "notifications" ("deleted_at")
+  WHERE "deleted_at" IS NOT NULL;

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1777292000000,
       "tag": "0044_audit_events",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1777310000000,
+      "tag": "0045_notification_purge_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/alerts.ts
+++ b/apps/web/lib/db/schema/alerts.ts
@@ -1,4 +1,5 @@
 import { pgTable, text, timestamp, jsonb, boolean, index } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
 import { createId } from '@paralleldrive/cuid2'
 import { organisations } from './organisations'
 import { hosts } from './hosts'
@@ -127,6 +128,7 @@ export const notifications = pgTable('notifications', {
   index('notifications_user_read_idx').on(table.userId, table.read),
   index('notifications_org_user_idx').on(table.organisationId, table.userId),
   index('notifications_user_created_idx').on(table.userId, table.createdAt),
+  index('notifications_deleted_at_idx').on(table.deletedAt).where(sql`${table.deletedAt} IS NOT NULL`),
 ])
 
 export const alertSilences = pgTable('alert_silences', {


### PR DESCRIPTION
## Summary
- add an ingest sweeper that immediately runs and then daily purges notifications soft-deleted for more than 90 days
- add a focused query unit test and partial deleted_at index for efficient cleanup
- update notification retention docs and PROGRESS.md next-work notes

## Validation
- go test ./... (apps/ingest)
- go build ./... (apps/ingest)
- pnpm --filter web db:validate
- pnpm --filter web type-check
- pnpm --filter web lint (exits 0; existing warnings outside this change)
- BETTER_AUTH_URL=http://localhost:3000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/ct_ops BETTER_AUTH_SECRET=0123456789abcdef0123456789abcdef pnpm --filter web build (passes; existing Turbopack trace warning)