### PR TITLE
test(web): add profile and invite dedupe e2e coverage

### DIFF
--- a/apps/web/tests/e2e/profile/profile.spec.ts
+++ b/apps/web/tests/e2e/profile/profile.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_USER } from '../fixtures/seed'
+
+test('authenticated user can update their display name from profile', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const updatedName = `Updated ${Date.now()}`
+
+  await page.goto('/profile')
+
+  await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible()
+  const nameInput = page.getByLabel('Full name')
+  await nameInput.click()
+  await nameInput.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`)
+  await nameInput.fill(updatedName)
+  await page.getByRole('button', { name: 'Save' }).click()
+
+  await expect(page.getByText('Saved')).toBeVisible()
+  await expect(nameInput).toHaveValue(updatedName)
+
+  const rows = await sql<Array<{ name: string }>>`
+    SELECT name
+    FROM "user"
+    WHERE email = ${TEST_USER.email}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  expect(rows[0]?.name).toBe(updatedName)
+})

--- a/apps/web/tests/e2e/team/invitations.spec.ts
+++ b/apps/web/tests/e2e/team/invitations.spec.ts
@@ -61,3 +61,39 @@ test('admin can create and cancel a team invitation', async ({ authenticatedPage
   expect(cancelledInviteRows).toHaveLength(1)
   expect(cancelledInviteRows[0]?.deleted_at).toBeTruthy()
 })
+
+test('admin cannot create a duplicate pending invitation for the same email address', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const inviteeEmail = 'duplicate-teammate@example.com'
+
+  await page.goto('/team')
+
+  await expect(page.getByTestId('team-heading')).toBeVisible()
+  await page.getByTestId('team-invite-open').click()
+  await page.getByTestId('team-invite-email').fill(inviteeEmail)
+  await page.getByTestId('team-invite-role').selectOption('engineer')
+  await page.getByTestId('team-invite-submit').click()
+  await expect(page.getByTestId('team-invite-link')).toBeVisible()
+  await page.getByTestId('team-invite-done').click()
+
+  await page.getByTestId('team-invite-open').click()
+  await page.getByTestId('team-invite-email').fill(inviteeEmail)
+  await page.getByTestId('team-invite-role').selectOption('org_admin')
+  await page.getByTestId('team-invite-submit').click()
+
+  await expect(page.getByText('An invitation has already been sent to this email address')).toBeVisible()
+  await expect(page.getByTestId('team-invite-link')).toHaveCount(0)
+
+  const inviteRows = await sql<Array<{ role: string; deleted_at: Date | null }>>`
+    SELECT role, deleted_at
+    FROM invitations
+    WHERE organisation_id = ${orgId}
+      AND email = ${inviteeEmail}
+    ORDER BY created_at ASC
+  `
+
+  expect(inviteRows).toHaveLength(1)
+  expect(inviteRows[0]?.role).toBe('engineer')
+  expect(inviteRows[0]?.deleted_at).toBeNull()
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for profile display-name updates
- extend team invitation coverage to reject duplicate pending invites
- validate both specs with the database-backed Playwright harness

## Testing
- pnpm --filter web test:e2e -- tests/e2e/profile/profile.spec.ts tests/e2e/team/invitations.spec.ts