### PR TITLE
fix(ingest): restrict terminal websocket origins

### DIFF
--- a/apps/docs/docs/features/terminal.md
+++ b/apps/docs/docs/features/terminal.md
@@ -120,6 +120,14 @@ If you stop the bundled nginx and terminate TLS with your own proxy (HAProxy, a 
 
 Set `INGEST_WS_URL=wss://host:8443` (or `ws://host:8080` for unencrypted LAN setups). The browser connects to that URL instead of the page origin. Only useful when you want the browser to talk to ingest directly rather than through any proxy.
 
+When you use direct mode across origins, also set `INGEST_TERMINAL_TRUSTED_ORIGINS` on ingest to the browser origins that should be allowed to open terminal WebSockets. Example:
+
+```env
+INGEST_TERMINAL_TRUSTED_ORIGINS=https://ct-ops.example.com,https://ops-admin.example.com
+```
+
+Leave `INGEST_TERMINAL_TRUSTED_ORIGINS` empty when the browser connects through the same origin or bundled proxy.
+
 #### Cloudflare Tunnel example
 
 In your `cloudflared` config, add a path-based ingress rule for `/ws/terminal/*` **before** the catch-all rule for the web app:

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -58,6 +58,7 @@ INGEST_WS_URL=
 | `INGEST_GRPC_PORT` | — | `9443` | gRPC listener port |
 | `INGEST_HTTP_PORT` | — | `8080` | HTTP port for JWKS endpoint and health check |
 | `INGEST_AGENT_DOWNLOAD_BASE_URL` | — | `https://localhost` | Public URL of the web app — agents construct their binary download URL from this |
+| `INGEST_TERMINAL_TRUSTED_ORIGINS` | — 🔒 | *(empty)* | Comma-separated browser origins allowed to open terminal WebSockets directly against ingest. Leave empty to require same-origin proxying |
 | `INGEST_WEB_SERVER_CERT` | — | `/etc/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. Ingest reads this and pushes rotations down the heartbeat stream when an operator swaps the cert, so agents keep verifying download URLs without manual CA distribution. Empty disables the rotation RPC |
 
 :::warning JWT Key Backup

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -108,7 +108,11 @@ func main() {
 	versionPoller := config.NewVersionPoller(cfg.Agent.LatestVersion, 5*time.Minute)
 	versionPoller.Start(ctx)
 	hbHandler := handlers.NewHeartbeatHandler(pool, issuer, q, versionPoller, cfg.Agent.DownloadBaseURL, agentCA, webServerCert)
-	terminalWSHandler := handlers.NewTerminalWSHandler(pool)
+	terminalWSHandler, err := handlers.NewTerminalWSHandler(pool, cfg.Terminal.TrustedOrigins)
+	if err != nil {
+		slog.Error("initialising terminal websocket handler", "err", err)
+		os.Exit(1)
+	}
 	inventoryHandler := handlers.NewInventoryHandler(pool, issuer)
 	renewHandler := handlers.NewRenewCertHandler(pool, agentCA)
 

--- a/apps/ingest/internal/config/config.go
+++ b/apps/ingest/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -12,13 +13,14 @@ import (
 
 // Config is the ingest service configuration loaded from a YAML file.
 type Config struct {
-	GRPCPort    int                   `yaml:"grpc_port"`
-	HTTPPort    int                   `yaml:"http_port"`
-	DatabaseURL string                `yaml:"database_url"`
-	TLS         TLSConfig             `yaml:"tls"`
-	JWT         JWTConfig             `yaml:"jwt"`
-	Queue       QueueConfig           `yaml:"queue"`
+	GRPCPort    int                     `yaml:"grpc_port"`
+	HTTPPort    int                     `yaml:"http_port"`
+	DatabaseURL string                  `yaml:"database_url"`
+	TLS         TLSConfig               `yaml:"tls"`
+	JWT         JWTConfig               `yaml:"jwt"`
+	Queue       QueueConfig             `yaml:"queue"`
 	Agent       AgentDistributionConfig `yaml:"agent"`
+	Terminal    TerminalConfig          `yaml:"terminal"`
 }
 
 // AgentDistributionConfig controls agent version management.
@@ -54,14 +56,21 @@ type TLSConfig struct {
 type JWTConfig struct {
 	// KeyFile is the path to the RSA private key PEM file used to sign agent JWTs.
 	// Generated on first start if it does not exist.
-	KeyFile     string        `yaml:"key_file"`
-	Issuer      string        `yaml:"issuer"`
-	TokenTTL    time.Duration `yaml:"token_ttl"`
+	KeyFile  string        `yaml:"key_file"`
+	Issuer   string        `yaml:"issuer"`
+	TokenTTL time.Duration `yaml:"token_ttl"`
 }
 
 type QueueConfig struct {
 	// Type is "inprocess" (buffered channels) or "redpanda".
 	Type string `yaml:"type"`
+}
+
+type TerminalConfig struct {
+	// TrustedOrigins allows cross-origin browser connections to the terminal
+	// WebSocket endpoint when INGEST_WS_URL points directly at ingest instead
+	// of using same-origin proxying. Leave empty to require same-origin only.
+	TrustedOrigins []string `yaml:"trusted_origins"`
 }
 
 // Load reads a YAML config file and applies INGEST_ environment overrides.
@@ -181,4 +190,20 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("INGEST_WEB_SERVER_CERT"); v != "" {
 		cfg.TLS.WebServerCertFile = v
 	}
+	if v := os.Getenv("INGEST_TERMINAL_TRUSTED_ORIGINS"); v != "" {
+		cfg.Terminal.TrustedOrigins = splitCSV(v)
+	}
+}
+
+func splitCSV(raw string) []string {
+	parts := strings.Split(raw, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		values = append(values, part)
+	}
+	return values
 }

--- a/apps/ingest/internal/config/config_test.go
+++ b/apps/ingest/internal/config/config_test.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLoadAppliesTerminalTrustedOriginsEnv(t *testing.T) {
+	t.Setenv("INGEST_TERMINAL_TRUSTED_ORIGINS", " https://app.example.com ,http://localhost:3000, ")
+
+	cfg, err := Load("/tmp/does-not-exist.yaml")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	want := []string{"https://app.example.com", "http://localhost:3000"}
+	if !reflect.DeepEqual(cfg.Terminal.TrustedOrigins, want) {
+		t.Fatalf("cfg.Terminal.TrustedOrigins = %#v, want %#v", cfg.Terminal.TrustedOrigins, want)
+	}
+}

--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -6,11 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -25,11 +27,19 @@ import (
 // TerminalWSHandler serves browser WebSocket connections for SSH-backed
 // terminal sessions. It never asks the agent to open a shell.
 type TerminalWSHandler struct {
-	pool *pgxpool.Pool
+	pool       *pgxpool.Pool
+	acceptOpts *websocket.AcceptOptions
 }
 
-func NewTerminalWSHandler(pool *pgxpool.Pool) *TerminalWSHandler {
-	return &TerminalWSHandler{pool: pool}
+func NewTerminalWSHandler(pool *pgxpool.Pool, trustedOrigins []string) (*TerminalWSHandler, error) {
+	acceptOpts, err := terminalWSAcceptOptions(trustedOrigins)
+	if err != nil {
+		return nil, err
+	}
+	return &TerminalWSHandler{
+		pool:       pool,
+		acceptOpts: acceptOpts,
+	}, nil
 }
 
 type wsMessage struct {
@@ -51,9 +61,7 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	sessionID := parts[0]
 
-	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
-	})
+	conn, err := websocket.Accept(w, r, h.acceptOpts)
 	if err != nil {
 		slog.Warn("terminal ws: accept failed", "err", err)
 		return
@@ -192,6 +200,36 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+func terminalWSAcceptOptions(trustedOrigins []string) (*websocket.AcceptOptions, error) {
+	patterns := make([]string, 0, len(trustedOrigins))
+	for _, raw := range trustedOrigins {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse terminal trusted origin %q: %w", raw, err)
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return nil, fmt.Errorf("terminal trusted origin %q must include scheme and host", raw)
+		}
+		if parsed.Path != "" && parsed.Path != "/" {
+			return nil, errors.New("terminal trusted origins must not include a path")
+		}
+		if parsed.RawQuery != "" || parsed.Fragment != "" {
+			return nil, errors.New("terminal trusted origins must not include query or fragment")
+		}
+
+		patterns = append(patterns, parsed.Scheme+"://"+parsed.Host)
+	}
+
+	return &websocket.AcceptOptions{
+		OriginPatterns: patterns,
+	}, nil
 }
 
 func (h *TerminalWSHandler) openSSHSession(ctx context.Context, hostID, host, username, password string) (*ssh.Client, *ssh.Session, io.WriteCloser, io.Reader, error) {

--- a/apps/ingest/internal/handlers/terminal_ws_security_test.go
+++ b/apps/ingest/internal/handlers/terminal_ws_security_test.go
@@ -1,0 +1,93 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestTerminalWSAcceptOptionsDefaultToSameOrigin(t *testing.T) {
+	opts, err := terminalWSAcceptOptions(nil)
+	if err != nil {
+		t.Fatalf("terminalWSAcceptOptions(nil) error = %v", err)
+	}
+	if opts.InsecureSkipVerify {
+		t.Fatal("expected same-origin default to keep origin verification enabled")
+	}
+	if len(opts.OriginPatterns) != 0 {
+		t.Fatalf("opts.OriginPatterns = %#v, want none", opts.OriginPatterns)
+	}
+}
+
+func TestTerminalWSAcceptOptionsAllowConfiguredOrigins(t *testing.T) {
+	opts, err := terminalWSAcceptOptions([]string{
+		"https://app.example.com",
+		"http://localhost:3000",
+	})
+	if err != nil {
+		t.Fatalf("terminalWSAcceptOptions() error = %v", err)
+	}
+
+	want := []string{"https://app.example.com", "http://localhost:3000"}
+	if !reflect.DeepEqual(opts.OriginPatterns, want) {
+		t.Fatalf("opts.OriginPatterns = %#v, want %#v", opts.OriginPatterns, want)
+	}
+}
+
+func TestTerminalWSAcceptOptionsRejectInvalidOrigins(t *testing.T) {
+	if _, err := terminalWSAcceptOptions([]string{"not-a-url"}); err == nil {
+		t.Fatal("expected invalid origin to be rejected")
+	}
+}
+
+func TestInsecureSkipVerifyTrueAllowlist(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
+	allowed := map[string]struct{}{
+		filepath.Join(repoRoot, "agent", "internal", "checks", "certificate.go"):                     {},
+		filepath.Join(repoRoot, "apps", "ingest", "internal", "handlers", "cert_refresh_sweeper.go"): {},
+	}
+
+	var unexpected []string
+	err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".worktrees", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(data), "InsecureSkipVerify: true") {
+			return nil
+		}
+		if _, ok := allowed[path]; ok {
+			return nil
+		}
+		unexpected = append(unexpected, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir() error = %v", err)
+	}
+	if len(unexpected) != 0 {
+		t.Fatalf("found unexpected InsecureSkipVerify: true call sites: %v", unexpected)
+	}
+}


### PR DESCRIPTION
## Summary
- require same-origin terminal WebSocket upgrades by default and only allow cross-origin access when `INGEST_TERMINAL_TRUSTED_ORIGINS` is explicitly configured
- validate and plumb trusted terminal origins through ingest startup instead of disabling the WebSocket origin check globally
- add guard tests that fail if new `InsecureSkipVerify: true` call sites appear outside the approved certificate flows

## Testing
- go test ./... (in `apps/ingest`)

Closes #346
