### PR TITLE
feat(auth): add email verification resend flow

### DIFF
--- a/apps/web/app/(auth)/check-email/page.tsx
+++ b/apps/web/app/(auth)/check-email/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { VerificationResendForm } from './verification-resend-form'
 
 export const metadata: Metadata = {
   title: 'Check your email',
@@ -28,8 +29,15 @@ export default async function CheckEmailPage({ searchParams }: CheckEmailPagePro
           address before CT-Ops will sign you in.
         </CardDescription>
       </CardHeader>
-      <CardContent className="text-sm text-muted-foreground">
-        After you open the link, CT-Ops will continue to the next step automatically.
+      <CardContent className="space-y-4">
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>After you open the link, CT-Ops will continue to the next step automatically.</p>
+          <p>
+            If the link has expired or you cannot find the email, confirm your password to send a
+            new verification link.
+          </p>
+        </div>
+        <VerificationResendForm initialEmail={email} />
       </CardContent>
       <CardFooter>
         <Link href="/login" className="text-sm text-foreground underline underline-offset-4">

--- a/apps/web/app/(auth)/check-email/verification-resend-form.tsx
+++ b/apps/web/app/(auth)/check-email/verification-resend-form.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import type { FormEvent } from 'react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { EMAIL_VERIFICATION_RESEND_SENT_MESSAGE } from '@/lib/auth/email-verification-resend'
+
+type VerificationResendFormProps = {
+  initialEmail?: string | null
+}
+
+export function VerificationResendForm({ initialEmail }: VerificationResendFormProps) {
+  const [email, setEmail] = useState(initialEmail ?? '')
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setMessage(null)
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      const res = await fetch('/api/auth/resend-verification-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          password,
+          callbackURL: '/dashboard',
+        }),
+      })
+      const data = await res.json().catch(() => null) as { message?: string } | null
+
+      if (!res.ok) {
+        setError(data?.message ?? 'Could not send a verification email. Please try again.')
+        return
+      }
+
+      setMessage(data?.message ?? EMAIL_VERIFICATION_RESEND_SENT_MESSAGE)
+      setPassword('')
+    } catch {
+      setError('Could not send a verification email. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="verification-email">Email</Label>
+        <Input
+          id="verification-email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          data-testid="verification-email"
+          required
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="verification-password">Password</Label>
+        <Input
+          id="verification-password"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          data-testid="verification-password"
+          required
+        />
+      </div>
+      <Button type="submit" disabled={isSubmitting} data-testid="resend-verification-email">
+        {isSubmitting ? 'Sending...' : 'Send new verification email'}
+      </Button>
+      {message && (
+        <p className="text-sm text-muted-foreground" data-testid="resend-verification-message">
+          {message}
+        </p>
+      )}
+      {error && (
+        <p className="text-sm text-destructive" data-testid="resend-verification-error">
+          {error}
+        </p>
+      )}
+    </form>
+  )
+}

--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -29,9 +29,15 @@ interface LoginFormProps {
   ldapLoginEnabled?: boolean
 }
 
+function isEmailNotVerifiedError(message: string, code?: string): boolean {
+  return code === 'EMAIL_NOT_VERIFIED' || message.toLowerCase().includes('email not verified')
+}
+
 export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
   const router = useRouter()
   const [serverError, setServerError] = useState<string | null>(null)
+  const [canResendVerification, setCanResendVerification] = useState(false)
+  const [verificationEmail, setVerificationEmail] = useState<string | null>(null)
   const [loginMode, setLoginMode] = useState<'local' | 'domain'>('local')
 
   const localForm = useForm<LocalLoginValues>({
@@ -44,13 +50,19 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
 
   async function onLocalSubmit(values: LocalLoginValues) {
     setServerError(null)
+    setCanResendVerification(false)
+    setVerificationEmail(null)
     const result = await signIn.email({
       email: values.email,
       password: values.password,
     })
 
     if (result.error) {
-      setServerError(result.error.message ?? 'Sign in failed. Check your credentials.')
+      const message = result.error.message ?? 'Sign in failed. Check your credentials.'
+      const isUnverifiedEmail = isEmailNotVerifiedError(message, result.error.code)
+      setServerError(message)
+      setCanResendVerification(isUnverifiedEmail)
+      setVerificationEmail(isUnverifiedEmail ? values.email : null)
       return
     }
 
@@ -59,6 +71,8 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
 
   async function onDomainSubmit(values: DomainLoginValues) {
     setServerError(null)
+    setCanResendVerification(false)
+    setVerificationEmail(null)
     try {
       const res = await fetch('/api/auth/ldap', {
         method: 'POST',
@@ -107,6 +121,8 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
               onClick={() => {
                 setLoginMode('local')
                 setServerError(null)
+                setCanResendVerification(false)
+                setVerificationEmail(null)
               }}
             >
               Local Account
@@ -121,6 +137,8 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
               onClick={() => {
                 setLoginMode('domain')
                 setServerError(null)
+                setCanResendVerification(false)
+                setVerificationEmail(null)
               }}
             >
               Domain Account
@@ -134,6 +152,26 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
           <CardContent className="space-y-4">
             {serverError && (
               <p className="text-sm text-destructive" data-testid="login-error">{serverError}</p>
+            )}
+            {canResendVerification && (
+              <div className="space-y-2 rounded-md border bg-muted/40 p-3 text-sm">
+                <p className="text-muted-foreground">
+                  Your account needs email verification before you can sign in. Use the link in
+                  your verification email, or manage verification if the previous link expired.
+                </p>
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                >
+                  <Link
+                    href={`/check-email${verificationEmail ? `?email=${encodeURIComponent(verificationEmail)}` : ''}`}
+                    data-testid="manage-email-verification"
+                  >
+                    Manage email verification
+                  </Link>
+                </Button>
+              </div>
             )}
             <div className="space-y-1.5">
               <Label htmlFor="email">Email</Label>

--- a/apps/web/app/api/auth/resend-verification-email/route.ts
+++ b/apps/web/app/api/auth/resend-verification-email/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createEmailVerificationToken } from 'better-auth/api'
+import { verifyPassword } from 'better-auth/crypto'
+import { and, eq, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { accounts, users } from '@/lib/db/schema'
+import { getBetterAuthSecret, getBetterAuthUrl, getRequireEmailVerification } from '@/lib/auth/env'
+import { sendVerificationEmail } from '@/lib/auth/email'
+import {
+  EMAIL_VERIFICATION_RESEND_INVALID_MESSAGE,
+  EMAIL_VERIFICATION_RESEND_SENT_MESSAGE,
+  createVerificationEmailUrl,
+  getVerificationResendClientIp,
+  normalizeVerificationEmail,
+  sanitizeVerificationCallbackPath,
+} from '@/lib/auth/email-verification-resend'
+import {
+  EMAIL_VERIFICATION_RESEND_THROTTLED_MESSAGE,
+  emailVerificationResendPolicy,
+} from '@/lib/auth/email-verification-rate-limit'
+import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
+
+const resendSchema = z.object({
+  email: z.string().trim().email().max(254),
+  password: z.string().min(1).max(128),
+  callbackURL: z.unknown().optional(),
+})
+
+async function withAuthDelay<T>(start: number, value: T): Promise<T> {
+  const minMs = 350 + Math.floor(Math.random() * 150)
+  const elapsed = Date.now() - start
+  if (elapsed < minMs) await new Promise((resolve) => setTimeout(resolve, minMs - elapsed))
+  return value
+}
+
+function invalidResponse() {
+  return NextResponse.json({ message: EMAIL_VERIFICATION_RESEND_INVALID_MESSAGE }, { status: 401 })
+}
+
+export async function POST(request: NextRequest) {
+  const requestStart = Date.now()
+  const ip = getVerificationResendClientIp(request)
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ message: 'Invalid request body.' }, { status: 400 })
+  }
+
+  const parsed = resendSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ message: 'Email and password are required.' }, { status: 400 })
+  }
+
+  const email = normalizeVerificationEmail(parsed.data.email)
+  if (!emailVerificationResendPolicy.check({ email, ip })) {
+    return NextResponse.json(
+      { message: EMAIL_VERIFICATION_RESEND_THROTTLED_MESSAGE },
+      { status: 429 },
+    )
+  }
+
+  const accountStatus = passwordLoginAttemptGuard.check(email)
+  if (!accountStatus.allowed) {
+    return NextResponse.json(
+      { message: 'Too many login attempts — please wait before trying again.' },
+      { status: 429 },
+    )
+  }
+
+  if (!getRequireEmailVerification()) {
+    return NextResponse.json({ message: EMAIL_VERIFICATION_RESEND_SENT_MESSAGE })
+  }
+
+  const [row] = await db
+    .select({ user: users, account: accounts })
+    .from(users)
+    .innerJoin(accounts, eq(accounts.userId, users.id))
+    .where(
+      and(
+        eq(users.email, email),
+        eq(accounts.providerId, 'credential'),
+        isNull(users.deletedAt),
+      ),
+    )
+    .limit(1)
+
+  const user = row?.user
+  const account = row?.account
+  const passwordHash = account?.password
+  if (!user || !passwordHash) {
+    await verifyPassword({
+      hash: '$argon2id$v=19$m=65536,t=3,p=4$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      password: parsed.data.password,
+    }).catch(() => undefined)
+    passwordLoginAttemptGuard.recordFailure(email)
+    return withAuthDelay(requestStart, invalidResponse())
+  }
+
+  const passwordMatches = await verifyPassword({
+    hash: passwordHash,
+    password: parsed.data.password,
+  })
+
+  if (!passwordMatches) {
+    passwordLoginAttemptGuard.recordFailure(email)
+    return withAuthDelay(requestStart, invalidResponse())
+  }
+
+  passwordLoginAttemptGuard.reset(email)
+
+  if (user.emailVerified || !user.isActive) {
+    return withAuthDelay(
+      requestStart,
+      NextResponse.json({ message: EMAIL_VERIFICATION_RESEND_SENT_MESSAGE }),
+    )
+  }
+
+  const callbackPath = sanitizeVerificationCallbackPath(parsed.data.callbackURL)
+  const token = await createEmailVerificationToken(getBetterAuthSecret(), user.email)
+  const verificationUrl = createVerificationEmailUrl({
+    baseUrl: getBetterAuthUrl(),
+    token,
+    callbackPath,
+  })
+
+  await sendVerificationEmail({
+    email: user.email,
+    name: user.name,
+    verificationUrl,
+  })
+
+  return withAuthDelay(
+    requestStart,
+    NextResponse.json({ message: EMAIL_VERIFICATION_RESEND_SENT_MESSAGE }),
+  )
+}

--- a/apps/web/lib/auth/email-verification-rate-limit.test.mjs
+++ b/apps/web/lib/auth/email-verification-rate-limit.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createEmailVerificationResendGuard,
+  createEmailVerificationResendPolicy,
+} from './email-verification-rate-limit.ts'
+
+test('email verification resend guard limits requests per normalized email', () => {
+  const guard = createEmailVerificationResendGuard(60_000, 3)
+
+  assert.equal(guard.check('User@Example.com'), true)
+  assert.equal(guard.check(' user@example.com '), true)
+  assert.equal(guard.check('USER@example.com'), true)
+  assert.equal(guard.check('user@example.com'), false)
+})
+
+test('email verification resend guard tracks different emails separately', () => {
+  const guard = createEmailVerificationResendGuard(60_000, 1)
+
+  assert.equal(guard.check('first@example.com'), true)
+  assert.equal(guard.check('first@example.com'), false)
+  assert.equal(guard.check('second@example.com'), true)
+})
+
+test('email verification resend policy limits burst requests per source IP', () => {
+  const policy = createEmailVerificationResendPolicy({
+    windowMs: 60_000,
+    maxRequestsPerEmail: 3,
+    maxRequestsPerIp: 2,
+  })
+
+  assert.equal(policy.check({ email: 'first@example.com', ip: '203.0.113.10' }), true)
+  assert.equal(policy.check({ email: 'second@example.com', ip: '203.0.113.10' }), true)
+  assert.equal(policy.check({ email: 'third@example.com', ip: '203.0.113.10' }), false)
+  assert.equal(policy.check({ email: 'third@example.com', ip: '203.0.113.11' }), true)
+})
+
+test('email verification resend policy allows requests after the window expires', () => {
+  const policy = createEmailVerificationResendPolicy({
+    windowMs: 60_000,
+    maxRequestsPerEmail: 1,
+    maxRequestsPerIp: 1,
+  })
+
+  assert.equal(policy.check({ email: 'user@example.com', ip: '203.0.113.10' }, 1_000), true)
+  assert.equal(policy.check({ email: 'user@example.com', ip: '203.0.113.10' }, 2_000), false)
+  assert.equal(policy.check({ email: 'user@example.com', ip: '203.0.113.10' }, 62_000), true)
+})

--- a/apps/web/lib/auth/email-verification-rate-limit.ts
+++ b/apps/web/lib/auth/email-verification-rate-limit.ts
@@ -1,0 +1,79 @@
+export const EMAIL_VERIFICATION_RESEND_THROTTLED_MESSAGE =
+  'Too many verification emails requested. Please wait a minute before trying again.'
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+function normalizeIdentifier(identifier: string): string {
+  return identifier.trim().toLowerCase()
+}
+
+function recentHits(
+  requestLog: Map<string, number[]>,
+  key: string,
+  windowMs: number,
+  now: number,
+): { normalized: string; hits: number[] } {
+  const normalized = normalizeIdentifier(key)
+  if (!normalized) return { normalized, hits: [] }
+
+  const cutoff = now - windowMs
+  return {
+    normalized,
+    hits: (requestLog.get(normalized) ?? []).filter((timestamp) => timestamp > cutoff),
+  }
+}
+
+function recordHit(requestLog: Map<string, number[]>, normalized: string, hits: number[], now: number) {
+  if (!normalized) return
+  hits.push(now)
+  requestLog.set(normalized, hits)
+}
+
+export function createEmailVerificationResendGuard(windowMs: number, maxRequests: number) {
+  const requestLog = new Map<string, number[]>()
+
+  return {
+    check(email: string, now = Date.now()): boolean {
+      const emailHits = recentHits(requestLog, normalizeEmail(email), windowMs, now)
+      if (emailHits.hits.length >= maxRequests) return false
+
+      recordHit(requestLog, emailHits.normalized, emailHits.hits, now)
+      return true
+    },
+  }
+}
+
+export function createEmailVerificationResendPolicy(options: {
+  windowMs: number
+  maxRequestsPerEmail: number
+  maxRequestsPerIp: number
+}) {
+  const emailRequests = new Map<string, number[]>()
+  const ipRequests = new Map<string, number[]>()
+
+  return {
+    check(input: { email: string; ip: string }, now = Date.now()): boolean {
+      const emailHits = recentHits(emailRequests, normalizeEmail(input.email), options.windowMs, now)
+      const ipHits = recentHits(ipRequests, input.ip, options.windowMs, now)
+
+      if (
+        emailHits.hits.length >= options.maxRequestsPerEmail ||
+        ipHits.hits.length >= options.maxRequestsPerIp
+      ) {
+        return false
+      }
+
+      recordHit(emailRequests, emailHits.normalized, emailHits.hits, now)
+      recordHit(ipRequests, ipHits.normalized, ipHits.hits, now)
+      return true
+    },
+  }
+}
+
+export const emailVerificationResendPolicy = createEmailVerificationResendPolicy({
+  windowMs: 60_000,
+  maxRequestsPerEmail: 3,
+  maxRequestsPerIp: 10,
+})

--- a/apps/web/lib/auth/email-verification-resend.test.mjs
+++ b/apps/web/lib/auth/email-verification-resend.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createVerificationEmailUrl,
+  getVerificationResendClientIp,
+  normalizeVerificationEmail,
+  sanitizeVerificationCallbackPath,
+} from './email-verification-resend.ts'
+
+test('normalizeVerificationEmail lowercases and trims email input', () => {
+  assert.equal(normalizeVerificationEmail(' User@Example.COM '), 'user@example.com')
+})
+
+test('getVerificationResendClientIp prefers the first forwarded address', () => {
+  const request = new Request('https://ct-ops.example.com/api/auth/resend-verification-email', {
+    headers: {
+      'x-forwarded-for': '203.0.113.10, 198.51.100.7',
+      'x-real-ip': '198.51.100.8',
+    },
+  })
+
+  assert.equal(getVerificationResendClientIp(request), '203.0.113.10')
+})
+
+test('sanitizeVerificationCallbackPath only allows local paths', () => {
+  assert.equal(sanitizeVerificationCallbackPath('/dashboard'), '/dashboard')
+  assert.equal(sanitizeVerificationCallbackPath('https://evil.example.com'), '/dashboard')
+  assert.equal(sanitizeVerificationCallbackPath('//evil.example.com/path'), '/dashboard')
+  assert.equal(sanitizeVerificationCallbackPath('/dashboard\nSet-Cookie: bad=1'), '/dashboard')
+})
+
+test('createVerificationEmailUrl builds a local verification URL', () => {
+  assert.equal(
+    createVerificationEmailUrl({
+      baseUrl: 'https://ct-ops.example.com/app',
+      token: 'token-value',
+      callbackPath: '/dashboard',
+    }),
+    'https://ct-ops.example.com/verify-email?token=token-value&callbackURL=%2Fdashboard',
+  )
+})

--- a/apps/web/lib/auth/email-verification-resend.ts
+++ b/apps/web/lib/auth/email-verification-resend.ts
@@ -1,0 +1,45 @@
+export const EMAIL_VERIFICATION_RESEND_INVALID_MESSAGE =
+  'We could not resend a verification email. Check your email and password, then try again.'
+
+export const EMAIL_VERIFICATION_RESEND_SENT_MESSAGE =
+  'Verification email sent. Check your inbox for the new link.'
+
+export function normalizeVerificationEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+export function getVerificationResendClientIp(request: Request): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip')?.trim() ||
+    'unknown'
+  )
+}
+
+export function sanitizeVerificationCallbackPath(value: unknown): string {
+  if (typeof value !== 'string') return '/dashboard'
+
+  const trimmed = value.trim()
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > 256 ||
+    !trimmed.startsWith('/') ||
+    trimmed.startsWith('//') ||
+    /[\r\n]/.test(trimmed)
+  ) {
+    return '/dashboard'
+  }
+
+  return trimmed
+}
+
+export function createVerificationEmailUrl(input: {
+  baseUrl: string
+  token: string
+  callbackPath: string
+}): string {
+  const url = new URL('/verify-email', input.baseUrl)
+  url.searchParams.set('token', input.token)
+  url.searchParams.set('callbackURL', input.callbackPath)
+  return url.toString()
+}

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -11,6 +11,11 @@ import {
   getBetterAuthUrl,
   getRequireEmailVerification,
 } from './env'
+import {
+  EMAIL_VERIFICATION_RESEND_THROTTLED_MESSAGE,
+  emailVerificationResendPolicy,
+} from './email-verification-rate-limit'
+import { getVerificationResendClientIp } from './email-verification-resend'
 import { passwordLoginAttemptGuard } from './login-attempts'
 
 const LOGIN_THROTTLED_MESSAGE = 'Too many login attempts — please wait before trying again.'
@@ -53,6 +58,21 @@ export const auth = betterAuth({
   ],
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path === '/send-verification-email') {
+        const email = typeof ctx.body?.email === 'string' ? ctx.body.email : ''
+        const request = ctx.request
+        const ip = request ? getVerificationResendClientIp(request) : 'unknown'
+        if (!emailVerificationResendPolicy.check({ email, ip })) {
+          throw new APIError('TOO_MANY_REQUESTS', {
+            message: EMAIL_VERIFICATION_RESEND_THROTTLED_MESSAGE,
+          })
+        }
+
+        throw new APIError('FORBIDDEN', {
+          message: 'Verification email resend requires password confirmation.',
+        })
+      }
+
       if (ctx.path !== '/sign-in/email') return
 
       const email = typeof ctx.body?.email === 'string' ? ctx.body.email : ''

--- a/apps/web/tests/e2e/auth/register.spec.ts
+++ b/apps/web/tests/e2e/auth/register.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/test'
-import { waitForVerificationUrl } from '../fixtures/email'
+import { countVerificationEmails, waitForVerificationUrl } from '../fixtures/email'
 import { getTestDb } from '../fixtures/db'
 
 const requireEmailVerification = process.env.REQUIRE_EMAIL_VERIFICATION !== 'false'
@@ -28,7 +28,23 @@ test('email sign-up requires verification before dashboard access', async ({ pag
   await page.getByTestId('login-password').fill(password)
   await page.getByTestId('login-submit').click()
   await expect(page.getByTestId('login-error')).toBeVisible()
-  await expect(page).toHaveURL(/\/login$/)
+  await page.getByTestId('manage-email-verification').click()
+  await page.waitForURL('**/check-email*')
+  await expect(page.getByTestId('verification-email')).toHaveValue(email)
+
+  const emailsBeforeInvalidResend = await countVerificationEmails(email)
+  const invalidResend = await page.request.post('/api/auth/resend-verification-email', {
+    data: {
+      email,
+      password: 'WrongPassword123!',
+    },
+  })
+  expect(invalidResend.status()).toBe(401)
+  await expect.poll(() => countVerificationEmails(email)).toBe(emailsBeforeInvalidResend)
+
+  await page.getByTestId('verification-password').fill(password)
+  await page.getByTestId('resend-verification-email').click()
+  await expect(page.getByTestId('resend-verification-message')).toContainText('Verification email sent')
 
   const verificationUrl = await waitForVerificationUrl(email)
   await page.goto(verificationUrl)

--- a/apps/web/tests/e2e/fixtures/email.ts
+++ b/apps/web/tests/e2e/fixtures/email.ts
@@ -41,3 +41,19 @@ export async function waitForVerificationUrl(to: string, timeoutMs = 10_000): Pr
 
   throw new Error(`Timed out waiting for verification email for ${to}`)
 }
+
+export async function countVerificationEmails(to: string): Promise<number> {
+  try {
+    const raw = await readFile(getCaptureFile(), 'utf8')
+    return raw
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as CapturedEmail)
+      .filter((message) => message.to === to && message.metadata?.verificationUrl)
+      .length
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return 0
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated email verification management flow for users who cannot sign in because their local account email is unverified.

- Adds a login-screen action that sends unverified users to the check-email management screen.
- Adds a resend form on the check-email screen that requires email and password confirmation.
- Adds a backend resend endpoint that validates credentials, rate-limits by email and source IP, avoids sending for verified/inactive accounts, sanitizes callback paths, and blocks Better Auth's public unauthenticated resend endpoint.
- Adds unit coverage for resend helper/rate-limit behavior and E2E coverage for invalid-password resend attempts not sending email.

## Validation

- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `pnpm --filter web test:e2e -- tests/e2e/auth/register.spec.ts`
- `pnpm --filter web test:e2e:no-email-verification`
- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=01234567890123456789012345678901 DATABASE_URL=postgres://test:test@127.0.0.1:5432/ctops_test pnpm --filter web build` (passes with existing Turbopack NFT and low-entropy dummy secret warnings)

## Notes

`pnpm --filter web test:unit` still fails in existing `lib/db/schema/metadata-validation.test.mjs` with `ERR_MODULE_NOT_FOUND` for `lib/db/schema/organisations` imported from `hosts.ts`; the new email verification unit tests pass before that existing failure.
