### PR TITLE
test(web): add e2e coverage for tag rules and schedules

### DIFF
--- a/apps/web/app/(dashboard)/settings/tag-rules/tag-rules-client.tsx
+++ b/apps/web/app/(dashboard)/settings/tag-rules/tag-rules-client.tsx
@@ -84,7 +84,7 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
   return (
     <div className="space-y-6 p-6">
       <div>
-        <h1 className="text-2xl font-semibold">Tag Rules</h1>
+        <h1 className="text-2xl font-semibold" data-testid="tag-rules-heading">Tag Rules</h1>
         <p className="text-muted-foreground text-sm">
           Rules auto-apply tags to hosts that match their filter. Evaluated at host approval and
           when you click Run.
@@ -93,6 +93,7 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
 
       {message && (
         <div
+          data-testid="tag-rules-message"
           className={`rounded-md border p-3 text-sm ${
             message.kind === 'error'
               ? 'border-destructive/50 bg-destructive/10 text-destructive'
@@ -130,7 +131,7 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
               </TableHeader>
               <TableBody>
                 {rules.map((r) => (
-                  <TableRow key={r.id}>
+                  <TableRow key={r.id} data-testid={`tag-rule-row-${r.id}`}>
                     <TableCell className="font-medium">{r.name}</TableCell>
                     <TableCell className="max-w-sm text-xs text-muted-foreground">
                       {summariseFilter(r.filter)}
@@ -157,6 +158,8 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
                           variant="ghost"
                           size="sm"
                           title="Run now"
+                          data-testid={`tag-rule-run-${r.id}`}
+                          aria-label={`Run tag rule ${r.name}`}
                           onClick={() => runMutation.mutate(r.id)}
                           disabled={runMutation.isPending}
                         >
@@ -166,6 +169,8 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
                           variant="ghost"
                           size="sm"
                           title={r.enabled ? 'Disable' : 'Enable'}
+                          data-testid={`tag-rule-toggle-${r.id}`}
+                          aria-label={`${r.enabled ? 'Disable' : 'Enable'} tag rule ${r.name}`}
                           onClick={() =>
                             toggleMutation.mutate({ ruleId: r.id, enabled: !r.enabled })
                           }
@@ -177,6 +182,8 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
                           variant="ghost"
                           size="sm"
                           title="Delete"
+                          data-testid={`tag-rule-delete-${r.id}`}
+                          aria-label={`Delete tag rule ${r.name}`}
                           onClick={() => deleteMutation.mutate(r.id)}
                           disabled={deleteMutation.isPending}
                         >

--- a/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
@@ -211,7 +211,7 @@ export function ScheduleForm({
         </h1>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-6" data-testid={`task-schedule-form-${mode}`}>
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Basics</CardTitle>
@@ -260,7 +260,7 @@ export function ScheduleForm({
                 onValueChange={(v) => setTaskType(v as ScheduledType)}
                 disabled={mode === 'edit'}
               >
-                <SelectTrigger>
+                <SelectTrigger data-testid="task-schedule-task-type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -282,7 +282,7 @@ export function ScheduleForm({
               <div>
                 <Label>Patch mode</Label>
                 <Select value={patchMode} onValueChange={(v) => setPatchMode(v as 'security' | 'all')}>
-                  <SelectTrigger>
+                  <SelectTrigger data-testid="task-schedule-patch-mode">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -384,7 +384,7 @@ export function ScheduleForm({
                   setTargetId('')
                 }}
               >
-                <SelectTrigger>
+                <SelectTrigger data-testid="task-schedule-target-type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -396,7 +396,7 @@ export function ScheduleForm({
             <div>
               <Label>{targetType === 'host' ? 'Host' : 'Group'}</Label>
               <Select value={targetId} onValueChange={setTargetId}>
-                <SelectTrigger>
+                <SelectTrigger data-testid="task-schedule-target-id">
                   <SelectValue placeholder={`Select a ${targetType}`} />
                 </SelectTrigger>
                 <SelectContent>
@@ -463,7 +463,7 @@ export function ScheduleForm({
             <div>
               <Label>Timezone</Label>
               <Select value={timezone} onValueChange={setTimezone}>
-                <SelectTrigger>
+                <SelectTrigger data-testid="task-schedule-timezone">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -505,7 +505,7 @@ export function ScheduleForm({
         )}
 
         <div className="flex items-center gap-2">
-          <Button type="submit" disabled={submit.isPending}>
+          <Button type="submit" disabled={submit.isPending} data-testid={`task-schedule-submit-${mode}`}>
             {submit.isPending ? (
               <Loader2 className="size-4 mr-2 animate-spin" />
             ) : (

--- a/apps/web/tests/e2e/settings/tag-rules.spec.ts
+++ b/apps/web/tests/e2e/settings/tag-rules.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ org_id: string }>>`
+    SELECT id AS org_id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.org_id
+}
+
+test('admin can run, disable, and delete a saved tag rule', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'tag-rule-host-match',
+        ${orgId},
+        'web-01',
+        'Web 01',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.20.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'tag-rule-host-ignore',
+        ${orgId},
+        'db-01',
+        'DB 01',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.20.0.20"]'::jsonb,
+        'offline',
+        NOW()
+      )
+  `
+
+  await sql`
+    INSERT INTO tag_rules (
+      id,
+      organisation_id,
+      name,
+      filter,
+      tags,
+      enabled
+    )
+    VALUES (
+      'tag-rule-e2e-1',
+      ${orgId},
+      'Production web hosts',
+      '{"hostnameContains":"web","status":["online"]}'::jsonb,
+      '[{"key":"env","value":"prod"}]'::jsonb,
+      true
+    )
+  `
+
+  await page.goto('/settings/tag-rules')
+
+  await expect(page.getByTestId('tag-rules-heading')).toBeVisible()
+  const ruleRow = page.getByTestId('tag-rule-row-tag-rule-e2e-1')
+  await expect(ruleRow).toContainText('Production web hosts')
+  await expect(ruleRow).toContainText('hostname contains "web"')
+  await expect(ruleRow).toContainText('status=online')
+  await expect(ruleRow).toContainText('env:prod')
+  await expect(ruleRow).toContainText('Enabled')
+
+  await page.getByTestId('tag-rule-run-tag-rule-e2e-1').click()
+  await expect(page.getByTestId('tag-rules-message')).toContainText('Applied rule to 1 host(s).')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ key: string; value: string }>>`
+        SELECT tags.key, tags.value
+        FROM resource_tags
+        JOIN tags ON tags.id = resource_tags.tag_id
+        WHERE resource_tags.resource_type = 'host'
+          AND resource_tags.resource_id = 'tag-rule-host-match'
+        ORDER BY tags.key ASC, tags.value ASC
+      `
+      return rows
+    })
+    .toEqual([{ key: 'env', value: 'prod' }])
+
+  const ignoredRows = await sql<Array<{ count: string }>>`
+    SELECT COUNT(*)::text AS count
+    FROM resource_tags
+    WHERE resource_type = 'host'
+      AND resource_id = 'tag-rule-host-ignore'
+  `
+  expect(ignoredRows[0]?.count).toBe('0')
+
+  await page.getByTestId('tag-rule-toggle-tag-rule-e2e-1').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ enabled: boolean }>>`
+        SELECT enabled
+        FROM tag_rules
+        WHERE id = 'tag-rule-e2e-1'
+        LIMIT 1
+      `
+      return rows[0]?.enabled ?? null
+    })
+    .toBe(false)
+
+  await page.getByTestId('tag-rule-delete-tag-rule-e2e-1').click()
+  await expect(ruleRow).toHaveCount(0)
+  await expect(page.getByTestId('tag-rules-message')).toContainText('Rule deleted.')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM tag_rules
+        WHERE id = 'tag-rule-e2e-1'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .toBeTruthy()
+})

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -120,3 +120,86 @@ test('admin can review, enable, and delete a scheduled task', async ({ authentic
     })
     .toBeTruthy()
 })
+
+test('admin can create a patch schedule from the new schedule form', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'schedule-create-host-1',
+      ${orgId},
+      'schedule-create-host-1',
+      'Schedule Create Host',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.40.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await page.goto('/tasks/schedules/new')
+
+  await expect(page.getByRole('heading', { name: 'New schedule' })).toBeVisible()
+  await page.getByLabel('Name').fill('Nightly patch run')
+  await page.getByLabel('Description (optional)').fill('Install all updates every night.')
+
+  await page.getByTestId('task-schedule-task-type').click()
+  await page.getByRole('option', { name: 'Patch' }).click()
+
+  await page.getByTestId('task-schedule-target-id').click()
+  await page.getByRole('option', { name: /schedule-create-host-1/i }).click()
+
+  await page.getByLabel('Cron expression (5 fields: minute hour dom month dow)').fill('15 2 * * *')
+  await page.getByTestId('task-schedule-timezone').click()
+  await page.getByRole('option', { name: 'Europe/London' }).click()
+
+  await expect(page.getByText(/\(in .*?\)/).first()).toBeVisible()
+
+  await page.getByTestId('task-schedule-submit-create').click()
+
+  await expect(page).toHaveURL(/\/tasks$/)
+  const scheduleRow = page.getByRole('row', { name: /Nightly patch run/i })
+  await expect(scheduleRow).toContainText('Patch')
+  await expect(scheduleRow).toContainText('schedule-create-host-1')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        name: string
+        cron_expression: string
+        timezone: string
+        target_id: string
+        task_type: string
+        config: { mode?: string }
+      }>>`
+        SELECT name, cron_expression, timezone, target_id, task_type, config
+        FROM task_schedules
+        WHERE organisation_id = ${orgId}
+          AND name = 'Nightly patch run'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      name: 'Nightly patch run',
+      cron_expression: '15 2 * * *',
+      timezone: 'Europe/London',
+      target_id: 'schedule-create-host-1',
+      task_type: 'patch',
+      config: { mode: 'all' },
+    })
+})


### PR DESCRIPTION
## Summary
- add end-to-end coverage for the saved tag rules management flow
- expand scheduled task coverage to create a patch schedule through the new schedule form
- add stable test selectors for the tag-rules and schedule-form interactions exercised by Playwright

## Testing
- pnpm --filter web test:e2e -- tests/e2e/settings/tag-rules.spec.ts tests/e2e/tasks/schedules.spec.ts
- pnpm --filter web exec eslint app/(dashboard)/settings/tag-rules/tag-rules-client.tsx app/(dashboard)/tasks/schedules/schedule-form.tsx tests/e2e/settings/tag-rules.spec.ts tests/e2e/tasks/schedules.spec.ts