### PR TITLE
test(web): add settings terminal e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -646,6 +646,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                 </div>
                 <Switch
                   checked={currentTerminalSettings.terminalEnabled}
+                  data-testid="settings-terminal-enabled-toggle"
                   onCheckedChange={(checked) =>
                     setLocalTerminalSettings({
                       ...currentTerminalSettings,
@@ -669,6 +670,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                     </div>
                     <Switch
                       checked={currentTerminalSettings.terminalLoggingEnabled}
+                      data-testid="settings-terminal-logging-toggle"
                       onCheckedChange={(checked) =>
                         setLocalTerminalSettings({ ...currentTerminalSettings, terminalLoggingEnabled: checked })
                       }
@@ -681,11 +683,12 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                   size="sm"
                   disabled={!terminalDirty || terminalMutation.isPending}
                   onClick={() => terminalMutation.mutate(currentTerminalSettings)}
+                  data-testid="settings-terminal-save"
                 >
                   {terminalMutation.isPending ? 'Saving...' : 'Save'}
                 </Button>
                 {terminalSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span className="flex items-center gap-1 text-sm text-green-700" data-testid="settings-terminal-success">
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>

--- a/apps/web/tests/e2e/settings/organisation-name.spec.ts
+++ b/apps/web/tests/e2e/settings/organisation-name.spec.ts
@@ -4,11 +4,29 @@ import { TEST_ORG } from '../fixtures/seed'
 
 test('admin can update the organisation name from settings', async ({ authenticatedPage: page }) => {
   const updatedName = `Updated Org ${Date.now()}`
+  const sql = getTestDb()
 
   await page.goto('/settings')
   await expect(page.getByTestId('settings-heading')).toBeVisible()
 
   const orgNameInput = page.getByTestId('settings-org-name-input')
+  await orgNameInput.click()
+  await orgNameInput.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`)
+  await orgNameInput.fill('A')
+  await page.getByTestId('settings-org-name-save').click()
+
+  await expect(page.getByText('Name must be at least 2 characters')).toBeVisible()
+
+  const beforeRows = await sql<Array<{ name: string }>>`
+    SELECT name
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+
+  expect(beforeRows).toHaveLength(1)
+  expect(beforeRows[0]?.name).toBe(TEST_ORG.name)
+
   await orgNameInput.click()
   await orgNameInput.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`)
   await orgNameInput.fill(updatedName)
@@ -17,7 +35,6 @@ test('admin can update the organisation name from settings', async ({ authentica
   await expect(page.getByTestId('settings-org-name-success')).toHaveText('Saved')
   await expect(orgNameInput).toHaveValue(updatedName)
 
-  const sql = getTestDb()
   const rows = await sql<Array<{ name: string }>>`
     SELECT name
     FROM organisations

--- a/apps/web/tests/e2e/settings/terminal-settings.spec.ts
+++ b/apps/web/tests/e2e/settings/terminal-settings.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+test('admin can update organisation terminal settings from settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  const terminalEnabledToggle = page.getByTestId('settings-terminal-enabled-toggle')
+  const terminalLoggingToggle = page.getByTestId('settings-terminal-logging-toggle')
+  const saveButton = page.getByTestId('settings-terminal-save')
+
+  await expect(terminalLoggingToggle).toBeVisible()
+
+  await terminalEnabledToggle.click()
+  await expect(terminalLoggingToggle).toBeHidden()
+  await saveButton.click()
+  await expect(page.getByTestId('settings-terminal-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: { terminalEnabled?: boolean; terminalLoggingEnabled?: boolean } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return {
+        terminalEnabled: rows[0]?.metadata?.terminalEnabled,
+        terminalLoggingEnabled: rows[0]?.metadata?.terminalLoggingEnabled,
+      }
+    })
+    .toEqual({
+      terminalEnabled: false,
+      terminalLoggingEnabled: false,
+    })
+
+  await terminalEnabledToggle.click()
+  await expect(terminalLoggingToggle).toBeVisible()
+  await terminalLoggingToggle.click()
+  await saveButton.click()
+  await expect(page.getByTestId('settings-terminal-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: { terminalEnabled?: boolean; terminalLoggingEnabled?: boolean } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return {
+        terminalEnabled: rows[0]?.metadata?.terminalEnabled,
+        terminalLoggingEnabled: rows[0]?.metadata?.terminalLoggingEnabled,
+      }
+    })
+    .toEqual({
+      terminalEnabled: true,
+      terminalLoggingEnabled: true,
+    })
+})


### PR DESCRIPTION
## Summary
- add end-to-end coverage for organisation terminal settings in the settings screen
- add stable settings terminal test ids for Playwright interactions and assertions
- expand organisation-name coverage to verify invalid short names are rejected without persisting

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/settings/organisation-name.spec.ts tests/e2e/settings/terminal-settings.spec.ts`
