### PR TITLE
fix(web): sanitise LDAP configuration responses

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -33,7 +33,7 @@ import {
   deleteLdapConfiguration,
   testLdapConnection,
 } from '@/lib/actions/ldap'
-import type { LdapConfiguration } from '@/lib/db/schema'
+import type { LdapConfigurationSafe } from '@/lib/actions/ldap'
 
 const EMPTY_FORM = {
   name: '',
@@ -122,13 +122,13 @@ export function LdapSettingsClient({
   initialConfigs,
 }: {
   orgId: string
-  initialConfigs: LdapConfiguration[]
+  initialConfigs: LdapConfigurationSafe[]
 }) {
   const queryClient = useQueryClient()
   const [showAddDialog, setShowAddDialog] = useState(false)
   const [addForm, setAddForm] = useState({ ...EMPTY_FORM })
   const [addError, setAddError] = useState<string | null>(null)
-  const [editingConfig, setEditingConfig] = useState<LdapConfiguration | null>(null)
+  const [editingConfig, setEditingConfig] = useState<LdapConfigurationSafe | null>(null)
   const [editForm, setEditForm] = useState({ ...EMPTY_FORM })
   const [editError, setEditError] = useState<string | null>(null)
   const [testResults, setTestResults] = useState<Record<string, { success?: boolean; error?: string }>>({})
@@ -187,7 +187,7 @@ export function LdapSettingsClient({
     },
   })
 
-  function openEditDialog(config: LdapConfiguration) {
+  function openEditDialog(config: LdapConfigurationSafe) {
     setEditForm({
       name: config.name,
       host: config.host,

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -7,8 +7,15 @@ import { z } from 'zod'
 import { db } from '@/lib/db'
 import { ldapConfigurations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
-import type { LdapConfiguration } from '@/lib/db/schema'
 import { encrypt, decrypt } from '@/lib/crypto/encrypt'
+import {
+  sanitiseLdapConfigurationForClient,
+  type LdapConfigurationSafe,
+} from '@/lib/ldap/config-client'
+import { testConnection as ldapTestConnection, searchUsers, lookupUserByDn, escapeLdapFilterValue } from '@/lib/ldap/client'
+import type { LdapUser, LdapUserDetail } from '@/lib/ldap/client'
+
+export type { LdapConfigurationSafe } from '@/lib/ldap/config-client'
 
 function safeDecrypt(value: string): string {
   try { return decrypt(value) } catch { return value }
@@ -21,8 +28,6 @@ function decryptConfigForDisplay<T extends { bindDn: string; tlsCertificate: str
     tlsCertificate: config.tlsCertificate ? safeDecrypt(config.tlsCertificate) : null,
   }
 }
-import { testConnection as ldapTestConnection, searchUsers, lookupUserByDn, escapeLdapFilterValue } from '@/lib/ldap/client'
-import type { LdapUser, LdapUserDetail } from '@/lib/ldap/client'
 
 const createLdapConfigSchema = z.object({
   name: z.string().min(1, 'Name is required').max(255),
@@ -67,7 +72,7 @@ const updateLdapConfigSchema = z.object({
 
 export async function getLdapConfigurations(
   orgId: string,
-): Promise<LdapConfiguration[]> {
+): Promise<LdapConfigurationSafe[]> {
   await requireOrgAdminAccess(orgId)
   const rows = await db.query.ldapConfigurations.findMany({
     where: and(
@@ -76,13 +81,13 @@ export async function getLdapConfigurations(
     ),
     orderBy: ldapConfigurations.createdAt,
   })
-  return rows.map(decryptConfigForDisplay)
+  return rows.map((row) => sanitiseLdapConfigurationForClient(decryptConfigForDisplay(row)))
 }
 
 export async function getLdapConfiguration(
   orgId: string,
   configId: string,
-): Promise<LdapConfiguration | null> {
+): Promise<LdapConfigurationSafe | null> {
   await requireOrgAdminAccess(orgId)
   const result = await db.query.ldapConfigurations.findFirst({
     where: and(
@@ -91,7 +96,7 @@ export async function getLdapConfiguration(
       isNull(ldapConfigurations.deletedAt),
     ),
   })
-  return result ? decryptConfigForDisplay(result) : null
+  return result ? sanitiseLdapConfigurationForClient(decryptConfigForDisplay(result)) : null
 }
 
 export async function createLdapConfiguration(

--- a/apps/web/lib/ldap/config-client.test.mjs
+++ b/apps/web/lib/ldap/config-client.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { sanitiseLdapConfigurationForClient } from './config-client.ts'
+
+test('sanitiseLdapConfigurationForClient omits bindPassword from client payloads', () => {
+  const safe = sanitiseLdapConfigurationForClient({
+    id: 'cfg_123',
+    organisationId: 'org_123',
+    name: 'Primary LDAP',
+    host: 'ldap.example.com',
+    port: 636,
+    useTls: true,
+    useStartTls: false,
+    tlsCertificate: 'stored-cert',
+    baseDn: 'dc=example,dc=com',
+    bindDn: 'stored-bind-dn',
+    bindPassword: 'stored-ciphertext',
+    userSearchBase: null,
+    userSearchFilter: '(uid={{username}})',
+    groupSearchBase: null,
+    groupSearchFilter: null,
+    usernameAttribute: 'uid',
+    emailAttribute: 'mail',
+    displayNameAttribute: 'cn',
+    enabled: true,
+    allowLogin: true,
+    createdAt: new Date('2026-04-18T15:32:43Z'),
+    updatedAt: new Date('2026-04-18T15:32:43Z'),
+    deletedAt: null,
+  })
+
+  assert.equal('bindPassword' in safe, false)
+  assert.equal(safe.name, 'Primary LDAP')
+  assert.equal(safe.host, 'ldap.example.com')
+})

--- a/apps/web/lib/ldap/config-client.ts
+++ b/apps/web/lib/ldap/config-client.ts
@@ -1,0 +1,12 @@
+import type { LdapConfiguration } from '../db/schema'
+import { sanitise } from '../response-sanitisation.ts'
+
+export type LdapConfigurationSafe = Omit<LdapConfiguration, 'bindPassword'>
+
+export function sanitiseLdapConfigurationForClient(
+  config: LdapConfiguration,
+): LdapConfigurationSafe {
+  return sanitise(config, {
+    bindPassword: 'omit',
+  }) as LdapConfigurationSafe
+}

--- a/apps/web/lib/response-sanitisation.test.mjs
+++ b/apps/web/lib/response-sanitisation.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { sanitise } from './response-sanitisation.ts'
+
+test('sanitise omits configured top-level fields', () => {
+  const safe = sanitise({
+    id: 'cfg_123',
+    bindDn: 'cn=svc,dc=example,dc=com',
+    bindPassword: 'ciphertext',
+    allowLogin: true,
+  }, {
+    bindPassword: 'omit',
+  })
+
+  assert.deepEqual(safe, {
+    id: 'cfg_123',
+    bindDn: 'cn=svc,dc=example,dc=com',
+    allowLogin: true,
+  })
+})
+
+test('sanitise omits configured nested fields', () => {
+  const safe = sanitise({
+    channel: {
+      url: 'https://hooks.example.com',
+      secret: 'super-secret',
+    },
+    untouched: 'value',
+  }, {
+    channel: {
+      secret: 'omit',
+    },
+  })
+
+  assert.deepEqual(safe, {
+    channel: {
+      url: 'https://hooks.example.com',
+    },
+    untouched: 'value',
+  })
+})

--- a/apps/web/lib/response-sanitisation.ts
+++ b/apps/web/lib/response-sanitisation.ts
@@ -1,0 +1,40 @@
+type SanitiseSchema = {
+  [key: string]: 'omit' | SanitiseSchema
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+export function sanitise<T>(value: T, schema: SanitiseSchema): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitise(item, schema)) as T
+  }
+
+  if (!isPlainObject(value)) {
+    return value
+  }
+
+  const safe: Record<string, unknown> = {}
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const rule = schema[key]
+    if (rule === 'omit') continue
+    if (rule && isPlainObject(nestedValue)) {
+      safe[key] = sanitise(nestedValue, rule)
+      continue
+    }
+    if (rule && Array.isArray(nestedValue)) {
+      safe[key] = nestedValue.map((item) =>
+        isPlainObject(item) ? sanitise(item, rule) : item,
+      )
+      continue
+    }
+
+    safe[key] = nestedValue
+  }
+
+  return safe as T
+}


### PR DESCRIPTION
## Summary
- stop returning LDAP bind password ciphertext from configuration read actions
- add a reusable response sanitiser helper for secret-shaped fields
- cover the generic sanitiser and LDAP payload contract with unit tests

## Testing
- node --experimental-strip-types --test lib/response-sanitisation.test.mjs lib/ldap/config-client.test.mjs
- pnpm type-check

Fixes #368