### PR TITLE
test(web): add agent enrolment and service account detail e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/service-accounts/[id]/service-account-detail-client.tsx
+++ b/apps/web/app/(dashboard)/service-accounts/[id]/service-account-detail-client.tsx
@@ -146,9 +146,11 @@ export function ServiceAccountDetailClient({
         <div className="flex-1">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-semibold text-foreground font-mono">
-              {account.username}
+              <span data-testid="service-account-detail-heading">{account.username}</span>
             </h1>
-            <StatusBadge status={account.status as DomainAccountStatus} />
+            <span data-testid="service-account-detail-status">
+              <StatusBadge status={account.status as DomainAccountStatus} />
+            </span>
           </div>
           {account.displayName && (
             <p className="text-muted-foreground mt-1">{account.displayName}</p>
@@ -159,13 +161,19 @@ export function ServiceAccountDetailClient({
             variant="outline"
             size="sm"
             onClick={() => setEditing(!editing)}
+            data-testid="service-account-edit-open"
           >
             <Pencil className="size-4 mr-1.5" />
             Edit
           </Button>
           <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
             <DialogTrigger asChild>
-              <Button variant="outline" size="sm" className="text-destructive hover:text-destructive">
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                data-testid="service-account-delete-open"
+              >
                 <Trash2 className="size-4 mr-1.5" />
                 Delete
               </Button>
@@ -183,6 +191,7 @@ export function ServiceAccountDetailClient({
                   variant="destructive"
                   onClick={() => deleteMutation.mutate()}
                   disabled={deleteMutation.isPending}
+                  data-testid="service-account-delete-confirm"
                 >
                   {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
                 </Button>
@@ -204,6 +213,7 @@ export function ServiceAccountDetailClient({
               <Input
                 value={editForm.displayName}
                 onChange={(e) => setEditForm({ ...editForm, displayName: e.target.value })}
+                data-testid="service-account-edit-display-name"
               />
             </div>
             <div className="space-y-1.5">
@@ -212,6 +222,7 @@ export function ServiceAccountDetailClient({
                 type="email"
                 value={editForm.email}
                 onChange={(e) => setEditForm({ ...editForm, email: e.target.value })}
+                data-testid="service-account-edit-email"
               />
             </div>
             <div className="space-y-1.5">
@@ -220,7 +231,7 @@ export function ServiceAccountDetailClient({
                 value={editForm.status}
                 onValueChange={(v) => setEditForm({ ...editForm, status: v as DomainAccountStatus })}
               >
-                <SelectTrigger className="w-48">
+                <SelectTrigger className="w-48" data-testid="service-account-edit-status">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -237,6 +248,7 @@ export function ServiceAccountDetailClient({
                 type="date"
                 value={editForm.passwordExpiresAt}
                 onChange={(e) => setEditForm({ ...editForm, passwordExpiresAt: e.target.value })}
+                data-testid="service-account-edit-password-expiry"
               />
               <p className="text-xs text-muted-foreground">
                 Leave blank if the password doesn&apos;t expire.
@@ -247,6 +259,7 @@ export function ServiceAccountDetailClient({
                 size="sm"
                 onClick={() => updateMutation.mutate()}
                 disabled={updateMutation.isPending}
+                data-testid="service-account-edit-save"
               >
                 {updateMutation.isPending ? 'Saving...' : 'Save'}
               </Button>

--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -182,7 +182,7 @@ export function AgentsSettingsClient({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-foreground">Agent Enrolment</h1>
+        <h1 className="text-2xl font-semibold text-foreground" data-testid="agent-enrolment-heading">Agent Enrolment</h1>
         <p className="text-muted-foreground mt-1">
           Manage enrolment tokens used to register new agents with your organisation.
         </p>
@@ -205,7 +205,7 @@ export function AgentsSettingsClient({
               <Package className="size-4 mr-1" />
               Download Install Bundle
             </Button>
-            <Button size="sm" onClick={() => setShowCreateDialog(true)}>
+            <Button size="sm" onClick={() => setShowCreateDialog(true)} data-testid="agent-enrolment-create-open">
               <Plus className="size-4 mr-1" />
               New Token
             </Button>
@@ -238,7 +238,7 @@ export function AgentsSettingsClient({
                   const status = tokenStatus(token)
                   const isActive = status.label === 'Active'
                   return (
-                    <TableRow key={token.id}>
+                    <TableRow key={token.id} data-testid="agent-enrolment-row">
                       <TableCell className="font-medium">{token.label}</TableCell>
                       <TableCell>
                         <div className="flex items-center gap-1">
@@ -284,6 +284,7 @@ export function AgentsSettingsClient({
                             className="text-red-600 hover:text-red-700 hover:bg-red-50 h-7"
                             onClick={() => revokeMutation.mutate(token.id)}
                             disabled={revokeMutation.isPending}
+                            data-testid="agent-enrolment-revoke"
                           >
                             <Trash2 className="size-3.5 mr-1" />
                             Revoke
@@ -353,8 +354,8 @@ export function AgentsSettingsClient({
                 Token created. Run this command on each server you want to enrol:
               </p>
 
-              <div className="flex items-start gap-2 p-3 bg-muted rounded-md">
-                <code className="text-xs font-mono flex-1 break-all leading-relaxed">
+                <div className="flex items-start gap-2 p-3 bg-muted rounded-md">
+                <code className="text-xs font-mono flex-1 break-all leading-relaxed" data-testid="agent-enrolment-install-command">
                   {newInstallCommand}
                 </code>
                 <CopyButton text={newInstallCommand} />
@@ -366,7 +367,7 @@ export function AgentsSettingsClient({
                 </summary>
                 <div className="mt-2 space-y-1">
                   <div className="flex items-center gap-2 p-3 bg-muted rounded-md">
-                    <code className="text-xs font-mono flex-1 break-all">{newTokenValue}</code>
+                    <code className="text-xs font-mono flex-1 break-all" data-testid="agent-enrolment-raw-token">{newTokenValue}</code>
                     <CopyButton text={newTokenValue} />
                   </div>
                   <p className="text-xs text-muted-foreground">
@@ -382,6 +383,7 @@ export function AgentsSettingsClient({
                     setNewTokenValue(null)
                     setNewInstallCommand(null)
                   }}
+                  data-testid="agent-enrolment-create-done"
                 >
                   Done
                 </Button>
@@ -394,6 +396,7 @@ export function AgentsSettingsClient({
                 <Input
                   id="label"
                   placeholder="e.g. Production servers"
+                  data-testid="agent-enrolment-label"
                   {...register('label')}
                 />
                 {errors.label && (
@@ -408,6 +411,7 @@ export function AgentsSettingsClient({
                   className="h-4 w-4 rounded border-border"
                   checked={autoApprove}
                   onChange={(e) => setValue('autoApprove', e.target.checked)}
+                  data-testid="agent-enrolment-auto-approve"
                 />
                 <div>
                   <Label htmlFor="autoApprove" className="font-normal cursor-pointer">
@@ -427,6 +431,7 @@ export function AgentsSettingsClient({
                   className="h-4 w-4 rounded border-border"
                   checked={skipVerify}
                   onChange={(e) => setValue('skipVerify', e.target.checked)}
+                  data-testid="agent-enrolment-skip-verify"
                 />
                 <div>
                   <Label htmlFor="skipVerify" className="font-normal cursor-pointer">
@@ -445,6 +450,7 @@ export function AgentsSettingsClient({
                     id="maxUses"
                     type="number"
                     min="1"
+                    data-testid="agent-enrolment-max-uses"
                     {...register('maxUses')}
                   />
                 </div>
@@ -454,6 +460,7 @@ export function AgentsSettingsClient({
                     id="expiresInDays"
                     type="number"
                     min="1"
+                    data-testid="agent-enrolment-expires-days"
                     {...register('expiresInDays')}
                   />
                 </div>
@@ -476,7 +483,7 @@ export function AgentsSettingsClient({
                 <Button type="button" variant="outline" onClick={() => setShowCreateDialog(false)}>
                   Cancel
                 </Button>
-                <Button type="submit" disabled={createMutation.isPending}>
+                <Button type="submit" disabled={createMutation.isPending} data-testid="agent-enrolment-create-submit">
                   {createMutation.isPending ? (
                     <>
                       <RefreshCw className="size-3.5 mr-1 animate-spin" />

--- a/apps/web/tests/e2e/service-accounts/service-accounts.spec.ts
+++ b/apps/web/tests/e2e/service-accounts/service-accounts.spec.ts
@@ -102,3 +102,105 @@ test('admin can review, filter, and add service accounts', async ({ authenticate
     },
   ])
 })
+
+test('admin can update and delete a service account from the detail page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  const licenceKey = await issueTestLicence({
+    orgId,
+    features: ['serviceAccountTracker'],
+  })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await sql`
+    INSERT INTO domain_accounts (
+      id,
+      organisation_id,
+      username,
+      display_name,
+      email,
+      status,
+      password_expires_at
+    )
+    VALUES (
+      'svc-account-detail',
+      ${orgId},
+      'svc-detail',
+      'Ops Service',
+      'ops-service@example.com',
+      'active',
+      DATE '2026-05-01'
+    )
+  `
+
+  await page.goto('/service-accounts')
+  await page.getByTestId('service-account-row-svc-account-detail').click()
+
+  await expect(page).toHaveURL(/\/service-accounts\/svc-account-detail$/)
+  await expect(page.getByTestId('service-account-detail-heading')).toContainText('svc-detail')
+  await expect(page.getByText('Ops Service')).toBeVisible()
+
+  await page.getByTestId('service-account-edit-open').click()
+  await page.getByTestId('service-account-edit-display-name').fill('Ops Service Updated')
+  await page.getByTestId('service-account-edit-email').fill('ops-updated@example.com')
+  await page.getByTestId('service-account-edit-status').click()
+  await page.getByRole('option', { name: 'Disabled' }).click()
+  await page.getByTestId('service-account-edit-password-expiry').fill('2026-06-15')
+  await page.getByTestId('service-account-edit-save').click()
+
+  await expect(page.getByText('Ops Service Updated')).toBeVisible()
+  await expect(page.getByText('ops-updated@example.com')).toBeVisible()
+  await expect(page.getByTestId('service-account-detail-status')).toContainText('Disabled')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        display_name: string | null
+        email: string | null
+        status: string
+        password_expires_at: string | null
+      }>>`
+        SELECT
+          display_name,
+          email,
+          status,
+          password_expires_at::text
+        FROM domain_accounts
+        WHERE id = 'svc-account-detail'
+        LIMIT 1
+      `
+
+      return rows[0] ?? null
+    })
+    .toEqual({
+      display_name: 'Ops Service Updated',
+      email: 'ops-updated@example.com',
+      status: 'disabled',
+      password_expires_at: '2026-06-15 00:00:00+00',
+    })
+
+  await page.getByTestId('service-account-delete-open').click()
+  await page.getByTestId('service-account-delete-confirm').click()
+
+  await expect(page).toHaveURL(/\/service-accounts$/)
+  await expect(page.getByTestId('service-account-row-svc-account-detail')).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM domain_accounts
+        WHERE id = 'svc-account-detail'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .toBeTruthy()
+})

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('admin can create and revoke an enrolment token from agent settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await page.goto('/settings/agents')
+
+  await expect(page.getByTestId('agent-enrolment-heading')).toBeVisible()
+  await page.getByTestId('agent-enrolment-create-open').click()
+
+  await page.getByTestId('agent-enrolment-label').fill('Datacenter Linux')
+  await page.getByTestId('agent-enrolment-skip-verify').click()
+  await page.getByTestId('agent-enrolment-max-uses').fill('3')
+  await page.getByTestId('agent-enrolment-expires-days').fill('14')
+  await page.getByTestId('agent-enrolment-create-submit').click()
+
+  const installCommand = page.getByTestId('agent-enrolment-install-command')
+  await expect(installCommand).toContainText('/api/agent/install?token=')
+  await expect(installCommand).not.toContainText('skip_verify=true')
+
+  await page.getByText('Show raw token (for manual config)').click()
+  const rawToken = (await page.getByTestId('agent-enrolment-raw-token').textContent())?.trim()
+  expect(rawToken).toBeTruthy()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        id: string
+        label: string
+        created_by_id: string
+        auto_approve: boolean
+        skip_verify: boolean
+        max_uses: number | null
+        usage_count: number
+        token: string
+        token_hash: string | null
+      }>>`
+        SELECT
+          id,
+          label,
+          created_by_id,
+          auto_approve,
+          skip_verify,
+          max_uses,
+          usage_count,
+          token,
+          token_hash
+        FROM agent_enrolment_tokens
+        WHERE organisation_id = ${orgId}
+          AND label = 'Datacenter Linux'
+        LIMIT 1
+      `
+
+      return rows[0] ?? null
+    })
+    .toMatchObject({
+      label: 'Datacenter Linux',
+      created_by_id: userId,
+      auto_approve: false,
+      skip_verify: false,
+      max_uses: 3,
+      usage_count: 0,
+      token: rawToken,
+    })
+
+  await page.getByTestId('agent-enrolment-create-done').click()
+
+  const tokenRow = page.getByTestId('agent-enrolment-row').filter({ hasText: 'Datacenter Linux' })
+  await expect(tokenRow).toContainText('0 / 3')
+  await expect(tokenRow).toContainText('Active')
+
+  await tokenRow.getByTestId('agent-enrolment-revoke').click()
+  await expect(tokenRow).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM agent_enrolment_tokens
+        WHERE organisation_id = ${orgId}
+          AND label = 'Datacenter Linux'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .toBeTruthy()
+})


### PR DESCRIPTION
## Summary\n- add E2E coverage for agent enrolment token creation and revocation\n- expand service account E2E coverage to exercise the detail page edit and delete flows\n- add stable test ids for the new E2E interactions\n\n## Testing\n- pnpm --filter web test:e2e -- tests/e2e/settings/agent-enrolment.spec.ts tests/e2e/service-accounts/service-accounts.spec.ts