### PR TITLE
test(web): add onboarding and invite acceptance coverage

### DIFF
--- a/apps/web/app/(setup)/onboarding/onboarding-form.tsx
+++ b/apps/web/app/(setup)/onboarding/onboarding-form.tsx
@@ -96,6 +96,7 @@ export function OnboardingForm() {
               placeholder="Acme Engineering"
               {...register('name')}
               onChange={handleNameChange}
+              data-testid="onboarding-name"
             />
             {errors.name && (
               <p className="text-xs text-destructive">{errors.name.message}</p>
@@ -111,6 +112,7 @@ export function OnboardingForm() {
                 placeholder="acme-engineering"
                 {...register('slug')}
                 onChange={(e) => setSlugPreview(e.target.value)}
+                data-testid="onboarding-slug"
               />
             </div>
             {errors.slug && (
@@ -124,7 +126,7 @@ export function OnboardingForm() {
           </p>
         </CardContent>
         <CardFooter>
-          <Button type="submit" className="w-full" disabled={isPending}>
+          <Button type="submit" className="w-full" disabled={isPending} data-testid="onboarding-submit">
             {isPending ? 'Creating…' : 'Create organisation'}
           </Button>
         </CardFooter>

--- a/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
+++ b/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
@@ -85,3 +85,81 @@ test('invite acceptance rejects logged-in users whose email does not match the i
   `
   expect(invite?.accepted_at).toBeNull()
 })
+
+test('invite acceptance attaches the matching user to the organisation', async ({ page }) => {
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const invitedEmail = `invitee-${suffix}@example.com`
+  const invitedPassword = 'TestPassword123!'
+  const inviteToken = `invite-token-${suffix}`
+
+  const signUpResponse = await page.request.post('/api/auth/sign-up/email', {
+    data: {
+      email: invitedEmail,
+      password: invitedPassword,
+      name: 'Invited User',
+    },
+  })
+  expect(signUpResponse.ok()).toBeTruthy()
+
+  await sql`
+    UPDATE "user"
+    SET email_verified = true,
+        is_active = true
+    WHERE email = ${invitedEmail}
+  `
+
+  await sql`
+    INSERT INTO invitations (
+      id,
+      email,
+      role,
+      token,
+      organisation_id,
+      invited_by_id,
+      expires_at,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      ${`invite-success-${suffix}`},
+      ${invitedEmail},
+      'org_admin',
+      ${inviteToken},
+      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+      NOW() + INTERVAL '1 day',
+      NOW(),
+      NOW()
+    )
+  `
+
+  const signInResponse = await page.request.post('/api/auth/sign-in/email', {
+    data: {
+      email: invitedEmail,
+      password: invitedPassword,
+    },
+  })
+  expect(signInResponse.ok()).toBeTruthy()
+
+  await page.goto(`/accept-invite?token=${inviteToken}`)
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+
+  const [invitee] = await sql<Array<{ organisation_id: string | null; role: string }>>`
+    SELECT organisation_id, role
+    FROM "user"
+    WHERE email = ${invitedEmail}
+    LIMIT 1
+  `
+  expect(invitee?.organisation_id).not.toBeNull()
+  expect(invitee?.role).toBe('org_admin')
+
+  const [invite] = await sql<Array<{ accepted_at: Date | null }>>`
+    SELECT accepted_at
+    FROM invitations
+    WHERE token = ${inviteToken}
+    LIMIT 1
+  `
+  expect(invite?.accepted_at).not.toBeNull()
+})

--- a/apps/web/tests/e2e/setup/onboarding.spec.ts
+++ b/apps/web/tests/e2e/setup/onboarding.spec.ts
@@ -1,0 +1,81 @@
+import { request as playwrightRequest } from '@playwright/test'
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+
+test('user without an organisation can create one from onboarding', async ({ browser, baseURL }) => {
+  if (!baseURL) throw new Error('baseURL must be configured')
+
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const email = `onboarding-${suffix}@example.com`
+  const password = 'TestPassword123!'
+  const organisationName = `Onboarding Org ${suffix}`
+  const organisationSlug = `onboarding-org-${suffix}`
+
+  const authRequest = await playwrightRequest.newContext({ baseURL })
+  try {
+    const signUpResponse = await authRequest.post('/api/auth/sign-up/email', {
+      data: {
+        email,
+        password,
+        name: 'Onboarding Test User',
+      },
+    })
+    expect(signUpResponse.ok()).toBeTruthy()
+
+    await sql`
+      UPDATE "user"
+      SET email_verified = true,
+          is_active = true
+      WHERE email = ${email}
+    `
+
+    const signInResponse = await authRequest.post('/api/auth/sign-in/email', {
+      data: {
+        email,
+        password,
+      },
+    })
+    expect(signInResponse.ok()).toBeTruthy()
+
+    const storageState = await authRequest.storageState()
+    const context = await browser.newContext({ storageState })
+    const page = await context.newPage()
+    try {
+      await page.goto('/onboarding')
+      await page.waitForURL('**/onboarding')
+      await expect(page.getByText('Create your organisation', { exact: true })).toBeVisible()
+
+      await page.getByTestId('onboarding-name').fill(organisationName)
+      await expect(page.getByTestId('onboarding-slug')).toHaveValue(organisationSlug)
+      await page.getByTestId('onboarding-submit').click()
+
+      await page.waitForURL('**/dashboard')
+      await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+    } finally {
+      await context.close()
+    }
+  } finally {
+    await authRequest.dispose()
+  }
+
+  const [user] = await sql<Array<{ organisation_id: string | null; role: string }>>`
+    SELECT organisation_id, role
+    FROM "user"
+    WHERE email = ${email}
+    LIMIT 1
+  `
+
+  expect(user?.organisation_id).not.toBeNull()
+  expect(user?.role).toBe('super_admin')
+
+  const [organisation] = await sql<Array<{ name: string; slug: string }>>`
+    SELECT name, slug
+    FROM organisations
+    WHERE slug = ${organisationSlug}
+    LIMIT 1
+  `
+
+  expect(organisation?.name).toBe(organisationName)
+  expect(organisation?.slug).toBe(organisationSlug)
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for the onboarding organisation-creation flow
- add a successful invite-acceptance E2E path alongside the existing mismatch rejection case
- add stable onboarding `data-testid` hooks for the new test

## Validation
- pnpm --filter web test:e2e -- tests/e2e/setup/onboarding.spec.ts tests/e2e/auth/invite-acceptance.spec.ts