### PR TITLE
fix(web): stabilise schedule form e2e selectors

### DIFF
--- a/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
@@ -206,7 +206,7 @@ export function ScheduleForm({
             Scheduled Tasks
           </Link>
         </Button>
-        <h1 className="text-2xl font-semibold text-foreground">
+        <h1 className="text-2xl font-semibold text-foreground" data-testid={`task-schedule-heading-${mode}`}>
           {mode === 'create' ? 'New schedule' : `Edit schedule: ${schedule?.name}`}
         </h1>
       </div>
@@ -479,11 +479,11 @@ export function ScheduleForm({
             <div>
               <Label>Next 5 scheduled runs</Label>
               {previewError ? (
-                <p className="text-sm text-destructive">{previewError}</p>
+                <p className="text-sm text-destructive" data-testid="task-schedule-preview-error">{previewError}</p>
               ) : preview.length === 0 ? (
-                <p className="text-sm text-muted-foreground">—</p>
+                <p className="text-sm text-muted-foreground" data-testid="task-schedule-preview-empty">—</p>
               ) : (
-                <ul className="text-sm space-y-0.5 mt-1">
+                <ul className="text-sm space-y-0.5 mt-1" data-testid="task-schedule-preview-list">
                   {preview.map((iso) => (
                     <li key={iso} className="font-mono text-xs">
                       {new Date(iso).toLocaleString()}{' '}

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -152,7 +152,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
 
   await page.goto('/tasks/schedules/new')
 
-  await expect(page.getByRole('heading', { name: 'New schedule' })).toBeVisible()
+  await expect(page.getByTestId('task-schedule-heading-create')).toBeVisible()
   await page.getByLabel('Name').fill('Nightly patch run')
   await page.getByLabel('Description (optional)').fill('Install all updates every night.')
 
@@ -166,7 +166,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
   await page.getByTestId('task-schedule-timezone').click()
   await page.getByRole('option', { name: 'Europe/London' }).click()
 
-  await expect(page.getByText(/\(in .*?\)/).first()).toBeVisible()
+  await expect(page.getByTestId('task-schedule-preview-list')).toBeVisible()
 
   await page.getByTestId('task-schedule-submit-create').click()
 


### PR DESCRIPTION
## Summary
- add direct schedule-form test selectors for the heading and preview list
- switch the schedule creation E2E to use those stable hooks instead of looser text matching

## Testing
- pnpm --filter web test:e2e -- tests/e2e/tasks/schedules.spec.ts
- pnpm --filter web exec eslint app/(dashboard)/tasks/schedules/schedule-form.tsx tests/e2e/tasks/schedules.spec.ts