### PR TITLE
fix(web): avoid e2e auth rate limit

### DIFF
--- a/apps/docs/docs/development/testing.md
+++ b/apps/docs/docs/development/testing.md
@@ -55,7 +55,7 @@ Per-test isolation is provided by an auto-running `autoTruncate` fixture that ru
 
 ## Authentication in tests
 
-The canonical pattern is the `authenticatedPage` fixture exported from `tests/e2e/fixtures/test.ts`. It programmatically signs in once per worker by POSTing to Better Auth's `/api/auth/sign-in/email`, captures the cookie via Playwright's `storageState`, and hands back a pre-authenticated page.
+The canonical pattern is the `authenticatedPage` fixture exported from `tests/e2e/fixtures/test.ts`. It creates a real Better Auth session row for the seeded user, writes the matching signed session cookie into Playwright's `storageState`, and hands back a pre-authenticated page. This keeps feature tests out of the sign-in endpoint's brute-force rate limit while still exercising the normal session validation path.
 
 ```ts
 import { test, expect } from '../fixtures/test'

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -9,23 +9,7 @@ import { randomBytes } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getBetterAuthSecret } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
-
-// Produce a signed cookie value in exactly the format Hono's serializeSigned uses:
-// encodeURIComponent(`${value}.${btoa(HMAC-SHA256(value, secret))}`).
-// Better Auth's getSession delegates cookie verification to Hono, so this must
-// match Hono's implementation byte-for-byte to avoid silent session failures.
-async function makeSessionCookieValue(token: string, secret: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  )
-  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(token))
-  const base64Sig = btoa(String.fromCharCode(...new Uint8Array(sig)))
-  return encodeURIComponent(`${token}.${base64Sig}`)
-}
+import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
 
 // 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
 const ldapRateLimit = createRateLimiter({

--- a/apps/web/lib/auth/session-cookie.ts
+++ b/apps/web/lib/auth/session-cookie.ts
@@ -1,0 +1,16 @@
+// Produce a signed cookie value in exactly the format Hono's serializeSigned uses:
+// encodeURIComponent(`${value}.${btoa(HMAC-SHA256(value, secret))}`).
+// Better Auth's getSession delegates cookie verification to Hono, so this must
+// match Hono's implementation byte-for-byte to avoid silent session failures.
+export async function makeSessionCookieValue(token: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(token))
+  const base64Sig = btoa(String.fromCharCode(...new Uint8Array(sig)))
+  return encodeURIComponent(`${token}.${base64Sig}`)
+}

--- a/apps/web/tests/e2e/fixtures/auth.ts
+++ b/apps/web/tests/e2e/fixtures/auth.ts
@@ -1,5 +1,10 @@
-import { request as playwrightRequest } from '@playwright/test'
+import { createId } from '@paralleldrive/cuid2'
+import { randomBytes } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { getBetterAuthSecret } from '../../../lib/auth/env'
+import { makeSessionCookieValue } from '../../../lib/auth/session-cookie'
+import { getTestDb } from './db'
 import { TEST_USER } from './seed'
 
 export const STORAGE_STATE_PATH = path.resolve(
@@ -10,25 +15,53 @@ export const STORAGE_STATE_PATH = path.resolve(
 )
 
 export async function getStorageStatePath(baseURL: string): Promise<string> {
-  return signInAndCacheStorageState(baseURL)
+  return createAndCacheStorageState(baseURL)
 }
 
-async function signInAndCacheStorageState(baseURL: string): Promise<string> {
-  const ctx = await playwrightRequest.newContext({ baseURL })
-  try {
-    const res = await ctx.post('/api/auth/sign-in/email', {
-      data: {
-        email: TEST_USER.email,
-        password: TEST_USER.password,
-      },
-    })
-    if (!res.ok()) {
-      const body = await res.text()
-      throw new Error(`sign-in failed: ${res.status()} ${body}`)
-    }
-    await ctx.storageState({ path: STORAGE_STATE_PATH })
-  } finally {
-    await ctx.dispose()
+async function createAndCacheStorageState(baseURL: string): Promise<string> {
+  const sql = getTestDb()
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id FROM "user" WHERE email = ${TEST_USER.email} LIMIT 1
+  `
+  const userId = rows[0]?.id
+  if (!userId) {
+    throw new Error(`E2E test user ${TEST_USER.email} has not been seeded`)
   }
+
+  const sessionToken = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+
+  await sql`
+    INSERT INTO "session" (id, expires_at, token, created_at, updated_at, user_id)
+    VALUES (${createId()}, ${expiresAt}, ${sessionToken}, NOW(), NOW(), ${userId})
+  `
+
+  const cookieValue = await makeSessionCookieValue(sessionToken, getBetterAuthSecret())
+  const url = new URL(baseURL)
+
+  await mkdir(path.dirname(STORAGE_STATE_PATH), { recursive: true })
+  await writeFile(
+    STORAGE_STATE_PATH,
+    JSON.stringify(
+      {
+        cookies: [
+          {
+            name: 'better-auth.session_token',
+            value: cookieValue,
+            domain: url.hostname,
+            path: '/',
+            expires: Math.floor(expiresAt.getTime() / 1000),
+            httpOnly: true,
+            secure: url.protocol === 'https:',
+            sameSite: 'Lax',
+          },
+        ],
+        origins: [],
+      },
+      null,
+      2,
+    ),
+  )
+
   return STORAGE_STATE_PATH
 }


### PR DESCRIPTION
## Summary
- replace repeated E2E fixture sign-ins with direct Better Auth session creation and signed cookie storage state
- extract the Better Auth/Hono session-cookie signer for reuse by LDAP auth and E2E fixtures
- update the E2E testing docs to describe the direct-session authenticated fixture

## Root cause
The authenticated Playwright fixture posted to `/api/auth/sign-in/email` for each authenticated feature test. At full-suite scale, those successful sign-ins consumed the production auth brute-force limiter budget and caused later tests to fail with 429 responses.

## Validation
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `pnpm --filter web test:e2e -- tests/e2e/profile/profile.spec.ts tests/e2e/settings/terminal-settings.spec.ts`
- `pnpm --filter web test:e2e` (23 passed, 1 skipped)