### PR TITLE
fix(web): redact sensitive error logs

### DIFF
--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -1,3 +1,4 @@
+import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import { users, accounts, sessions, ldapConfigurations } from '@/lib/db/schema'
@@ -210,14 +211,14 @@ export async function POST(request: NextRequest) {
       return withAuthDelay(requestStart, response)
     }
 
-    console.error(`[LDAP] All configs failed for user "${username}":`, errors)
+    logError(`[LDAP] All configs failed for user "${username}":`, errors)
     passwordLoginAttemptGuard.recordFailure(username)
     return withAuthDelay(
       requestStart,
       NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
     )
   } catch (err) {
-    console.error('[LDAP] Unexpected error during login:', err)
+    logError('[LDAP] Unexpected error during login:', err)
     return withAuthDelay(
       requestStart,
       NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 }),

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -1,3 +1,4 @@
+import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import archiver from 'archiver'
 import { z } from 'zod'
@@ -626,7 +627,7 @@ async function runTransferJob(job: TransferJob, request: TransferRequest, baseUr
 
     await refreshTransferTaskStatus(job)
   } catch (err) {
-    console.error('Bundle transfer failed:', err)
+    logError('Bundle transfer failed:', err)
     const cleanupDir = job.tempDir
     publishJob(job, {
       phase: 'failed',

--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -1,3 +1,4 @@
+import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import * as crypto from 'crypto'
 import * as forge from 'node-forge'
@@ -152,7 +153,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json({ ok: false, error: 'Unknown action' }, { status: 400 })
   } catch (err) {
-    console.error('[certificate-checker] Unexpected error:', err)
+    logError('[certificate-checker] Unexpected error:', err)
     const message = err instanceof Error ? err.message : 'Internal error'
     // Expose the message only for operational errors whose text is explicitly user-friendly
     // (e.g. SSRF guard, size limit, parse failure). Avoid leaking raw stack traces.

--- a/apps/web/app/api/tools/jenkins-bundler/route.ts
+++ b/apps/web/app/api/tools/jenkins-bundler/route.ts
@@ -1,3 +1,4 @@
+import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import {
@@ -375,7 +376,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       transitivePlugins,
     } satisfies JenkinsBundlerResponse)
   } catch (err) {
-    console.error('[jenkins-bundler] error:', err)
+    logError('[jenkins-bundler] error:', err)
     const message = err instanceof Error ? err.message : 'Internal error'
     const isSafe =
       message.startsWith('Upstream returned') ||

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError, logWarn } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -173,7 +174,7 @@ export async function approveAgent(
       if (finalTags.length > 0) {
         const result = await assignTagsToResource(orgId, 'host', host.id, finalTags)
         if ('error' in result) {
-          console.warn('Failed to apply tags on approval:', result.error)
+          logWarn('Failed to apply tags on approval:', result.error)
         }
       }
 
@@ -183,7 +184,7 @@ export async function approveAgent(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to approve agent:', err)
+    logError('Failed to approve agent:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -256,7 +257,7 @@ export async function rejectAgent(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to reject agent:', err)
+    logError('Failed to reject agent:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -557,7 +558,7 @@ export async function createEnrolmentToken(
 
     return { token: record.token, id: record.id }
   } catch (err) {
-    console.error('Failed to create enrolment token:', err)
+    logError('Failed to create enrolment token:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -595,7 +596,7 @@ export async function revokeEnrolmentToken(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to revoke enrolment token:', err)
+    logError('Failed to revoke enrolment token:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -1189,7 +1190,7 @@ export async function deleteHost(
     if (hostNotFound) return { error: 'Host not found' }
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete host:', err)
+    logError('Failed to delete host:', err)
     return { error: 'An unexpected error occurred while deleting the host' }
   }
 }
@@ -1270,7 +1271,7 @@ export async function uninstallAndDeleteHost(
 
     return await deleteHost(orgId, hostId)
   } catch (err) {
-    console.error('Failed to uninstall agent and delete host:', err)
+    logError('Failed to uninstall agent and delete host:', err)
     return { error: 'An unexpected error occurred while uninstalling the agent' }
   }
 }

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { headers } from 'next/headers'
 import { db } from '@/lib/db'
 import { invitations, users } from '@/lib/db/schema'
@@ -69,7 +70,7 @@ export async function acceptInvite(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to accept invite:', err)
+    logError('Failed to accept invite:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/domain-accounts.ts
+++ b/apps/web/lib/actions/domain-accounts.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -171,7 +172,7 @@ export async function createDomainAccount(
     if (message.includes('domain_accounts_org_username_idx')) {
       return { error: 'An account with this username already exists' }
     }
-    console.error('Failed to create service account:', err)
+    logError('Failed to create service account:', err)
     return { error: 'Failed to create service account' }
   }
 }

--- a/apps/web/lib/actions/host-groups.ts
+++ b/apps/web/lib/actions/host-groups.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -41,7 +42,7 @@ export async function createGroup(
     if (!group) return { error: 'Failed to create group' }
     return { success: true, group }
   } catch (err) {
-    console.error('Failed to create group:', err)
+    logError('Failed to create group:', err)
     return { error: 'Failed to create group' }
   }
 }
@@ -66,7 +67,7 @@ export async function updateGroup(
     if (result.length === 0) return { error: 'Group not found' }
     return { success: true }
   } catch (err) {
-    console.error('Failed to update group:', err)
+    logError('Failed to update group:', err)
     return { error: 'Failed to update group' }
   }
 }
@@ -94,7 +95,7 @@ export async function deleteGroup(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete group:', err)
+    logError('Failed to delete group:', err)
     return { error: 'Failed to delete group' }
   }
 }
@@ -167,7 +168,7 @@ export async function addHostToGroup(
     })
     return { success: true }
   } catch (err) {
-    console.error('Failed to add host to group:', err)
+    logError('Failed to add host to group:', err)
     return { error: 'Failed to add host to group' }
   }
 }
@@ -195,7 +196,7 @@ export async function removeHostFromGroup(
     if (result.length === 0) return { error: 'Membership not found' }
     return { success: true }
   } catch (err) {
-    console.error('Failed to remove host from group:', err)
+    logError('Failed to remove host from group:', err)
     return { error: 'Failed to remove host from group' }
   }
 }

--- a/apps/web/lib/actions/host-settings.ts
+++ b/apps/web/lib/actions/host-settings.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
@@ -59,7 +60,7 @@ export async function updateHostCollectionSettings(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update host collection settings:', err)
+    logError('Failed to update host collection settings:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -106,7 +107,7 @@ export async function updateOrgDefaultCollectionSettings(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update org default collection settings:', err)
+    logError('Failed to update org default collection settings:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -131,7 +132,7 @@ export async function createLdapConfiguration(
     if (!row) return { error: 'Insert failed' }
     return { success: true, id: row.id }
   } catch (err) {
-    console.error('Failed to create LDAP configuration:', err)
+    logError('Failed to create LDAP configuration:', err)
     return { error: 'Failed to create LDAP configuration' }
   }
 }

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
@@ -90,7 +91,7 @@ export async function createNetwork(
     if (!network) return { error: 'Failed to create network' }
     return { success: true, network }
   } catch (err) {
-    console.error('Failed to create network:', err)
+    logError('Failed to create network:', err)
     return { error: 'Failed to create network' }
   }
 }
@@ -126,7 +127,7 @@ export async function updateNetwork(
     if (result.length === 0) return { error: 'Network not found' }
     return { success: true }
   } catch (err) {
-    console.error('Failed to update network:', err)
+    logError('Failed to update network:', err)
     return { error: 'Failed to update network' }
   }
 }
@@ -164,7 +165,7 @@ export async function deleteNetwork(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete network:', err)
+    logError('Failed to delete network:', err)
     return { error: 'Failed to delete network' }
   }
 }
@@ -209,7 +210,7 @@ export async function addHostToNetwork(
     })
     return { success: true }
   } catch (err) {
-    console.error('Failed to add host to network:', err)
+    logError('Failed to add host to network:', err)
     return { error: 'Failed to add host to network' }
   }
 }
@@ -242,7 +243,7 @@ export async function removeHostFromNetwork(
     if (result.length === 0) return { error: 'Membership not found' }
     return { success: true }
   } catch (err) {
-    console.error('Failed to remove host from network:', err)
+    logError('Failed to remove host from network:', err)
     return { error: 'Failed to remove host from network' }
   }
 }

--- a/apps/web/lib/actions/notes.ts
+++ b/apps/web/lib/actions/notes.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
@@ -282,7 +283,7 @@ export async function createNote(
     })
     return { success: true, note: created }
   } catch (err) {
-    console.error('Failed to create note:', err)
+    logError('Failed to create note:', err)
     return { error: 'Failed to create note' }
   }
 }
@@ -366,7 +367,7 @@ export async function updateNote(
       return { success: true as const, note: updated }
     })
   } catch (err) {
-    console.error('Failed to update note:', err)
+    logError('Failed to update note:', err)
     return { error: 'Failed to update note' }
   }
 }
@@ -399,7 +400,7 @@ export async function deleteNote(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete note:', err)
+    logError('Failed to delete note:', err)
     return { error: 'Failed to delete note' }
   }
 }
@@ -461,7 +462,7 @@ export async function setNoteTargets(
       return { success: true as const }
     })
   } catch (err) {
-    console.error('Failed to set note targets:', err)
+    logError('Failed to set note targets:', err)
     return { error: 'Failed to update targets' }
   }
 }
@@ -532,7 +533,7 @@ export async function toggleNotePin(
       return { success: true as const }
     })
   } catch (err) {
-    console.error('Failed to toggle pin:', err)
+    logError('Failed to toggle pin:', err)
     return { error: 'Failed to update pin' }
   }
 }
@@ -568,7 +569,7 @@ export async function toggleNotePrivate(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to toggle privacy:', err)
+    logError('Failed to toggle privacy:', err)
     return { error: 'Failed to update privacy' }
   }
 }
@@ -612,7 +613,7 @@ export async function addNoteReaction(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to add reaction:', err)
+    logError('Failed to add reaction:', err)
     return { error: 'Failed to add reaction' }
   }
 }
@@ -639,7 +640,7 @@ export async function removeNoteReaction(
       )
     return { success: true }
   } catch (err) {
-    console.error('Failed to remove reaction:', err)
+    logError('Failed to remove reaction:', err)
     return { error: 'Failed to remove reaction' }
   }
 }

--- a/apps/web/lib/actions/organisations.ts
+++ b/apps/web/lib/actions/organisations.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { organisations, users } from '@/lib/db/schema'
@@ -50,7 +51,7 @@ export async function createOrganisation(
 
     return { organisation }
   } catch (err) {
-    console.error('Failed to create organisation:', err)
+    logError('Failed to create organisation:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { users, organisations } from '@/lib/db/schema'
@@ -29,7 +30,7 @@ export async function updateName(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update name:', err)
+    logError('Failed to update name:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -65,7 +66,7 @@ export async function updateEmail(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update email:', err)
+    logError('Failed to update email:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -97,7 +98,7 @@ export async function updateTheme(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update theme:', err)
+    logError('Failed to update theme:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -169,7 +170,7 @@ export async function updatePassword(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to change password:', err)
+    logError('Failed to change password:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/security.ts
+++ b/apps/web/lib/actions/security.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { readFile } from 'node:fs/promises'
 import { createPublicKey, X509Certificate } from 'node:crypto'
 import { z } from 'zod'
@@ -65,7 +66,7 @@ export async function getSecurityOverview(): Promise<SecurityOverview | { error:
 
     return { serverTls, agentCa }
   } catch (err) {
-    console.error('getSecurityOverview failed:', err)
+    logError('getSecurityOverview failed:', err)
     return { error: err instanceof Error ? err.message : 'An unexpected error occurred' }
   }
 }
@@ -136,7 +137,7 @@ export async function uploadAgentCA(
 
     return { success: true, fingerprint }
   } catch (err) {
-    console.error('uploadAgentCA failed:', err)
+    logError('uploadAgentCA failed:', err)
     return { error: err instanceof Error ? err.message : 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -42,7 +43,7 @@ export async function updateOrgName(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update org name:', err)
+    logError('Failed to update org name:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -101,7 +102,7 @@ export async function updateMetricRetention(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update metric retention:', err)
+    logError('Failed to update metric retention:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -154,7 +155,7 @@ export async function saveLicenceKey(
 
     return { success: true, tier: result.payload.tier }
   } catch (err) {
-    console.error('Failed to save licence key:', err)
+    logError('Failed to save licence key:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -187,7 +188,7 @@ export async function generateActivationToken(
     })
     return { success: true, token }
   } catch (err) {
-    console.error('Failed to generate activation token:', err)
+    logError('Failed to generate activation token:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -87,7 +88,7 @@ export async function updateSoftwareInventorySettings(
       .where(eq(organisations.id, orgId))
     return { success: true }
   } catch (err) {
-    console.error('Failed to update software inventory settings:', err)
+    logError('Failed to update software inventory settings:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -140,7 +141,7 @@ export async function triggerSoftwareScan(
       return { success: true as const, taskRunId: run.id }
     })
   } catch (err) {
-    console.error('Failed to trigger software scan:', err)
+    logError('Failed to trigger software scan:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -801,7 +802,7 @@ export async function saveSoftwareReport(
       .returning()
     return { success: true, id: row!.id }
   } catch (err) {
-    console.error('Failed to save report:', err)
+    logError('Failed to save report:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -826,7 +827,7 @@ export async function deleteSavedReport(
       )
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete saved report:', err)
+    logError('Failed to delete saved report:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/tag-rules.ts
+++ b/apps/web/lib/actions/tag-rules.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -88,7 +89,7 @@ export async function bulkAssignTags(
     }
     return { success: true, applied }
   } catch (err) {
-    console.error('Failed to bulk assign tags:', err)
+    logError('Failed to bulk assign tags:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -123,7 +124,7 @@ export async function createTagRule(
     if (!row) return { error: 'Failed to create rule' }
     return { success: true, id: row.id }
   } catch (err) {
-    console.error('Failed to create tag rule:', err)
+    logError('Failed to create tag rule:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -165,7 +166,7 @@ export async function updateTagRule(
       .where(and(eq(tagRules.id, ruleId), eq(tagRules.organisationId, orgId)))
     return { success: true }
   } catch (err) {
-    console.error('Failed to update tag rule:', err)
+    logError('Failed to update tag rule:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -182,7 +183,7 @@ export async function deleteTagRule(
       .where(and(eq(tagRules.id, ruleId), eq(tagRules.organisationId, orgId)))
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete tag rule:', err)
+    logError('Failed to delete tag rule:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -206,7 +207,7 @@ export async function runTagRule(
     if (!rule) return { error: 'Rule not found' }
     return bulkAssignTags(orgId, rule.filter, rule.tags)
   } catch (err) {
-    console.error('Failed to run tag rule:', err)
+    logError('Failed to run tag rule:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/tags.ts
+++ b/apps/web/lib/actions/tags.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -154,7 +155,7 @@ export async function assignTagsToResource(
     })
     return { success: true }
   } catch (err) {
-    console.error('Failed to assign tags:', err)
+    logError('Failed to assign tags:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -181,7 +182,7 @@ export async function removeTagFromResource(
     })
     return { success: true }
   } catch (err) {
-    console.error('Failed to remove tag:', err)
+    logError('Failed to remove tag:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -260,7 +261,7 @@ export async function replaceResourceTags(
     })
     return { success: true }
   } catch (err) {
-    console.error('Failed to replace tags:', err)
+    logError('Failed to replace tags:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -329,7 +330,7 @@ export async function updateOrgDefaultTags(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update org default tags:', err)
+    logError('Failed to update org default tags:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
@@ -85,7 +86,7 @@ async function createTaskRun(
       return { success: true, taskRunId: run.id }
     })
   } catch (err) {
-    console.error('Failed to create task run:', err)
+    logError('Failed to create task run:', err)
     return { error: 'Failed to create task run' }
   }
 }
@@ -318,7 +319,7 @@ export async function cancelTaskRun(
       return { success: true }
     })
   } catch (err) {
-    console.error('Failed to cancel task run:', err)
+    logError('Failed to cancel task run:', err)
     return { error: 'Failed to cancel task run' }
   }
 }
@@ -551,7 +552,7 @@ export async function deleteTaskRuns(
     })
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete task runs:', err)
+    logError('Failed to delete task runs:', err)
     return { error: 'Failed to delete task runs' }
   }
 }

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
@@ -234,7 +235,7 @@ export async function createSchedule(
     if (!row) return { error: 'Failed to create schedule' }
     return { success: true, id: row.id }
   } catch (err) {
-    console.error('Failed to create schedule:', err)
+    logError('Failed to create schedule:', err)
     return { error: 'Failed to create schedule' }
   }
 }
@@ -297,7 +298,7 @@ export async function updateSchedule(
       .where(eq(taskSchedules.id, id))
     return { success: true }
   } catch (err) {
-    console.error('Failed to update schedule:', err)
+    logError('Failed to update schedule:', err)
     return { error: 'Failed to update schedule' }
   }
 }
@@ -338,7 +339,7 @@ export async function setScheduleEnabled(
       .where(eq(taskSchedules.id, id))
     return { success: true }
   } catch (err) {
-    console.error('Failed to toggle schedule:', err)
+    logError('Failed to toggle schedule:', err)
     return { error: 'Failed to update schedule' }
   }
 }
@@ -365,7 +366,7 @@ export async function deleteSchedule(
       )
     return { success: true }
   } catch (err) {
-    console.error('Failed to delete schedule:', err)
+    logError('Failed to delete schedule:', err)
     return { error: 'Failed to delete schedule' }
   }
 }

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
@@ -145,7 +146,7 @@ export async function createTerminalSession(
       websocketToken,
     }
   } catch (err) {
-    console.error('Failed to create terminal session:', err)
+    logError('Failed to create terminal session:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -223,7 +224,7 @@ export async function updateOrgTerminalSettings(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update org terminal settings:', err)
+    logError('Failed to update org terminal settings:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -299,7 +300,7 @@ export async function updateHostTerminalSettings(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update host terminal settings:', err)
+    logError('Failed to update host terminal settings:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { logError } from '@/lib/logging'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
@@ -140,7 +141,7 @@ export async function inviteUser(
     const baseUrl = getBetterAuthOrigin()
     return { inviteLink: `${baseUrl}/register?invite=${invite.token}` }
   } catch (err) {
-    console.error('Failed to invite user:', err)
+    logError('Failed to invite user:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -202,7 +203,7 @@ export async function updateUserRole(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to update role:', err)
+    logError('Failed to update role:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -238,7 +239,7 @@ export async function deactivateUser(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to deactivate user:', err)
+    logError('Failed to deactivate user:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -258,7 +259,7 @@ export async function reactivateUser(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to reactivate user:', err)
+    logError('Failed to reactivate user:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -317,7 +318,7 @@ export async function removeUser(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to remove user:', err)
+    logError('Failed to remove user:', err)
     return { error: 'An unexpected error occurred' }
   }
 }
@@ -337,7 +338,7 @@ export async function cancelInvite(
 
     return { success: true }
   } catch (err) {
-    console.error('Failed to cancel invite:', err)
+    logError('Failed to cancel invite:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/agent/cache-prewarm.ts
+++ b/apps/web/lib/agent/cache-prewarm.ts
@@ -1,3 +1,4 @@
+import { logWarn } from '@/lib/logging'
 import fs from 'fs'
 import path from 'path'
 import { REQUIRED_AGENT_VERSION } from './version'
@@ -71,7 +72,7 @@ export async function prewarmAgentCache(): Promise<void> {
     }
     release = (await res.json()) as GitHubRelease
   } catch (err) {
-    console.warn('[agent-cache] Could not reach GitHub — skipping prewarm', err)
+    logWarn('[agent-cache] Could not reach GitHub — skipping prewarm', err)
     return
   }
 
@@ -131,6 +132,6 @@ async function downloadIfMissing(
       `[agent-cache] Cached ${versionedName} (${(buffer.byteLength / 1024 / 1024).toFixed(1)} MB)`
     )
   } catch (err) {
-    console.warn(`[agent-cache] Error downloading ${baseName}:`, err)
+    logWarn(`[agent-cache] Error downloading ${baseName}:`, err)
   }
 }

--- a/apps/web/lib/logging.test.mjs
+++ b/apps/web/lib/logging.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { redactLogValue, sanitiseErrorForLog } from './logging.ts'
+
+test('redactLogValue redacts nested sensitive keys without dropping safe fields', () => {
+  const value = redactLogValue({
+    username: 'alice',
+    token: 'secret-token',
+    nested: {
+      password: 'secret-password',
+      ok: true,
+    },
+    channels: [
+      { kind: 'smtp', bindPassword: 'ldap-secret' },
+      { kind: 'slack', webhookUrl: 'https://example.com/hook' },
+    ],
+  })
+
+  assert.deepEqual(value, {
+    username: 'alice',
+    token: '[REDACTED]',
+    nested: {
+      password: '[REDACTED]',
+      ok: true,
+    },
+    channels: [
+      { kind: 'smtp', bindPassword: '[REDACTED]' },
+      { kind: 'slack', webhookUrl: 'https://example.com/hook' },
+    ],
+  })
+})
+
+test('sanitiseErrorForLog preserves basic error metadata and redacts attached config', () => {
+  const error = new Error('Request failed')
+  Object.assign(error, {
+    code: 'EAUTH',
+    config: {
+      username: 'alerts@example.com',
+      password: 'smtp-password',
+      token: 'smtp-token',
+    },
+  })
+
+  const safe = sanitiseErrorForLog(error)
+
+  assert.equal(safe.name, 'Error')
+  assert.equal(safe.message, 'Request failed')
+  assert.equal(safe.code, 'EAUTH')
+  assert.equal(safe.config, '[REDACTED]')
+  assert.match(safe.stack, /Request failed/)
+})
+
+test('redactLogValue handles circular references', () => {
+  const value = { name: 'loop' }
+  value.self = value
+
+  assert.deepEqual(redactLogValue(value), {
+    name: 'loop',
+    self: '[Circular]',
+  })
+})

--- a/apps/web/lib/logging.ts
+++ b/apps/web/lib/logging.ts
@@ -1,0 +1,113 @@
+const REDACTED = '[REDACTED]'
+const CIRCULAR = '[Circular]'
+const MAX_DEPTH = 6
+const SENSITIVE_KEY_PATTERN =
+  /(pass(word)?|token|secret|authorization|cookie|session|private[_-]?key|api[_-]?key|bindpassword|config)/i
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function redactObject(
+  value: Record<string, unknown>,
+  seen: WeakSet<object>,
+  depth: number,
+): Record<string, unknown> {
+  const safe: Record<string, unknown> = {}
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    safe[key] = SENSITIVE_KEY_PATTERN.test(key)
+      ? REDACTED
+      : redactLogValue(nestedValue, seen, depth + 1)
+  }
+
+  return safe
+}
+
+export function redactLogValue(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): unknown {
+  if (value == null) return value
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+  if (typeof value === 'bigint') return value.toString()
+  if (typeof value === 'function') return `[Function ${value.name || 'anonymous'}]`
+  if (value instanceof Date) return value.toISOString()
+  if (value instanceof URL) return value.toString()
+  if (depth >= MAX_DEPTH) return '[Truncated]'
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactLogValue(item, seen, depth + 1))
+  }
+
+  if (value instanceof Error) {
+    return sanitiseErrorForLog(value, seen, depth + 1)
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) return CIRCULAR
+    seen.add(value)
+
+    if (isPlainObject(value)) {
+      return redactObject(value, seen, depth)
+    }
+
+    return redactObject({ ...value }, seen, depth)
+  }
+
+  return String(value)
+}
+
+export function sanitiseErrorForLog(
+  error: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): unknown {
+  if (!(error instanceof Error)) {
+    return redactLogValue(error, seen, depth)
+  }
+
+  const safe: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+  }
+
+  if (typeof error.stack === 'string' && error.stack.length > 0) {
+    safe.stack = error.stack
+  }
+
+  for (const [key, value] of Object.entries(error)) {
+    safe[key] = SENSITIVE_KEY_PATTERN.test(key)
+      ? REDACTED
+      : redactLogValue(value, seen, depth + 1)
+  }
+
+  return safe
+}
+
+export function logError(message: string, error: unknown, context?: unknown): void {
+  if (context === undefined) {
+    console.error(message, { error: sanitiseErrorForLog(error) })
+    return
+  }
+
+  console.error(message, {
+    error: sanitiseErrorForLog(error),
+    context: redactLogValue(context),
+  })
+}
+
+export function logWarn(message: string, error: unknown, context?: unknown): void {
+  if (context === undefined) {
+    console.warn(message, { error: sanitiseErrorForLog(error) })
+    return
+  }
+
+  console.warn(message, {
+    error: sanitiseErrorForLog(error),
+    context: redactLogValue(context),
+  })
+}

--- a/apps/web/tests/e2e/hosts/inventory.spec.ts
+++ b/apps/web/tests/e2e/hosts/inventory.spec.ts
@@ -5,12 +5,14 @@ import { TEST_ORG } from '../fixtures/seed'
 test('authenticated user can search and filter the host inventory', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
 
-  const [{ id: orgId }] = await sql<Array<{ id: string }>>`
+  const orgRows = await sql<Array<{ id: string }>>`
     SELECT id
     FROM organisations
     WHERE slug = ${TEST_ORG.slug}
     LIMIT 1
   `
+  expect(orgRows).toHaveLength(1)
+  const orgId = orgRows[0]!.id
 
   await sql`
     INSERT INTO hosts (


### PR DESCRIPTION
## Summary
- add a shared web log sanitizer that redacts secret-shaped keys and error-attached config
- route server action and API error/warn logging through the sanitizer instead of logging raw errors
- add unit coverage for nested redaction, error sanitising, and circular references

## Testing
- `node --experimental-strip-types --test lib/logging.test.mjs`
- `pnpm --filter web type-check`
- `pnpm --filter web test:unit` *(still fails on existing unrelated issue #645: `metadata-validation.test.mjs` import resolution in `hosts.ts`)*

Fixes #351