### PR TITLE
fix(web): move host networks tab to infrastructure

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -77,42 +77,7 @@ import { listNetworksForHost, listNetworks, addHostToNetwork, removeHostFromNetw
 import type { HostGroup } from '@/lib/db/schema'
 import type { HostGroupWithCount } from '@/lib/actions/host-groups'
 import type { NetworkWithMembership, NetworkWithCount } from '@/lib/actions/networks'
-
-type ParentTabId = 'overview' | 'monitoring' | 'infrastructure' | 'inventory' | 'notes' | 'management' | 'tools'
-type Tab = 'overview' | 'storage' | 'network' | 'metrics' | 'checks' | 'alerts' | 'users' | 'settings' | 'groups' | 'host-networks' | 'tasks' | 'logs' | 'terminal' | 'packages' | 'notes'
-
-const TAB_LABELS: Record<Tab, string> = {
-  overview: 'Overview',
-  storage: 'Storage',
-  network: 'Network',
-  metrics: 'Metrics',
-  checks: 'Checks',
-  alerts: 'Alerts',
-  users: 'Users',
-  settings: 'Settings',
-  groups: 'Groups',
-  'host-networks': 'Networks',
-  tasks: 'Tasks',
-  logs: 'Logs',
-  terminal: 'Terminal',
-  packages: 'Packages',
-  notes: 'Notes',
-}
-
-const PARENT_TABS: Array<{
-  id: ParentTabId
-  label: string
-  defaultTab: Tab
-  children: Tab[] | null
-}> = [
-  { id: 'overview', label: 'Overview', defaultTab: 'overview', children: null },
-  { id: 'monitoring', label: 'Monitoring', defaultTab: 'metrics', children: ['metrics', 'checks', 'alerts'] },
-  { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network'] },
-  { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages'] },
-  { id: 'notes', label: 'Notes', defaultTab: 'notes', children: null },
-  { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'host-networks', 'settings'] },
-  { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
-]
+import { PARENT_TABS, TAB_LABELS, type ParentTabId, type Tab } from '@/lib/hosts/host-detail-tabs'
 
 interface Props {
   host: HostWithAgent

--- a/apps/web/lib/hosts/host-detail-tabs.test.mjs
+++ b/apps/web/lib/hosts/host-detail-tabs.test.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { PARENT_TABS } from './host-detail-tabs.ts'
+
+test('host network membership tab belongs under infrastructure', () => {
+  const infrastructure = PARENT_TABS.find((tab) => tab.id === 'infrastructure')
+  const management = PARENT_TABS.find((tab) => tab.id === 'management')
+
+  assert.ok(infrastructure)
+  assert.ok(management)
+  assert.ok(infrastructure.children?.includes('host-networks'))
+  assert.equal(management.children?.includes('host-networks'), false)
+})

--- a/apps/web/lib/hosts/host-detail-tabs.ts
+++ b/apps/web/lib/hosts/host-detail-tabs.ts
@@ -1,0 +1,58 @@
+export type ParentTabId =
+  | 'overview'
+  | 'monitoring'
+  | 'infrastructure'
+  | 'inventory'
+  | 'notes'
+  | 'management'
+  | 'tools'
+
+export type Tab =
+  | 'overview'
+  | 'storage'
+  | 'network'
+  | 'metrics'
+  | 'checks'
+  | 'alerts'
+  | 'users'
+  | 'settings'
+  | 'groups'
+  | 'host-networks'
+  | 'tasks'
+  | 'logs'
+  | 'terminal'
+  | 'packages'
+  | 'notes'
+
+export const TAB_LABELS: Record<Tab, string> = {
+  overview: 'Overview',
+  storage: 'Storage',
+  network: 'Network',
+  metrics: 'Metrics',
+  checks: 'Checks',
+  alerts: 'Alerts',
+  users: 'Users',
+  settings: 'Settings',
+  groups: 'Groups',
+  'host-networks': 'Networks',
+  tasks: 'Tasks',
+  logs: 'Logs',
+  terminal: 'Terminal',
+  packages: 'Packages',
+  notes: 'Notes',
+}
+
+export const PARENT_TABS: Array<{
+  id: ParentTabId
+  label: string
+  defaultTab: Tab
+  children: Tab[] | null
+}> = [
+  { id: 'overview', label: 'Overview', defaultTab: 'overview', children: null },
+  { id: 'monitoring', label: 'Monitoring', defaultTab: 'metrics', children: ['metrics', 'checks', 'alerts'] },
+  { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network', 'host-networks'] },
+  { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages'] },
+  { id: 'notes', label: 'Notes', defaultTab: 'notes', children: null },
+  { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'settings'] },
+  { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
+]


### PR DESCRIPTION
## Summary

- Moves the host network membership sub-tab from Management into Infrastructure on the host detail screen.
- Extracts host detail tab metadata into a small shared module so placement is covered by a focused unit test.

## Validation

- `node --experimental-strip-types --test lib/hosts/host-detail-tabs.test.mjs`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint` (passes with existing warnings)
- `pnpm --dir apps/web test:unit`

## Notes

- This is a navigation-only UI change; no backend behavior or authorization paths changed.