### PR TITLE
test(web): add hosts inventory and settings e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -365,7 +365,7 @@ export function HostsClient({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-foreground">Hosts</h1>
+        <h1 className="text-2xl font-semibold text-foreground" data-testid="hosts-heading">Hosts</h1>
         <p className="text-muted-foreground mt-1">
           {stats.total.toLocaleString()} host{stats.total !== 1 ? 's' : ''} registered
         </p>
@@ -584,10 +584,11 @@ export function HostsClient({
                 onChange={(e) => handleSearchChange(e.target.value)}
                 placeholder="Search hostname, display name or IP…"
                 className="pl-9"
+                data-testid="hosts-search-input"
               />
             </div>
             <Select value={status} onValueChange={(v) => handleStatusChange(v as StatusFilter)}>
-              <SelectTrigger className="w-40">
+              <SelectTrigger className="w-40" data-testid="hosts-status-filter">
                 <SelectValue placeholder="Status" />
               </SelectTrigger>
               <SelectContent>
@@ -598,7 +599,7 @@ export function HostsClient({
               </SelectContent>
             </Select>
             <Select value={os} onValueChange={handleOsChange}>
-              <SelectTrigger className="w-44">
+              <SelectTrigger className="w-44" data-testid="hosts-os-filter">
                 <SelectValue placeholder="OS" />
               </SelectTrigger>
               <SelectContent>
@@ -626,7 +627,13 @@ export function HostsClient({
               </SelectContent>
             </Select>
             {hasActiveFilters && (
-              <Button variant="ghost" size="sm" onClick={resetFilters} className="gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={resetFilters}
+                className="gap-1"
+                data-testid="hosts-clear-filters"
+              >
                 <X className="size-3.5" />
                 Clear filters
               </Button>

--- a/apps/web/tests/e2e/hosts/inventory.spec.ts
+++ b/apps/web/tests/e2e/hosts/inventory.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+test('authenticated user can search and filter the host inventory', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  const [{ id: orgId }] = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      cpu_percent,
+      memory_percent,
+      disk_percent,
+      last_seen_at
+    )
+    VALUES
+      (
+        'host-alpha',
+        ${orgId},
+        'alpha-node',
+        'Alpha Node',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.0.0.10"]'::jsonb,
+        'online',
+        15,
+        20,
+        25,
+        NOW()
+      ),
+      (
+        'host-beta',
+        ${orgId},
+        'beta-node',
+        'Beta Node',
+        'Windows 11',
+        'x86_64',
+        '["10.0.0.20"]'::jsonb,
+        'offline',
+        35,
+        40,
+        45,
+        NOW() - INTERVAL '2 hours'
+      )
+  `
+
+  await page.goto('/hosts')
+
+  await expect(page.getByTestId('hosts-heading')).toBeVisible()
+  await expect(page.getByText('2 hosts registered')).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Alpha Node' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
+
+  await page.getByTestId('hosts-search-input').fill('10.0.0.20')
+  await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Alpha Node' })).toHaveCount(0)
+  await expect(page.getByTestId('hosts-clear-filters')).toBeVisible()
+
+  await page.getByTestId('hosts-clear-filters').click()
+  await expect(page.getByRole('link', { name: 'Alpha Node' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
+
+  await page.getByTestId('hosts-status-filter').click()
+  await page.getByRole('option', { name: 'Offline' }).click()
+
+  await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Alpha Node' })).toHaveCount(0)
+
+  await page.getByTestId('hosts-os-filter').click()
+  await page.getByRole('option', { name: 'Windows 11' }).click()
+
+  await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
+  await expect(page.getByText('Showing 1–1 of 1')).toBeVisible()
+})

--- a/apps/web/tests/e2e/settings/organisation-name.spec.ts
+++ b/apps/web/tests/e2e/settings/organisation-name.spec.ts
@@ -28,3 +28,35 @@ test('admin can update the organisation name from settings', async ({ authentica
   expect(rows).toHaveLength(1)
   expect(rows[0]?.name).toBe(updatedName)
 })
+
+test('organisation name validation rejects names shorter than two characters', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await sql`
+    UPDATE organisations
+    SET name = ${TEST_ORG.name}
+    WHERE slug = ${TEST_ORG.slug}
+  `
+
+  await page.goto('/settings')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  const orgNameInput = page.getByTestId('settings-org-name-input')
+  await orgNameInput.click()
+  await orgNameInput.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`)
+  await orgNameInput.fill('A')
+  await page.getByTestId('settings-org-name-save').click()
+
+  await expect(page.getByText('Name must be at least 2 characters')).toBeVisible()
+  await expect(page.getByTestId('settings-org-name-success')).toHaveCount(0)
+
+  const rows = await sql<Array<{ name: string }>>`
+    SELECT name
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  expect(rows[0]?.name).toBe(TEST_ORG.name)
+})


### PR DESCRIPTION
## Summary
- add a new hosts inventory E2E spec that seeds real hosts and covers search plus status/OS filtering
- expand the organisation settings E2E coverage to assert short-name validation does not persist invalid data
- add stable hosts page test ids for the inventory controls used by the new E2E coverage

## Testing
- pnpm --filter web test:e2e -- tests/e2e/hosts/inventory.spec.ts tests/e2e/settings/organisation-name.spec.ts