### PR TITLE
test(web): cover settings org name and activation token flows

### DIFF
--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -309,6 +309,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                 <Label htmlFor="org-name">Organisation name</Label>
                 <Input
                   id="org-name"
+                  data-testid="settings-org-name-input"
                   {...orgForm.register('name')}
                 />
                 {orgForm.formState.errors.name && (
@@ -318,11 +319,19 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                 )}
               </div>
               <div className="flex items-center gap-3">
-                <Button type="submit" size="sm" disabled={orgMutation.isPending}>
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={orgMutation.isPending}
+                  data-testid="settings-org-name-save"
+                >
                   {orgMutation.isPending ? 'Saving…' : 'Save'}
                 </Button>
                 {orgSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span
+                    className="flex items-center gap-1 text-sm text-green-700"
+                    data-testid="settings-org-name-success"
+                  >
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>
@@ -892,6 +901,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                       variant="outline"
                       onClick={copyActivationToken}
                       className="shrink-0"
+                      data-testid="activation-token-copy"
                     >
                       {activationCopied ? (
                         <>

--- a/apps/web/tests/e2e/settings/activation-token.spec.ts
+++ b/apps/web/tests/e2e/settings/activation-token.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '../fixtures/test'
+import { decodeActivationToken } from '@/lib/licence-activation-token'
+import { TEST_ORG } from '../fixtures/seed'
 
 test('admin can generate an activation token from settings', async ({ authenticatedPage: page }) => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
   await page.goto('/settings')
 
   await expect(page.getByTestId('settings-heading')).toBeVisible()
@@ -12,6 +15,30 @@ test('admin can generate an activation token from settings', async ({ authentica
   await expect(page.getByTestId('activation-token-generate')).toHaveText('Generate a new token')
 
   const firstToken = await activationToken.textContent()
+  expect(firstToken).toBeTruthy()
+  const firstDecoded = decodeActivationToken(firstToken ?? '')
+  expect(firstDecoded.ok).toBe(true)
+  if (firstDecoded.ok) {
+    expect(firstDecoded.payload.installOrgName).toBe(TEST_ORG.name)
+    expect(firstDecoded.payload.installOrgId).toBeTruthy()
+  }
+
+  await page.getByTestId('activation-token-copy').click()
+  await expect(page.getByTestId('activation-token-copy')).toContainText('Copied')
+  await expect
+    .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(firstToken)
+
   await page.getByTestId('activation-token-generate').click()
   await expect(activationToken).not.toHaveText(firstToken ?? '')
+
+  const secondToken = await activationToken.textContent()
+  expect(secondToken).toBeTruthy()
+  const secondDecoded = decodeActivationToken(secondToken ?? '')
+  expect(secondDecoded.ok).toBe(true)
+  if (firstDecoded.ok && secondDecoded.ok) {
+    expect(secondDecoded.payload.installOrgId).toBe(firstDecoded.payload.installOrgId)
+    expect(secondDecoded.payload.installOrgName).toBe(TEST_ORG.name)
+    expect(secondDecoded.payload.nonce).not.toBe(firstDecoded.payload.nonce)
+  }
 })

--- a/apps/web/tests/e2e/settings/organisation-name.spec.ts
+++ b/apps/web/tests/e2e/settings/organisation-name.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+test('admin can update the organisation name from settings', async ({ authenticatedPage: page }) => {
+  const updatedName = `Updated Org ${Date.now()}`
+
+  await page.goto('/settings')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  const orgNameInput = page.getByTestId('settings-org-name-input')
+  await orgNameInput.click()
+  await orgNameInput.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`)
+  await orgNameInput.fill(updatedName)
+  await page.getByTestId('settings-org-name-save').click()
+
+  await expect(page.getByTestId('settings-org-name-success')).toHaveText('Saved')
+  await expect(orgNameInput).toHaveValue(updatedName)
+
+  const sql = getTestDb()
+  const rows = await sql<Array<{ name: string }>>`
+    SELECT name
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  expect(rows[0]?.name).toBe(updatedName)
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for updating the organisation name from settings
- strengthen the activation-token settings E2E to validate decoded payloads and copy behavior
- add stable settings test ids needed by the Playwright harness

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/settings/activation-token.spec.ts tests/e2e/settings/organisation-name.spec.ts`

## Notes
- Filed #637 for an unrelated notification bell hydration mismatch surfaced during the settings E2E run.
