### PR TITLE
test(web): cover profile password and notification read flows

### DIFF
--- a/apps/web/app/(dashboard)/profile/profile-client.tsx
+++ b/apps/web/app/(dashboard)/profile/profile-client.tsx
@@ -196,7 +196,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
               <p className="text-sm text-destructive">{passwordError}</p>
             )}
             {passwordSuccess && (
-              <p className="flex items-center gap-1 text-sm text-green-700">
+              <p className="flex items-center gap-1 text-sm text-green-700" data-testid="profile-password-success">
                 <CheckCircle2 className="size-4" />
                 Password updated successfully
               </p>
@@ -207,6 +207,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
                 id="current-password"
                 type="password"
                 autoComplete="current-password"
+                data-testid="profile-password-current"
                 {...passwordForm.register('currentPassword')}
               />
               {passwordForm.formState.errors.currentPassword && (
@@ -221,6 +222,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
                 id="new-password"
                 type="password"
                 autoComplete="new-password"
+                data-testid="profile-password-new"
                 {...passwordForm.register('newPassword')}
               />
               {passwordForm.formState.errors.newPassword && (
@@ -235,6 +237,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
                 id="confirm-password"
                 type="password"
                 autoComplete="new-password"
+                data-testid="profile-password-confirm"
                 {...passwordForm.register('confirmPassword')}
               />
               {passwordForm.formState.errors.confirmPassword && (
@@ -243,7 +246,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
                 </p>
               )}
             </div>
-            <Button type="submit" size="sm" disabled={passwordMutation.isPending}>
+            <Button type="submit" size="sm" disabled={passwordMutation.isPending} data-testid="profile-password-submit">
               {passwordMutation.isPending ? 'Updating…' : 'Update password'}
             </Button>
           </form>

--- a/apps/web/tests/e2e/notifications/inbox.spec.ts
+++ b/apps/web/tests/e2e/notifications/inbox.spec.ts
@@ -78,11 +78,12 @@ test('authenticated user can review, filter, and bulk delete notifications', asy
 
   await expect(page.getByTestId('notifications-heading')).toBeVisible()
   await expect(page.getByTestId('notifications-tab-unread')).toContainText('2')
-  await expect(page.getByTestId('notification-card-notification-unread-critical')).toBeVisible()
+  const unreadCriticalCard = page.getByTestId('notification-card-notification-unread-critical')
+  await expect(unreadCriticalCard).toBeVisible()
   await expect(page.getByTestId('notification-card-notification-unread-warning')).toBeVisible()
   await expect(page.getByTestId('notification-card-notification-read-info')).toBeVisible()
 
-  await page.getByTestId('notification-card-notification-unread-critical').click()
+  await unreadCriticalCard.getByText('CPU usage is above threshold').click()
 
   await expect
     .poll(async () => {
@@ -129,4 +130,92 @@ test('authenticated user can review, filter, and bulk delete notifications', asy
       deleted_at: expect.any(Date),
     },
   ])
+})
+
+test('authenticated user can mark all unread notifications as read', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO notifications (
+      id,
+      organisation_id,
+      user_id,
+      subject,
+      body,
+      severity,
+      resource_type,
+      resource_id,
+      read,
+      created_at
+    )
+    VALUES
+      (
+        'notification-mark-all-read-1',
+        ${orgId},
+        ${userId},
+        'Certificate expires soon',
+        'api.internal.example expires in three days.',
+        'warning',
+        'certificate',
+        'certificate-mark-all-read-1',
+        false,
+        NOW() - INTERVAL '15 minutes'
+      ),
+      (
+        'notification-mark-all-read-2',
+        ${orgId},
+        ${userId},
+        'Agent heartbeat missed',
+        'worker-01 has not checked in recently.',
+        'critical',
+        'host',
+        'host-mark-all-read-2',
+        false,
+        NOW() - INTERVAL '8 minutes'
+      ),
+      (
+        'notification-mark-all-read-3',
+        ${orgId},
+        ${userId},
+        'Inventory completed',
+        'The overnight inventory sync finished successfully.',
+        'info',
+        'host',
+        'host-mark-all-read-3',
+        true,
+        NOW() - INTERVAL '2 minutes'
+      )
+  `
+
+  await page.goto('/notifications')
+
+  await expect(page.getByTestId('notifications-heading')).toBeVisible()
+  await expect(page.getByTestId('notifications-tab-unread')).toContainText('2')
+
+  await page.getByRole('button', { name: 'Mark all read' }).click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ id: string; read: boolean }>>`
+        SELECT id, read
+        FROM notifications
+        WHERE id IN (
+          'notification-mark-all-read-1',
+          'notification-mark-all-read-2',
+          'notification-mark-all-read-3'
+        )
+        ORDER BY id ASC
+      `
+
+      return rows
+    })
+    .toEqual([
+      { id: 'notification-mark-all-read-1', read: true },
+      { id: 'notification-mark-all-read-2', read: true },
+      { id: 'notification-mark-all-read-3', read: true },
+    ])
+
+  await page.getByTestId('notifications-tab-unread').click()
+  await expect(page.getByText('No unread notifications')).toBeVisible()
 })

--- a/apps/web/tests/e2e/profile/profile.spec.ts
+++ b/apps/web/tests/e2e/profile/profile.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures/test'
+import { request as playwrightRequest } from '@playwright/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_USER } from '../fixtures/seed'
 
@@ -27,4 +28,60 @@ test('authenticated user can update their display name from profile', async ({ a
 
   expect(rows).toHaveLength(1)
   expect(rows[0]?.name).toBe(updatedName)
+})
+
+test('authenticated user can change their password from profile', async ({ authenticatedPage: page, baseURL }) => {
+  if (!baseURL) throw new Error('baseURL must be configured')
+
+  const updatedPassword = 'UpdatedPassword123!'
+  const authRequest = await playwrightRequest.newContext({ baseURL })
+
+  try {
+    await page.goto('/profile')
+
+    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible()
+    await page.getByTestId('profile-password-current').fill(TEST_USER.password)
+    await page.getByTestId('profile-password-new').fill(updatedPassword)
+    await page.getByTestId('profile-password-confirm').fill(updatedPassword)
+    await page.getByTestId('profile-password-submit').click()
+
+    await expect(page.getByTestId('profile-password-success')).toBeVisible()
+
+    const oldPasswordResponse = await authRequest.post('/api/auth/sign-in/email', {
+      data: {
+        email: TEST_USER.email,
+        password: TEST_USER.password,
+      },
+    })
+    expect(oldPasswordResponse.ok()).toBe(false)
+
+    const newPasswordResponse = await authRequest.post('/api/auth/sign-in/email', {
+      data: {
+        email: TEST_USER.email,
+        password: updatedPassword,
+      },
+    })
+    expect(newPasswordResponse.ok()).toBe(true)
+
+    await page.getByTestId('profile-password-current').fill(updatedPassword)
+    await page.getByTestId('profile-password-new').fill(TEST_USER.password)
+    await page.getByTestId('profile-password-confirm').fill(TEST_USER.password)
+    await page.getByTestId('profile-password-submit').click()
+    await expect(page.getByTestId('profile-password-success')).toBeVisible()
+
+    const restoreCheckRequest = await playwrightRequest.newContext({ baseURL })
+    try {
+      const restoredPasswordResponse = await restoreCheckRequest.post('/api/auth/sign-in/email', {
+        data: {
+          email: TEST_USER.email,
+          password: TEST_USER.password,
+        },
+      })
+      expect(restoredPasswordResponse.ok()).toBe(true)
+    } finally {
+      await restoreCheckRequest.dispose()
+    }
+  } finally {
+    await authRequest.dispose()
+  }
 })


### PR DESCRIPTION
## Summary
- add E2E coverage for profile password changes, including sign-in verification and password restore
- add E2E coverage for the notifications header "Mark all read" flow
- tighten the existing notifications spec to click the actual readable card content instead of the non-clickable wrapper

## Validation
- pnpm --filter web test:e2e -- tests/e2e/profile/profile.spec.ts tests/e2e/notifications/inbox.spec.ts