### PR TITLE
fix(web): enforce LDAP TLS certificate validation

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -111,7 +111,7 @@ function CertificateUpload({
         Upload Certificate (.pem, .crt)
       </Button>
       <p className="text-xs text-muted-foreground">
-        Upload a CA certificate to verify the LDAP server identity. Without a certificate, TLS connections will skip server verification.
+        Upload a CA certificate when the LDAP server uses a private CA. Otherwise TLS connections use the platform trust store to verify the server identity.
       </p>
     </div>
   )

--- a/apps/web/lib/ldap/client.ts
+++ b/apps/web/lib/ldap/client.ts
@@ -1,6 +1,7 @@
 import { Client } from 'ldapts'
 import { decrypt } from '@/lib/crypto/encrypt'
 import type { LdapConfiguration } from '@/lib/db/schema'
+import { getTlsOptions } from './tls-options'
 
 export interface LdapUser {
   dn: string
@@ -27,13 +28,6 @@ export function escapeLdapFilterValue(value: string): string {
 
 function safeDecrypt(value: string): string {
   try { return decrypt(value) } catch { return value }
-}
-
-function getTlsOptions(config: LdapConfiguration): Record<string, unknown> | undefined {
-  if (!config.useTls && !config.useStartTls) return undefined
-  return config.tlsCertificate
-    ? { ca: [safeDecrypt(config.tlsCertificate)], rejectUnauthorized: true }
-    : { rejectUnauthorized: false }
 }
 
 function getBindDn(config: LdapConfiguration): string {

--- a/apps/web/lib/ldap/tls-options.test.mjs
+++ b/apps/web/lib/ldap/tls-options.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getTlsOptions } from './tls-options.ts'
+
+test('getTlsOptions keeps certificate verification enabled when no custom CA is configured', () => {
+  const tlsOptions = getTlsOptions({
+    useTls: true,
+    useStartTls: false,
+    tlsCertificate: null,
+  })
+
+  assert.deepEqual(tlsOptions, {})
+  assert.equal(tlsOptions?.rejectUnauthorized, undefined)
+})
+
+test('getTlsOptions includes a CA bundle without disabling verification', () => {
+  const tlsOptions = getTlsOptions({
+    useTls: true,
+    useStartTls: false,
+    tlsCertificate: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
+  })
+
+  assert.deepEqual(tlsOptions, {
+    ca: ['-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----'],
+    rejectUnauthorized: true,
+  })
+})

--- a/apps/web/lib/ldap/tls-options.ts
+++ b/apps/web/lib/ldap/tls-options.ts
@@ -1,0 +1,18 @@
+import { decrypt } from '../crypto/encrypt.ts'
+
+type LdapTlsConfig = {
+  useTls: boolean
+  useStartTls: boolean
+  tlsCertificate: string | null
+}
+
+function safeDecrypt(value: string): string {
+  try { return decrypt(value) } catch { return value }
+}
+
+export function getTlsOptions(config: LdapTlsConfig): Record<string, unknown> | undefined {
+  if (!config.useTls && !config.useStartTls) return undefined
+  return config.tlsCertificate
+    ? { ca: [safeDecrypt(config.tlsCertificate)], rejectUnauthorized: true }
+    : {}
+}


### PR DESCRIPTION
## Summary
- stop overriding LDAP TLS verification when no custom CA is configured
- cover the TLS option behavior with a focused regression test
- update the LDAP settings copy to describe platform trust-store verification

## Testing
- node --experimental-strip-types --test apps/web/lib/ldap/tls-options.test.mjs
- pnpm --filter web type-check

Closes #649