### PR TITLE
fix(web): require admin auth for LDAP settings actions

### DIFF
--- a/apps/web/lib/actions/action-auth-core.ts
+++ b/apps/web/lib/actions/action-auth-core.ts
@@ -4,6 +4,10 @@ export type OrgScopedUser = {
   deletedAt: Date | null
 }
 
+export type OrgAdminScopedUser = OrgScopedUser & {
+  role: string
+}
+
 export function assertOrgAccess(user: OrgScopedUser, orgId: string): void {
   if (!user.isActive || user.deletedAt) {
     throw new Error('forbidden: inactive user')
@@ -11,5 +15,13 @@ export function assertOrgAccess(user: OrgScopedUser, orgId: string): void {
 
   if (user.organisationId !== orgId) {
     throw new Error('forbidden: organisation mismatch')
+  }
+}
+
+export function assertOrgAdminAccess(user: OrgAdminScopedUser, orgId: string): void {
+  assertOrgAccess(user, orgId)
+
+  if (user.role !== 'org_admin' && user.role !== 'super_admin') {
+    throw new Error('forbidden: admin role required')
   }
 }

--- a/apps/web/lib/actions/action-auth.test.mjs
+++ b/apps/web/lib/actions/action-auth.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { assertOrgAccess } from './action-auth-core.ts'
+import { assertOrgAccess, assertOrgAdminAccess } from './action-auth-core.ts'
 
 test('assertOrgAccess rejects inactive users', () => {
   assert.throws(
@@ -27,5 +27,28 @@ test('assertOrgAccess rejects cross-org access', () => {
 test('assertOrgAccess allows active users in their own organisation', () => {
   assert.doesNotThrow(
     () => assertOrgAccess({ organisationId: 'org-1', isActive: true, deletedAt: null }, 'org-1'),
+  )
+})
+
+test('assertOrgAdminAccess rejects non-admin roles in the same organisation', () => {
+  assert.throws(
+    () => assertOrgAdminAccess({
+      organisationId: 'org-1',
+      isActive: true,
+      deletedAt: null,
+      role: 'engineer',
+    }, 'org-1'),
+    /forbidden: admin role required/,
+  )
+})
+
+test('assertOrgAdminAccess allows org admins in their own organisation', () => {
+  assert.doesNotThrow(
+    () => assertOrgAdminAccess({
+      organisationId: 'org-1',
+      isActive: true,
+      deletedAt: null,
+      role: 'org_admin',
+    }, 'org-1'),
   )
 })

--- a/apps/web/lib/actions/action-auth.ts
+++ b/apps/web/lib/actions/action-auth.ts
@@ -1,8 +1,14 @@
 import { getRequiredSession, type RequiredSession } from '@/lib/auth/session'
-import { assertOrgAccess } from '@/lib/actions/action-auth-core'
+import { assertOrgAccess, assertOrgAdminAccess } from '@/lib/actions/action-auth-core'
 
 export async function requireOrgAccess(orgId: string): Promise<RequiredSession> {
   const session = await getRequiredSession()
   assertOrgAccess(session.user, orgId)
+  return session
+}
+
+export async function requireOrgAdminAccess(orgId: string): Promise<RequiredSession> {
+  const session = await getRequiredSession()
+  assertOrgAdminAccess(session.user, orgId)
   return session
 }

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -68,7 +68,7 @@ const updateLdapConfigSchema = z.object({
 export async function getLdapConfigurations(
   orgId: string,
 ): Promise<LdapConfiguration[]> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const rows = await db.query.ldapConfigurations.findMany({
     where: and(
       eq(ldapConfigurations.organisationId, orgId),
@@ -83,7 +83,7 @@ export async function getLdapConfiguration(
   orgId: string,
   configId: string,
 ): Promise<LdapConfiguration | null> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const result = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),
@@ -98,7 +98,7 @@ export async function createLdapConfiguration(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const parsed = createLdapConfigSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -142,7 +142,7 @@ export async function updateLdapConfiguration(
   configId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const parsed = updateLdapConfigSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -191,7 +191,7 @@ export async function deleteLdapConfiguration(
   orgId: string,
   configId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const existing = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),
@@ -213,7 +213,7 @@ export async function testLdapConnection(
   orgId: string,
   configId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const config = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),


### PR DESCRIPTION
## Summary
- add a shared org-admin action guard alongside the existing org membership guard
- require org-admin authorization for LDAP settings read, write, delete, and connection-test server actions
- add regression coverage for admin-only org action enforcement

## Testing
- `pnpm --filter web exec node --experimental-strip-types --test lib/actions/action-auth.test.mjs`
- `pnpm --filter web test:unit`
- `pnpm --filter web type-check`

Closes #650
