### PR TITLE
test(web): add task and notification e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/tasks/schedules-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules-client.tsx
@@ -104,7 +104,7 @@ export function SchedulesClient({
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">Scheduled Tasks</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="task-schedules-heading">Scheduled Tasks</h1>
           <p className="text-muted-foreground mt-1">
             Run patches, custom scripts, service actions, and inventory scans on a recurring cadence.
           </p>
@@ -126,7 +126,7 @@ export function SchedulesClient({
       )}
 
       {schedules.length === 0 ? (
-        <Card>
+        <Card data-testid="task-schedules-empty">
           <CardContent className="py-12 text-center">
             <p className="text-muted-foreground">
               No schedules yet.
@@ -159,7 +159,7 @@ export function SchedulesClient({
             </TableHeader>
             <TableBody>
               {schedules.map((s) => (
-                <TableRow key={s.id}>
+                <TableRow key={s.id} data-testid={`task-schedule-row-${s.id}`}>
                   <TableCell>
                     <Link href={`/tasks/schedules/${s.id}`} className="font-medium hover:underline">
                       {s.name}
@@ -195,6 +195,7 @@ export function SchedulesClient({
                   </TableCell>
                   <TableCell>
                     <Switch
+                      data-testid={`task-schedule-toggle-${s.id}`}
                       checked={s.enabled}
                       disabled={!canEdit || toggle.isPending}
                       onCheckedChange={(checked) => toggle.mutate({ id: s.id, enabled: checked })}
@@ -226,6 +227,7 @@ export function SchedulesClient({
                             variant="ghost"
                             size="icon"
                             title="Delete"
+                            data-testid={`task-schedule-delete-${s.id}`}
                             onClick={() => setDeleteTarget(s)}
                           >
                             <Trash2 className="size-4" />
@@ -253,6 +255,7 @@ export function SchedulesClient({
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
+              data-testid="task-schedule-delete-confirm"
               onClick={() => deleteTarget && remove.mutate(deleteTarget.id)}
               disabled={remove.isPending}
             >

--- a/apps/web/tests/e2e/notifications/inbox.spec.ts
+++ b/apps/web/tests/e2e/notifications/inbox.spec.ts
@@ -219,3 +219,102 @@ test('authenticated user can mark all unread notifications as read', async ({ au
   await page.getByTestId('notifications-tab-unread').click()
   await expect(page.getByText('No unread notifications')).toBeVisible()
 })
+
+test('authenticated user can mark selected read notifications as unread', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO notifications (
+      id,
+      organisation_id,
+      user_id,
+      subject,
+      body,
+      severity,
+      resource_type,
+      resource_id,
+      read,
+      created_at
+    )
+    VALUES
+      (
+        'notification-mark-unread-1',
+        ${orgId},
+        ${userId},
+        'Patch window completed',
+        'The scheduled patch run completed successfully.',
+        'info',
+        'host',
+        'host-mark-unread-1',
+        true,
+        NOW() - INTERVAL '20 minutes'
+      ),
+      (
+        'notification-mark-unread-2',
+        ${orgId},
+        ${userId},
+        'Certificate inventory refreshed',
+        'A certificate scan refreshed the inventory.',
+        'warning',
+        'certificate',
+        'certificate-mark-unread-2',
+        true,
+        NOW() - INTERVAL '12 minutes'
+      ),
+      (
+        'notification-mark-unread-3',
+        ${orgId},
+        ${userId},
+        'Agent check-in recovered',
+        'worker-02 is reporting normally again.',
+        'info',
+        'host',
+        'host-mark-unread-3',
+        false,
+        NOW() - INTERVAL '3 minutes'
+      )
+  `
+
+  await page.goto('/notifications')
+
+  await expect(page.getByTestId('notification-card-notification-mark-unread-1')).toBeVisible()
+  await expect(page.getByTestId('notification-card-notification-mark-unread-2')).toBeVisible()
+
+  await page
+    .getByTestId('notification-card-notification-mark-unread-1')
+    .getByRole('checkbox')
+    .click()
+  await page
+    .getByTestId('notification-card-notification-mark-unread-2')
+    .getByRole('checkbox')
+    .click()
+  await page.getByTestId('notifications-bulk-mark-unread').click()
+
+  await expect(page.getByTestId('notifications-tab-unread')).toContainText('3')
+  await page.getByTestId('notifications-tab-unread').click()
+  await expect(page.getByTestId('notification-card-notification-mark-unread-1')).toBeVisible()
+  await expect(page.getByTestId('notification-card-notification-mark-unread-2')).toBeVisible()
+  await expect(page.getByTestId('notification-card-notification-mark-unread-3')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ id: string; read: boolean }>>`
+        SELECT id, read
+        FROM notifications
+        WHERE id IN (
+          'notification-mark-unread-1',
+          'notification-mark-unread-2',
+          'notification-mark-unread-3'
+        )
+        ORDER BY id ASC
+      `
+
+      return rows
+    })
+    .toEqual([
+      { id: 'notification-mark-unread-1', read: false },
+      { id: 'notification-mark-unread-2', read: false },
+      { id: 'notification-mark-unread-3', read: false },
+    ])
+})

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('admin can review, enable, and delete a scheduled task', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'schedule-host-1',
+      ${orgId},
+      'schedule-host-1',
+      'Schedule Host',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.30.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`
+    INSERT INTO task_schedules (
+      id,
+      organisation_id,
+      created_by,
+      name,
+      description,
+      task_type,
+      config,
+      target_type,
+      target_id,
+      max_parallel,
+      cron_expression,
+      timezone,
+      enabled,
+      next_run_at
+    )
+    VALUES (
+      'schedule-e2e-1',
+      ${orgId},
+      ${userId},
+      'Weekly patch run',
+      'Apply security patches to a critical host.',
+      'patch',
+      '{"mode":"security"}'::jsonb,
+      'host',
+      'schedule-host-1',
+      1,
+      '0 3 * * 1',
+      'UTC',
+      false,
+      NOW() + INTERVAL '6 days'
+    )
+  `
+
+  await page.goto('/tasks')
+
+  await expect(page.getByTestId('task-schedules-heading')).toBeVisible()
+  const scheduleRow = page.getByTestId('task-schedule-row-schedule-e2e-1')
+  await expect(scheduleRow).toContainText('Weekly patch run')
+  await expect(scheduleRow).toContainText('Patch')
+  await expect(scheduleRow).toContainText('schedule-host-1')
+
+  await page.getByTestId('task-schedule-toggle-schedule-e2e-1').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ enabled: boolean }>>`
+        SELECT enabled
+        FROM task_schedules
+        WHERE id = 'schedule-e2e-1'
+        LIMIT 1
+      `
+      return rows[0]?.enabled ?? null
+    })
+    .toBe(true)
+
+  await page.getByTestId('task-schedule-delete-schedule-e2e-1').click()
+  await page.getByTestId('task-schedule-delete-confirm').click()
+  await expect(scheduleRow).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM task_schedules
+        WHERE id = 'schedule-e2e-1'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .toBeTruthy()
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for scheduled tasks so a seeded schedule can be listed, enabled, and deleted against the in-memory database harness
- add notification coverage for bulk marking selected read notifications back to unread
- add stable scheduled-task test ids used by the new E2E interactions

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/tasks/schedules.spec.ts tests/e2e/notifications/inbox.spec.ts`
