### PR TITLE
fix(web): enforce a single style for simple reads

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 65 — Query-style lint guard for auditability
+
+**Drizzle query-style convergence** (`apps/web/eslint.config.mjs`, `apps/web/lib/eslint/`, `apps/web/lib/actions/`, `apps/web/app/api/admin/hosts/bulk-delete/route.ts`)
+- Added a local ESLint rule that rejects straightforward single-table `db.select().from(...)` and `tx.select().from(...)` reads, while still allowing query-builder paths that need joins, grouping, or aggregate SQL.
+- Normalised the remaining simple single-table reads in licence, tags, notes, tag-rule preview, agent cleanup/collision helpers, software inventory filters, and the admin bulk-delete route onto `db.query.*` / `tx.query.*`.
+- This satisfies security finding `I-07` / issue `#366` by making the preferred read pattern explicit and enforceable without forcing a risky broad rewrite of aggregate/reporting queries.
+
+**Validation**
+- Added focused unit coverage for the custom ESLint rule so future regressions fail close to the policy.
+
 ### Session 64 — Penetration testing scope and rules of engagement
 
 **Security engagement documentation** (`PENTEST.md`)

--- a/apps/web/app/api/admin/hosts/bulk-delete/route.ts
+++ b/apps/web/app/api/admin/hosts/bulk-delete/route.ts
@@ -57,10 +57,14 @@ export async function POST(request: NextRequest) {
   }
   const { hostnamePrefix } = parsed.data
 
-  const matching = await db
-    .select({ id: hosts.id, organisationId: hosts.organisationId, hostname: hosts.hostname })
-    .from(hosts)
-    .where(and(like(hosts.hostname, `${hostnamePrefix}%`), isNull(hosts.deletedAt)))
+  const matching = await db.query.hosts.findMany({
+    columns: {
+      id: true,
+      organisationId: true,
+      hostname: true,
+    },
+    where: and(like(hosts.hostname, `${hostnamePrefix}%`), isNull(hosts.deletedAt)),
+  })
 
   const failed: string[] = []
   let deleted = 0

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import localRules from "./lib/eslint/index.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -16,6 +17,14 @@ const eslintConfig = defineConfig([
     "migrate.js",
     "scripts/validate-migrations.js",
   ]),
+  {
+    plugins: {
+      local: localRules,
+    },
+    rules: {
+      "local/no-single-table-select": "error",
+    },
+  },
   {
     // Playwright fixtures use a `use()` callback that the react-hooks plugin
     // mistakes for React's `use()` hook. Disable that rule inside the e2e

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -206,20 +206,18 @@ async function findOnlineHostCollision(
   const ipOverlap = ips.length > 0
     ? sql`${hosts.ipAddresses} ?| ARRAY[${sql.join(ips.map((ip) => sql`${ip}`), sql`, `)}]::text[]`
     : sql`false`
-  const rows = await db
-    .select({ id: hosts.id, hostname: hosts.hostname })
-    .from(hosts)
-    .where(
-      and(
+  return (
+    await db.query.hosts.findFirst({
+      columns: { id: true, hostname: true },
+      where: and(
         eq(hosts.organisationId, orgId),
         isNull(hosts.deletedAt),
         eq(hosts.status, 'online'),
         sql`(${hosts.agentId} IS NULL OR ${hosts.agentId} <> ${excludeAgentId})`,
         sql`(${hosts.hostname} = ${hostname} OR ${ipOverlap})`,
       ),
-    )
-    .limit(1)
-  return rows[0] ?? null
+    })
+  ) ?? null
 }
 
 export async function rejectAgent(
@@ -784,19 +782,16 @@ export async function getHostMetrics(
   }
 
   // Raw path (short spans) or final fallback — always capped to prevent huge payloads
-  return db
-    .select()
-    .from(hostMetrics)
-    .where(
-      and(
-        eq(hostMetrics.organisationId, orgId),
-        eq(hostMetrics.hostId, hostId),
-        gte(hostMetrics.recordedAt, from),
-        lte(hostMetrics.recordedAt, to),
-      ),
-    )
-    .orderBy(asc(hostMetrics.recordedAt))
-    .limit(MAX_DATA_POINTS)
+  return db.query.hostMetrics.findMany({
+    where: and(
+      eq(hostMetrics.organisationId, orgId),
+      eq(hostMetrics.hostId, hostId),
+      gte(hostMetrics.recordedAt, from),
+      lte(hostMetrics.recordedAt, to),
+    ),
+    orderBy: [asc(hostMetrics.recordedAt)],
+    limit: MAX_DATA_POINTS,
+  })
 }
 
 export async function getAgentOfflinePeriods(
@@ -811,18 +806,16 @@ export async function getAgentOfflinePeriods(
   // started before the visible range.
   const lookback = new Date(from.getTime() - 3_600_000)
 
-  const events = await db
-    .select({ status: agentStatusHistory.status, createdAt: agentStatusHistory.createdAt })
-    .from(agentStatusHistory)
-    .where(
-      and(
-        eq(agentStatusHistory.agentId, agentId),
-        eq(agentStatusHistory.organisationId, orgId),
-        gte(agentStatusHistory.createdAt, lookback),
-        lte(agentStatusHistory.createdAt, to),
-      ),
-    )
-    .orderBy(asc(agentStatusHistory.createdAt))
+  const events = await db.query.agentStatusHistory.findMany({
+    columns: { status: true, createdAt: true },
+    where: and(
+      eq(agentStatusHistory.agentId, agentId),
+      eq(agentStatusHistory.organisationId, orgId),
+      gte(agentStatusHistory.createdAt, lookback),
+      lte(agentStatusHistory.createdAt, to),
+    ),
+    orderBy: [asc(agentStatusHistory.createdAt)],
+  })
 
   const periods: OfflinePeriod[] = []
   let offlineStart: number | null = null
@@ -1024,23 +1017,23 @@ export async function deleteHost(
       // 5. Certificate events & certificates (certificates reference both
       //    discovered_by_host_id AND check_id, so must be deleted before checks)
       const hostCheckIds = (
-        await tx
-          .select({ id: checks.id })
-          .from(checks)
-          .where(and(eq(checks.hostId, hostId), eq(checks.organisationId, orgId)))
+        await tx.query.checks.findMany({
+          columns: { id: true },
+          where: and(eq(checks.hostId, hostId), eq(checks.organisationId, orgId)),
+        })
       ).map((c) => c.id)
 
-      const hostCerts = await tx
-        .select({ id: certificates.id })
-        .from(certificates)
-        .where(and(
+      const hostCerts = await tx.query.certificates.findMany({
+        columns: { id: true },
+        where: and(
           eq(certificates.organisationId, orgId),
           sql`(${certificates.discoveredByHostId} = ${hostId}${
             hostCheckIds.length > 0
               ? sql` OR ${certificates.checkId} IN (${sql.join(hostCheckIds.map((id) => sql`${id}`), sql`, `)})`
               : sql``
           })`,
-        ))
+        ),
+      })
 
       if (hostCerts.length > 0) {
         const certIds = hostCerts.map((c) => c.id)
@@ -1064,17 +1057,18 @@ export async function deleteHost(
         .where(and(eq(checks.hostId, hostId), eq(checks.organisationId, orgId)))
 
       // 7a. Notifications referencing this host's alert instances (FK constraint)
-      await tx
-        .delete(notifications)
-        .where(and(
-          inArray(
-            notifications.alertInstanceId,
-            tx
-              .select({ id: alertInstances.id })
-              .from(alertInstances)
-              .where(and(eq(alertInstances.hostId, hostId), eq(alertInstances.organisationId, orgId))),
-          ),
-        ))
+      const hostAlertInstanceIds = (
+        await tx.query.alertInstances.findMany({
+          columns: { id: true },
+          where: and(eq(alertInstances.hostId, hostId), eq(alertInstances.organisationId, orgId)),
+        })
+      ).map((instance) => instance.id)
+
+      if (hostAlertInstanceIds.length > 0) {
+        await tx
+          .delete(notifications)
+          .where(inArray(notifications.alertInstanceId, hostAlertInstanceIds))
+      }
 
       // 7b. Alert instances
       await tx
@@ -1167,16 +1161,16 @@ export async function deleteHost(
         // Capture the agent's client cert serial before we delete the row so
         // we can blacklist it — otherwise a deleted agent whose cert is still
         // inside its validity window could reconnect and register fresh.
-        const [agentRow] = await tx
-          .select({ serial: agents.clientCertSerial })
-          .from(agents)
-          .where(eq(agents.id, host.agentId))
-        if (agentRow?.serial) {
+        const agentRow = await tx.query.agents.findFirst({
+          columns: { clientCertSerial: true },
+          where: eq(agents.id, host.agentId),
+        })
+        if (agentRow?.clientCertSerial) {
           await tx
             .insert(revokedCertificates)
             .values({
               organisationId: orgId,
-              serial: agentRow.serial,
+              serial: agentRow.clientCertSerial,
               reason: 'Host deleted',
             })
             .onConflictDoNothing()

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -34,14 +34,13 @@ export type EffectiveLicence = {
 // Cached per-request so multiple requireFeature() calls in one server action
 // don't re-validate the JWT repeatedly.
 const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicence> => {
-  const [org] = await db
-    .select({
-      licenceTier: organisations.licenceTier,
-      licenceKey: organisations.licenceKey,
-    })
-    .from(organisations)
-    .where(eq(organisations.id, orgId))
-    .limit(1)
+  const org = await db.query.organisations.findFirst({
+    columns: {
+      licenceTier: true,
+      licenceKey: true,
+    },
+    where: eq(organisations.id, orgId),
+  })
 
   if (!org) {
     return { tier: 'community', features: [] }

--- a/apps/web/lib/actions/notes.ts
+++ b/apps/web/lib/actions/notes.ts
@@ -144,12 +144,11 @@ export async function listNotes(
     conditions.push(eq(notes.authorId, session.user.id))
   }
 
-  return db
-    .select()
-    .from(notes)
-    .where(and(...conditions))
-    .orderBy(desc(notes.updatedAt))
-    .limit(500)
+  return db.query.notes.findMany({
+    where: and(...conditions),
+    orderBy: [desc(notes.updatedAt)],
+    limit: 500,
+  })
 }
 
 // websearch_to_tsquery is forgiving of partial queries but still throws on

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -16,7 +16,7 @@ import {
   hostGroupMembers,
   hostGroups,
 } from '@/lib/db/schema'
-import { eq, and, isNull, desc, sql, ilike, count, countDistinct, gte, lte, inArray } from 'drizzle-orm'
+import { eq, and, isNull, desc, ilike, countDistinct, gte, inArray } from 'drizzle-orm'
 import type {
   SoftwarePackage,
   SoftwareScan,
@@ -383,16 +383,14 @@ export async function getSoftwareReport(
 
   // Filter by host group if needed
   if (filters.hostGroupIds && filters.hostGroupIds.length > 0) {
-    const members = await db
-      .select({ hostId: hostGroupMembers.hostId })
-      .from(hostGroupMembers)
-      .where(
-        and(
-          eq(hostGroupMembers.organisationId, orgId),
-          inArray(hostGroupMembers.groupId, filters.hostGroupIds),
-          isNull(hostGroupMembers.deletedAt),
-        ),
-      )
+    const members = await db.query.hostGroupMembers.findMany({
+      columns: { hostId: true },
+      where: and(
+        eq(hostGroupMembers.organisationId, orgId),
+        inArray(hostGroupMembers.groupId, filters.hostGroupIds),
+        isNull(hostGroupMembers.deletedAt),
+      ),
+    })
     const memberHostIds = new Set(members.map((m) => m.hostId))
     filtered = filtered.filter((p) => memberHostIds.has(p.hostId))
   }
@@ -464,23 +462,21 @@ export async function getNewPackages(
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - windowDays)
 
-  const rows = await db
-    .select({
-      name: softwarePackages.name,
-      source: softwarePackages.source,
-      hostId: softwarePackages.hostId,
-      firstSeenAt: softwarePackages.firstSeenAt,
-    })
-    .from(softwarePackages)
-    .where(
-      and(
-        eq(softwarePackages.organisationId, orgId),
-        isNull(softwarePackages.removedAt),
-        isNull(softwarePackages.deletedAt),
-        gte(softwarePackages.firstSeenAt, cutoff),
-      ),
-    )
-    .orderBy(desc(softwarePackages.firstSeenAt))
+  const rows = await db.query.softwarePackages.findMany({
+    columns: {
+      name: true,
+      source: true,
+      hostId: true,
+      firstSeenAt: true,
+    },
+    where: and(
+      eq(softwarePackages.organisationId, orgId),
+      isNull(softwarePackages.removedAt),
+      isNull(softwarePackages.deletedAt),
+      gte(softwarePackages.firstSeenAt, cutoff),
+    ),
+    orderBy: [desc(softwarePackages.firstSeenAt)],
+  })
 
   const grouped = new Map<string, NewPackageRow>()
   for (const row of rows) {
@@ -679,21 +675,17 @@ export async function getPackageVersions(
 ): Promise<string[]> {
   await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
-  const rows = await db
-    .select({ version: softwarePackages.version })
-    .from(softwarePackages)
-    .where(
-      and(
-        eq(softwarePackages.organisationId, orgId),
-        eq(softwarePackages.name, packageName),
-        isNull(softwarePackages.removedAt),
-        isNull(softwarePackages.deletedAt),
-      ),
-    )
-    .groupBy(softwarePackages.version)
-    .orderBy(softwarePackages.version)
+  const rows = await db.query.softwarePackages.findMany({
+    columns: { version: true },
+    where: and(
+      eq(softwarePackages.organisationId, orgId),
+      eq(softwarePackages.name, packageName),
+      isNull(softwarePackages.removedAt),
+      isNull(softwarePackages.deletedAt),
+    ),
+  })
 
-  return rows.map((r) => r.version).sort((a, b) => compareVersions(b, a))
+  return [...new Set(rows.map((row) => row.version))].sort((a, b) => compareVersions(b, a))
 }
 
 // ── Compare two hosts ─────────────────────────────────────────────────────────

--- a/apps/web/lib/actions/tag-rules.ts
+++ b/apps/web/lib/actions/tag-rules.ts
@@ -50,18 +50,18 @@ export async function previewHostFilter(
   const where = buildHostFilterWhere(orgId, parsed.data)
   if (!where) return []
 
-  const rows = await db
-    .select({
-      id: hosts.id,
-      hostname: hosts.hostname,
-      displayName: hosts.displayName,
-      os: hosts.os,
-      status: hosts.status,
-      ipAddresses: hosts.ipAddresses,
-    })
-    .from(hosts)
-    .where(where)
-    .limit(1000)
+  const rows = await db.query.hosts.findMany({
+    columns: {
+      id: true,
+      hostname: true,
+      displayName: true,
+      os: true,
+      status: true,
+      ipAddresses: true,
+    },
+    where,
+    limit: 1000,
+  })
 
   return rows as HostFilterResult[]
 }

--- a/apps/web/lib/actions/tags.ts
+++ b/apps/web/lib/actions/tags.ts
@@ -65,12 +65,11 @@ export async function searchTags(
     )
   }
 
-  return db
-    .select()
-    .from(tags)
-    .where(and(...conditions))
-    .orderBy(desc(tags.usageCount), asc(tags.key), asc(tags.value))
-    .limit(limit)
+  return db.query.tags.findMany({
+    where: and(...conditions),
+    orderBy: [desc(tags.usageCount), asc(tags.key), asc(tags.value)],
+    limit,
+  })
 }
 
 // Looks up an existing tag case-insensitively, inserting it if absent. The
@@ -82,18 +81,15 @@ async function upsertTag(
   orgId: string,
   pair: TagPair,
 ): Promise<string> {
-  const existing = await tx
-    .select({ id: tags.id })
-    .from(tags)
-    .where(
-      and(
-        eq(tags.organisationId, orgId),
-        sql`lower(${tags.key}) = lower(${pair.key})`,
-        sql`lower(${tags.value}) = lower(${pair.value})`,
-      ),
-    )
-    .limit(1)
-  if (existing[0]?.id) return existing[0].id
+  const existing = await tx.query.tags.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(tags.organisationId, orgId),
+      sql`lower(${tags.key}) = lower(${pair.key})`,
+      sql`lower(${tags.value}) = lower(${pair.value})`,
+    ),
+  })
+  if (existing?.id) return existing.id
 
   try {
     const [row] = await tx
@@ -105,18 +101,15 @@ async function upsertTag(
     // Concurrent insert won the race — re-read.
   }
 
-  const retry = await tx
-    .select({ id: tags.id })
-    .from(tags)
-    .where(
-      and(
-        eq(tags.organisationId, orgId),
-        sql`lower(${tags.key}) = lower(${pair.key})`,
-        sql`lower(${tags.value}) = lower(${pair.value})`,
-      ),
-    )
-    .limit(1)
-  const id = retry[0]?.id
+  const retry = await tx.query.tags.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(tags.organisationId, orgId),
+      sql`lower(${tags.key}) = lower(${pair.key})`,
+      sql`lower(${tags.value}) = lower(${pair.value})`,
+    ),
+  })
+  const id = retry?.id
   if (!id) throw new Error('Tag upsert could not resolve tag id')
   return id
 }

--- a/apps/web/lib/eslint/index.mjs
+++ b/apps/web/lib/eslint/index.mjs
@@ -1,0 +1,9 @@
+import noSingleTableSelect from './no-single-table-select.mjs'
+
+const plugin = {
+  rules: {
+    'no-single-table-select': noSingleTableSelect,
+  },
+}
+
+export default plugin

--- a/apps/web/lib/eslint/no-single-table-select.mjs
+++ b/apps/web/lib/eslint/no-single-table-select.mjs
@@ -1,0 +1,114 @@
+const COMPLEX_CHAIN_METHODS = new Set([
+  'groupBy',
+  'having',
+  'innerJoin',
+  'leftJoin',
+  'rightJoin',
+  'fullJoin',
+  'for',
+])
+
+const AGGREGATE_CALLEES = new Set([
+  'avg',
+  'count',
+  'countDistinct',
+  'max',
+  'min',
+  'sum',
+  'sql',
+])
+
+function getPropertyName(memberExpression) {
+  if (memberExpression.computed) return null
+  if (memberExpression.property.type === 'Identifier') return memberExpression.property.name
+  return null
+}
+
+function isDatabaseHandle(node) {
+  return node?.type === 'Identifier' && (node.name === 'db' || node.name === 'tx')
+}
+
+function containsComplexSelection(node, seen = new WeakSet()) {
+  if (!node || typeof node !== 'object') return false
+  if (seen.has(node)) return false
+  seen.add(node)
+
+  if (node.type === 'TaggedTemplateExpression') {
+    return node.tag?.type === 'Identifier' && node.tag.name === 'sql'
+  }
+
+  if (node.type === 'CallExpression') {
+    if (node.callee.type === 'Identifier' && AGGREGATE_CALLEES.has(node.callee.name)) {
+      return true
+    }
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'parent') continue
+    if (Array.isArray(value)) {
+      if (value.some((entry) => containsComplexSelection(entry, seen))) return true
+      continue
+    }
+    if (containsComplexSelection(value, seen)) return true
+  }
+
+  return false
+}
+
+function getChainMethodsAfter(node) {
+  const methods = []
+  let current = node
+
+  while (
+    current.parent?.type === 'MemberExpression' &&
+    current.parent.object === current &&
+    current.parent.parent?.type === 'CallExpression' &&
+    current.parent.parent.callee === current.parent
+  ) {
+    const methodName = getPropertyName(current.parent)
+    if (methodName) methods.push(methodName)
+    current = current.parent.parent
+  }
+
+  return methods
+}
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer db.query.* for straightforward single-table reads',
+    },
+    schema: [],
+    messages: {
+      preferQueryApi:
+        'Use the relational query API for single-table reads; keep select/from for joins, grouping, or aggregate SQL only.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        if (getPropertyName(node.callee) !== 'from') return
+
+        const selectCall = node.callee.object
+        if (selectCall?.type !== 'CallExpression' || selectCall.callee.type !== 'MemberExpression') return
+        if (getPropertyName(selectCall.callee) !== 'select') return
+        if (!isDatabaseHandle(selectCall.callee.object)) return
+
+        const chainMethods = getChainMethodsAfter(node)
+        if (chainMethods.some((method) => COMPLEX_CHAIN_METHODS.has(method))) return
+
+        const selection = selectCall.arguments[0]
+        if (containsComplexSelection(selection)) return
+
+        context.report({
+          node,
+          messageId: 'preferQueryApi',
+        })
+      },
+    }
+  },
+}
+
+export default rule

--- a/apps/web/lib/eslint/no-single-table-select.test.mjs
+++ b/apps/web/lib/eslint/no-single-table-select.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { Linter } from 'eslint'
+
+import rule from './no-single-table-select.mjs'
+
+function lint(code) {
+  const linter = new Linter({ configType: 'flat' })
+  return linter.verify(
+    code,
+    [
+      {
+        languageOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        },
+        plugins: {
+          local: {
+            rules: {
+              'no-single-table-select': rule,
+            },
+          },
+        },
+        rules: {
+          'local/no-single-table-select': 'error',
+        },
+      },
+    ],
+    'test.js',
+  )
+}
+
+test('no-single-table-select allows aggregates and joins', () => {
+  assert.deepEqual(
+    lint(`
+      const rows = await db.select({ total: count() }).from(tags).where(eq(tags.organisationId, orgId))
+    `),
+    [],
+  )
+
+  assert.deepEqual(
+    lint(`
+      const rows = await db
+        .select({ tagId: tags.id, hostId: hosts.id })
+        .from(tags)
+        .innerJoin(hosts, eq(hosts.organisationId, tags.organisationId))
+    `),
+    [],
+  )
+})
+
+test('no-single-table-select flags simple single-table reads on db and tx', () => {
+  const dbMessages = lint(`
+    const rows = await db
+      .select()
+      .from(tags)
+      .where(eq(tags.organisationId, orgId))
+      .orderBy(desc(tags.usageCount))
+  `)
+  assert.equal(dbMessages.length, 1)
+  assert.equal(dbMessages[0]?.messageId, 'preferQueryApi')
+
+  const txMessages = lint(`
+    const rows = await tx
+      .select({ id: tags.id })
+      .from(tags)
+      .where(eq(tags.organisationId, orgId))
+  `)
+  assert.equal(txMessages.length, 1)
+  assert.equal(txMessages[0]?.messageId, 'preferQueryApi')
+})


### PR DESCRIPTION
## Summary
- add a local ESLint rule that rejects simple single-table `db.select().from(...)` / `tx.select().from(...)` reads
- convert the remaining simple single-table reads to `db.query.*` / `tx.query.*` while leaving aggregate and join queries on the builder API
- record the I-07 hardening work in `PROGRESS.md`

## Testing
- `node --test apps/web/lib/eslint/no-single-table-select.test.mjs`
- `pnpm --dir apps/web lint lib/actions lib/eslint app/api/admin/hosts/bulk-delete/route.ts` (passes with 3 pre-existing warnings in unrelated files)
- `pnpm --dir apps/web type-check`

Closes #366