### PR TITLE
fix(web): add missing dashboard and host e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -23,13 +23,18 @@ function StatRow({
   label,
   value,
   className,
+  testId,
 }: {
   label: string
   value: number | string
   className?: string
+  testId?: string
 }) {
   return (
-    <div className="flex items-center justify-between py-1.5 border-b border-border last:border-0">
+    <div
+      className="flex items-center justify-between py-1.5 border-b border-border last:border-0"
+      data-testid={testId}
+    >
       <span className="text-sm text-muted-foreground">{label}</span>
       <span className={`text-sm font-medium tabular-nums ${className ?? 'text-foreground'}`}>
         {value}
@@ -88,16 +93,18 @@ export function DashboardClient() {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-1">
-            <StatRow label="Total enrolled" value={data.agents.total} />
+            <StatRow label="Total enrolled" value={data.agents.total} testId="dashboard-agents-total" />
             <StatRow
               label="Online"
               value={data.agents.online}
               className={data.agents.online > 0 ? 'text-green-700' : 'text-foreground'}
+              testId="dashboard-agents-online"
             />
             <StatRow
               label="Offline"
               value={data.agents.offline}
               className={data.agents.offline > 0 ? 'text-amber-600' : 'text-foreground'}
+              testId="dashboard-agents-offline"
             />
           </CardContent>
         </Card>
@@ -117,16 +124,19 @@ export function DashboardClient() {
               label="Valid"
               value={data.certificates.valid}
               className={data.certificates.valid > 0 ? 'text-green-700' : 'text-foreground'}
+              testId="dashboard-certificates-valid"
             />
             <StatRow
               label="Expiring soon"
               value={data.certificates.expiringSoon}
               className={data.certificates.expiringSoon > 0 ? 'text-amber-600' : 'text-foreground'}
+              testId="dashboard-certificates-expiring-soon"
             />
             <StatRow
               label="Expired"
               value={data.certificates.expired}
               className={data.certificates.expired > 0 ? 'text-destructive' : 'text-foreground'}
+              testId="dashboard-certificates-expired"
             />
           </CardContent>
         </Card>
@@ -146,11 +156,13 @@ export function DashboardClient() {
               label="Firing"
               value={data.alerts.firing}
               className={data.alerts.firing > 0 ? 'text-destructive' : 'text-foreground'}
+              testId="dashboard-alerts-firing"
             />
             <StatRow
               label="Acknowledged"
               value={data.alerts.acknowledged}
               className={data.alerts.acknowledged > 0 ? 'text-amber-600' : 'text-foreground'}
+              testId="dashboard-alerts-acknowledged"
             />
           </CardContent>
         </Card>
@@ -165,12 +177,12 @@ export function DashboardClient() {
           </CardHeader>
           <CardContent>
             {!hasIssues ? (
-              <div className="flex items-center gap-2 text-green-700 py-1">
+              <div className="flex items-center gap-2 text-green-700 py-1" data-testid="dashboard-summary-nominal">
                 <CheckCircle2 className="size-4" />
                 <span className="text-sm font-medium">All systems nominal</span>
               </div>
             ) : (
-              <ul className="space-y-1.5">
+              <ul className="space-y-1.5" data-testid="dashboard-summary-issues">
                 {data.alerts.firing > 0 && (
                   <li className="flex items-center gap-2 text-destructive text-sm">
                     <XCircle className="size-4 shrink-0" />

--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -501,7 +501,7 @@ export function HostsClient({
       </div>
 
       {isAdmin && pendingAgents.length > 0 && (
-        <Card className="border-amber-200 bg-amber-50">
+        <Card className="border-amber-200 bg-amber-50" data-testid="pending-agent-approvals">
           <CardHeader className="pb-3">
             <CardTitle className="text-base text-amber-900 flex items-center gap-2">
               <Clock className="size-4" />
@@ -524,7 +524,7 @@ export function HostsClient({
               </TableHeader>
               <TableBody>
                 {pendingAgents.map((agent) => (
-                  <TableRow key={agent.id}>
+                  <TableRow key={agent.id} data-testid={`pending-agent-row-${agent.id}`}>
                     <TableCell className="font-medium text-amber-900">{agent.hostname}</TableCell>
                     <TableCell className="text-amber-800">
                       {agent.os ?? '—'} {agent.arch ? `(${agent.arch})` : ''}
@@ -542,6 +542,7 @@ export function HostsClient({
                           className="bg-green-600 hover:bg-green-700 text-white"
                           onClick={() => approveMutation.mutate({ agentId: agent.id })}
                           disabled={approveMutation.isPending}
+                          data-testid={`pending-agent-approve-${agent.id}`}
                         >
                           Approve
                         </Button>
@@ -551,6 +552,7 @@ export function HostsClient({
                           className="border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800"
                           onClick={() => rejectMutation.mutate({ agentId: agent.id })}
                           disabled={rejectMutation.isPending}
+                          data-testid={`pending-agent-reject-${agent.id}`}
                         >
                           Reject
                         </Button>

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -200,7 +200,7 @@ async function findOnlineHostCollision(
   ips: string[],
 ): Promise<{ id: string; hostname: string } | null> {
   const ipOverlap = ips.length > 0
-    ? sql`ip_addresses ?| ${ips}::text[]`
+    ? sql`${hosts.ipAddresses} ?| ARRAY[${sql.join(ips.map((ip) => sql`${ip}`), sql`, `)}]::text[]`
     : sql`false`
   const rows = await db
     .select({ id: hosts.id, hostname: hosts.hostname })

--- a/apps/web/tests/e2e/dashboard/overview.spec.ts
+++ b/apps/web/tests/e2e/dashboard/overview.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('overview aggregates agent, certificate, and alert counts for the organisation', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO agents (id, organisation_id, hostname, public_key, status, os, arch)
+    VALUES
+      ('agent-online', ${orgId}, 'agent-online', 'pk-online', 'active', 'Ubuntu 24.04', 'x86_64'),
+      ('agent-offline', ${orgId}, 'agent-offline', 'pk-offline', 'offline', 'Ubuntu 24.04', 'x86_64')
+  `
+
+  await sql`
+    INSERT INTO hosts (id, organisation_id, agent_id, hostname, display_name, os, arch, ip_addresses, status)
+    VALUES
+      ('host-alert', ${orgId}, 'agent-online', 'host-alert', 'Alert Host', 'Ubuntu 24.04', 'x86_64', '["10.20.0.10"]'::jsonb, 'online')
+  `
+
+  await sql`
+    INSERT INTO alert_rules (id, organisation_id, host_id, name, condition_type, config, severity)
+    VALUES
+      (
+        'alert-rule-cpu',
+        ${orgId},
+        'host-alert',
+        'High CPU',
+        'metric_threshold',
+        '{"metric":"cpu","operator":"gt","threshold":90}'::jsonb,
+        'critical'
+      )
+  `
+
+  await sql`
+    INSERT INTO alert_instances (id, rule_id, host_id, organisation_id, status, message, triggered_at)
+    VALUES
+      ('alert-firing', 'alert-rule-cpu', 'host-alert', ${orgId}, 'firing', 'CPU over threshold', NOW()),
+      ('alert-ack', 'alert-rule-cpu', 'host-alert', ${orgId}, 'acknowledged', 'Investigating CPU', NOW())
+  `
+
+  await sql`
+    INSERT INTO certificates (
+      id,
+      organisation_id,
+      source,
+      host,
+      port,
+      server_name,
+      common_name,
+      issuer,
+      sans,
+      not_before,
+      not_after,
+      fingerprint_sha256,
+      status,
+      details
+    )
+    VALUES
+      (
+        'cert-valid',
+        ${orgId},
+        'discovered',
+        'valid.example.com',
+        443,
+        'valid.example.com',
+        'valid.example.com',
+        'CT Test CA',
+        '["valid.example.com"]'::jsonb,
+        NOW() - INTERVAL '10 days',
+        NOW() + INTERVAL '20 days',
+        'fingerprint-valid',
+        'valid',
+        '{"subject":"CN=valid.example.com","issuer":"CN=CT Test CA","serialNumber":"1001","signatureAlgorithm":"sha256WithRSAEncryption","keyAlgorithm":"RSA-2048","isSelfSigned":false,"chain":[]}'::jsonb
+      ),
+      (
+        'cert-expiring',
+        ${orgId},
+        'discovered',
+        'expiring.example.com',
+        443,
+        'expiring.example.com',
+        'expiring.example.com',
+        'CT Test CA',
+        '["expiring.example.com"]'::jsonb,
+        NOW() - INTERVAL '20 days',
+        NOW() + INTERVAL '2 days',
+        'fingerprint-expiring',
+        'expiring_soon',
+        '{"subject":"CN=expiring.example.com","issuer":"CN=CT Test CA","serialNumber":"1002","signatureAlgorithm":"sha256WithRSAEncryption","keyAlgorithm":"RSA-2048","isSelfSigned":false,"chain":[]}'::jsonb
+      ),
+      (
+        'cert-expired',
+        ${orgId},
+        'discovered',
+        'expired.example.com',
+        443,
+        'expired.example.com',
+        'expired.example.com',
+        'CT Test CA',
+        '["expired.example.com"]'::jsonb,
+        NOW() - INTERVAL '40 days',
+        NOW() - INTERVAL '1 day',
+        'fingerprint-expired',
+        'expired',
+        '{"subject":"CN=expired.example.com","issuer":"CN=CT Test CA","serialNumber":"1003","signatureAlgorithm":"sha256WithRSAEncryption","keyAlgorithm":"RSA-2048","isSelfSigned":false,"chain":[]}'::jsonb
+      )
+  `
+
+  await page.goto('/dashboard')
+
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+  await expect(page.getByTestId('dashboard-agents-total')).toContainText('2')
+  await expect(page.getByTestId('dashboard-agents-online')).toContainText('1')
+  await expect(page.getByTestId('dashboard-agents-offline')).toContainText('1')
+  await expect(page.getByTestId('dashboard-certificates-valid')).toContainText('1')
+  await expect(page.getByTestId('dashboard-certificates-expiring-soon')).toContainText('1')
+  await expect(page.getByTestId('dashboard-certificates-expired')).toContainText('1')
+  await expect(page.getByTestId('dashboard-alerts-firing')).toContainText('1')
+  await expect(page.getByTestId('dashboard-alerts-acknowledged')).toContainText('1')
+
+  const summary = page.getByTestId('dashboard-summary-issues')
+  await expect(summary).toContainText('1 alert firing')
+  await expect(summary).toContainText('1 certificate expired')
+  await expect(summary).toContainText('1 agent offline')
+})

--- a/apps/web/tests/e2e/hosts/inventory.spec.ts
+++ b/apps/web/tests/e2e/hosts/inventory.spec.ts
@@ -2,17 +2,25 @@ import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_ORG } from '../fixtures/seed'
 
-test('authenticated user can search and filter the host inventory', async ({ authenticatedPage: page }) => {
-  const sql = getTestDb()
-
-  const orgRows = await sql<Array<{ id: string }>>`
-    SELECT id
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
     FROM organisations
-    WHERE slug = ${TEST_ORG.slug}
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = 'e2e@example.com'
     LIMIT 1
   `
-  expect(orgRows).toHaveLength(1)
-  const orgId = orgRows[0]!.id
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('authenticated user can search and filter the host inventory', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
 
   await sql`
     INSERT INTO hosts (
@@ -68,6 +76,7 @@ test('authenticated user can search and filter the host inventory', async ({ aut
   await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
 
   await page.getByTestId('hosts-search-input').fill('10.0.0.20')
+  await expect(page.getByText('Showing 1–1 of 1')).toBeVisible()
   await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Alpha Node' })).toHaveCount(0)
   await expect(page.getByTestId('hosts-clear-filters')).toBeVisible()
@@ -87,4 +96,76 @@ test('authenticated user can search and filter the host inventory', async ({ aut
 
   await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
   await expect(page.getByText('Showing 1–1 of 1')).toBeVisible()
+})
+
+test('admin can approve a pending agent from the host inventory page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO agents (
+      id,
+      organisation_id,
+      hostname,
+      public_key,
+      status,
+      os,
+      arch
+    )
+    VALUES (
+      'pending-agent-1',
+      ${orgId},
+      'pending-node',
+      'pending-public-key-1',
+      'pending',
+      'Ubuntu 24.04',
+      'arm64'
+    )
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      agent_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status
+    )
+    VALUES (
+      'pending-host-1',
+      ${orgId},
+      'pending-agent-1',
+      'pending-node',
+      'Pending Node',
+      'Ubuntu 24.04',
+      'arm64',
+      '["10.0.1.50"]'::jsonb,
+      'unknown'
+    )
+  `
+
+  await page.goto('/hosts')
+
+  await expect(page.getByTestId('pending-agent-approvals')).toBeVisible()
+  await expect(page.getByTestId('pending-agent-row-pending-agent-1')).toContainText('pending-node')
+  await expect(page.getByText('Pending approval')).toBeVisible()
+
+  await page.getByTestId('pending-agent-approve-pending-agent-1').click()
+
+  await expect(page.getByTestId('pending-agent-approvals')).toHaveCount(0)
+
+  const agentRows = await sql<Array<{ status: string; approved_by_id: string | null }>>`
+    SELECT status, approved_by_id
+    FROM agents
+    WHERE id = 'pending-agent-1'
+    LIMIT 1
+  `
+
+  expect(agentRows).toHaveLength(1)
+  expect(agentRows[0]?.status).toBe('active')
+  expect(agentRows[0]?.approved_by_id).toBe(userId)
 })


### PR DESCRIPTION
## Summary
- add a new dashboard overview E2E spec that seeds agents, certificates, and alerts
- extend the hosts inventory E2E coverage to exercise pending-agent approval
- fix pending agent approval IP collision checks so approval works when a host has IP addresses

## Testing
- TESTCONTAINERS_RYUK_DISABLED=true pnpm --filter web test:e2e -- tests/e2e/dashboard/overview.spec.ts tests/e2e/hosts/inventory.spec.ts