### PR TITLE
feat(web): centralize SMTP relay settings

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,22 @@
 
 ## What Has Been Built
 
+### Session 62 — Central SMTP relay settings
+
+**Notification email delivery** (`apps/web/lib/actions/notification-settings.ts`, `apps/web/app/(dashboard)/settings/settings-client.tsx`, `apps/web/lib/notifications/`)
+- Moved SMTP relay configuration out of per-alert channels and into organisation Settings as a central SMTP relay.
+- Added admin-only save/test actions for the relay; SMTP passwords are encrypted before storage and redacted from client responses.
+- Backend validation now restricts SMTP ports and rejects private/reserved relay hosts when the relay is enabled.
+- Alert email channels now store only channel name and recipient addresses; relay host, credentials, encryption, and sender identity come from central settings.
+
+**Alert dispatch** (`apps/web/lib/actions/alerts.ts`, `apps/ingest/internal/handlers/notify.go`, `apps/ingest/internal/db/queries/alerts.sql.go`)
+- Web test notifications and ingest alert delivery now combine central relay settings with each email channel's recipients.
+- Ingest keeps backward-compatible fallback support for legacy SMTP channel rows that still contain relay details.
+
+**Test coverage**
+- Added web unit coverage for SMTP recipient normalisation, relay redaction, and delivery through an in-process mock SMTP server.
+- Added ingest Go coverage for SMTP delivery through an in-process mock SMTP server.
+
 ### Session 61 — Agent guidance and E2E harness documentation
 
 **Agent operating rules** (`AGENTS.md`)

--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -152,20 +152,24 @@ func GetRecentCheckResults(ctx context.Context, pool *pgxpool.Pool, checkID stri
 
 // SmtpChannelRow is a row from notification_channels where type = 'smtp'.
 type SmtpChannelRow struct {
-	ID         string
-	ConfigJSON string // raw JSONB as text
+	ID              string
+	ConfigJSON      string // raw notification_channels.config JSONB as text
+	RelayConfigJSON string // raw organisations.metadata.notificationSettings.smtpRelay JSONB as text; may be empty
 }
 
 // GetEnabledSmtpChannels returns all enabled, non-deleted SMTP notification
 // channels for the given organisation.
 func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]SmtpChannelRow, error) {
 	const q = `
-		SELECT id, config::text
-		FROM notification_channels
-		WHERE organisation_id = $1
-		  AND type = 'smtp'
-		  AND enabled = true
-		  AND deleted_at IS NULL
+		SELECT c.id,
+		       c.config::text,
+		       COALESCE(o.metadata->'notificationSettings'->'smtpRelay', '{}'::jsonb)::text
+		FROM notification_channels c
+		JOIN organisations o ON o.id = c.organisation_id
+		WHERE c.organisation_id = $1
+		  AND c.type = 'smtp'
+		  AND c.enabled = true
+		  AND c.deleted_at IS NULL
 	`
 	rows, err := pool.Query(ctx, q, orgID)
 	if err != nil {
@@ -176,7 +180,7 @@ func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, orgID strin
 	var result []SmtpChannelRow
 	for rows.Next() {
 		var r SmtpChannelRow
-		if err := rows.Scan(&r.ID, &r.ConfigJSON); err != nil {
+		if err := rows.Scan(&r.ID, &r.ConfigJSON, &r.RelayConfigJSON); err != nil {
 			return nil, err
 		}
 		result = append(result, r)
@@ -299,8 +303,8 @@ func GetEnabledTelegramChannels(ctx context.Context, pool *pgxpool.Pool, orgID s
 
 // OrgNotificationSettingsRow holds the notification settings from org metadata.
 type OrgNotificationSettingsRow struct {
-	InAppEnabled   bool
-	InAppRoles     []string
+	InAppEnabled    bool
+	InAppRoles      []string
 	AllowUserOptOut bool
 }
 

--- a/apps/ingest/internal/handlers/notify.go
+++ b/apps/ingest/internal/handlers/notify.go
@@ -18,13 +18,14 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	ctcrypto "github.com/carrtech-dev/ct-ops/ingest/internal/crypto"
 	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
 )
 
 // AlertEvent is the payload sent to webhook notification channels.
 type AlertEvent struct {
-	Event     string `json:"event"`     // "alert.fired" | "alert.resolved"
-	Severity  string `json:"severity"`  // "info" | "warning" | "critical"
+	Event     string `json:"event"`    // "alert.fired" | "alert.resolved"
+	Severity  string `json:"severity"` // "info" | "warning" | "critical"
 	Host      string `json:"host"`
 	Rule      string `json:"rule"`
 	Message   string `json:"message"`
@@ -71,12 +72,23 @@ type smtpChannelConfig struct {
 	Host        string   `json:"host"`
 	Port        int      `json:"port"`
 	Encryption  string   `json:"encryption"` // 'none' | 'starttls' | 'tls'
-	Secure      *bool    `json:"secure"`      // legacy field — superseded by Encryption
+	Secure      *bool    `json:"secure"`     // legacy field — superseded by Encryption
 	Username    string   `json:"username"`
 	Password    string   `json:"password"`
 	FromAddress string   `json:"fromAddress"`
 	FromName    string   `json:"fromName"`
 	ToAddresses []string `json:"toAddresses"`
+}
+
+type smtpRelayConfig struct {
+	Enabled           bool   `json:"enabled"`
+	Host              string `json:"host"`
+	Port              int    `json:"port"`
+	Encryption        string `json:"encryption"` // 'none' | 'starttls' | 'tls'
+	Username          string `json:"username"`
+	PasswordEncrypted string `json:"passwordEncrypted"`
+	FromAddress       string `json:"fromAddress"`
+	FromName          string `json:"fromName"`
 }
 
 func (c *smtpChannelConfig) effectiveEncryption() string {
@@ -88,6 +100,28 @@ func (c *smtpChannelConfig) effectiveEncryption() string {
 		return "tls"
 	}
 	return "starttls"
+}
+
+func smtpConfigFromRelay(relay smtpRelayConfig, recipients []string) (smtpChannelConfig, error) {
+	password := ""
+	if relay.PasswordEncrypted != "" {
+		decrypted, err := ctcrypto.Decrypt(relay.PasswordEncrypted)
+		if err != nil {
+			return smtpChannelConfig{}, fmt.Errorf("decrypt smtp password: %w", err)
+		}
+		password = string(decrypted)
+	}
+
+	return smtpChannelConfig{
+		Host:        relay.Host,
+		Port:        relay.Port,
+		Encryption:  relay.Encryption,
+		Username:    relay.Username,
+		Password:    password,
+		FromAddress: relay.FromAddress,
+		FromName:    relay.FromName,
+		ToAddresses: recipients,
+	}, nil
 }
 
 // sendSmtpEmail delivers an AlertEvent to a single SMTP channel.
@@ -193,6 +227,26 @@ func dispatchSmtp(smtpChannels []queries.SmtpChannelRow, event AlertEvent) {
 		var cfg smtpChannelConfig
 		if err := json.Unmarshal([]byte(ch.ConfigJSON), &cfg); err != nil {
 			slog.Warn("dispatchSmtp: unmarshal channel config", "channel_id", ch.ID, "err", err)
+			continue
+		}
+		if ch.RelayConfigJSON != "" && ch.RelayConfigJSON != "{}" {
+			var relay smtpRelayConfig
+			if err := json.Unmarshal([]byte(ch.RelayConfigJSON), &relay); err != nil {
+				slog.Warn("dispatchSmtp: unmarshal relay config", "channel_id", ch.ID, "err", err)
+				continue
+			}
+			if !relay.Enabled {
+				continue
+			}
+			relayCfg, err := smtpConfigFromRelay(relay, cfg.ToAddresses)
+			if err != nil {
+				slog.Warn("dispatchSmtp: prepare relay config", "channel_id", ch.ID, "err", err)
+				continue
+			}
+			cfg = relayCfg
+		}
+		if cfg.Host == "" || cfg.FromAddress == "" || len(cfg.ToAddresses) == 0 {
+			slog.Warn("dispatchSmtp: incomplete smtp configuration", "channel_id", ch.ID)
 			continue
 		}
 		go func(c smtpChannelConfig) {

--- a/apps/ingest/internal/handlers/notify_smtp_test.go
+++ b/apps/ingest/internal/handlers/notify_smtp_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type smtpTestMessage struct {
+	from string
+	to   []string
+	data string
+}
+
+func startMockSMTPServer(t *testing.T) (addr string, messages *[]smtpTestMessage, closeFn func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var mu sync.Mutex
+	var captured []smtpTestMessage
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		write := func(format string, args ...any) {
+			_, _ = fmt.Fprintf(conn, format+"\r\n", args...)
+		}
+		write("220 mock.smtp ESMTP")
+
+		current := smtpTestMessage{}
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			upper := strings.ToUpper(line)
+			switch {
+			case strings.HasPrefix(upper, "EHLO") || strings.HasPrefix(upper, "HELO"):
+				write("250 mock.smtp")
+			case strings.HasPrefix(upper, "MAIL FROM:"):
+				current = smtpTestMessage{from: line}
+				write("250 ok")
+			case strings.HasPrefix(upper, "RCPT TO:"):
+				current.to = append(current.to, line)
+				write("250 ok")
+			case upper == "DATA":
+				write("354 end with dot")
+				var b strings.Builder
+				for {
+					dataLine, err := reader.ReadString('\n')
+					if err != nil {
+						return
+					}
+					dataLine = strings.TrimRight(dataLine, "\r\n")
+					if dataLine == "." {
+						break
+					}
+					b.WriteString(dataLine)
+					b.WriteByte('\n')
+				}
+				current.data = b.String()
+				mu.Lock()
+				captured = append(captured, current)
+				mu.Unlock()
+				write("250 queued")
+			case upper == "QUIT":
+				write("221 bye")
+				return
+			default:
+				write("250 ok")
+			}
+		}
+	}()
+
+	return ln.Addr().String(), &captured, func() {
+		_ = ln.Close()
+		<-done
+	}
+}
+
+func TestSendSmtpEmailDeliversToMockServer(t *testing.T) {
+	addr, messages, closeFn := startMockSMTPServer(t)
+	defer closeFn()
+
+	host, portText, ok := strings.Cut(addr, ":")
+	if !ok {
+		t.Fatalf("unexpected addr %q", addr)
+	}
+	var port int
+	if _, err := fmt.Sscanf(portText, "%d", &port); err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	err := sendSmtpEmail(smtpChannelConfig{
+		Host:        host,
+		Port:        port,
+		Encryption:  "none",
+		FromAddress: "alerts@example.com",
+		FromName:    "CT-Ops Alerts",
+		ToAddresses: []string{"ops@example.com", "team@example.com"},
+	}, AlertEvent{
+		Event:     "alert.test",
+		Severity:  "info",
+		Host:      "test-host",
+		Rule:      "Test Rule",
+		Message:   "SMTP delivery test",
+		Timestamp: "2026-04-27T12:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("sendSmtpEmail: %v", err)
+	}
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	msg := (*messages)[0]
+	if !strings.Contains(msg.from, "alerts@example.com") {
+		t.Fatalf("MAIL FROM did not include sender: %q", msg.from)
+	}
+	if len(msg.to) != 2 {
+		t.Fatalf("expected 2 recipients, got %d", len(msg.to))
+	}
+	if !strings.Contains(msg.data, "[CT-Ops] TEST") {
+		t.Fatalf("message did not include subject: %q", msg.data)
+	}
+	if !strings.Contains(msg.data, "SMTP delivery test") {
+		t.Fatalf("message did not include body: %q", msg.data)
+	}
+}

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -214,61 +214,14 @@ function AddWebhookDialog({
   )
 }
 
-// ─── SMTP Dialog ──────────────────────────────────────────────────────────────
-
-type SmtpEncryptionValue = 'none' | 'starttls' | 'tls'
-
-const ENCRYPTION_DEFAULTS: Record<SmtpEncryptionValue, number> = {
-  none: 25,
-  starttls: 587,
-  tls: 465,
-}
-
-const ENCRYPTION_LABELS: Record<SmtpEncryptionValue, { label: string; description: string }> = {
-  none:     { label: 'None',     description: 'Unencrypted — not recommended' },
-  starttls: { label: 'STARTTLS', description: 'Plain connect, upgrades to TLS (port 587)' },
-  tls:      { label: 'SSL/TLS',  description: 'Direct TLS connection (port 465)' },
-}
+// ─── SMTP Recipient Dialog ───────────────────────────────────────────────────
 
 const smtpFormSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
-  host: z.string().min(1, 'Host is required'),
-  port: z.number().int().min(1).max(65535),
-  encryption: z.enum(['none', 'starttls', 'tls']),
-  username: z.string().optional(),
-  password: z.string().optional(),
-  fromAddress: z.string().email('Must be a valid email'),
-  fromName: z.string().optional(),
   toAddresses: z.string().min(1, 'At least one recipient required'),
 })
 
 type SmtpFormValues = z.infer<typeof smtpFormSchema>
-
-function SmtpEncryptionSelect({
-  value,
-  onChange,
-}: {
-  value: SmtpEncryptionValue
-  onChange: (v: SmtpEncryptionValue) => void
-}) {
-  return (
-    <Select value={value} onValueChange={(v) => onChange(v as SmtpEncryptionValue)}>
-      <SelectTrigger>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {(Object.entries(ENCRYPTION_LABELS) as [SmtpEncryptionValue, { label: string; description: string }][]).map(
-          ([key, { label, description }]) => (
-            <SelectItem key={key} value={key}>
-              <span className="font-medium">{label}</span>
-              <span className="ml-2 text-muted-foreground text-xs">{description}</span>
-            </SelectItem>
-          ),
-        )}
-      </SelectContent>
-    </Select>
-  )
-}
 
 function AddSmtpDialog({
   orgId,
@@ -285,20 +238,8 @@ function AddSmtpDialog({
     register,
     handleSubmit,
     reset,
-    watch,
-    setValue,
     formState: { errors, isSubmitting },
-  } = useForm<SmtpFormValues>({
-    resolver: zodResolver(smtpFormSchema),
-    defaultValues: { port: 587, encryption: 'starttls' },
-  })
-
-  const encryption = watch('encryption') as SmtpEncryptionValue
-
-  function handleEncryptionChange(v: SmtpEncryptionValue) {
-    setValue('encryption', v)
-    setValue('port', ENCRYPTION_DEFAULTS[v])
-  }
+  } = useForm<SmtpFormValues>({ resolver: zodResolver(smtpFormSchema) })
 
   async function onSubmit(values: SmtpFormValues) {
     const toAddresses = values.toAddresses
@@ -310,13 +251,6 @@ function AddSmtpDialog({
       name: values.name,
       type: 'smtp',
       config: {
-        host: values.host,
-        port: values.port,
-        encryption: values.encryption,
-        username: values.username || undefined,
-        password: values.password || undefined,
-        fromAddress: values.fromAddress,
-        fromName: values.fromName || undefined,
         toAddresses,
       },
     })
@@ -330,56 +264,13 @@ function AddSmtpDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Add SMTP Channel</DialogTitle>
+          <DialogTitle>Add Email Channel</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="smtp-name">Name</Label>
             <Input id="smtp-name" placeholder="e.g. Ops Alerts" {...register('name')} />
             {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
-          </div>
-          <div className="grid grid-cols-3 gap-3">
-            <div className="col-span-2 space-y-1.5">
-              <Label htmlFor="smtp-host">Host</Label>
-              <Input id="smtp-host" placeholder="smtp.example.com" {...register('host')} />
-              {errors.host && <p className="text-sm text-red-600">{errors.host.message}</p>}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="smtp-port">Port</Label>
-              <Input id="smtp-port" type="number" {...register('port', { valueAsNumber: true })} />
-              {errors.port && <p className="text-sm text-red-600">{errors.port.message}</p>}
-            </div>
-          </div>
-          <div className="space-y-1.5">
-            <Label>Encryption</Label>
-            <SmtpEncryptionSelect value={encryption} onChange={handleEncryptionChange} />
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="smtp-username">
-                Username <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input id="smtp-username" placeholder="user@example.com" {...register('username')} />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="smtp-password">
-                Password <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input id="smtp-password" type="password" placeholder="••••••••" {...register('password')} />
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="smtp-from">From address</Label>
-              <Input id="smtp-from" placeholder="alerts@example.com" {...register('fromAddress')} />
-              {errors.fromAddress && <p className="text-sm text-red-600">{errors.fromAddress.message}</p>}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="smtp-fromname">
-                From name <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input id="smtp-fromname" placeholder="CT-Ops Alerts" {...register('fromName')} />
-            </div>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="smtp-to">Recipients</Label>
@@ -391,6 +282,9 @@ function AddSmtpDialog({
             <p className="text-xs text-muted-foreground">Comma-separated list of email addresses</p>
             {errors.toAddresses && <p className="text-sm text-red-600">{errors.toAddresses.message}</p>}
           </div>
+          <p className="text-xs text-muted-foreground">
+            SMTP relay settings are managed in Settings → Notification Settings.
+          </p>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
@@ -559,17 +453,10 @@ function EditWebhookDialog({
   )
 }
 
-// ─── Edit SMTP Dialog ──────────────────────────────────────────────────────────
+// ─── Edit SMTP Recipient Dialog ───────────────────────────────────────────────
 
 const editSmtpFormSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
-  host: z.string().min(1, 'Host is required'),
-  port: z.number().int().min(1).max(65535),
-  encryption: z.enum(['none', 'starttls', 'tls']),
-  username: z.string().optional(),
-  password: z.string().optional(),
-  fromAddress: z.string().email('Must be a valid email'),
-  fromName: z.string().optional(),
   toAddresses: z.string().min(1, 'At least one recipient required'),
 })
 
@@ -591,30 +478,14 @@ function EditSmtpDialog({
   const {
     register,
     handleSubmit,
-    watch,
-    setValue,
     formState: { errors, isSubmitting },
   } = useForm<EditSmtpFormValues>({
     resolver: zodResolver(editSmtpFormSchema),
     defaultValues: {
       name: channel.name,
-      host: channel.config.host,
-      port: channel.config.port,
-      encryption: channel.config.encryption,
-      username: channel.config.username ?? '',
-      password: '',
-      fromAddress: channel.config.fromAddress,
-      fromName: channel.config.fromName ?? '',
       toAddresses: channel.config.toAddresses.join(', '),
     },
   })
-
-  const encryption = watch('encryption') as SmtpEncryptionValue
-
-  function handleEncryptionChange(v: SmtpEncryptionValue) {
-    setValue('encryption', v)
-    setValue('port', ENCRYPTION_DEFAULTS[v])
-  }
 
   async function onSubmit(values: EditSmtpFormValues) {
     const toAddresses = values.toAddresses
@@ -624,13 +495,6 @@ function EditSmtpDialog({
 
     const result = await updateNotificationChannel(orgId, channel.id, {
       name: values.name,
-      host: values.host,
-      port: values.port,
-      encryption: values.encryption,
-      username: values.username || undefined,
-      password: values.password || undefined,
-      fromAddress: values.fromAddress,
-      fromName: values.fromName || undefined,
       toAddresses,
     })
     if ('error' in result) return
@@ -642,7 +506,7 @@ function EditSmtpDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Edit SMTP Channel</DialogTitle>
+          <DialogTitle>Edit Email Channel</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
@@ -650,63 +514,15 @@ function EditSmtpDialog({
             <Input id="edit-smtp-name" {...register('name')} />
             {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
           </div>
-          <div className="grid grid-cols-3 gap-3">
-            <div className="col-span-2 space-y-1.5">
-              <Label htmlFor="edit-smtp-host">Host</Label>
-              <Input id="edit-smtp-host" {...register('host')} />
-              {errors.host && <p className="text-sm text-red-600">{errors.host.message}</p>}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="edit-smtp-port">Port</Label>
-              <Input id="edit-smtp-port" type="number" {...register('port', { valueAsNumber: true })} />
-              {errors.port && <p className="text-sm text-red-600">{errors.port.message}</p>}
-            </div>
-          </div>
-          <div className="space-y-1.5">
-            <Label>Encryption</Label>
-            <SmtpEncryptionSelect value={encryption} onChange={handleEncryptionChange} />
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="edit-smtp-username">
-                Username <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input id="edit-smtp-username" {...register('username')} />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="edit-smtp-password">
-                Password{' '}
-                <span className="text-muted-foreground font-normal">
-                  ({channel.config.hasPassword ? 'leave blank to keep existing' : 'optional'})
-                </span>
-              </Label>
-              <Input
-                id="edit-smtp-password"
-                type="password"
-                placeholder={channel.config.hasPassword ? '••••••••' : ''}
-                {...register('password')}
-              />
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="edit-smtp-from">From address</Label>
-              <Input id="edit-smtp-from" {...register('fromAddress')} />
-              {errors.fromAddress && <p className="text-sm text-red-600">{errors.fromAddress.message}</p>}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="edit-smtp-fromname">
-                From name <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input id="edit-smtp-fromname" {...register('fromName')} />
-            </div>
-          </div>
           <div className="space-y-1.5">
             <Label htmlFor="edit-smtp-to">Recipients</Label>
             <Input id="edit-smtp-to" {...register('toAddresses')} />
             <p className="text-xs text-muted-foreground">Comma-separated list of email addresses</p>
             {errors.toAddresses && <p className="text-sm text-red-600">{errors.toAddresses.message}</p>}
           </div>
+          <p className="text-xs text-muted-foreground">
+            SMTP relay settings are managed in Settings → Notification Settings.
+          </p>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
@@ -1652,7 +1468,7 @@ export function AlertsClient({
               onClick={() => setAddSmtpOpen(true)}
             >
               <Plus className="size-3.5 mr-1" />
-              Add SMTP
+              Add Email
             </Button>
             <Button
               size="sm"
@@ -1695,7 +1511,7 @@ export function AlertsClient({
                       {ch.type === 'smtp' ? (
                         <Badge variant="outline" className="gap-1">
                           <Mail className="size-3" />
-                          SMTP
+                          Email
                         </Badge>
                       ) : ch.type === 'slack' ? (
                         <Badge variant="outline" className="gap-1">
@@ -1717,7 +1533,7 @@ export function AlertsClient({
                     <TableCell className="text-sm text-muted-foreground">
                       {ch.type === 'smtp' ? (
                         <span>
-                          {ch.config.host}:{ch.config.port} ({ch.config.encryption.toUpperCase()}) → {ch.config.toAddresses.join(', ')}
+                          {ch.config.toAddresses.join(', ')}
                         </span>
                       ) : ch.type === 'slack' ? (
                         <span className="font-mono truncate block max-w-xs">{ch.config.webhookUrl}</span>

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -10,20 +10,26 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Users, TerminalSquare, ScrollText, Bell, ScanLine, Tag as TagIcon, Copy, Check } from 'lucide-react'
+import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Users, TerminalSquare, ScrollText, Bell, ScanLine, Tag as TagIcon, Copy, Check, Mail, FlaskConical } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
 import { updateOrgName, saveLicenceKey, updateMetricRetention, generateActivationToken } from '@/lib/actions/settings'
 import { getOrgDefaultCollectionSettings, updateOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
 import { getOrgTerminalSettings, updateOrgTerminalSettings } from '@/lib/actions/terminal'
-import { getOrgNotificationSettings, updateOrgNotificationSettings } from '@/lib/actions/notification-settings'
+import {
+  getOrgNotificationSettings,
+  getOrgSmtpRelaySettings,
+  sendTestSmtpRelaySettings,
+  updateOrgNotificationSettings,
+  updateOrgSmtpRelaySettings,
+} from '@/lib/actions/notification-settings'
 import { getSoftwareInventorySettings, updateSoftwareInventorySettings } from '@/lib/actions/software-inventory'
 import { getOrgDefaultTags, updateOrgDefaultTags } from '@/lib/actions/tags'
 import { TagEditor, type EditorTag } from '@/components/shared/tag-editor'
 import type { TagPair } from '@/lib/db/schema'
 import type { OrgTerminalSettings } from '@/lib/actions/terminal'
-import type { OrgNotificationSettingsFull } from '@/lib/actions/notification-settings'
+import type { OrgNotificationSettingsFull, OrgSmtpRelaySettingsInput } from '@/lib/actions/notification-settings'
 import type { Organisation, HostCollectionSettings, SoftwareInventorySettings } from '@/lib/db/schema'
 import { DEFAULT_COLLECTION_SETTINGS } from '@/lib/db/schema'
 import { COMMUNITY_MAX_RETENTION_DAYS, hasFeature, type LicenceTier } from '@/lib/features'
@@ -69,6 +75,31 @@ const RETENTION_OPTIONS = [
   { value: '180', label: '180 days' },
   { value: '365', label: '1 year' },
 ]
+
+type SmtpEncryptionValue = 'none' | 'starttls' | 'tls'
+
+const SMTP_ENCRYPTION_DEFAULT_PORTS: Record<SmtpEncryptionValue, number> = {
+  none: 25,
+  starttls: 587,
+  tls: 465,
+}
+
+const SMTP_ENCRYPTION_OPTIONS = [
+  { value: 'none', label: 'None' },
+  { value: 'starttls', label: 'STARTTLS' },
+  { value: 'tls', label: 'SSL/TLS' },
+] as const
+
+const EMPTY_SMTP_RELAY_SETTINGS: OrgSmtpRelaySettingsInput = {
+  enabled: false,
+  host: '',
+  port: 587,
+  encryption: 'starttls',
+  username: '',
+  password: '',
+  fromAddress: '',
+  fromName: '',
+}
 
 export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
   const queryClient = useQueryClient()
@@ -248,6 +279,50 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
       setTimeout(() => setNotificationSaveSuccess(false), 3000)
     },
   })
+
+  const [smtpSaveSuccess, setSmtpSaveSuccess] = useState(false)
+  const [smtpError, setSmtpError] = useState<string | null>(null)
+  const [smtpTestResult, setSmtpTestResult] = useState<{ success?: boolean; error?: string } | null>(null)
+  const { data: smtpRelayDefaults } = useQuery({
+    queryKey: ['org-smtp-relay-settings', org.id],
+    queryFn: () => getOrgSmtpRelaySettings(org.id),
+  })
+  const [localSmtpRelaySettings, setLocalSmtpRelaySettings] = useState<OrgSmtpRelaySettingsInput | null>(null)
+  const currentSmtpRelaySettings = localSmtpRelaySettings ?? {
+    ...EMPTY_SMTP_RELAY_SETTINGS,
+    ...(smtpRelayDefaults ?? {}),
+    password: '',
+  }
+  const smtpDirty = localSmtpRelaySettings !== null
+
+  const smtpMutation = useMutation({
+    mutationFn: (settings: OrgSmtpRelaySettingsInput) => updateOrgSmtpRelaySettings(org.id, settings),
+    onSuccess: (result) => {
+      if ('error' in result) {
+        setSmtpError(result.error)
+        setSmtpSaveSuccess(false)
+        return
+      }
+      setLocalSmtpRelaySettings(null)
+      setSmtpError(null)
+      setSmtpSaveSuccess(true)
+      queryClient.invalidateQueries({ queryKey: ['org-smtp-relay-settings', org.id] })
+      setTimeout(() => setSmtpSaveSuccess(false), 3000)
+    },
+  })
+
+  const smtpTestMutation = useMutation({
+    mutationFn: () => sendTestSmtpRelaySettings(org.id),
+    onSuccess: (result) => {
+      setSmtpTestResult('error' in result ? { error: result.error } : { success: true })
+    },
+  })
+
+  function updateSmtpRelaySetting(patch: Partial<OrgSmtpRelaySettingsInput>) {
+    setLocalSmtpRelaySettings({ ...currentSmtpRelaySettings, ...patch })
+    setSmtpError(null)
+    setSmtpTestResult(null)
+  }
 
   // Software inventory settings
   const [swInvSaveSuccess, setSwInvSaveSuccess] = useState(false)
@@ -725,6 +800,177 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                 <>
                   <p>Receiving roles: {currentNotificationSettings.inAppRoles.join(', ')}</p>
                   <p>User opt-out: {currentNotificationSettings.allowUserOptOut ? 'Allowed' : 'Not allowed'}</p>
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* SMTP Relay section */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Mail className="size-4 text-muted-foreground" />
+            SMTP Relay
+          </CardTitle>
+          <CardDescription>
+            Central email delivery settings used by alert email channels.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {isAdmin ? (
+            <>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="text-sm">Enable SMTP relay</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Email notification channels use this relay for delivery
+                  </p>
+                </div>
+                <Switch
+                  checked={currentSmtpRelaySettings.enabled}
+                  onCheckedChange={(enabled) => updateSmtpRelaySetting({ enabled })}
+                />
+              </div>
+              {currentSmtpRelaySettings.enabled && (
+                <>
+                  <div className="grid grid-cols-3 gap-3">
+                    <div className="col-span-2 space-y-1.5">
+                      <Label htmlFor="smtp-relay-host">Host</Label>
+                      <Input
+                        id="smtp-relay-host"
+                        placeholder="smtp.example.com"
+                        value={currentSmtpRelaySettings.host}
+                        onChange={(e) => updateSmtpRelaySetting({ host: e.target.value })}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="smtp-relay-port">Port</Label>
+                      <Input
+                        id="smtp-relay-port"
+                        type="number"
+                        value={currentSmtpRelaySettings.port}
+                        onChange={(e) => updateSmtpRelaySetting({ port: Number(e.target.value) })}
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="smtp-relay-encryption">Encryption</Label>
+                    <Select
+                      value={currentSmtpRelaySettings.encryption}
+                      onValueChange={(value) => {
+                        const encryption = value as SmtpEncryptionValue
+                        updateSmtpRelaySetting({
+                          encryption,
+                          port: SMTP_ENCRYPTION_DEFAULT_PORTS[encryption],
+                        })
+                      }}
+                    >
+                      <SelectTrigger id="smtp-relay-encryption" className="w-48">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SMTP_ENCRYPTION_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="smtp-relay-username">
+                        Username <span className="text-muted-foreground font-normal">(optional)</span>
+                      </Label>
+                      <Input
+                        id="smtp-relay-username"
+                        value={currentSmtpRelaySettings.username ?? ''}
+                        onChange={(e) => updateSmtpRelaySetting({ username: e.target.value })}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="smtp-relay-password">
+                        Password{' '}
+                        <span className="text-muted-foreground font-normal">
+                          ({smtpRelayDefaults?.hasPassword ? 'leave blank to keep existing' : 'optional'})
+                        </span>
+                      </Label>
+                      <Input
+                        id="smtp-relay-password"
+                        type="password"
+                        placeholder={smtpRelayDefaults?.hasPassword ? '••••••••' : ''}
+                        value={currentSmtpRelaySettings.password ?? ''}
+                        onChange={(e) => updateSmtpRelaySetting({ password: e.target.value })}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="smtp-relay-from-address">From address</Label>
+                      <Input
+                        id="smtp-relay-from-address"
+                        placeholder="alerts@example.com"
+                        value={currentSmtpRelaySettings.fromAddress}
+                        onChange={(e) => updateSmtpRelaySetting({ fromAddress: e.target.value })}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="smtp-relay-from-name">
+                        From name <span className="text-muted-foreground font-normal">(optional)</span>
+                      </Label>
+                      <Input
+                        id="smtp-relay-from-name"
+                        placeholder="CT-Ops Alerts"
+                        value={currentSmtpRelaySettings.fromName ?? ''}
+                        onChange={(e) => updateSmtpRelaySetting({ fromName: e.target.value })}
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+              {smtpError && <p className="text-sm text-destructive">{smtpError}</p>}
+              {smtpTestResult?.error && <p className="text-sm text-destructive">{smtpTestResult.error}</p>}
+              {smtpTestResult?.success && (
+                <p className="flex items-center gap-1 text-sm text-green-700">
+                  <CheckCircle2 className="size-4" />
+                  Test email sent
+                </p>
+              )}
+              <div className="flex items-center gap-3 pt-2 border-t">
+                <Button
+                  size="sm"
+                  disabled={!smtpDirty || smtpMutation.isPending}
+                  onClick={() => smtpMutation.mutate(currentSmtpRelaySettings)}
+                >
+                  {smtpMutation.isPending ? 'Saving…' : 'Save'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={smtpDirty || smtpTestMutation.isPending || !smtpRelayDefaults?.enabled}
+                  onClick={() => smtpTestMutation.mutate()}
+                >
+                  <FlaskConical className="size-3.5 mr-1" />
+                  {smtpTestMutation.isPending ? 'Testing…' : 'Test'}
+                </Button>
+                {smtpSaveSuccess && (
+                  <span className="flex items-center gap-1 text-sm text-green-700">
+                    <CheckCircle2 className="size-4" />
+                    Saved
+                  </span>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="space-y-2 text-sm">
+              <p>SMTP relay: {smtpRelayDefaults?.enabled ? 'Enabled' : 'Disabled'}</p>
+              {smtpRelayDefaults?.enabled && (
+                <>
+                  <p>Host: {smtpRelayDefaults.host}:{smtpRelayDefaults.port}</p>
+                  <p>Encryption: {smtpRelayDefaults.encryption.toUpperCase()}</p>
+                  <p>From: {smtpRelayDefaults.fromAddress}</p>
                 </>
               )}
             </div>

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -4,11 +4,13 @@ import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { createHmac } from 'crypto'
-import nodemailer from 'nodemailer'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { assertPublicHost, assertPublicUrl } from '@/lib/net/ssrf-guard'
 import { getRequiredSession } from '@/lib/auth/session'
 import { writeAuditEvent } from '@/lib/audit/events'
+import { decrypt } from '@/lib/crypto/encrypt'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
+import { sendSmtpMessage } from '@/lib/notifications/smtp-send'
 
 const testNotificationLimiter = createRateLimiter(60_000, 5)
 import { db } from '@/lib/db'
@@ -23,11 +25,12 @@ import type {
   NotificationChannel,
   WebhookChannelConfig,
   SmtpChannelConfig,
-  SmtpEncryption,
   SlackChannelConfig,
   TelegramChannelConfig,
   AlertSilence,
 } from '@/lib/db/schema'
+import { organisations } from '@/lib/db/schema'
+import type { SmtpEncryption } from '@/lib/notifications/smtp-settings'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -71,12 +74,6 @@ const updateAlertRuleSchema = z.object({
   config: z.union([checkStatusConfigSchema, metricThresholdConfigSchema, certExpiryConfigSchema]).optional(),
 })
 
-const smtpEncryptionSchema = z.enum(['none', 'starttls', 'tls'])
-
-// Standard SMTP submission ports. Port 25 (server-to-server relay) is included
-// for self-hosted mail servers; 465 (SMTPS), 587 (submission), 2525 (alt).
-const SMTP_ALLOWED_PORTS = [25, 465, 587, 2525] as const
-
 const httpsUrl = z
   .string()
   .url()
@@ -95,18 +92,6 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
     name: z.string().min(1).max(100),
     type: z.literal('smtp'),
     config: z.object({
-      host: z.string().min(1),
-      port: z
-        .number()
-        .int()
-        .refine((p) => (SMTP_ALLOWED_PORTS as readonly number[]).includes(p), {
-          message: `SMTP port must be one of: ${SMTP_ALLOWED_PORTS.join(', ')}`,
-        }),
-      encryption: smtpEncryptionSchema,
-      username: z.string().optional(),
-      password: z.string().optional(),
-      fromAddress: z.string().email(),
-      fromName: z.string().optional(),
       toAddresses: z.array(z.string().email()).min(1),
     }),
   }),
@@ -501,14 +486,7 @@ export type NotificationChannelSafe = Omit<NotificationChannel, 'config' | 'type
   | {
       type: 'smtp'
       config: {
-        host: string
-        port: number
-        encryption: SmtpEncryption
-        username?: string
-        fromAddress: string
-        fromName?: string
         toAddresses: string[]
-        hasPassword: boolean
       }
     }
   | { type: 'slack'; config: { webhookUrl: string } }
@@ -521,7 +499,8 @@ function normaliseSmtpConfig(raw: unknown): SmtpChannelConfig {
   if (obj.encryption !== undefined) return obj as unknown as SmtpChannelConfig
   // Rows written with the old `secure: boolean` field
   const encryption: SmtpEncryption = obj.secure ? 'tls' : 'starttls'
-  const { secure: _removed, ...rest } = obj
+  const rest = { ...obj }
+  delete rest.secure
   return { ...rest, encryption } as unknown as SmtpChannelConfig
 }
 
@@ -542,14 +521,7 @@ export async function getNotificationChannels(orgId: string): Promise<Notificati
         ...ch,
         type: 'smtp' as const,
         config: {
-          host: cfg.host,
-          port: cfg.port,
-          encryption: cfg.encryption,
-          username: cfg.username,
-          fromAddress: cfg.fromAddress,
-          fromName: cfg.fromName,
           toAddresses: cfg.toAddresses,
-          hasPassword: !!(cfg.password),
         },
       }
     }
@@ -600,7 +572,7 @@ export async function createNotificationChannel(
         organisationId: orgId,
         name: data.name,
         type: data.type,
-        config: data.config as WebhookChannelConfig | SmtpChannelConfig,
+        config: data.config as WebhookChannelConfig | SmtpChannelConfig | SlackChannelConfig | TelegramChannelConfig,
       })
       .returning({ id: notificationChannels.id })
 
@@ -669,18 +641,6 @@ const updateWebhookChannelSchema = z.object({
 
 const updateSmtpChannelSchema = z.object({
   name: z.string().min(1).max(100),
-  host: z.string().min(1),
-  port: z
-    .number()
-    .int()
-    .refine((p) => (SMTP_ALLOWED_PORTS as readonly number[]).includes(p), {
-      message: `SMTP port must be one of: ${SMTP_ALLOWED_PORTS.join(', ')}`,
-    }),
-  encryption: smtpEncryptionSchema,
-  username: z.string().optional(),
-  password: z.string().optional(),
-  fromAddress: z.string().email(),
-  fromName: z.string().optional(),
   toAddresses: z.array(z.string().email()).min(1),
 })
 
@@ -731,17 +691,9 @@ export async function updateNotificationChannel(
     } else if (existing.type === 'smtp') {
       const parsed = updateSmtpChannelSchema.safeParse(input)
       if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
-      const { name, host, port, encryption, username, password, fromAddress, fromName, toAddresses } = parsed.data
+      const { name, toAddresses } = parsed.data
       nextName = name
-      const existingConfig = normaliseSmtpConfig(existing.config)
       const newConfig: SmtpChannelConfig = {
-        host,
-        port,
-        encryption,
-        username: username || undefined,
-        password: password || existingConfig.password,
-        fromAddress,
-        fromName: fromName || undefined,
         toAddresses,
       }
       await db
@@ -848,20 +800,33 @@ export async function sendTestNotification(
       return { error: err instanceof Error ? err.message : 'Request failed' }
     }
   } else if (existing.type === 'smtp') {
-    const cfg = normaliseSmtpConfig(existing.config)
-    await assertPublicHost(cfg.host)
-    const transporter = nodemailer.createTransport({
-      host: cfg.host,
-      port: cfg.port,
-      secure: cfg.encryption === 'tls',
-      requireTLS: cfg.encryption === 'starttls',
-      auth: cfg.username ? { user: cfg.username, pass: cfg.password ?? '' } : undefined,
+    const channelCfg = normaliseSmtpConfig(existing.config)
+    const org = await db.query.organisations.findFirst({
+      where: eq(organisations.id, orgId),
+      columns: { metadata: true },
     })
-
+    const relay = parseOrgMetadata(org?.metadata).notificationSettings?.smtpRelay
+    if (!relay?.enabled) return { error: 'Central SMTP relay is not enabled' }
+    await assertPublicHost(relay.host)
+    let password = ''
+    if (relay.passwordEncrypted) {
+      try {
+        password = decrypt(relay.passwordEncrypted)
+      } catch {
+        return { error: 'Stored SMTP password could not be decrypted' }
+      }
+    }
     try {
-      await transporter.sendMail({
-        from: cfg.fromName ? `"${cfg.fromName}" <${cfg.fromAddress}>` : cfg.fromAddress,
-        to: cfg.toAddresses.join(', '),
+      await sendSmtpMessage({
+        host: relay.host,
+        port: relay.port,
+        encryption: relay.encryption,
+        username: relay.username,
+        password,
+        fromAddress: relay.fromAddress,
+        fromName: relay.fromName,
+      }, {
+        to: channelCfg.toAddresses,
         subject: 'CT-Ops Test Notification',
         text: 'This is a test notification from CT-Ops. Your SMTP channel is configured correctly.',
         html: '<p>This is a test notification from <strong>CT-Ops</strong>. Your SMTP channel is configured correctly.</p>',

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -10,6 +10,19 @@ import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 import type { OrgNotificationSettings } from '@/lib/db/schema/organisations'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES, DEFAULT_NOTIFICATION_ROLES } from '@/lib/auth/roles'
+import { encrypt, decrypt } from '@/lib/crypto/encrypt'
+import { assertPublicHost } from '@/lib/net/ssrf-guard'
+import {
+  SMTP_ALLOWED_PORTS,
+  sanitiseSmtpRelayForClient,
+  smtpEncryptionSchema,
+  type SmtpRelaySettings,
+  type SmtpRelaySettingsSafe,
+} from '@/lib/notifications/smtp-settings'
+import { sendSmtpMessage } from '@/lib/notifications/smtp-send'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+const smtpRelayTestLimiter = createRateLimiter(60_000, 5)
 
 const updateOrgNotificationSettingsSchema = z.object({
   inAppEnabled: z.boolean(),
@@ -24,6 +37,24 @@ export interface OrgNotificationSettingsFull {
   inAppRoles: string[]
   allowUserOptOut: boolean
 }
+
+const updateOrgSmtpRelaySettingsSchema = z.object({
+  enabled: z.boolean(),
+  host: z.string().min(1, 'Host is required'),
+  port: z
+    .number()
+    .int()
+    .refine((p) => (SMTP_ALLOWED_PORTS as readonly number[]).includes(p), {
+      message: `SMTP port must be one of: ${SMTP_ALLOWED_PORTS.join(', ')}`,
+    }),
+  encryption: smtpEncryptionSchema,
+  username: z.string().optional(),
+  password: z.string().optional(),
+  fromAddress: z.string().email('From address must be a valid email'),
+  fromName: z.string().optional(),
+})
+
+export type OrgSmtpRelaySettingsInput = z.infer<typeof updateOrgSmtpRelaySettingsSchema>
 
 export async function getOrgNotificationSettings(
   orgId: string,
@@ -88,5 +119,132 @@ export async function updateOrgNotificationSettings(
     return { success: true }
   } catch {
     return { error: 'Failed to update notification settings' }
+  }
+}
+
+export async function getOrgSmtpRelaySettings(
+  orgId: string,
+): Promise<SmtpRelaySettingsSafe | null> {
+  await requireOrgAccess(orgId)
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+    columns: { metadata: true },
+  })
+  const meta = parseOrgMetadata(org?.metadata)
+  return sanitiseSmtpRelayForClient(meta.notificationSettings?.smtpRelay)
+}
+
+async function getAdminOrgMetadata(orgId: string): Promise<
+  | { metadata: ReturnType<typeof parseOrgMetadata>; error?: undefined }
+  | { metadata?: undefined; error: string }
+> {
+  await requireOrgAccess(orgId)
+  const session = await getRequiredSession()
+
+  if (!ADMIN_ROLES.includes(session.user.role)) {
+    return { error: 'You do not have permission to update SMTP settings' }
+  }
+
+  if (session.user.organisationId !== orgId) {
+    return { error: 'Organisation mismatch' }
+  }
+
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+    columns: { metadata: true },
+  })
+  if (!org) return { error: 'Organisation not found' }
+
+  return { metadata: parseOrgMetadata(org.metadata) }
+}
+
+export async function updateOrgSmtpRelaySettings(
+  orgId: string,
+  input: unknown,
+): Promise<{ success: true } | { error: string }> {
+  const access = await getAdminOrgMetadata(orgId)
+  if ('error' in access) return { error: access.error ?? 'Unable to load SMTP settings' }
+
+  const parsed = updateOrgSmtpRelaySettingsSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  }
+
+  const existing = access.metadata.notificationSettings?.smtpRelay
+  const { password, username, fromName, ...data } = parsed.data
+  if (data.enabled) {
+    try {
+      await assertPublicHost(data.host)
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'SMTP host is not allowed' }
+    }
+  }
+  const smtpRelay: SmtpRelaySettings = {
+    ...data,
+    username: username || undefined,
+    passwordEncrypted: password ? encrypt(password) : existing?.passwordEncrypted,
+    fromName: fromName || undefined,
+  }
+
+  const updatedMetadata = {
+    ...access.metadata,
+    notificationSettings: {
+      ...access.metadata.notificationSettings,
+      smtpRelay,
+    } satisfies OrgNotificationSettings,
+  }
+
+  try {
+    await db
+      .update(organisations)
+      .set({ metadata: updatedMetadata, updatedAt: new Date() })
+      .where(eq(organisations.id, orgId))
+    return { success: true }
+  } catch {
+    return { error: 'Failed to update SMTP settings' }
+  }
+}
+
+export async function sendTestSmtpRelaySettings(
+  orgId: string,
+): Promise<{ success: true } | { error: string }> {
+  const access = await getAdminOrgMetadata(orgId)
+  if ('error' in access) return { error: access.error ?? 'Unable to load SMTP settings' }
+  if (!smtpRelayTestLimiter.check(orgId)) {
+    return { error: 'Too many requests — please wait before sending another SMTP test.' }
+  }
+
+  const cfg = access.metadata.notificationSettings?.smtpRelay
+  if (!cfg?.enabled) return { error: 'SMTP relay is not enabled' }
+
+  await assertPublicHost(cfg.host)
+
+  let password = ''
+  if (cfg.passwordEncrypted) {
+    try {
+      password = decrypt(cfg.passwordEncrypted)
+    } catch {
+      return { error: 'Stored SMTP password could not be decrypted' }
+    }
+  }
+
+  try {
+    await sendSmtpMessage({
+      host: cfg.host,
+      port: cfg.port,
+      encryption: cfg.encryption,
+      username: cfg.username,
+      password,
+      fromAddress: cfg.fromAddress,
+      fromName: cfg.fromName,
+    }, {
+      to: [cfg.fromAddress],
+      subject: 'CT-Ops SMTP Test',
+      text: 'This is a test email from CT-Ops. Your central SMTP relay is configured correctly.',
+      html: '<p>This is a test email from <strong>CT-Ops</strong>. Your central SMTP relay is configured correctly.</p>',
+    })
+    return { success: true }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to send SMTP test' }
   }
 }

--- a/apps/web/lib/db/schema/alerts.ts
+++ b/apps/web/lib/db/schema/alerts.ts
@@ -2,6 +2,7 @@ import { pgTable, text, timestamp, jsonb, boolean, index } from 'drizzle-orm/pg-
 import { sql } from 'drizzle-orm'
 import { createId } from '@paralleldrive/cuid2'
 import { organisations } from './organisations'
+import type { SmtpEncryption } from '../../notifications/smtp-settings'
 import { hosts } from './hosts'
 import { users } from './auth'
 
@@ -34,18 +35,18 @@ export interface WebhookChannelConfig {
   secret?: string
 }
 
-export type SmtpEncryption = 'none' | 'starttls' | 'tls'
-
 export interface SmtpChannelConfig {
-  host: string
-  port: number
-  /** 'none' = plain, 'starttls' = STARTTLS on connect, 'tls' = direct SSL/TLS */
-  encryption: SmtpEncryption
+  /** Recipient routing for SMTP alert delivery. Relay settings live in organisation metadata. */
+  toAddresses: string[]
+  /** Legacy relay fields kept only so existing rows can be read and migrated in-place. */
+  host?: string
+  port?: number
+  encryption?: SmtpEncryption
+  secure?: boolean
   username?: string
   password?: string
-  fromAddress: string
+  fromAddress?: string
   fromName?: string
-  toAddresses: string[]
 }
 
 export interface SlackChannelConfig {

--- a/apps/web/lib/db/schema/organisations.ts
+++ b/apps/web/lib/db/schema/organisations.ts
@@ -3,11 +3,13 @@ import { createId } from '@paralleldrive/cuid2'
 import { z } from 'zod'
 import { DEFAULT_NOTIFICATION_ROLES } from '../../auth/roles'
 import type { HostCollectionSettings } from './hosts'
+import { smtpRelaySettingsSchema, type SmtpRelaySettings } from '../../notifications/smtp-settings'
 
 export interface OrgNotificationSettings {
   inAppEnabled?: boolean      // default true — master switch for in-app notifications
   inAppRoles?: string[]       // default ['super_admin','org_admin','engineer']
   allowUserOptOut?: boolean   // default true — whether users can individually opt out
+  smtpRelay?: SmtpRelaySettings
 }
 
 export interface SoftwareInventorySettings {
@@ -47,6 +49,7 @@ const orgNotificationSettingsSchema = z.object({
   inAppEnabled: z.boolean().optional().catch(undefined),
   inAppRoles: z.array(z.string()).catch([...DEFAULT_NOTIFICATION_ROLES]).optional(),
   allowUserOptOut: z.boolean().optional().catch(undefined),
+  smtpRelay: smtpRelaySettingsSchema.optional().catch(undefined),
 }).strip()
 
 const softwareInventorySettingsSchema = z.object({

--- a/apps/web/lib/notifications/smtp-send.test.mjs
+++ b/apps/web/lib/notifications/smtp-send.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import net from 'node:net'
+
+import { sendSmtpMessage } from './smtp-send.ts'
+
+function startMockSmtpServer() {
+  const messages = []
+  const server = net.createServer((socket) => {
+    let mode = 'command'
+    let data = ''
+    let current = { from: '', to: [] }
+
+    socket.setEncoding('utf8')
+    socket.write('220 mock.smtp ESMTP\r\n')
+    socket.on('data', (chunk) => {
+      for (const line of chunk.split(/\r\n/)) {
+        if (line === '') continue
+        if (mode === 'data') {
+          if (line === '.') {
+            messages.push({ ...current, data })
+            data = ''
+            mode = 'command'
+            socket.write('250 queued\r\n')
+          } else {
+            data += `${line}\n`
+          }
+          continue
+        }
+
+        if (/^(EHLO|HELO)\b/i.test(line)) socket.write('250 mock.smtp\r\n')
+        else if (/^MAIL FROM:/i.test(line)) {
+          current = { from: line, to: [] }
+          socket.write('250 ok\r\n')
+        } else if (/^RCPT TO:/i.test(line)) {
+          current.to.push(line)
+          socket.write('250 ok\r\n')
+        } else if (/^DATA$/i.test(line)) {
+          mode = 'data'
+          socket.write('354 end with dot\r\n')
+        } else if (/^QUIT$/i.test(line)) {
+          socket.write('221 bye\r\n')
+          socket.end()
+        } else {
+          socket.write('250 ok\r\n')
+        }
+      }
+    })
+  })
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        messages,
+        close: () => new Promise((done) => server.close(done)),
+      })
+    })
+  })
+}
+
+test('sendSmtpMessage delivers mail through an SMTP server', async () => {
+  const smtp = await startMockSmtpServer()
+  try {
+    await sendSmtpMessage(
+      {
+        host: '127.0.0.1',
+        port: smtp.port,
+        encryption: 'none',
+        fromAddress: 'alerts@example.com',
+        fromName: 'CT-Ops Alerts',
+      },
+      {
+        to: ['ops@example.com', 'team@example.com'],
+        subject: 'CT-Ops Test',
+        text: 'Plain text body',
+        html: '<p>Plain text body</p>',
+      },
+    )
+
+    assert.equal(smtp.messages.length, 1)
+    assert.match(smtp.messages[0].from, /alerts@example\.com/)
+    assert.equal(smtp.messages[0].to.length, 2)
+    assert.match(smtp.messages[0].data, /Subject: CT-Ops Test/)
+    assert.match(smtp.messages[0].data, /Plain text body/)
+  } finally {
+    await smtp.close()
+  }
+})

--- a/apps/web/lib/notifications/smtp-send.ts
+++ b/apps/web/lib/notifications/smtp-send.ts
@@ -1,0 +1,37 @@
+import nodemailer from 'nodemailer'
+import type { SmtpEncryption } from './smtp-settings'
+
+export interface SmtpSendConfig {
+  host: string
+  port: number
+  encryption: SmtpEncryption
+  username?: string
+  password?: string
+  fromAddress: string
+  fromName?: string
+}
+
+export interface SmtpMessage {
+  to: string[]
+  subject: string
+  text: string
+  html: string
+}
+
+export async function sendSmtpMessage(config: SmtpSendConfig, message: SmtpMessage): Promise<void> {
+  const transporter = nodemailer.createTransport({
+    host: config.host,
+    port: config.port,
+    secure: config.encryption === 'tls',
+    requireTLS: config.encryption === 'starttls',
+    auth: config.username ? { user: config.username, pass: config.password ?? '' } : undefined,
+  })
+
+  await transporter.sendMail({
+    from: config.fromName ? `"${config.fromName}" <${config.fromAddress}>` : config.fromAddress,
+    to: message.to.join(', '),
+    subject: message.subject,
+    text: message.text,
+    html: message.html,
+  })
+}

--- a/apps/web/lib/notifications/smtp-settings.test.mjs
+++ b/apps/web/lib/notifications/smtp-settings.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  SMTP_ALLOWED_PORTS,
+  normaliseSmtpRecipients,
+  sanitiseSmtpRelayForClient,
+} from './smtp-settings.ts'
+
+test('normaliseSmtpRecipients trims comma-separated addresses and rejects empty output', () => {
+  assert.deepEqual(normaliseSmtpRecipients('ops@example.com, team@example.com,, '), [
+    'ops@example.com',
+    'team@example.com',
+  ])
+  assert.throws(() => normaliseSmtpRecipients(' , '), /At least one recipient/)
+})
+
+test('sanitiseSmtpRelayForClient hides stored password material', () => {
+  const safe = sanitiseSmtpRelayForClient({
+    enabled: true,
+    host: 'smtp.example.com',
+    port: 587,
+    encryption: 'starttls',
+    username: 'alerts@example.com',
+    passwordEncrypted: 'secret-ciphertext',
+    fromAddress: 'alerts@example.com',
+    fromName: 'CT-Ops Alerts',
+  })
+
+  assert.deepEqual(safe, {
+    enabled: true,
+    host: 'smtp.example.com',
+    port: 587,
+    encryption: 'starttls',
+    username: 'alerts@example.com',
+    hasPassword: true,
+    fromAddress: 'alerts@example.com',
+    fromName: 'CT-Ops Alerts',
+  })
+})
+
+test('SMTP_ALLOWED_PORTS documents the supported relay ports', () => {
+  assert.deepEqual(SMTP_ALLOWED_PORTS, [25, 465, 587, 2525])
+})

--- a/apps/web/lib/notifications/smtp-settings.ts
+++ b/apps/web/lib/notifications/smtp-settings.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod'
+
+export const SMTP_ALLOWED_PORTS = [25, 465, 587, 2525] as const
+
+export const smtpEncryptionSchema = z.enum(['none', 'starttls', 'tls'])
+
+export type SmtpEncryption = z.infer<typeof smtpEncryptionSchema>
+
+export interface SmtpRelaySettings {
+  enabled: boolean
+  host: string
+  port: number
+  encryption: SmtpEncryption
+  username?: string
+  passwordEncrypted?: string
+  fromAddress: string
+  fromName?: string
+}
+
+export interface SmtpRelaySettingsSafe {
+  enabled: boolean
+  host: string
+  port: number
+  encryption: SmtpEncryption
+  username?: string
+  hasPassword: boolean
+  fromAddress: string
+  fromName?: string
+}
+
+export const smtpRelaySettingsSchema = z.object({
+  enabled: z.boolean(),
+  host: z.string().min(1),
+  port: z
+    .number()
+    .int()
+    .refine((p) => (SMTP_ALLOWED_PORTS as readonly number[]).includes(p), {
+      message: `SMTP port must be one of: ${SMTP_ALLOWED_PORTS.join(', ')}`,
+    }),
+  encryption: smtpEncryptionSchema,
+  username: z.string().optional().catch(undefined),
+  passwordEncrypted: z.string().optional().catch(undefined),
+  fromAddress: z.string().email(),
+  fromName: z.string().optional().catch(undefined),
+}).strip()
+
+export function normaliseSmtpRecipients(input: string): string[] {
+  const recipients = input
+    .split(',')
+    .map((addr) => addr.trim())
+    .filter(Boolean)
+
+  if (recipients.length === 0) {
+    throw new Error('At least one recipient is required')
+  }
+
+  const emailSchema = z.string().email()
+  for (const recipient of recipients) {
+    const parsed = emailSchema.safeParse(recipient)
+    if (!parsed.success) {
+      throw new Error(`${recipient} is not a valid email address`)
+    }
+  }
+
+  return recipients
+}
+
+export function sanitiseSmtpRelayForClient(settings?: SmtpRelaySettings): SmtpRelaySettingsSafe | null {
+  if (!settings) return null
+  return {
+    enabled: settings.enabled,
+    host: settings.host,
+    port: settings.port,
+    encryption: settings.encryption,
+    username: settings.username,
+    hasPassword: !!settings.passwordEncrypted,
+    fromAddress: settings.fromAddress,
+    fromName: settings.fromName,
+  }
+}


### PR DESCRIPTION
## Summary
- move SMTP relay configuration into organisation Settings and keep email alert channels as recipient lists
- encrypt stored SMTP passwords and redact them from client reads
- update web test notifications and ingest alert delivery to combine central relay settings with channel recipients, retaining legacy SMTP channel fallback
- add mock SMTP delivery tests for web and ingest

## Validation
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint -- app/'(dashboard)'/settings/settings-client.tsx app/'(dashboard)'/alerts/alerts-client.tsx lib/actions/alerts.ts lib/actions/notification-settings.ts lib/notifications/smtp-send.ts lib/notifications/smtp-settings.ts
- node --experimental-strip-types --test lib/notifications/smtp-settings.test.mjs lib/notifications/smtp-send.test.mjs
- go test ./internal/handlers ./internal/db/queries (from apps/ingest)

## Notes
- Full `pnpm --dir apps/web test:unit` currently reports one existing loader failure in `lib/db/schema/metadata-validation.test.mjs`: Node's stripped TypeScript runner cannot resolve the extensionless `./organisations` import from `hosts.ts`. The new SMTP tests pass in the same run.