### PR TITLE
ci(docs): retry docs dependency install

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -48,7 +48,16 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @ct-ops/docs --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm install --filter @ct-ops/docs --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
 
       - name: Build docs
         run: pnpm --filter @ct-ops/docs build


### PR DESCRIPTION
## Summary
- retry the docs deploy pnpm install up to three times with a short backoff
- align docs deploy install behavior with the existing web PR check retry handling for transient runner filesystem failures

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-docs.yml"); puts "yaml ok"'
- pnpm install --filter @ct-ops/docs --frozen-lockfile
- pnpm --filter @ct-ops/docs build

## Testing note
- This is a CI workflow hardening change, so a test-first workflow is not practical; validation was performed by parsing the workflow YAML and running the affected docs install/build commands locally.