### PR TITLE
fix(certificates): verify tracked refreshes by default

### DIFF
--- a/apps/ingest/internal/db/queries/certificates.sql.go
+++ b/apps/ingest/internal/db/queries/certificates.sql.go
@@ -295,6 +295,7 @@ type TrackedCertRow struct {
 	ServerName             string
 	TrackedURL             string
 	RefreshIntervalSeconds int
+	TLSSkipVerify          bool
 	FingerprintSHA256      string
 	NotAfter               time.Time
 	Status                 string
@@ -310,6 +311,7 @@ func ListCertsDueForUrlRefresh(
 	const q = `
 		SELECT id, organisation_id, host, port, server_name,
 		       tracked_url, COALESCE(refresh_interval_seconds, 3600),
+		       COALESCE((metadata->>'tlsSkipVerify')::boolean, false),
 		       fingerprint_sha256, not_after, status
 		FROM certificates
 		WHERE tracked_url IS NOT NULL
@@ -333,6 +335,7 @@ func ListCertsDueForUrlRefresh(
 		if err := rows.Scan(
 			&r.ID, &r.OrgID, &r.Host, &r.Port, &r.ServerName,
 			&r.TrackedURL, &r.RefreshIntervalSeconds,
+			&r.TLSSkipVerify,
 			&r.FingerprintSHA256, &r.NotAfter, &r.Status,
 		); err != nil {
 			return nil, err

--- a/apps/ingest/internal/handlers/cert_refresh_sweeper.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper.go
@@ -66,7 +66,7 @@ func runCertRefreshTick(ctx context.Context, pool *pgxpool.Pool) {
 }
 
 func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.TrackedCertRow) {
-	leaf, chain, err := fetchLeafAndChain(ctx, row.TrackedURL)
+	leaf, chain, err := fetchLeafAndChain(ctx, row.TrackedURL, row.TLSSkipVerify)
 	if err != nil {
 		slog.Info("cert refresh: fetch failed", "cert_id", row.ID, "url", row.TrackedURL, "err", err)
 		if qErr := queries.MarkCertRefreshFailed(ctx, pool, row.ID, truncateError(err.Error())); qErr != nil {
@@ -174,7 +174,20 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 // fetchLeafAndChain opens a TLS connection to the trackedUrl and returns the
 // peer leaf certificate plus the intermediate chain (everything after the
 // leaf).
-func fetchLeafAndChain(ctx context.Context, trackedURL string) (*x509.Certificate, []*x509.Certificate, error) {
+func fetchLeafAndChain(ctx context.Context, trackedURL string, skipVerify bool) (*x509.Certificate, []*x509.Certificate, error) {
+	return fetchLeafAndChainWithOptions(ctx, trackedURL, fetchLeafAndChainOptions{skipVerify: skipVerify})
+}
+
+type fetchLeafAndChainOptions struct {
+	rootCAs    *x509.CertPool
+	skipVerify bool
+}
+
+func fetchLeafAndChainWithOptions(
+	ctx context.Context,
+	trackedURL string,
+	opts fetchLeafAndChainOptions,
+) (*x509.Certificate, []*x509.Certificate, error) {
 	host, port, serverName, err := parseTrackedURL(trackedURL)
 	if err != nil {
 		return nil, nil, err
@@ -189,7 +202,8 @@ func fetchLeafAndChain(ctx context.Context, trackedURL string) (*x509.Certificat
 
 	tlsConn := tls.Client(rawConn, &tls.Config{
 		ServerName:         serverName,
-		InsecureSkipVerify: true, // we record the cert regardless of trust chain
+		RootCAs:            opts.rootCAs,
+		InsecureSkipVerify: opts.skipVerify,
 	})
 	defer tlsConn.Close()
 

--- a/apps/ingest/internal/handlers/cert_refresh_sweeper_test.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper_test.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestFetchLeafAndChainVerifiesTrustedRootsByDefault(t *testing.T) {
+	t.Parallel()
+
+	rootPEM, serverCert, closeServer := startTestTLSServer(t)
+	defer closeServer()
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(rootPEM) {
+		t.Fatal("AppendCertsFromPEM() = false")
+	}
+
+	leaf, chain, err := fetchLeafAndChainWithOptions(context.Background(), serverCert.url, fetchLeafAndChainOptions{
+		rootCAs: roots,
+	})
+	if err != nil {
+		t.Fatalf("fetchLeafAndChainWithOptions() error = %v", err)
+	}
+	if leaf.Subject.CommonName != "localhost" {
+		t.Fatalf("leaf.Subject.CommonName = %q, want localhost", leaf.Subject.CommonName)
+	}
+	if len(chain) != 0 {
+		t.Fatalf("len(chain) = %d, want 0", len(chain))
+	}
+}
+
+func TestFetchLeafAndChainRejectsUntrustedRootsUnlessOptedOut(t *testing.T) {
+	t.Parallel()
+
+	_, serverCert, closeServer := startTestTLSServer(t)
+	defer closeServer()
+
+	if _, _, err := fetchLeafAndChainWithOptions(context.Background(), serverCert.url, fetchLeafAndChainOptions{}); err == nil {
+		t.Fatal("expected untrusted certificate to fail verification")
+	}
+
+	if _, _, err := fetchLeafAndChainWithOptions(context.Background(), serverCert.url, fetchLeafAndChainOptions{
+		skipVerify: true,
+	}); err != nil {
+		t.Fatalf("fetchLeafAndChainWithOptions(skipVerify=true) error = %v", err)
+	}
+}
+
+type testTLSServer struct {
+	url string
+}
+
+func startTestTLSServer(t *testing.T) ([]byte, testTLSServer, func()) {
+	t.Helper()
+
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(root) error = %v", err)
+	}
+	rootTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "ct-ops test root",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(root) error = %v", err)
+	}
+	rootPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate(root) error = %v", err)
+	}
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey(leaf) error = %v", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		IsCA:         false,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootCert, &leafKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate(leaf) error = %v", err)
+	}
+
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+	leafKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(leafKey)})
+	tlsCert, err := tls.X509KeyPair(leafPEM, leafKeyPEM)
+	if err != nil {
+		t.Fatalf("tls.X509KeyPair() error = %v", err)
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err != nil {
+		t.Fatalf("tls.Listen() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case <-done:
+					return
+				default:
+					return
+				}
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				_ = conn.(*tls.Conn).Handshake()
+				<-done
+			}(conn)
+		}
+	}()
+
+	addr := ln.Addr().String()
+	serverURL := &url.URL{Scheme: "https", Host: addr}
+
+	return rootPEM, testTLSServer{url: serverURL.String()}, func() {
+		close(done)
+		_ = ln.Close()
+	}
+}

--- a/apps/ingest/internal/handlers/terminal_ws_security_test.go
+++ b/apps/ingest/internal/handlers/terminal_ws_security_test.go
@@ -51,8 +51,7 @@ func TestInsecureSkipVerifyTrueAllowlist(t *testing.T) {
 
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
 	allowed := map[string]struct{}{
-		filepath.Join(repoRoot, "agent", "internal", "checks", "certificate.go"):                     {},
-		filepath.Join(repoRoot, "apps", "ingest", "internal", "handlers", "cert_refresh_sweeper.go"): {},
+		filepath.Join(repoRoot, "agent", "internal", "checks", "certificate.go"): {},
 	}
 
 	var unexpected []string

--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -261,6 +261,7 @@ function TrackControls({ orgId, source }: { orgId: string; source: TrackSource }
   const [state, setState] = useState<TrackState>({ status: 'idle' })
   const [dialogOpen, setDialogOpen] = useState(false)
   const [refreshInterval, setRefreshInterval] = useState('3600')
+  const [tlsSkipVerify, setTlsSkipVerify] = useState(false)
 
   async function submitUpload() {
     if (source.kind !== 'upload') return
@@ -276,6 +277,7 @@ function TrackControls({ orgId, source }: { orgId: string; source: TrackSource }
     const result = await trackCertificateFromUrl(orgId, {
       url: source.url,
       refreshIntervalSeconds: parseInt(refreshInterval, 10),
+      tlsSkipVerify,
     })
     applyResult(result)
   }
@@ -375,6 +377,20 @@ function TrackControls({ orgId, source }: { orgId: string; source: TrackSource }
                 </SelectContent>
               </Select>
             </div>
+            <label className="flex items-start gap-3 rounded-lg border px-3 py-3">
+              <input
+                type="checkbox"
+                className="mt-1"
+                checked={tlsSkipVerify}
+                onChange={(e) => setTlsSkipVerify(e.target.checked)}
+              />
+              <div className="space-y-1">
+                <span className="text-sm font-medium">Allow insecure re-checks for untrusted/self-signed certs</span>
+                <p className="text-xs text-muted-foreground">
+                  Off by default. Enable only when this endpoint cannot chain to system trust roots.
+                </p>
+              </div>
+            </label>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -22,6 +22,10 @@ import { createRateLimiter } from '@/lib/rate-limit'
 
 const trackFromUrlLimiter = createRateLimiter(60_000, 20)
 
+type CertificateTrackingMetadata = {
+  tlsSkipVerify?: boolean
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type CertificateListFilters = {
@@ -173,6 +177,7 @@ const trackFromUrlSchema = z.object({
     (v) => (REFRESH_INTERVAL_OPTIONS as readonly number[]).includes(v),
     { message: 'Refresh interval must be 15m, 1h, 6h, or 24h' },
   ).optional(),
+  tlsSkipVerify: z.boolean().optional(),
 })
 
 // 64 KB is well beyond any real certificate chain; rejects degenerate payloads.
@@ -237,6 +242,26 @@ async function findExistingCertByIdentity(
   })
 }
 
+function asTrackingMetadata(value: unknown): CertificateTrackingMetadata {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  return value as CertificateTrackingMetadata
+}
+
+function buildTrackingMetadata(
+  existing: unknown,
+  tlsSkipVerify: boolean,
+): CertificateTrackingMetadata {
+  const metadata = { ...asTrackingMetadata(existing) }
+  if (tlsSkipVerify) {
+    metadata.tlsSkipVerify = true
+  } else {
+    delete metadata.tlsSkipVerify
+  }
+  return metadata
+}
+
 export async function trackCertificateFromUrl(
   orgId: string,
   input: unknown,
@@ -256,7 +281,7 @@ export async function trackCertificateFromUrl(
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
   }
 
-  const { url, refreshIntervalSeconds = 3600 } = parsed.data
+  const { url, refreshIntervalSeconds = 3600, tlsSkipVerify = false } = parsed.data
 
   let result
   try {
@@ -277,12 +302,18 @@ export async function trackCertificateFromUrl(
     orgId, host, port, serverName, certificate.fingerprintSha256,
   )
   if (existing) {
-    if (existing.trackedUrl !== url || existing.refreshIntervalSeconds !== refreshIntervalSeconds) {
+    const currentTlsSkipVerify = asTrackingMetadata(existing.metadata).tlsSkipVerify === true
+    if (
+      existing.trackedUrl !== url
+      || existing.refreshIntervalSeconds !== refreshIntervalSeconds
+      || currentTlsSkipVerify !== tlsSkipVerify
+    ) {
       await db
         .update(certificates)
         .set({
           trackedUrl: url,
           refreshIntervalSeconds,
+          metadata: buildTrackingMetadata(existing.metadata, tlsSkipVerify),
           lastRefreshedAt: new Date(),
           lastRefreshError: null,
           updatedAt: new Date(),
@@ -308,6 +339,7 @@ export async function trackCertificateFromUrl(
       fingerprintSha256: certificate.fingerprintSha256,
       status,
       details: buildDetailsFromParsed(certificate),
+      metadata: buildTrackingMetadata(undefined, tlsSkipVerify),
       trackedUrl: url,
       refreshIntervalSeconds,
       lastRefreshedAt: new Date(),


### PR DESCRIPTION
## Summary
- verify tracked certificate refreshes against system trust roots by default in ingest
- add a per-certificate `tlsSkipVerify` opt-in for tracked URL refreshes in the certificate checker flow
- add ingest tests that cover trusted, untrusted, and explicit skip-verify refresh behavior

## Root cause
The certificate refresh sweeper always used `InsecureSkipVerify: true`, so any man-in-the-middle with a different untrusted certificate could suppress expiry tracking by feeding forged certificate metadata.

## Validation
- `go test ./internal/handlers`
- `pnpm type-check`

Closes #356.
