### PR TITLE
fix(web): restore schema metadata unit tests

### DIFF
--- a/apps/web/lib/db/schema/agents.ts
+++ b/apps/web/lib/db/schema/agents.ts
@@ -1,8 +1,8 @@
 import { pgTable, text, timestamp, jsonb, boolean, integer } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
 import { z } from 'zod'
-import { organisations } from './organisations'
-import { users } from './auth'
+import { organisations } from './organisations.ts'
+import { users } from './auth.ts'
 
 export interface AgentEnrolmentTokenMetadata {
   tags?: Array<{ key: string; value: string }>

--- a/apps/web/lib/db/schema/auth.ts
+++ b/apps/web/lib/db/schema/auth.ts
@@ -1,6 +1,6 @@
 import { pgTable, text, timestamp, boolean } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
-import { organisations } from './organisations'
+import { organisations } from './organisations.ts'
 
 // Better Auth core tables
 export const users = pgTable('user', {

--- a/apps/web/lib/db/schema/hosts.ts
+++ b/apps/web/lib/db/schema/hosts.ts
@@ -1,8 +1,8 @@
 import { pgTable, text, timestamp, jsonb, integer, real } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
 import { z } from 'zod'
-import { organisations } from './organisations'
-import { agents } from './agents'
+import { organisations } from './organisations.ts'
+import { agents } from './agents.ts'
 
 export interface DiskInfo {
   mount_point: string

--- a/apps/web/lib/db/schema/metadata-validation.test.mjs
+++ b/apps/web/lib/db/schema/metadata-validation.test.mjs
@@ -1,8 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import hostsModule from './hosts.ts'
-import organisationsModule from './organisations.ts'
+import * as hostsModule from './hosts.ts'
+import * as organisationsModule from './organisations.ts'
 
 const { parseHostMetadata } = hostsModule
 const { parseOrgMetadata } = organisationsModule

--- a/apps/web/lib/db/schema/organisations.ts
+++ b/apps/web/lib/db/schema/organisations.ts
@@ -1,9 +1,9 @@
 import { pgTable, text, timestamp, jsonb, integer } from 'drizzle-orm/pg-core'
 import { createId } from '@paralleldrive/cuid2'
 import { z } from 'zod'
-import { DEFAULT_NOTIFICATION_ROLES } from '../../auth/roles'
+import { DEFAULT_NOTIFICATION_ROLES } from '../../auth/roles.ts'
 import type { HostCollectionSettings } from './hosts'
-import { smtpRelaySettingsSchema, type SmtpRelaySettings } from '../../notifications/smtp-settings'
+import { smtpRelaySettingsSchema, type SmtpRelaySettings } from '../../notifications/smtp-settings.ts'
 
 export interface OrgNotificationSettings {
   inAppEnabled?: boolean      // default true — master switch for in-app notifications

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- restore the web schema metadata unit test path under Node's ESM test runner
- use explicit local `.ts` specifiers for the schema modules traversed by `metadata-validation.test.mjs`
- enable `allowImportingTsExtensions` in the web tsconfig so `tsc --noEmit` accepts those imports

## Evidence
- local `pnpm --dir apps/web test:unit` on `origin/main` failed in `apps/web/lib/db/schema/metadata-validation.test.mjs`
- failure path: `apps/web/lib/db/schema/hosts.ts` imported `./organisations` without a resolvable ESM extension
- after that was corrected, the same test still failed because it used default imports against named-export modules
- recent SMTP centralization commit `c2fafe4` added a new runtime schema import in `apps/web/lib/db/schema/organisations.ts`, which kept this test path in active use during the scan

## Approach
- keep the change scoped to the schema modules used by the failing metadata validation test
- update the test to namespace-import named exports
- keep validation focused on the affected web and ingest areas

## Validation
- `go test ./apps/ingest/internal/handlers/...`
- `pnpm --dir apps/web test:unit`
- `pnpm --dir apps/web type-check`
- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=abcdefghijklmnopqrstuvwxyz123456 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/ctops pnpm --dir apps/web build`
