### PR TITLE
fix(web): centralise authz guards

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 68 — Centralised authz guards
+
+**Shared authz guard layer** (`apps/web/lib/auth/guards.ts`, `apps/web/lib/actions/`, `apps/web/lib/eslint/`, `SECURITY.md`)
+- Added shared web authz helpers for active-user, same-org, admin-role, and writable-role checks so role and organisation enforcement lives in one place instead of being reimplemented ad hoc across server actions.
+- Migrated the remaining raw `session.user` authorisation checks in org settings, networks, notes, certificates, terminal, task schedules, software inventory, notifications, users, and security actions onto the shared helpers or the existing `requireOrgAccess` / `requireOrgAdminAccess` wrappers.
+- Added a local ESLint rule that rejects direct `session.user.organisationId` / `session.user.role` comparisons and role-list `includes()` checks in web auth/action code, and marked security finding `I-10` complete.
+
+**Validation**
+- Added focused unit coverage for the new guards and the new ESLint rule.
+- Validation run: `pnpm --filter web exec node --experimental-strip-types --test lib/actions/action-auth.test.mjs lib/auth/guards.test.mjs lib/eslint/no-single-table-select.test.mjs lib/eslint/no-raw-session-checks.test.mjs`, `pnpm --filter web exec eslint lib/actions/users.ts lib/actions/security.ts lib/actions/notification-settings.ts lib/actions/settings.ts lib/actions/networks.ts lib/actions/software-inventory.ts lib/actions/terminal.ts lib/actions/task-schedules.ts lib/actions/notes.ts lib/actions/notes-resolver.ts lib/actions/certificates.ts lib/actions/action-auth-core.ts lib/auth/guards.ts lib/eslint/no-raw-session-checks.mjs lib/eslint/no-raw-session-checks.test.mjs`, and `pnpm --filter web type-check`.
+
 ### Session 67 — Administration information architecture
 
 **Administration layout** (`apps/web/components/shared/sidebar.tsx`, `apps/web/app/(dashboard)/settings/`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -446,7 +446,7 @@ Severity key: **C**ritical / **H**igh / **M**edium / **L**ow / **I**nfo.
 - [ ] **[I-07] Mixed query styles (`db.query.X.findMany` vs. `db.select().from(X)`) complicate audits**
 - [ ] **[I-08] Consider Row-Level Security (RLS) in Postgres scoped on `organisation_id`** — defence in depth should any server-side check miss its org filter
 - [ ] **[I-09] Response sanitisation layer** — generic utility for stripping secret-shaped fields before returning
-- [ ] **[I-10] Centralised authz helpers** — `requireRole('org_admin')`, `requireSameOrg(session, resource)` — to reduce the number of repeated (and repeatedly forgotten) checks
+- [x] **[I-10] Centralised authz helpers** — shared guards now enforce role/org checks and ESLint flags raw `session.user` authz comparisons in web actions
 
 ---
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -26,6 +26,15 @@ const eslintConfig = defineConfig([
     },
   },
   {
+    files: ["lib/actions/**/*.ts", "lib/auth/**/*.ts"],
+    plugins: {
+      local: localRules,
+    },
+    rules: {
+      "local/no-raw-session-checks": "error",
+    },
+  },
+  {
     // Playwright fixtures use a `use()` callback that the react-hooks plugin
     // mistakes for React's `use()` hook. Disable that rule inside the e2e
     // suite — no React code lives here.

--- a/apps/web/lib/actions/action-auth-core.ts
+++ b/apps/web/lib/actions/action-auth-core.ts
@@ -1,3 +1,5 @@
+import { requireOrgAdmin, requireSameOrg } from '../auth/guards.ts'
+
 export type OrgScopedUser = {
   organisationId: string | null
   isActive: boolean
@@ -9,19 +11,9 @@ export type OrgAdminScopedUser = OrgScopedUser & {
 }
 
 export function assertOrgAccess(user: OrgScopedUser, orgId: string): void {
-  if (!user.isActive || user.deletedAt) {
-    throw new Error('forbidden: inactive user')
-  }
-
-  if (user.organisationId !== orgId) {
-    throw new Error('forbidden: organisation mismatch')
-  }
+  requireSameOrg(user, orgId)
 }
 
 export function assertOrgAdminAccess(user: OrgAdminScopedUser, orgId: string): void {
-  assertOrgAccess(user, orgId)
-
-  if (user.role !== 'org_admin' && user.role !== 'super_admin') {
-    throw new Error('forbidden: admin role required')
-  }
+  requireOrgAdmin(user, orgId)
 }

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -7,8 +7,9 @@ import { db } from '@/lib/db'
 import { certificates, certificateEvents } from '@/lib/db/schema'
 import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm'
 import type { Certificate, CertificateEvent, CertificateStatus, CertificateDetails } from '@/lib/db/schema'
-import { getRequiredSession } from '@/lib/auth/session'
 import { requireFeature } from '@/lib/actions/licence-guard'
+import { hasRole } from '@/lib/auth/guards'
+import { MEMBERSHIP_ROLES } from '@/lib/auth/roles'
 import { escapeLikePattern } from '@/lib/utils'
 import { computeExpiryStatus } from '@/lib/certificates/expiry'
 import {
@@ -144,12 +145,8 @@ export async function deleteCertificate(
   orgId: string,
   certId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) {
-    return { error: 'Organisation mismatch' }
-  }
-  if (session.user.role === 'read_only') {
+  const session = await requireOrgAccess(orgId)
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) {
     return { error: 'Insufficient permissions to delete certificates' }
   }
 
@@ -272,10 +269,6 @@ export async function trackCertificateFromUrl(
 ): Promise<TrackCertificateResult> {
   await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) {
-    return { error: 'Organisation mismatch' }
-  }
   if (!await trackFromUrlLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before adding more certificates.' }
   }
@@ -369,10 +362,6 @@ export async function trackCertificateFromUpload(
 ): Promise<TrackCertificateResult> {
   await requireOrgAccess(orgId)
   await requireFeature(orgId, 'certExpiryTracker')
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) {
-    return { error: 'Organisation mismatch' }
-  }
 
   const parsed = trackFromUploadSchema.safeParse(input)
   if (!parsed.success) {

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -1,15 +1,16 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import { networks, hostNetworkMemberships, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, sql } from 'drizzle-orm'
 import { z } from 'zod'
+import { hasRole } from '@/lib/auth/guards'
 import { getRequiredSession } from '@/lib/auth/session'
 import type { Network, Host } from '@/lib/db/schema'
-import { ADMIN_ROLES, MEMBERSHIP_ROLES } from '@/lib/auth/roles'
+import { MEMBERSHIP_ROLES } from '@/lib/auth/roles'
 
 export type NetworkWithCount = Network & { hostCount: number }
 export type NetworkWithMembership = Network & { autoAssigned: boolean }
@@ -66,9 +67,9 @@ export async function createNetwork(
   orgId: string,
   data: { name: string; cidr: string; description?: string },
 ): Promise<{ success: true; network: Network } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -101,9 +102,9 @@ export async function updateNetwork(
   networkId: string,
   data: { name: string; cidr: string; description?: string },
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -136,9 +137,9 @@ export async function deleteNetwork(
   orgId: string,
   networkId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -179,7 +180,7 @@ export async function addHostToNetwork(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   const session = await getRequiredSession()
-  if (!MEMBERSHIP_ROLES.includes(session.user.role)) {
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -222,7 +223,7 @@ export async function removeHostFromNetwork(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   const session = await getRequiredSession()
-  if (!MEMBERSHIP_ROLES.includes(session.user.role)) {
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) {
     return { error: 'You do not have permission to perform this action' }
   }
 

--- a/apps/web/lib/actions/notes-resolver.ts
+++ b/apps/web/lib/actions/notes-resolver.ts
@@ -4,7 +4,7 @@ import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import { sql } from 'drizzle-orm'
-import { getRequiredSession } from '@/lib/auth/session'
+import { hasRole } from '@/lib/auth/guards'
 import type { Note, NoteCategory } from '@/lib/db/schema'
 
 export type ResolvedNoteSource = 'direct' | 'group' | 'tag_selector'
@@ -39,12 +39,10 @@ export async function resolveNotesForHost(
   hostId: string,
   opts: { includePrivate?: boolean; categories?: NoteCategory[] } = {},
 ): Promise<ResolvedNote[]> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return []
+  const session = await requireOrgAccess(orgId)
 
   const userId = session.user.id
-  const isSuperAdmin = session.user.role === 'super_admin'
+  const isSuperAdmin = hasRole(session.user, 'super_admin')
   const includePrivateFilter = opts.includePrivate !== false
 
   const categoryFilter =

--- a/apps/web/lib/actions/notes.ts
+++ b/apps/web/lib/actions/notes.ts
@@ -22,7 +22,7 @@ import {
   or,
 } from 'drizzle-orm'
 import { z } from 'zod'
-import { getRequiredSession } from '@/lib/auth/session'
+import { hasRole } from '@/lib/auth/guards'
 import {
   canReadNote,
   canWriteNote,
@@ -120,16 +120,14 @@ export async function listNotes(
     mineOnly?: boolean
   } = {},
 ): Promise<Note[]> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return []
+  const session = await requireOrgAccess(orgId)
 
   const conditions = [
     eq(notes.organisationId, orgId),
     isNull(notes.deletedAt),
     // Privacy: exclude other users' private notes unless you are the author or
     // super_admin.
-    session.user.role === 'super_admin'
+    hasRole(session.user, 'super_admin')
       ? undefined
       : or(eq(notes.isPrivate, false), eq(notes.authorId, session.user.id)),
   ].filter((c): c is NonNullable<typeof c> => c !== undefined)
@@ -155,14 +153,12 @@ export async function listNotes(
 // truly malformed input — the ILIKE fallback means a user's search box always
 // returns something sensible even if they paste an unbalanced quote.
 export async function searchNotes(orgId: string, q: string): Promise<Note[]> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return []
+  const session = await requireOrgAccess(orgId)
   const trimmed = q.trim()
   if (trimmed.length === 0) return []
 
   const privacyFilter =
-    session.user.role === 'super_admin'
+    hasRole(session.user, 'super_admin')
       ? sql`TRUE`
       : sql`(n.is_private = FALSE OR n.author_id = ${session.user.id})`
 
@@ -200,9 +196,7 @@ export async function getNote(
   orgId: string,
   noteId: string,
 ): Promise<{ note: Note; targets: NoteTarget[] } | null> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return null
+  const session = await requireOrgAccess(orgId)
 
   const note = await db.query.notes.findFirst({
     where: and(
@@ -227,9 +221,7 @@ export async function createNote(
   orgId: string,
   input: z.input<typeof createNoteSchema>,
 ): Promise<{ success: true; note: Note } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
   if (!canCreateNote(session.user)) {
     return { error: 'You do not have permission to perform this action' }
   }
@@ -292,9 +284,7 @@ export async function updateNote(
   noteId: string,
   input: z.input<typeof updateNoteSchema>,
 ): Promise<{ success: true; note: Note } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
 
   const parsed = updateNoteSchema.safeParse(input)
   if (!parsed.success) {
@@ -375,9 +365,7 @@ export async function deleteNote(
   orgId: string,
   noteId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
 
   try {
     const existing = await db.query.notes.findFirst({
@@ -412,9 +400,7 @@ export async function setNoteTargets(
   noteId: string,
   targets: z.input<typeof targetSchema>[],
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
 
   const parsed = z.array(targetSchema).max(50).safeParse(targets)
   if (!parsed.success) {
@@ -473,9 +459,7 @@ export async function toggleNotePin(
   noteTargetId: string,
   pinned: boolean,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
 
   try {
     return await db.transaction(async (tx) => {
@@ -544,9 +528,7 @@ export async function toggleNotePrivate(
   noteId: string,
   isPrivate: boolean,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
 
   try {
     const existing = await db.query.notes.findFirst({
@@ -580,9 +562,7 @@ export async function addNoteReaction(
   noteId: string,
   reaction: NoteReactionType,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
   if (!NOTE_REACTIONS.includes(reaction)) return { error: 'Invalid reaction' }
 
   try {
@@ -622,9 +602,7 @@ export async function removeNoteReaction(
   noteId: string,
   reaction: NoteReactionType,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Not found' }
+  const session = await requireOrgAccess(orgId)
 
   try {
     await db
@@ -649,8 +627,6 @@ export async function listNoteReactions(
   noteId: string,
 ): Promise<NoteReaction[]> {
   await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return []
 
   return db.query.noteReactions.findMany({
     where: and(eq(noteReactions.noteId, noteId), eq(noteReactions.organisationId, orgId)),
@@ -663,9 +639,7 @@ export async function listNoteRevisions(
   orgId: string,
   noteId: string,
 ): Promise<NoteRevision[]> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return []
+  const session = await requireOrgAccess(orgId)
 
   const note = await db.query.notes.findFirst({
     where: and(eq(notes.id, noteId), eq(notes.organisationId, orgId)),

--- a/apps/web/lib/actions/notification-settings.ts
+++ b/apps/web/lib/actions/notification-settings.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -8,8 +8,7 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 import type { OrgNotificationSettings } from '@/lib/db/schema/organisations'
-import { getRequiredSession } from '@/lib/auth/session'
-import { ADMIN_ROLES, DEFAULT_NOTIFICATION_ROLES } from '@/lib/auth/roles'
+import { DEFAULT_NOTIFICATION_ROLES } from '@/lib/auth/roles'
 import { encrypt, decrypt } from '@/lib/crypto/encrypt'
 import { assertPublicHost } from '@/lib/net/ssrf-guard'
 import {
@@ -87,15 +86,10 @@ export async function updateOrgNotificationSettings(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to update notification settings' }
-  }
-
-  if (session.user.organisationId !== orgId) {
-    return { error: 'Organisation mismatch' }
   }
 
   const parsed = updateOrgNotificationSettingsSchema.safeParse(input)
@@ -148,15 +142,10 @@ async function getAdminOrgMetadata(orgId: string): Promise<
   | { metadata: ReturnType<typeof parseOrgMetadata>; error?: undefined }
   | { metadata?: undefined; error: string }
 > {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to update SMTP settings' }
-  }
-
-  if (session.user.organisationId !== orgId) {
-    return { error: 'Organisation mismatch' }
   }
 
   const org = await db.query.organisations.findFirst({

--- a/apps/web/lib/actions/security.ts
+++ b/apps/web/lib/actions/security.ts
@@ -10,13 +10,12 @@ import { certificateAuthorities } from '@/lib/db/schema/certificate-authorities'
 import { encrypt } from '@/lib/crypto/encrypt'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { requireRole } from '@/lib/auth/guards'
 import type { SecurityOverview } from './security-types'
 
 async function requireAdmin(): Promise<void> {
   const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
-    throw new Error('forbidden: admin role required')
-  }
+  requireRole(session.user, ADMIN_ROLES)
 }
 
 const SERVER_TLS_CERT_PATH = process.env['INGEST_TLS_CERT'] ?? '/etc/ct-ops/tls/server.crt'
@@ -141,4 +140,3 @@ export async function uploadAgentCA(
     return { error: err instanceof Error ? err.message : 'An unexpected error occurred' }
   }
 }
-

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { createId } from '@paralleldrive/cuid2'
@@ -10,10 +10,8 @@ import { organisations } from '@/lib/db/schema'
 import { eq, sql } from 'drizzle-orm'
 import { validateLicenceKey } from '@/lib/licence'
 import { encodeActivationToken } from '@/lib/licence-activation-token'
-import { getRequiredSession } from '@/lib/auth/session'
 import { hasLicenceFeature } from '@/lib/actions/licence-guard'
 import { COMMUNITY_MAX_RETENTION_DAYS } from '@/lib/features'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { writeAuditEvent } from '@/lib/audit/events'
 
 const updateOrgNameSchema = z.object({
@@ -24,9 +22,9 @@ export async function updateOrgName(
   orgId: string,
   name: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -56,9 +54,9 @@ export async function updateMetricRetention(
   orgId: string,
   days: number,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -111,9 +109,10 @@ export async function saveLicenceKey(
   orgId: string,
   key: string,
 ): Promise<{ success: true; tier: string } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  let session
+  try {
+    session = await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -163,13 +162,10 @@ export async function saveLicenceKey(
 export async function generateActivationToken(
   orgId: string,
 ): Promise<{ success: true; token: string } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
-  }
-  if (session.user.organisationId !== orgId) {
-    return { error: 'You can only generate activation tokens for your own organisation' }
   }
 
   try {

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -23,11 +23,9 @@ import type {
   SavedSoftwareReport,
   SoftwareInventorySettings,
 } from '@/lib/db/schema'
-import { getRequiredSession } from '@/lib/auth/session'
 import { requireFeature } from '@/lib/actions/licence-guard'
 import { escapeLikePattern } from '@/lib/utils'
 import { compareVersions } from '@/lib/version-compare'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 
@@ -70,9 +68,9 @@ export async function updateSoftwareInventorySettings(
   orgId: string,
   settings: SoftwareInventorySettings,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -107,9 +105,10 @@ export async function triggerSoftwareScan(
   orgId: string,
   hostId: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  let session
+  try {
+    session = await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
   if (!await triggerScanLimiter.check(orgId)) {
@@ -764,9 +763,8 @@ const saveReportSchema = z.object({
 })
 
 export async function listSavedReports(orgId: string): Promise<SavedSoftwareReport[]> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
-  const session = await getRequiredSession()
   return db.query.savedSoftwareReports.findMany({
     where: and(
       eq(savedSoftwareReports.organisationId, orgId),
@@ -782,9 +780,8 @@ export async function saveSoftwareReport(
   name: string,
   filters: SoftwareReportFilters,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
-  const session = await getRequiredSession()
   const parsed = saveReportSchema.safeParse({ name, filters })
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid data' }
@@ -811,9 +808,8 @@ export async function deleteSavedReport(
   orgId: string,
   reportId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   await requireFeature(orgId, 'reportsExport')
-  const session = await getRequiredSession()
   try {
     await db
       .update(savedSoftwareReports)

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -7,7 +7,8 @@ import { db } from '@/lib/db'
 import { taskSchedules, taskRuns, hostGroups, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, desc, inArray } from 'drizzle-orm'
 import { CronExpressionParser } from 'cron-parser'
-import { getRequiredSession } from '@/lib/auth/session'
+import { MEMBERSHIP_ROLES } from '@/lib/auth/roles'
+import { hasRole } from '@/lib/auth/guards'
 import { z } from 'zod'
 import type { TaskSchedule, TaskType, TaskConfig } from '@/lib/db/schema'
 import {
@@ -191,10 +192,8 @@ export async function createSchedule(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
-  if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
+  const session = await requireOrgAccess(orgId)
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
 
   const parsed = scheduleInputSchema.safeParse(input)
   if (!parsed.success) {
@@ -245,10 +244,8 @@ export async function updateSchedule(
   id: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
-  if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
+  const session = await requireOrgAccess(orgId)
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
 
   const existing = await db.query.taskSchedules.findFirst({
     where: and(
@@ -308,10 +305,8 @@ export async function setScheduleEnabled(
   id: string,
   enabled: boolean,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
-  if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
+  const session = await requireOrgAccess(orgId)
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
 
   const existing = await db.query.taskSchedules.findFirst({
     where: and(
@@ -348,10 +343,8 @@ export async function deleteSchedule(
   orgId: string,
   id: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
-  if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
+  const session = await requireOrgAccess(orgId)
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
 
   try {
     await db
@@ -380,10 +373,8 @@ export async function runScheduleNow(
   orgId: string,
   id: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
-  if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
+  const session = await requireOrgAccess(orgId)
+  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
 
   const schedule = await db.query.taskSchedules.findFirst({
     where: and(

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import { organisations, hosts, terminalSessions } from '@/lib/db/schema'
@@ -11,7 +11,8 @@ import { createHash, randomBytes } from 'node:crypto'
 import { getRequiredSession } from '@/lib/auth/session'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 import { parseHostMetadata } from '@/lib/db/schema/hosts'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { MEMBERSHIP_ROLES } from '@/lib/auth/roles'
+import { hasRole } from '@/lib/auth/guards'
 import { writeAuditEvent } from '@/lib/audit/events'
 
 export interface TerminalAccessResult {
@@ -32,12 +33,11 @@ export async function checkTerminalAccess(
   orgId: string,
   hostId: string,
 ): Promise<TerminalAccessResult | TerminalAccessDenied> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
+  const session = await requireOrgAccess(orgId)
   const { user } = session
 
   // 1. Role check
-  if (user.role === 'read_only') {
+  if (!hasRole(user, MEMBERSHIP_ROLES)) {
     return { allowed: false, reason: 'Terminal access requires at minimum engineer role' }
   }
 
@@ -179,9 +179,10 @@ export async function updateOrgTerminalSettings(
   orgId: string,
   settings: OrgTerminalSettings,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  let session
+  try {
+    session = await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 
@@ -257,9 +258,10 @@ export async function updateHostTerminalSettings(
   hostId: string,
   settings: HostTerminalSettings,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  let session
+  try {
+    session = await requireOrgAdminAccess(orgId)
+  } catch {
     return { error: 'You do not have permission to perform this action' }
   }
 

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -9,8 +9,6 @@ import { users, invitations } from '@/lib/db/schema'
 import { eq, and, isNull, isNotNull, gt } from 'drizzle-orm'
 import type { User, Invitation } from '@/lib/db/schema'
 import { getBetterAuthOrigin } from '@/lib/auth/env'
-import { getRequiredSession, type RequiredSession } from '@/lib/auth/session'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { writeAuditEvent } from '@/lib/audit/events'
 
 const inviteSchema = z.object({
@@ -22,35 +20,10 @@ const updateRoleSchema = z.object({
   role: z.enum(['super_admin', 'org_admin', 'engineer', 'read_only']),
 })
 
-async function requireOrgSession(orgId: string): Promise<RequiredSession> {
-  const session = await getRequiredSession()
-
-  if (!session.user.isActive || session.user.deletedAt) {
-    throw new Error('forbidden: inactive user')
-  }
-
-  if (session.user.organisationId !== orgId) {
-    throw new Error('forbidden: organisation mismatch')
-  }
-
-  return session
-}
-
-async function requireOrgAdmin(orgId: string): Promise<RequiredSession> {
-  const session = await requireOrgSession(orgId)
-
-  if (!ADMIN_ROLES.includes(session.user.role)) {
-    throw new Error('forbidden: admin role required')
-  }
-
-  return session
-}
-
 export async function getOrgUsers(
   orgId: string,
 ): Promise<{ members: User[]; pendingInvites: Invitation[] }> {
   await requireOrgAccess(orgId)
-  await requireOrgSession(orgId)
 
   const [members, pendingInvites] = await Promise.all([
     db.query.users.findMany({
@@ -79,7 +52,7 @@ export async function inviteUser(
   }
 
   try {
-    const session = await requireOrgAdmin(orgId)
+    const session = await requireOrgAdminAccess(orgId)
 
     // Check for a previously removed user — restore them rather than re-registering,
     // since their account (and email) still exist in the database.
@@ -158,7 +131,7 @@ export async function updateUserRole(
   }
 
   try {
-    const session = await requireOrgAdmin(orgId)
+    const session = await requireOrgAdminAccess(orgId)
     const targetUser = await db.query.users.findFirst({
       where: and(eq(users.id, targetUserId), eq(users.organisationId, orgId)),
       columns: { id: true, email: true, role: true },
@@ -214,7 +187,7 @@ export async function deactivateUser(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   try {
-    const session = await requireOrgAdmin(orgId)
+    const session = await requireOrgAdminAccess(orgId)
 
     if (session.user.id === targetUserId) {
       return { error: 'You cannot deactivate your own account' }
@@ -250,7 +223,7 @@ export async function reactivateUser(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   try {
-    await requireOrgAdmin(orgId)
+    await requireOrgAdminAccess(orgId)
 
     await db
       .update(users)
@@ -270,7 +243,7 @@ export async function removeUser(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   try {
-    const session = await requireOrgAdmin(orgId)
+    const session = await requireOrgAdminAccess(orgId)
 
     if (session.user.id === targetUserId) {
       return { error: 'You cannot remove your own account' }
@@ -329,7 +302,7 @@ export async function cancelInvite(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   try {
-    await requireOrgAdmin(orgId)
+    await requireOrgAdminAccess(orgId)
 
     await db
       .update(invitations)

--- a/apps/web/lib/auth/guards.test.mjs
+++ b/apps/web/lib/auth/guards.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  hasRole,
+  isSameOrg,
+  requireActiveUser,
+  requireOrgAdmin,
+  requireOrgWriteAccess,
+  requireSameOrg,
+} from './guards.ts'
+
+const activeAdmin = {
+  organisationId: 'org-1',
+  role: 'org_admin',
+  isActive: true,
+  deletedAt: null,
+}
+
+test('requireActiveUser rejects inactive or deleted users', () => {
+  assert.throws(
+    () => requireActiveUser({ ...activeAdmin, isActive: false }),
+    /forbidden: inactive user/,
+  )
+  assert.throws(
+    () => requireActiveUser({ ...activeAdmin, deletedAt: new Date() }),
+    /forbidden: inactive user/,
+  )
+})
+
+test('requireSameOrg accepts either org ids or org-scoped resources', () => {
+  assert.doesNotThrow(() => requireSameOrg(activeAdmin, 'org-1'))
+  assert.doesNotThrow(() => requireSameOrg(activeAdmin, { organisationId: 'org-1' }))
+  assert.equal(isSameOrg(activeAdmin, { organisationId: 'org-2' }), false)
+})
+
+test('requireSameOrg rejects cross-org access', () => {
+  assert.throws(
+    () => requireSameOrg(activeAdmin, 'org-2'),
+    /forbidden: organisation mismatch/,
+  )
+})
+
+test('requireOrgAdmin rejects non-admin roles', () => {
+  assert.throws(
+    () => requireOrgAdmin({ ...activeAdmin, role: 'engineer' }, 'org-1'),
+    /forbidden: admin role required/,
+  )
+})
+
+test('requireOrgWriteAccess rejects read-only users', () => {
+  assert.throws(
+    () => requireOrgWriteAccess({ ...activeAdmin, role: 'read_only' }, 'org-1'),
+    /forbidden: write role required/,
+  )
+})
+
+test('hasRole handles single and multiple role checks', () => {
+  assert.equal(hasRole(activeAdmin, 'org_admin'), true)
+  assert.equal(hasRole(activeAdmin, ['super_admin', 'engineer']), false)
+})

--- a/apps/web/lib/auth/guards.ts
+++ b/apps/web/lib/auth/guards.ts
@@ -1,0 +1,61 @@
+import { ADMIN_ROLES, MEMBERSHIP_ROLES } from './roles.ts'
+import type { SessionUser } from './session.ts'
+
+type OrgScopedUser = Pick<SessionUser, 'organisationId' | 'isActive' | 'deletedAt'>
+type GuardUser = OrgScopedUser & Pick<SessionUser, 'role'>
+type OrgTarget = string | { organisationId: string | null }
+type RoleInput = string | readonly string[]
+
+function toOrganisationId(target: OrgTarget): string | null {
+  return typeof target === 'string' ? target : target.organisationId
+}
+
+function toRoleList(roles: RoleInput): readonly string[] {
+  return typeof roles === 'string' ? [roles] : roles
+}
+
+export function isActiveUser(user: OrgScopedUser): boolean {
+  return user.isActive && !user.deletedAt
+}
+
+export function hasRole(user: Pick<SessionUser, 'role'>, roles: RoleInput): boolean {
+  return toRoleList(roles).includes(user.role)
+}
+
+export function isSameOrg(user: Pick<SessionUser, 'organisationId'>, target: OrgTarget): boolean {
+  return user.organisationId === toOrganisationId(target)
+}
+
+export function requireActiveUser(user: OrgScopedUser): void {
+  if (!isActiveUser(user)) {
+    throw new Error('forbidden: inactive user')
+  }
+}
+
+export function requireSameOrg(user: OrgScopedUser, target: OrgTarget): void {
+  requireActiveUser(user)
+
+  if (!isSameOrg(user, target)) {
+    throw new Error('forbidden: organisation mismatch')
+  }
+}
+
+export function requireRole(
+  user: Pick<SessionUser, 'role'>,
+  roles: RoleInput,
+  message = 'forbidden: admin role required',
+): void {
+  if (!hasRole(user, roles)) {
+    throw new Error(message)
+  }
+}
+
+export function requireOrgAdmin(user: GuardUser, target: OrgTarget): void {
+  requireSameOrg(user, target)
+  requireRole(user, ADMIN_ROLES)
+}
+
+export function requireOrgWriteAccess(user: GuardUser, target: OrgTarget): void {
+  requireSameOrg(user, target)
+  requireRole(user, MEMBERSHIP_ROLES, 'forbidden: write role required')
+}

--- a/apps/web/lib/eslint/index.mjs
+++ b/apps/web/lib/eslint/index.mjs
@@ -1,7 +1,9 @@
 import noSingleTableSelect from './no-single-table-select.mjs'
+import noRawSessionChecks from './no-raw-session-checks.mjs'
 
 const plugin = {
   rules: {
+    'no-raw-session-checks': noRawSessionChecks,
     'no-single-table-select': noSingleTableSelect,
   },
 }

--- a/apps/web/lib/eslint/no-raw-session-checks.mjs
+++ b/apps/web/lib/eslint/no-raw-session-checks.mjs
@@ -1,0 +1,49 @@
+function isSessionUserMember(node) {
+  return (
+    node?.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property.type === 'Identifier' &&
+    (node.property.name === 'organisationId' || node.property.name === 'role') &&
+    node.object?.type === 'MemberExpression' &&
+    !node.object.computed &&
+    node.object.property.type === 'Identifier' &&
+    node.object.property.name === 'user' &&
+    node.object.object?.type === 'Identifier' &&
+    node.object.object.name === 'session'
+  )
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prefer shared auth guards over ad hoc session.user authorisation checks',
+    },
+    schema: [],
+    messages: {
+      useGuard: 'Use helpers from @/lib/auth/guards or @/lib/actions/action-auth instead of raw session.user authz checks.',
+    },
+  },
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (isSessionUserMember(node.left) || isSessionUserMember(node.right)) {
+          context.report({ node, messageId: 'useGuard' })
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          !node.callee.computed &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'includes' &&
+          node.arguments.some((arg) => isSessionUserMember(arg))
+        ) {
+          context.report({ node, messageId: 'useGuard' })
+        }
+      },
+    }
+  },
+}
+
+export default rule

--- a/apps/web/lib/eslint/no-raw-session-checks.test.mjs
+++ b/apps/web/lib/eslint/no-raw-session-checks.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { Linter } from 'eslint'
+
+import rule from './no-raw-session-checks.mjs'
+
+function lint(code) {
+  const linter = new Linter({ configType: 'flat' })
+  return linter.verify(
+    code,
+    [
+      {
+        languageOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        },
+        plugins: {
+          local: {
+            rules: {
+              'no-raw-session-checks': rule,
+            },
+          },
+        },
+        rules: {
+          'local/no-raw-session-checks': 'error',
+        },
+      },
+    ],
+    'test.js',
+  )
+}
+
+test('no-raw-session-checks allows helper-based checks', () => {
+  assert.deepEqual(
+    lint(`
+      async function run() {
+        const session = await requireOrgAccess(orgId)
+        if (!hasRole(session.user, ADMIN_ROLES)) return { error: 'forbidden' }
+        if (!isSameOrg(session.user, note)) return []
+      }
+    `),
+    [],
+  )
+})
+
+test('no-raw-session-checks flags direct organisation and role comparisons', () => {
+  const messages = lint(`
+    async function run() {
+      if (session.user.organisationId !== orgId) return { error: 'Organisation mismatch' }
+      if (session.user.role === 'read_only') return { error: 'Insufficient permissions' }
+      if (!ADMIN_ROLES.includes(session.user.role)) return { error: 'forbidden' }
+    }
+  `)
+
+  assert.equal(messages.length, 3)
+  assert(messages.every((message) => message.messageId === 'useGuard'))
+})


### PR DESCRIPTION
## Summary
- add shared authz guards for same-org, admin-role, and writable-role checks
- migrate server actions off raw `session.user` org/role comparisons
- add an ESLint rule plus focused tests to block those ad hoc checks in `lib/actions` and `lib/auth`

## Testing
- pnpm --filter web exec node --experimental-strip-types --test lib/actions/action-auth.test.mjs lib/auth/guards.test.mjs lib/eslint/no-single-table-select.test.mjs lib/eslint/no-raw-session-checks.test.mjs
- pnpm --filter web exec eslint lib/actions/users.ts lib/actions/security.ts lib/actions/notification-settings.ts lib/actions/settings.ts lib/actions/networks.ts lib/actions/software-inventory.ts lib/actions/terminal.ts lib/actions/task-schedules.ts lib/actions/notes.ts lib/actions/notes-resolver.ts lib/actions/certificates.ts lib/actions/action-auth-core.ts lib/auth/guards.ts lib/eslint/no-raw-session-checks.mjs lib/eslint/no-raw-session-checks.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint

Closes #369