### PR TITLE
fix(ingest): cap inventory chunk size

### DIFF
--- a/apps/ingest/internal/handlers/inventory.go
+++ b/apps/ingest/internal/handlers/inventory.go
@@ -24,6 +24,8 @@ type InventoryHandler struct {
 	issuer *auth.JWTIssuer
 }
 
+const maxInventoryPackagesPerChunk = 1000
+
 // NewInventoryHandler creates an InventoryHandler.
 func NewInventoryHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer) *InventoryHandler {
 	return &InventoryHandler{pool: pool, issuer: issuer}
@@ -64,6 +66,9 @@ func (h *InventoryHandler) SubmitSoftwareInventory(stream agentv1.IngestService_
 	source := strings.TrimSpace(first.Source)
 	if source == "" {
 		source = "other"
+	}
+	if err := validateInventoryChunk(first); err != nil {
+		return err
 	}
 
 	// ── Validate scan_id belongs to this agent ────────────────────────────────
@@ -152,6 +157,10 @@ func (h *InventoryHandler) SubmitSoftwareInventory(stream agentv1.IngestService_
 			_ = queries.FailSoftwareScan(ctx, h.pool, softwareScanID, chunkErr.Error())
 			return status.Errorf(codes.Internal, "receiving chunk: %v", chunkErr)
 		}
+		if err := validateInventoryChunk(chunk); err != nil {
+			_ = queries.FailSoftwareScan(ctx, h.pool, softwareScanID, err.Error())
+			return err
+		}
 
 		if err := processChunk(chunk); err != nil {
 			slog.Error("inventory: upserting chunk", "scan_id", scanID, "chunk", chunk.ChunkIndex, "err", err)
@@ -214,6 +223,18 @@ func (h *InventoryHandler) finalise(
 	)
 
 	return stream.SendAndClose(&agentv1.SoftwareInventoryAck{Received: int32(totalReceived)})
+}
+
+func validateInventoryChunk(chunk *agentv1.SoftwareInventoryChunk) error {
+	if len(chunk.Packages) > maxInventoryPackagesPerChunk {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"inventory chunk %d exceeds maximum of %d packages",
+			chunk.ChunkIndex,
+			maxInventoryPackagesPerChunk,
+		)
+	}
+	return nil
 }
 
 // authenticateStream validates the agent JWT from gRPC metadata and returns

--- a/apps/ingest/internal/handlers/inventory_test.go
+++ b/apps/ingest/internal/handlers/inventory_test.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+func TestValidateInventoryChunkAllowsConfiguredLimit(t *testing.T) {
+	chunk := &agentv1.SoftwareInventoryChunk{
+		ChunkIndex: 7,
+		Packages:   make([]*agentv1.SoftwarePackage, maxInventoryPackagesPerChunk),
+	}
+
+	if err := validateInventoryChunk(chunk); err != nil {
+		t.Fatalf("validateInventoryChunk() unexpected error: %v", err)
+	}
+}
+
+func TestValidateInventoryChunkRejectsOversizedChunk(t *testing.T) {
+	chunk := &agentv1.SoftwareInventoryChunk{
+		ChunkIndex: 8,
+		Packages:   make([]*agentv1.SoftwarePackage, maxInventoryPackagesPerChunk+1),
+	}
+
+	err := validateInventoryChunk(chunk)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("status.Code(err) = %v, want %v (err=%v)", status.Code(err), codes.InvalidArgument, err)
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- reject software inventory chunks that exceed the server-side package-count cap before upserting
- keep the cap above the agent's current 500-package chunk size to avoid breaking normal scans
- add handler tests covering the allowed boundary and oversized rejection

## Testing
- go test ./apps/ingest/internal/handlers
- go test ./apps/ingest/internal/...

Closes #345