### PR TITLE
feat(web): prompt for SMTP relay test recipient

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 66 — SMTP relay test recipient prompt
+
+**SMTP relay testing UX** (`apps/web/app/(dashboard)/settings/settings-client.tsx`, `apps/web/lib/actions/notification-settings.ts`, `apps/web/lib/notifications/smtp-settings.ts`)
+- Changed the central SMTP Relay **Test** button to open a modal that asks which email address should receive the test message.
+- The backend test action now validates a single requested recipient and sends the test email there instead of defaulting to the configured sender address.
+- The modal remains open after sending and shows a sanitized SMTP test log with recipient, relay endpoint, sender, auth mode, host validation, and final success/error status without exposing credentials.
+
+**Validation**
+- Added focused unit coverage for SMTP test-recipient normalization.
+- Validation run: `pnpm --filter web exec node --experimental-strip-types --test lib/notifications/smtp-settings.test.mjs`, `pnpm --filter web type-check`, and `pnpm --filter web test:unit`.
+
 ### Session 65 — Query-style lint guard for auditability
 
 **Drizzle query-style convergence** (`apps/web/eslint.config.mjs`, `apps/web/lib/eslint/`, `apps/web/lib/actions/`, `apps/web/app/api/admin/hosts/bulk-delete/route.ts`)

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { FormEvent } from 'react'
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
@@ -14,6 +15,7 @@ import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Use
 import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { updateOrgName, saveLicenceKey, updateMetricRetention, generateActivationToken } from '@/lib/actions/settings'
 import { getOrgDefaultCollectionSettings, updateOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
 import { getOrgTerminalSettings, updateOrgTerminalSettings } from '@/lib/actions/terminal'
@@ -29,7 +31,7 @@ import { getOrgDefaultTags, updateOrgDefaultTags } from '@/lib/actions/tags'
 import { TagEditor, type EditorTag } from '@/components/shared/tag-editor'
 import type { TagPair } from '@/lib/db/schema'
 import type { OrgTerminalSettings } from '@/lib/actions/terminal'
-import type { OrgNotificationSettingsFull, OrgSmtpRelaySettingsInput } from '@/lib/actions/notification-settings'
+import type { OrgNotificationSettingsFull, OrgSmtpRelaySettingsInput, SmtpRelayTestLogEntry } from '@/lib/actions/notification-settings'
 import type { Organisation, HostCollectionSettings, SoftwareInventorySettings } from '@/lib/db/schema'
 import { DEFAULT_COLLECTION_SETTINGS } from '@/lib/db/schema'
 import { COMMUNITY_MAX_RETENTION_DAYS, hasFeature, type LicenceTier } from '@/lib/features'
@@ -282,7 +284,14 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
 
   const [smtpSaveSuccess, setSmtpSaveSuccess] = useState(false)
   const [smtpError, setSmtpError] = useState<string | null>(null)
-  const [smtpTestResult, setSmtpTestResult] = useState<{ success?: boolean; error?: string } | null>(null)
+  const [smtpTestDialogOpen, setSmtpTestDialogOpen] = useState(false)
+  const [smtpTestEmail, setSmtpTestEmail] = useState('')
+  const [smtpTestResult, setSmtpTestResult] = useState<{
+    success?: boolean
+    error?: string
+    recipient?: string
+    log?: SmtpRelayTestLogEntry[]
+  } | null>(null)
   const { data: smtpRelayDefaults } = useQuery({
     queryKey: ['org-smtp-relay-settings', org.id],
     queryFn: () => getOrgSmtpRelaySettings(org.id),
@@ -312,11 +321,21 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
   })
 
   const smtpTestMutation = useMutation({
-    mutationFn: () => sendTestSmtpRelaySettings(org.id),
-    onSuccess: (result) => {
-      setSmtpTestResult('error' in result ? { error: result.error } : { success: true })
+    mutationFn: (recipient: string) => sendTestSmtpRelaySettings(org.id, recipient),
+    onSuccess: (result, recipient) => {
+      if ('error' in result) {
+        setSmtpTestResult({ error: result.error, log: result.log })
+        return
+      }
+      setSmtpTestResult({ success: true, recipient, log: result.log })
     },
   })
+
+  function handleSmtpTestSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSmtpTestResult(null)
+    smtpTestMutation.mutate(smtpTestEmail)
+  }
 
   function updateSmtpRelaySetting(patch: Partial<OrgSmtpRelaySettingsInput>) {
     setLocalSmtpRelaySettings({ ...currentSmtpRelaySettings, ...patch })
@@ -950,11 +969,13 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                 </>
               )}
               {smtpError && <p className="text-sm text-destructive">{smtpError}</p>}
-              {smtpTestResult?.error && <p className="text-sm text-destructive">{smtpTestResult.error}</p>}
+              {smtpTestResult?.error && !smtpTestDialogOpen && (
+                <p className="text-sm text-destructive">{smtpTestResult.error}</p>
+              )}
               {smtpTestResult?.success && (
                 <p className="flex items-center gap-1 text-sm text-green-700">
                   <CheckCircle2 className="size-4" />
-                  Test email sent
+                  Test email sent{smtpTestResult.recipient ? ` to ${smtpTestResult.recipient}` : ''}
                 </p>
               )}
               <div className="flex items-center gap-3 pt-2 border-t">
@@ -969,7 +990,11 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                   size="sm"
                   variant="outline"
                   disabled={smtpDirty || smtpTestMutation.isPending || !smtpRelayDefaults?.enabled}
-                  onClick={() => smtpTestMutation.mutate()}
+                  onClick={() => {
+                    setSmtpTestResult(null)
+                    setSmtpTestDialogOpen(true)
+                  }}
+                  data-testid="smtp-relay-test-open"
                 >
                   <FlaskConical className="size-3.5 mr-1" />
                   {smtpTestMutation.isPending ? 'Testing…' : 'Test'}
@@ -981,6 +1006,99 @@ export function SettingsClient({ org, isAdmin }: SettingsClientProps) {
                   </span>
                 )}
               </div>
+              <Dialog
+                open={smtpTestDialogOpen}
+                onOpenChange={(open) => {
+                  if (smtpTestMutation.isPending) return
+                  setSmtpTestDialogOpen(open)
+                  if (!open) {
+                    setSmtpTestEmail('')
+                    setSmtpTestResult(null)
+                  }
+                }}
+              >
+                <DialogContent className="sm:max-w-md">
+                  <form onSubmit={handleSmtpTestSubmit} className="space-y-4">
+                    <DialogHeader>
+                      <DialogTitle>Send SMTP test email</DialogTitle>
+                      <DialogDescription>
+                        Enter the mailbox that should receive this test message.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="smtp-relay-test-recipient">Email address</Label>
+                      <Input
+                        id="smtp-relay-test-recipient"
+                        type="email"
+                        inputMode="email"
+                        autoComplete="email"
+                        placeholder="ops@example.com"
+                        value={smtpTestEmail}
+                        onChange={(event) => {
+                          setSmtpTestEmail(event.target.value)
+                          setSmtpTestResult(null)
+                        }}
+                        disabled={smtpTestMutation.isPending}
+                        data-testid="smtp-relay-test-recipient"
+                      />
+                    </div>
+                    {smtpTestResult?.error && (
+                      <p className="text-sm text-destructive" data-testid="smtp-relay-test-error">
+                        {smtpTestResult.error}
+                      </p>
+                    )}
+                    {smtpTestResult?.success && (
+                      <p className="flex items-center gap-1 text-sm text-green-700" data-testid="smtp-relay-test-success">
+                        <CheckCircle2 className="size-4" />
+                        Test email sent to {smtpTestResult.recipient}
+                      </p>
+                    )}
+                    {smtpTestResult?.log && smtpTestResult.log.length > 0 && (
+                      <div className="space-y-2 rounded-md border bg-muted/30 p-3" data-testid="smtp-relay-test-log">
+                        <div className="flex items-center gap-2 text-sm font-medium">
+                          <ScrollText className="size-4 text-muted-foreground" />
+                          SMTP log
+                        </div>
+                        <ol className="space-y-1 text-xs">
+                          {smtpTestResult.log.map((entry, index) => (
+                            <li
+                              key={`${entry.level}-${index}-${entry.message}`}
+                              className={
+                                entry.level === 'success'
+                                  ? 'text-green-700'
+                                  : entry.level === 'error'
+                                    ? 'text-destructive'
+                                    : 'text-muted-foreground'
+                              }
+                            >
+                              <span className="font-medium uppercase">{entry.level}</span>
+                              <span className="mx-1">-</span>
+                              <span>{entry.message}</span>
+                            </li>
+                          ))}
+                        </ol>
+                      </div>
+                    )}
+                    <DialogFooter>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setSmtpTestDialogOpen(false)}
+                        disabled={smtpTestMutation.isPending}
+                      >
+                        {smtpTestResult ? 'Close' : 'Cancel'}
+                      </Button>
+                      <Button
+                        type="submit"
+                        disabled={smtpTestMutation.isPending || smtpTestEmail.trim().length === 0}
+                        data-testid="smtp-relay-test-submit"
+                      >
+                        {smtpTestMutation.isPending ? 'Sending…' : smtpTestResult ? 'Send again' : 'Send test'}
+                      </Button>
+                    </DialogFooter>
+                  </form>
+                </DialogContent>
+              </Dialog>
             </>
           ) : (
             <div className="space-y-2 text-sm">

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -14,6 +14,7 @@ import { encrypt, decrypt } from '@/lib/crypto/encrypt'
 import { assertPublicHost } from '@/lib/net/ssrf-guard'
 import {
   SMTP_ALLOWED_PORTS,
+  normaliseSmtpTestRecipient,
   sanitiseSmtpRelayForClient,
   smtpEncryptionSchema,
   type SmtpRelaySettings,
@@ -59,6 +60,11 @@ const updateOrgSmtpRelaySettingsSchema = z.object({
 })
 
 export type OrgSmtpRelaySettingsInput = z.infer<typeof updateOrgSmtpRelaySettingsSchema>
+
+export interface SmtpRelayTestLogEntry {
+  level: 'info' | 'success' | 'error'
+  message: string
+}
 
 export async function getOrgNotificationSettings(
   orgId: string,
@@ -211,26 +217,61 @@ export async function updateOrgSmtpRelaySettings(
 
 export async function sendTestSmtpRelaySettings(
   orgId: string,
-): Promise<{ success: true } | { error: string }> {
+  recipientInput: unknown,
+): Promise<{ success: true; log: SmtpRelayTestLogEntry[] } | { error: string; log: SmtpRelayTestLogEntry[] }> {
+  const log: SmtpRelayTestLogEntry[] = []
   const access = await getAdminOrgMetadata(orgId)
-  if ('error' in access) return { error: access.error ?? 'Unable to load SMTP settings' }
+  if ('error' in access) {
+    return {
+      error: access.error ?? 'Unable to load SMTP settings',
+      log: [{ level: 'error', message: access.error ?? 'Unable to load SMTP settings' }],
+    }
+  }
   if (!await smtpRelayTestLimiter.check(orgId)) {
-    return { error: 'Too many requests — please wait before sending another SMTP test.' }
+    return {
+      error: 'Too many requests — please wait before sending another SMTP test.',
+      log: [{ level: 'error', message: 'SMTP test rate limit exceeded' }],
+    }
   }
 
-  const cfg = access.metadata.notificationSettings?.smtpRelay
-  if (!cfg?.enabled) return { error: 'SMTP relay is not enabled' }
+  let recipient: string
+  try {
+    recipient = normaliseSmtpTestRecipient(recipientInput)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Enter a valid email address'
+    return { error: message, log: [{ level: 'error', message }] }
+  }
+  log.push({ level: 'info', message: `Recipient: ${recipient}` })
 
-  await assertPublicHost(cfg.host)
+  const cfg = access.metadata.notificationSettings?.smtpRelay
+  if (!cfg?.enabled) {
+    log.push({ level: 'error', message: 'SMTP relay is not enabled' })
+    return { error: 'SMTP relay is not enabled', log }
+  }
+
+  log.push({ level: 'info', message: `Relay: ${cfg.host}:${cfg.port} (${cfg.encryption.toUpperCase()})` })
+  log.push({ level: 'info', message: `Sender: ${cfg.fromAddress}` })
+
+  try {
+    await assertPublicHost(cfg.host)
+    log.push({ level: 'info', message: 'Relay host passed public host validation' })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'SMTP host is not allowed'
+    log.push({ level: 'error', message })
+    return { error: message, log }
+  }
 
   let password = ''
   if (cfg.passwordEncrypted) {
     try {
       password = decrypt(cfg.passwordEncrypted)
     } catch {
-      return { error: 'Stored SMTP password could not be decrypted' }
+      log.push({ level: 'error', message: 'Stored SMTP password could not be decrypted' })
+      return { error: 'Stored SMTP password could not be decrypted', log }
     }
   }
+  log.push({ level: 'info', message: cfg.username ? `Authentication: enabled as ${cfg.username}` : 'Authentication: disabled' })
+  log.push({ level: 'info', message: 'Sending SMTP test message' })
 
   try {
     await sendSmtpMessage({
@@ -242,13 +283,16 @@ export async function sendTestSmtpRelaySettings(
       fromAddress: cfg.fromAddress,
       fromName: cfg.fromName,
     }, {
-      to: [cfg.fromAddress],
+      to: [recipient],
       subject: 'CT-Ops SMTP Test',
       text: 'This is a test email from CT-Ops. Your central SMTP relay is configured correctly.',
       html: '<p>This is a test email from <strong>CT-Ops</strong>. Your central SMTP relay is configured correctly.</p>',
     })
-    return { success: true }
+    log.push({ level: 'success', message: 'SMTP server accepted the test message' })
+    return { success: true, log }
   } catch (err) {
-    return { error: err instanceof Error ? err.message : 'Failed to send SMTP test' }
+    const message = err instanceof Error ? err.message : 'Failed to send SMTP test'
+    log.push({ level: 'error', message })
+    return { error: message, log }
   }
 }

--- a/apps/web/lib/notifications/smtp-settings.test.mjs
+++ b/apps/web/lib/notifications/smtp-settings.test.mjs
@@ -5,6 +5,7 @@ import {
   SMTP_ALLOWED_PORTS,
   normaliseSmtpRecipients,
   sanitiseSmtpRelayForClient,
+  normaliseSmtpTestRecipient,
 } from './smtp-settings.ts'
 
 test('normaliseSmtpRecipients trims comma-separated addresses and rejects empty output', () => {
@@ -13,6 +14,12 @@ test('normaliseSmtpRecipients trims comma-separated addresses and rejects empty 
     'team@example.com',
   ])
   assert.throws(() => normaliseSmtpRecipients(' , '), /At least one recipient/)
+})
+
+test('normaliseSmtpTestRecipient accepts one trimmed email address only', () => {
+  assert.equal(normaliseSmtpTestRecipient(' ops@example.com '), 'ops@example.com')
+  assert.throws(() => normaliseSmtpTestRecipient('ops@example.com, team@example.com'), /Enter one email address/)
+  assert.throws(() => normaliseSmtpTestRecipient('not-an-email'), /valid email address/)
 })
 
 test('sanitiseSmtpRelayForClient hides stored password material', () => {

--- a/apps/web/lib/notifications/smtp-settings.ts
+++ b/apps/web/lib/notifications/smtp-settings.ts
@@ -65,6 +65,29 @@ export function normaliseSmtpRecipients(input: string): string[] {
   return recipients
 }
 
+export function normaliseSmtpTestRecipient(input: unknown): string {
+  const parsedInput = z.string().max(320, 'Email address is too long').safeParse(input)
+  if (!parsedInput.success) {
+    throw new Error(parsedInput.error.issues[0]?.message ?? 'Enter a valid email address')
+  }
+
+  const recipient = parsedInput.data.trim()
+  if (!recipient) {
+    throw new Error('Enter an email address')
+  }
+
+  if (recipient.includes(',')) {
+    throw new Error('Enter one email address')
+  }
+
+  const parsedEmail = z.string().email('Enter a valid email address').safeParse(recipient)
+  if (!parsedEmail.success) {
+    throw new Error(parsedEmail.error.issues[0]?.message ?? 'Enter a valid email address')
+  }
+
+  return parsedEmail.data
+}
+
 export function sanitiseSmtpRelayForClient(settings?: SmtpRelaySettings): SmtpRelaySettingsSafe | null {
   if (!settings) return null
   return {


### PR DESCRIPTION
## Summary
- open an SMTP relay test modal that asks for the recipient email address
- send the test message to the requested recipient after backend validation
- keep the modal open with a sanitized SMTP test log for success and error outcomes

## Validation
- pnpm --filter web exec node --experimental-strip-types --test lib/notifications/smtp-settings.test.mjs
- pnpm --filter web type-check
- pnpm --filter web test:unit
- pnpm --filter web lint (passes with existing warnings)