### PR TITLE
fix(auth): bind invite redemption to invited email

### DIFF
--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -11,6 +11,10 @@ import { createRateLimiter } from '@/lib/rate-limit'
 // 10 invite-token lookups per IP per 60 s — prevents token enumeration
 const inviteRateLimit = createRateLimiter(60_000, 10)
 
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
 async function getClientIp(): Promise<string> {
   const h = await headers()
   return h.get('x-forwarded-for')?.split(',')[0]?.trim() ?? h.get('x-real-ip') ?? 'unknown'
@@ -52,6 +56,26 @@ export async function acceptInvite(
 
     if (!invite) {
       return { error: 'Invitation not found or has expired' }
+    }
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+    })
+
+    if (!user) {
+      return { error: 'Account not found' }
+    }
+
+    if (user.organisationId) {
+      return { error: 'This account already belongs to an organisation' }
+    }
+
+    if (!user.emailVerified) {
+      return { error: 'Verify your email before accepting this invitation' }
+    }
+
+    if (normalizeEmail(user.email) !== normalizeEmail(invite.email)) {
+      return { error: 'This invitation was sent to a different email address' }
     }
 
     await db

--- a/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
+++ b/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_USER, TEST_ORG } from '../fixtures/seed'
+
+test('invite acceptance rejects logged-in users whose email does not match the invitation', async ({
+  page,
+}) => {
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const attackerEmail = `attacker-${suffix}@example.com`
+  const attackerPassword = 'TestPassword123!'
+  const invitedEmail = `victim-${suffix}@example.com`
+  const inviteToken = `invite-token-${suffix}`
+
+  await page.request.post('/api/auth/sign-up/email', {
+    data: {
+      email: attackerEmail,
+      password: attackerPassword,
+      name: 'Invite Attacker',
+    },
+  })
+
+  await sql`
+    UPDATE "user"
+    SET email_verified = true,
+        is_active = true
+    WHERE email = ${attackerEmail}
+  `
+
+  await sql`
+    INSERT INTO invitations (
+      id,
+      email,
+      role,
+      token,
+      organisation_id,
+      invited_by_id,
+      expires_at,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      ${`invite-${suffix}`},
+      ${invitedEmail},
+      'org_admin',
+      ${inviteToken},
+      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+      NOW() + INTERVAL '1 day',
+      NOW(),
+      NOW()
+    )
+  `
+
+  const signInResponse = await page.request.post('/api/auth/sign-in/email', {
+    data: {
+      email: attackerEmail,
+      password: attackerPassword,
+    },
+  })
+  expect(signInResponse.ok()).toBeTruthy()
+
+  await page.goto('/onboarding')
+  await page.waitForURL('**/onboarding')
+
+  await page.goto(`/accept-invite?token=${inviteToken}`)
+
+  await page.waitForURL('**/onboarding')
+  await expect(page.getByText('Create your organisation', { exact: true })).toBeVisible()
+
+  const [attacker] = await sql<Array<{ organisation_id: string | null; role: string }>>`
+    SELECT organisation_id, role
+    FROM "user"
+    WHERE email = ${attackerEmail}
+    LIMIT 1
+  `
+  expect(attacker?.organisation_id).toBeNull()
+  expect(attacker?.role).toBe('engineer')
+
+  const [invite] = await sql<Array<{ accepted_at: Date | null }>>`
+    SELECT accepted_at
+    FROM invitations
+    WHERE token = ${inviteToken}
+    LIMIT 1
+  `
+  expect(invite?.accepted_at).toBeNull()
+})


### PR DESCRIPTION
## Summary
- bind invite redemption to the authenticated account's verified email address on the server
- reject invite acceptance for accounts that already belong to an organisation
- add an e2e regression covering a logged-in attacker redeeming another user's invite

## Root cause
`acceptInvite()` trusted possession of the invite token plus the caller's `userId`, and never checked that the accepting account actually owned the invited email address.

## Testing
- `pnpm --filter web test:e2e -- tests/e2e/auth/invite-acceptance.spec.ts`
- `pnpm --filter web type-check`

Fixes #648
