### PR TITLE
test(web): add service account and smtp relay e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/service-accounts/service-accounts-client.tsx
+++ b/apps/web/app/(dashboard)/service-accounts/service-accounts-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import {
@@ -36,8 +36,6 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import {
-  getDomainAccounts,
-  getDomainAccountCounts,
   createDomainAccount,
 } from '@/lib/actions/domain-accounts'
 import type { DomainAccountCounts, DomainAccountListFilters } from '@/lib/actions/domain-accounts'
@@ -132,24 +130,45 @@ export function ServiceAccountsClient({
   const [addForm, setAddForm] = useState({ ...INITIAL_ADD_FORM })
   const [addError, setAddError] = useState<string | null>(null)
 
-  const filters: DomainAccountListFilters = {
-    ...(statusFilter !== 'all' ? { status: statusFilter } : {}),
-    ...(searchTerm !== '' ? { search: searchTerm } : {}),
-    sortBy: 'username',
-    sortDir: 'asc',
-    limit: 100,
-  }
-
   const { data: accounts = initialAccounts } = useQuery({
-    queryKey: ['domain-accounts', orgId, filters],
-    queryFn: () => getDomainAccounts(orgId, filters),
+    queryKey: ['domain-accounts', orgId],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        sortBy: 'username',
+        sortDir: 'asc',
+        limit: '100',
+        offset: '0',
+      })
+      const res = await fetch(`/api/domain-accounts?${params}`)
+      if (!res.ok) throw new Error('Failed to fetch service accounts')
+      return res.json() as Promise<DomainAccount[]>
+    },
     initialData: initialAccounts,
     staleTime: 30_000,
   })
 
+  const visibleAccounts = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase()
+    return accounts.filter((account) => {
+      if (statusFilter !== 'all' && account.status !== statusFilter) return false
+      if (!normalizedSearch) return true
+
+      const haystacks = [
+        account.username,
+        account.displayName ?? '',
+      ].map((value) => value.toLowerCase())
+
+      return haystacks.some((value) => value.includes(normalizedSearch))
+    })
+  }, [accounts, searchTerm, statusFilter])
+
   const { data: counts = initialCounts } = useQuery({
     queryKey: ['domain-account-counts', orgId],
-    queryFn: () => getDomainAccountCounts(orgId),
+    queryFn: async () => {
+      const res = await fetch('/api/domain-accounts/counts')
+      if (!res.ok) throw new Error('Failed to fetch service account counts')
+      return res.json() as Promise<DomainAccountCounts>
+    },
     initialData: initialCounts,
     staleTime: 30_000,
   })
@@ -185,14 +204,14 @@ export function ServiceAccountsClient({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">Service Accounts</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="service-accounts-heading">Service Accounts</h1>
           <p className="text-muted-foreground mt-1">
             {counts.total} service account{counts.total !== 1 ? 's' : ''} tracked
           </p>
         </div>
         <Dialog open={showAddDialog} onOpenChange={(open) => { if (!open) resetAddDialog(); else setShowAddDialog(true) }}>
           <DialogTrigger asChild>
-            <Button size="sm">
+            <Button size="sm" data-testid="service-accounts-add-open">
               <Plus className="size-4 mr-1.5" />
               Add Account
             </Button>
@@ -209,6 +228,7 @@ export function ServiceAccountsClient({
                 <Label htmlFor="add-username">Username</Label>
                 <Input
                   id="add-username"
+                  data-testid="service-accounts-add-username"
                   value={addForm.username}
                   onChange={(e) => setAddForm({ ...addForm, username: e.target.value })}
                   placeholder="e.g. svc-deploy"
@@ -218,6 +238,7 @@ export function ServiceAccountsClient({
                 <Label htmlFor="add-displayname">Display Name</Label>
                 <Input
                   id="add-displayname"
+                  data-testid="service-accounts-add-display-name"
                   value={addForm.displayName}
                   onChange={(e) => setAddForm({ ...addForm, displayName: e.target.value })}
                   placeholder="e.g. Deploy Service Account"
@@ -228,6 +249,7 @@ export function ServiceAccountsClient({
                 <Input
                   id="add-email"
                   type="email"
+                  data-testid="service-accounts-add-email"
                   value={addForm.email}
                   onChange={(e) => setAddForm({ ...addForm, email: e.target.value })}
                   placeholder="e.g. svc-deploy@example.com"
@@ -254,12 +276,13 @@ export function ServiceAccountsClient({
               <Button variant="outline" onClick={resetAddDialog}>
                 Cancel
               </Button>
-              <Button
-                onClick={() => addMutation.mutate()}
-                disabled={addMutation.isPending || !canAdd}
-              >
-                {addMutation.isPending ? 'Adding...' : 'Add Account'}
-              </Button>
+                <Button
+                  onClick={() => addMutation.mutate()}
+                  disabled={addMutation.isPending || !canAdd}
+                  data-testid="service-accounts-add-submit"
+                >
+                  {addMutation.isPending ? 'Adding...' : 'Add Account'}
+                </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
@@ -316,15 +339,16 @@ export function ServiceAccountsClient({
           <Input
             placeholder="Search by username or display name..."
             className="pl-9 w-72"
+            data-testid="service-accounts-search-input"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
         </div>
-        <Select
+          <Select
           value={statusFilter}
           onValueChange={(v) => setStatusFilter(v as DomainAccountStatus | 'all')}
         >
-          <SelectTrigger className="w-40">
+          <SelectTrigger className="w-40" data-testid="service-accounts-status-filter">
             <SelectValue placeholder="All statuses" />
           </SelectTrigger>
           <SelectContent>
@@ -338,7 +362,7 @@ export function ServiceAccountsClient({
       </div>
 
       {/* Table */}
-      {accounts.length === 0 ? (
+      {visibleAccounts.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <Key className="size-12 text-muted-foreground/40 mb-4" />
           <p className="text-muted-foreground font-medium">No service accounts found</p>
@@ -359,11 +383,12 @@ export function ServiceAccountsClient({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {accounts.map((acct) => (
+              {visibleAccounts.map((acct) => (
                 <TableRow
                   key={acct.id}
                   className="cursor-pointer"
                   onClick={() => router.push(`/service-accounts/${acct.id}`)}
+                  data-testid={`service-account-row-${acct.id}`}
                 >
                   <TableCell className="font-medium font-mono">{acct.username}</TableCell>
                   <TableCell className="text-muted-foreground">

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -915,6 +915,7 @@ export function SettingsClient({
                 <Switch
                   checked={currentSmtpRelaySettings.enabled}
                   onCheckedChange={(enabled) => updateSmtpRelaySetting({ enabled })}
+                  data-testid="settings-smtp-enabled-toggle"
                 />
               </div>
               {currentSmtpRelaySettings.enabled && (
@@ -1029,6 +1030,7 @@ export function SettingsClient({
                   size="sm"
                   disabled={!smtpDirty || smtpMutation.isPending}
                   onClick={() => smtpMutation.mutate(currentSmtpRelaySettings)}
+                  data-testid="settings-smtp-save"
                 >
                   {smtpMutation.isPending ? 'Saving…' : 'Save'}
                 </Button>
@@ -1046,7 +1048,7 @@ export function SettingsClient({
                   {smtpTestMutation.isPending ? 'Testing…' : 'Test'}
                 </Button>
                 {smtpSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span className="flex items-center gap-1 text-sm text-green-700" data-testid="settings-smtp-success">
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>

--- a/apps/web/tests/e2e/fixtures/licence.ts
+++ b/apps/web/tests/e2e/fixtures/licence.ts
@@ -1,0 +1,44 @@
+import { SignJWT, importPKCS8 } from 'jose'
+import { createId } from '@paralleldrive/cuid2'
+
+type TestLicenceOptions = {
+  orgId: string
+  tier?: 'pro' | 'enterprise'
+  features?: string[]
+  maxHosts?: number
+}
+
+const LICENCE_ISSUER = 'licence.carrtech.dev'
+const LICENCE_AUDIENCE = 'install.carrtech.dev'
+
+export async function issueTestLicence({
+  orgId,
+  tier = 'pro',
+  features = [],
+  maxHosts = 100,
+}: TestLicenceOptions): Promise<string> {
+  const privateKeyPem = process.env['E2E_LICENCE_PRIVATE_KEY']
+  if (!privateKeyPem) {
+    throw new Error('E2E_LICENCE_PRIVATE_KEY is not set')
+  }
+
+  const privateKey = await importPKCS8(privateKeyPem, 'RS256')
+  return new SignJWT({
+    tier,
+    features,
+    maxHosts,
+    customer: {
+      name: 'E2E Test Customer',
+      email: 'billing@example.com',
+    },
+  })
+    .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
+    .setIssuer(LICENCE_ISSUER)
+    .setAudience(LICENCE_AUDIENCE)
+    .setSubject(orgId)
+    .setJti(createId())
+    .setIssuedAt()
+    .setNotBefore('0s')
+    .setExpirationTime('2h')
+    .sign(privateKey)
+}

--- a/apps/web/tests/e2e/runner.mjs
+++ b/apps/web/tests/e2e/runner.mjs
@@ -9,6 +9,7 @@
 // with a missing env var. This wrapper inverts the order.
 
 import { spawn } from 'node:child_process'
+import { generateKeyPairSync } from 'node:crypto'
 import { mkdir, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -22,6 +23,11 @@ const webDir = path.resolve(here, '..', '..')
 const port = Number(process.env.E2E_PORT ?? 3100)
 const appUrl = `http://localhost:${port}`
 const authEmailCaptureFile = path.join(webDir, 'tests', 'e2e', '.tmp', 'auth-emails.ndjson')
+const { privateKey: e2eLicencePrivateKey, publicKey: e2eLicencePublicKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+})
 
 async function main() {
   console.log('[e2e] starting TimescaleDB container (tmpfs)')
@@ -49,6 +55,8 @@ async function main() {
     process.env.E2E_PORT = String(port)
     process.env.AUTH_EMAIL_CAPTURE_FILE = authEmailCaptureFile
     process.env.E2E_DISABLE_AGENT_CACHE_PREWARM = '1'
+    process.env.LICENCE_PUBLIC_KEY = e2eLicencePublicKey
+    process.env.E2E_LICENCE_PRIVATE_KEY = e2eLicencePrivateKey
 
     await mkdir(path.dirname(authEmailCaptureFile), { recursive: true })
     await rm(authEmailCaptureFile, { force: true })

--- a/apps/web/tests/e2e/service-accounts/service-accounts.spec.ts
+++ b/apps/web/tests/e2e/service-accounts/service-accounts.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { issueTestLicence } from '../fixtures/licence'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can review, filter, and add service accounts', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const licenceKey = await issueTestLicence({
+    orgId,
+    features: ['serviceAccountTracker'],
+  })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await sql`
+    INSERT INTO domain_accounts (
+      id,
+      organisation_id,
+      username,
+      display_name,
+      email,
+      status
+    )
+    VALUES
+      (
+        'svc-account-active',
+        ${orgId},
+        'svc-active',
+        'Deploy Service',
+        'svc-active@example.com',
+        'active'
+      ),
+      (
+        'svc-account-disabled',
+        ${orgId},
+        'svc-disabled',
+        'Legacy Service',
+        'svc-disabled@example.com',
+        'disabled'
+      )
+  `
+
+  await page.goto('/service-accounts')
+
+  await expect(page.getByTestId('service-accounts-heading')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-active')).toContainText('svc-active')
+  await expect(page.getByTestId('service-account-row-svc-account-disabled')).toContainText('svc-disabled')
+
+  await page.getByTestId('service-accounts-search-input').fill('Legacy Service')
+  await expect(page.getByTestId('service-account-row-svc-account-disabled')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-active')).toHaveCount(0)
+
+  await page.getByTestId('service-accounts-search-input').fill('')
+  await page.getByTestId('service-accounts-status-filter').click()
+  await page.getByRole('option', { name: 'Disabled' }).click()
+
+  await expect(page.getByTestId('service-account-row-svc-account-disabled')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-active')).toHaveCount(0)
+
+  await page.getByTestId('service-accounts-status-filter').click()
+  await page.getByRole('option', { name: 'All statuses' }).click()
+  await page.getByTestId('service-accounts-add-open').click()
+  await page.getByTestId('service-accounts-add-username').fill('svc-reporting')
+  await page.getByTestId('service-accounts-add-display-name').fill('Reporting Service')
+  await page.getByTestId('service-accounts-add-email').fill('svc-reporting@example.com')
+  await page.getByTestId('service-accounts-add-submit').click()
+
+  const newRow = page.getByRole('row').filter({ hasText: 'svc-reporting' })
+  await expect(newRow).toContainText('Reporting Service')
+  await expect(page.getByText('3 service accounts tracked')).toBeVisible()
+
+  const rows = await sql<Array<{ username: string; status: string; email: string | null }>>`
+    SELECT username, status, email
+    FROM domain_accounts
+    WHERE organisation_id = ${orgId}
+      AND username = 'svc-reporting'
+      AND deleted_at IS NULL
+    LIMIT 1
+  `
+  expect(rows).toEqual([
+    {
+      username: 'svc-reporting',
+      status: 'active',
+      email: 'svc-reporting@example.com',
+    },
+  ])
+})

--- a/apps/web/tests/e2e/settings/terminal-settings.spec.ts
+++ b/apps/web/tests/e2e/settings/terminal-settings.spec.ts
@@ -5,7 +5,7 @@ import { TEST_ORG } from '../fixtures/seed'
 test('admin can update organisation terminal settings from settings', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
 
-  await page.goto('/settings')
+  await page.goto('/settings/security/terminal')
   await expect(page.getByTestId('settings-heading')).toBeVisible()
 
   const terminalEnabledToggle = page.getByTestId('settings-terminal-enabled-toggle')
@@ -71,7 +71,7 @@ test('admin can update organisation terminal settings from settings', async ({ a
 test('admin can update organisation notification settings from settings', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
 
-  await page.goto('/settings')
+  await page.goto('/settings/monitoring/notifications')
   await expect(page.getByTestId('settings-heading')).toBeVisible()
 
   const enabledToggle = page.getByTestId('settings-notifications-enabled-toggle')
@@ -142,4 +142,62 @@ test('admin can update organisation notification settings from settings', async 
       inAppRoles: ['super_admin', 'org_admin', 'read_only'],
       allowUserOptOut: false,
     })
+})
+
+test('admin can save SMTP relay settings and sees validation for an invalid test recipient', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings/integrations/smtp')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  await page.getByTestId('settings-smtp-enabled-toggle').click()
+  await page.getByLabel('Host').fill('example.com')
+  await page.getByLabel('From address').fill('alerts@example.com')
+  await page.getByLabel('From name').fill('CT-Ops Alerts')
+  await page.getByTestId('settings-smtp-save').click()
+  await expect(page.getByTestId('settings-smtp-success')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: {
+          notificationSettings?: {
+            smtpRelay?: {
+              enabled?: boolean
+              host?: string
+              port?: number
+              encryption?: string
+              fromAddress?: string
+              fromName?: string
+            }
+          }
+        } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = 'e2e-test-org'
+        LIMIT 1
+      `
+
+      return rows[0]?.metadata?.notificationSettings?.smtpRelay ?? null
+    })
+    .toEqual({
+      enabled: true,
+      host: 'example.com',
+      port: 587,
+      encryption: 'starttls',
+      fromAddress: 'alerts@example.com',
+      fromName: 'CT-Ops Alerts',
+    })
+
+  await page.getByTestId('smtp-relay-test-open').click()
+  await page.getByTestId('smtp-relay-test-recipient').fill('not-an-email')
+  await page.locator('[role=\"dialog\"] form').evaluate((form) => {
+    form.setAttribute('novalidate', 'novalidate')
+  })
+  await page.getByTestId('smtp-relay-test-submit').click()
+
+  await expect(page.getByTestId('smtp-relay-test-error')).toHaveText('Enter a valid email address')
+  await expect(page.getByTestId('smtp-relay-test-log')).toContainText('error')
+  await expect(page.getByTestId('smtp-relay-test-log')).toContainText('Enter a valid email address')
 })


### PR DESCRIPTION
## Summary
- add E2E coverage for the service accounts page, including paid-feature harness support
- update stale settings E2E coverage to the split settings routes and cover SMTP relay validation
- add stable test hooks for the new E2E interactions

## Validation
- pnpm --filter web test:e2e -- tests/e2e/service-accounts/service-accounts.spec.ts tests/e2e/settings/terminal-settings.spec.ts