### PR TITLE
test(web): add notifications and settings e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -348,7 +348,10 @@ export function NotificationsClient({
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground flex items-center gap-2">
+          <h1
+            className="text-2xl font-semibold text-foreground flex items-center gap-2"
+            data-testid="notifications-heading"
+          >
             <Bell className="size-6" />
             Notifications
           </h1>
@@ -376,6 +379,7 @@ export function NotificationsClient({
       {/* Filter tabs */}
       <div className="flex items-center gap-1 border-b">
         <button
+          data-testid="notifications-tab-all"
           className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
             filter === 'all'
               ? 'border-primary text-foreground'
@@ -386,6 +390,7 @@ export function NotificationsClient({
           All
         </button>
         <button
+          data-testid="notifications-tab-unread"
           className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors flex items-center gap-1.5 ${
             filter === 'unread'
               ? 'border-primary text-foreground'
@@ -416,6 +421,7 @@ export function NotificationsClient({
           {/* Select all + bulk action toolbar */}
           <div className="flex items-center gap-3 px-1 py-1.5">
             <Checkbox
+              data-testid="notifications-select-all"
               checked={allSelected ? true : someSelected ? 'indeterminate' : false}
               onCheckedChange={(checked) => {
                 if (checked) {
@@ -434,6 +440,7 @@ export function NotificationsClient({
               <>
                 <div className="h-4 w-px bg-border" />
                 <Button
+                  data-testid="notifications-bulk-mark-read"
                   size="sm"
                   variant="outline"
                   className="h-7 text-xs"
@@ -444,6 +451,7 @@ export function NotificationsClient({
                   Mark as read
                 </Button>
                 <Button
+                  data-testid="notifications-bulk-mark-unread"
                   size="sm"
                   variant="outline"
                   className="h-7 text-xs"
@@ -453,6 +461,7 @@ export function NotificationsClient({
                   Mark as unread
                 </Button>
                 <Button
+                  data-testid="notifications-bulk-delete"
                   size="sm"
                   variant="outline"
                   className="h-7 text-xs text-destructive hover:bg-destructive hover:text-destructive-foreground"
@@ -478,6 +487,7 @@ export function NotificationsClient({
           {displayed.map((n) => (
             <Card
               key={n.id}
+              data-testid={`notification-card-${n.id}`}
               className={`transition-colors ${!n.read ? 'border-blue-200 bg-blue-50/30 dark:border-blue-800 dark:bg-blue-950/20' : ''} ${
                 selectedIds.has(n.id) ? 'ring-1 ring-primary' : ''
               }`}

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -731,6 +731,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                   </p>
                 </div>
                 <Switch
+                  data-testid="settings-notifications-enabled-toggle"
                   checked={currentNotificationSettings.inAppEnabled}
                   onCheckedChange={(checked) =>
                     setLocalNotificationSettings({
@@ -742,7 +743,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
               </div>
               {currentNotificationSettings.inAppEnabled && (
                 <>
-                  <div className="space-y-2">
+                  <div className="space-y-2" data-testid="settings-notifications-role-list">
                     <Label className="text-sm">Roles that receive notifications</Label>
                     <p className="text-xs text-muted-foreground">
                       Select which roles get in-app notifications when alerts fire or resolve
@@ -752,6 +753,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                         <div key={role.value} className="flex items-center gap-2">
                           <Checkbox
                             id={`role-${role.value}`}
+                            data-testid={`settings-notifications-role-${role.value}`}
                             checked={currentNotificationSettings.inAppRoles.includes(role.value)}
                             onCheckedChange={(checked) => {
                               const roles = checked
@@ -778,6 +780,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                       </p>
                     </div>
                     <Switch
+                      data-testid="settings-notifications-allow-opt-out-toggle"
                       checked={currentNotificationSettings.allowUserOptOut}
                       onCheckedChange={(checked) =>
                         setLocalNotificationSettings({
@@ -791,6 +794,7 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
               )}
               <div className="flex items-center gap-3 pt-2 border-t">
                 <Button
+                  data-testid="settings-notifications-save"
                   size="sm"
                   disabled={!notificationDirty || notificationMutation.isPending}
                   onClick={() => notificationMutation.mutate(currentNotificationSettings)}
@@ -798,7 +802,10 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                   {notificationMutation.isPending ? 'Saving...' : 'Save'}
                 </Button>
                 {notificationSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span
+                    className="flex items-center gap-1 text-sm text-green-700"
+                    data-testid="settings-notifications-success"
+                  >
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>

--- a/apps/web/tests/e2e/notifications/inbox.spec.ts
+++ b/apps/web/tests/e2e/notifications/inbox.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('authenticated user can review, filter, and bulk delete notifications', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO notifications (
+      id,
+      organisation_id,
+      user_id,
+      subject,
+      body,
+      severity,
+      resource_type,
+      resource_id,
+      read,
+      created_at
+    )
+    VALUES
+      (
+        'notification-unread-critical',
+        ${orgId},
+        ${userId},
+        'CPU usage is above threshold',
+        'CPU usage on alpha-node exceeded the configured threshold.',
+        'critical',
+        'host',
+        'host-alpha',
+        false,
+        NOW() - INTERVAL '10 minutes'
+      ),
+      (
+        'notification-unread-warning',
+        ${orgId},
+        ${userId},
+        'Disk usage is climbing',
+        'Disk usage on beta-node crossed the warning threshold.',
+        'warning',
+        'host',
+        'host-beta',
+        false,
+        NOW() - INTERVAL '5 minutes'
+      ),
+      (
+        'notification-read-info',
+        ${orgId},
+        ${userId},
+        'Inventory scan completed',
+        'The latest inventory scan completed successfully.',
+        'info',
+        'host',
+        'host-gamma',
+        true,
+        NOW() - INTERVAL '2 minutes'
+      )
+  `
+
+  await page.goto('/notifications')
+
+  await expect(page.getByTestId('notifications-heading')).toBeVisible()
+  await expect(page.getByTestId('notifications-tab-unread')).toContainText('2')
+  await expect(page.getByTestId('notification-card-notification-unread-critical')).toBeVisible()
+  await expect(page.getByTestId('notification-card-notification-unread-warning')).toBeVisible()
+  await expect(page.getByTestId('notification-card-notification-read-info')).toBeVisible()
+
+  await page.getByTestId('notification-card-notification-unread-critical').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ read: boolean }>>`
+        SELECT read
+        FROM notifications
+        WHERE id = 'notification-unread-critical'
+        LIMIT 1
+      `
+      return rows[0]?.read ?? null
+    })
+    .toBe(true)
+
+  await page.getByTestId('notifications-tab-unread').click()
+  await expect(page.getByTestId('notification-card-notification-unread-critical')).toHaveCount(0)
+  await expect(page.getByTestId('notification-card-notification-unread-warning')).toBeVisible()
+
+  await page.getByTestId('notifications-select-all').click()
+  await page.getByTestId('notifications-bulk-delete').click()
+
+  await expect(page.getByText('No unread notifications')).toBeVisible()
+
+  const rows = await sql<Array<{ id: string; read: boolean; deleted_at: Date | null }>>`
+    SELECT id, read, deleted_at
+    FROM notifications
+    WHERE id IN ('notification-unread-critical', 'notification-unread-warning', 'notification-read-info')
+    ORDER BY id ASC
+  `
+
+  expect(rows).toEqual([
+    {
+      id: 'notification-read-info',
+      read: true,
+      deleted_at: null,
+    },
+    {
+      id: 'notification-unread-critical',
+      read: true,
+      deleted_at: null,
+    },
+    {
+      id: 'notification-unread-warning',
+      read: false,
+      deleted_at: expect.any(Date),
+    },
+  ])
+})

--- a/apps/web/tests/e2e/settings/terminal-settings.spec.ts
+++ b/apps/web/tests/e2e/settings/terminal-settings.spec.ts
@@ -67,3 +67,79 @@ test('admin can update organisation terminal settings from settings', async ({ a
       terminalLoggingEnabled: true,
     })
 })
+
+test('admin can update organisation notification settings from settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  const enabledToggle = page.getByTestId('settings-notifications-enabled-toggle')
+  const allowOptOutToggle = page.getByTestId('settings-notifications-allow-opt-out-toggle')
+  const engineerRole = page.getByTestId('settings-notifications-role-engineer')
+  const readOnlyRole = page.getByTestId('settings-notifications-role-read_only')
+  const saveButton = page.getByTestId('settings-notifications-save')
+
+  await enabledToggle.click()
+  await expect(page.getByTestId('settings-notifications-role-list')).toHaveCount(0)
+  await saveButton.click()
+  await expect(page.getByTestId('settings-notifications-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: {
+          notificationSettings?: {
+            inAppEnabled?: boolean
+            inAppRoles?: string[]
+            allowUserOptOut?: boolean
+          }
+        } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return rows[0]?.metadata?.notificationSettings ?? null
+    })
+    .toEqual({
+      inAppEnabled: false,
+      inAppRoles: ['super_admin', 'org_admin', 'engineer'],
+      allowUserOptOut: true,
+    })
+
+  await enabledToggle.click()
+  await expect(page.getByTestId('settings-notifications-role-list')).toBeVisible()
+  await engineerRole.click()
+  await readOnlyRole.click()
+  await allowOptOutToggle.click()
+  await saveButton.click()
+  await expect(page.getByTestId('settings-notifications-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: {
+          notificationSettings?: {
+            inAppEnabled?: boolean
+            inAppRoles?: string[]
+            allowUserOptOut?: boolean
+          }
+        } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return rows[0]?.metadata?.notificationSettings ?? null
+    })
+    .toEqual({
+      inAppEnabled: true,
+      inAppRoles: ['super_admin', 'org_admin', 'read_only'],
+      allowUserOptOut: false,
+    })
+})


### PR DESCRIPTION
## What changed
- add a notifications inbox E2E spec that seeds inbox rows in the in-memory test database and verifies read-state updates, unread filtering, and bulk deletion
- expand the settings E2E coverage to exercise the notification settings controls and assert the saved organisation metadata
- add stable `data-testid` hooks for the notifications inbox and settings notification controls used by the new tests

## Why
The notifications dashboard had no end-to-end coverage, and the existing settings suite did not cover the notification settings section.

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/notifications/inbox.spec.ts tests/e2e/settings/terminal-settings.spec.ts`
