### PR TITLE
fix(web): add local account password reset

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,11 +9,22 @@
 **Phase 5 — Tooling + release hardening (in progress)**
 
 ## Current Status
-🟢 Phase 5 progressing — tooling has expanded beyond Directory User Lookup and SSL Certificate Checker into Jenkins/GitLab air-gap bundle generation, recursive plugin dependency resolution, offline install bundles, host-mediated bundle transfer, and better transfer/download status. Since the last update the platform has also had a substantial release-hardening pass: local auth email verification, login lockout, shared database-backed auth and abuse throttles across replicas, trusted-origin mutation checks, org-authenticated server actions, enrolment-token limits, certificate-checker SSRF and parsing hardening, signed-update enforcement, terminal SSH credential enforcement, heartbeat/JWT tightening, agent script limits, ingest gRPC caps, config-file permission validation, digest-pinned customer bundles, installer checksum verification, and broader E2E/process coverage.
+🟢 Phase 5 progressing — tooling has expanded beyond Directory User Lookup and SSL Certificate Checker into Jenkins/GitLab air-gap bundle generation, recursive plugin dependency resolution, offline install bundles, host-mediated bundle transfer, and better transfer/download status. Since the last update the platform has also had a substantial release-hardening pass: local auth email verification, login lockout, self-service password reset for local accounts, shared database-backed auth and abuse throttles across replicas, trusted-origin mutation checks, org-authenticated server actions, enrolment-token limits, certificate-checker SSRF and parsing hardening, signed-update enforcement, terminal SSH credential enforcement, heartbeat/JWT tightening, agent script limits, ingest gRPC caps, config-file permission validation, digest-pinned customer bundles, installer checksum verification, and broader E2E/process coverage.
 
 ---
 
 ## What Has Been Built
+
+### Session 69 — Local account password reset flow
+
+**Self-service password reset** (`apps/web/app/(auth)/forgot-password/`, `apps/web/app/reset-password/`, `apps/web/lib/auth/`)
+- Added a local-account password reset entry point from the email/password login form so users who forgot their password are no longer stranded at sign-in.
+- Wired Better Auth's reset capability into CT-Ops by configuring `sendResetPassword`, revoking existing sessions on reset, and sending captured/SMTP password-reset emails through the shared auth email helper.
+- Added a reset request page plus a token-based reset form that validates new passwords, safely constrains post-reset redirects to in-app paths, and returns the user to `/login?reset=1` with a success notice after the password changes.
+
+**Validation**
+- Added targeted E2E coverage for requesting a reset from the login page, consuming the reset email, setting a new password, and signing in with the updated credential.
+- Validation run: `pnpm --dir apps/web test:e2e tests/e2e/auth/login.spec.ts` and `pnpm --dir apps/web type-check`.
 
 ### Session 68 — Centralised authz guards
 

--- a/apps/web/app/(auth)/forgot-password/page.tsx
+++ b/apps/web/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { ForgotPasswordForm } from './reset-request-form'
+
+export const metadata: Metadata = {
+  title: 'Forgot password',
+}
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />
+}

--- a/apps/web/app/(auth)/forgot-password/reset-request-form.tsx
+++ b/apps/web/app/(auth)/forgot-password/reset-request-form.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Enter a valid email address'),
+})
+
+type ForgotPasswordValues = z.infer<typeof forgotPasswordSchema>
+
+export function ForgotPasswordForm() {
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  const form = useForm<ForgotPasswordValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+  })
+
+  async function onSubmit(values: ForgotPasswordValues) {
+    setServerError(null)
+    setSuccessMessage(null)
+
+    try {
+      const res = await fetch('/api/auth/request-password-reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: values.email,
+          redirectTo: '/login?reset=1',
+        }),
+      })
+
+      const data = (await res.json().catch(() => null)) as { message?: string } | null
+      if (!res.ok) {
+        setServerError(data?.message ?? 'Unable to request a password reset right now.')
+        return
+      }
+
+      void data
+      setSuccessMessage('If an account exists for that email, we sent a password reset link.')
+    } catch {
+      setServerError('Unable to request a password reset right now.')
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Reset your password</CardTitle>
+        <CardDescription>
+          Enter the email address for your local CT-Ops account and we&apos;ll send you a reset link.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent className="space-y-4">
+          {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+          {successMessage && (
+            <p className="text-sm text-foreground" data-testid="forgot-password-success">
+              {successMessage}
+            </p>
+          )}
+          <div className="space-y-1.5">
+            <Label htmlFor="forgot-password-email">Email</Label>
+            <Input
+              id="forgot-password-email"
+              type="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              data-testid="forgot-password-email"
+              {...form.register('email')}
+            />
+            {form.formState.errors.email && (
+              <p className="text-xs text-destructive">{form.formState.errors.email.message}</p>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3">
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={form.formState.isSubmitting}
+            data-testid="forgot-password-submit"
+          >
+            {form.formState.isSubmitting ? 'Sending reset link...' : 'Send reset link'}
+          </Button>
+          <Link href="/login" className="text-sm text-foreground underline underline-offset-4">
+            Back to sign in
+          </Link>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -27,13 +27,14 @@ type DomainLoginValues = z.infer<typeof domainLoginSchema>
 
 interface LoginFormProps {
   ldapLoginEnabled?: boolean
+  notice?: string | null
 }
 
 function isEmailNotVerifiedError(message: string, code?: string): boolean {
   return code === 'EMAIL_NOT_VERIFIED' || message.toLowerCase().includes('email not verified')
 }
 
-export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
+export function LoginForm({ ldapLoginEnabled = false, notice = null }: LoginFormProps) {
   const router = useRouter()
   const [serverError, setServerError] = useState<string | null>(null)
   const [canResendVerification, setCanResendVerification] = useState(false)
@@ -150,6 +151,9 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
       {loginMode === 'local' ? (
         <form onSubmit={localForm.handleSubmit(onLocalSubmit)}>
           <CardContent className="space-y-4">
+            {notice && (
+              <p className="text-sm text-foreground" data-testid="login-notice">{notice}</p>
+            )}
             {serverError && (
               <p className="text-sm text-destructive" data-testid="login-error">{serverError}</p>
             )}
@@ -199,6 +203,15 @@ export function LoginForm({ ldapLoginEnabled = false }: LoginFormProps) {
               {localForm.formState.errors.password && (
                 <p className="text-xs text-destructive">{localForm.formState.errors.password.message}</p>
               )}
+            </div>
+            <div className="text-right">
+              <Link
+                href="/forgot-password"
+                className="text-sm text-foreground underline underline-offset-4"
+                data-testid="forgot-password-link"
+              >
+                Forgot password?
+              </Link>
             </div>
           </CardContent>
           <CardFooter className="flex flex-col gap-3">

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -12,7 +12,17 @@ export const metadata: Metadata = {
   title: 'Sign in',
 }
 
-export default async function LoginPage() {
+type LoginPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const params = await searchParams
   const session = await auth.api.getSession({ headers: await headers() })
   if (session) {
     const user = await db.query.users.findFirst({ where: eq(users.id, session.user.id) })
@@ -20,6 +30,12 @@ export default async function LoginPage() {
   }
 
   const ldapEnabled = await hasLdapLoginEnabled()
+  const resetComplete = readParam(params.reset) === '1'
 
-  return <LoginForm ldapLoginEnabled={ldapEnabled} />
+  return (
+    <LoginForm
+      ldapLoginEnabled={ldapEnabled}
+      notice={resetComplete ? 'Your password has been reset. Sign in with your new password.' : null}
+    />
+  )
 }

--- a/apps/web/app/reset-password/[token]/page.tsx
+++ b/apps/web/app/reset-password/[token]/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next'
+import { ResetPasswordForm } from './reset-password-form'
+
+export const metadata: Metadata = {
+  title: 'Choose a new password',
+}
+
+type ResetPasswordPageProps = {
+  params: Promise<{ token: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function ResetPasswordPage({
+  params,
+  searchParams,
+}: ResetPasswordPageProps) {
+  const { token } = await params
+  const query = await searchParams
+  const callbackURL = readParam(query.callbackURL)
+
+  return <ResetPasswordForm token={token} callbackURL={callbackURL} />
+}

--- a/apps/web/app/reset-password/[token]/reset-password-form.tsx
+++ b/apps/web/app/reset-password/[token]/reset-password-form.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+const resetPasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(12, 'Password must be at least 12 characters')
+      .max(128, 'Password must be at most 128 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  })
+
+type ResetPasswordValues = z.infer<typeof resetPasswordSchema>
+
+type ResetPasswordFormProps = {
+  token: string
+  callbackURL: string | null
+}
+
+function getSafeCallbackUrl(callbackURL: string | null): string {
+  if (!callbackURL) return '/login?reset=1'
+  if (!callbackURL.startsWith('/') || callbackURL.startsWith('//')) return '/login?reset=1'
+  return callbackURL
+}
+
+export function ResetPasswordForm({ token, callbackURL }: ResetPasswordFormProps) {
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const form = useForm<ResetPasswordValues>({
+    resolver: zodResolver(resetPasswordSchema),
+  })
+
+  async function onSubmit(values: ResetPasswordValues) {
+    setServerError(null)
+
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token,
+          newPassword: values.newPassword,
+        }),
+      })
+
+      const data = (await res.json().catch(() => null)) as { message?: string } | null
+      if (!res.ok) {
+        setServerError(data?.message ?? 'Unable to reset your password.')
+        return
+      }
+
+      router.push(getSafeCallbackUrl(callbackURL))
+    } catch {
+      setServerError('Unable to reset your password.')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/40 px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">CT-Ops</h1>
+          <p className="text-sm text-muted-foreground mt-1">Choose a new password for your account</p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Choose a new password</CardTitle>
+            <CardDescription>
+              Set a new password for your local CT-Ops account.
+            </CardDescription>
+          </CardHeader>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <CardContent className="space-y-4">
+              {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+              <div className="space-y-1.5">
+                <Label htmlFor="new-password">New password</Label>
+                <Input
+                  id="new-password"
+                  type="password"
+                  autoComplete="new-password"
+                  data-testid="reset-password-new-password"
+                  {...form.register('newPassword')}
+                />
+                {form.formState.errors.newPassword && (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.newPassword.message}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="confirm-password">Confirm new password</Label>
+                <Input
+                  id="confirm-password"
+                  type="password"
+                  autoComplete="new-password"
+                  data-testid="reset-password-confirm-password"
+                  {...form.register('confirmPassword')}
+                />
+                {form.formState.errors.confirmPassword && (
+                  <p className="text-xs text-destructive">
+                    {form.formState.errors.confirmPassword.message}
+                  </p>
+                )}
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-3">
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={form.formState.isSubmitting}
+                data-testid="reset-password-submit"
+              >
+                {form.formState.isSubmitting ? 'Saving password...' : 'Save new password'}
+              </Button>
+              <Link href="/login" className="text-sm text-foreground underline underline-offset-4">
+                Back to sign in
+              </Link>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/lib/auth/email.ts
+++ b/apps/web/lib/auth/email.ts
@@ -94,3 +94,36 @@ export async function sendVerificationEmail(input: {
     metadata: { verificationUrl: input.verificationUrl },
   })
 }
+
+export async function sendPasswordResetEmail(input: {
+  email: string
+  name: string
+  resetUrl: string
+}): Promise<void> {
+  const subject = 'Reset your CT-Ops password'
+  const text = [
+    `Hi ${input.name || 'there'},`,
+    '',
+    'We received a request to reset your CT-Ops password.',
+    'Use the link below to choose a new password:',
+    input.resetUrl,
+    '',
+    'If you did not request this, you can ignore this email.',
+  ].join('\n')
+
+  const html = [
+    `<p>Hi ${input.name || 'there'},</p>`,
+    '<p>We received a request to reset your CT-Ops password.</p>',
+    `<p><a href="${input.resetUrl}">Reset password</a></p>`,
+    `<p>If the button does not work, use this link:<br /><a href="${input.resetUrl}">${input.resetUrl}</a></p>`,
+    '<p>If you did not request this, you can ignore this email.</p>',
+  ].join('')
+
+  await sendAuthEmail({
+    to: input.email,
+    subject,
+    text,
+    html,
+    metadata: { resetUrl: input.resetUrl },
+  })
+}

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -4,7 +4,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor } from 'better-auth/plugins'
 import { db } from '@/lib/db'
 import * as schema from '@/lib/db/schema'
-import { sendVerificationEmail } from './email'
+import { sendPasswordResetEmail, sendVerificationEmail } from './email'
 import {
   getBetterAuthOrigin,
   getBetterAuthSecret,
@@ -36,6 +36,20 @@ export const auth = betterAuth({
     requireEmailVerification,
     minPasswordLength: 12,
     maxPasswordLength: 128,
+    sendResetPassword: async ({ user, url, token }) => {
+      const appResetUrl = new URL(`/reset-password/${token}`, getBetterAuthOrigin())
+      const callbackURL = new URL(url).searchParams.get('callbackURL')
+      if (callbackURL) {
+        appResetUrl.searchParams.set('callbackURL', callbackURL)
+      }
+
+      await sendPasswordResetEmail({
+        email: user.email,
+        name: user.name,
+        resetUrl: appResetUrl.toString(),
+      })
+    },
+    revokeSessionsOnPasswordReset: true,
   },
   emailVerification: {
     autoSignInAfterVerification: true,

--- a/apps/web/tests/e2e/auth/login.spec.ts
+++ b/apps/web/tests/e2e/auth/login.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures/test'
+import { waitForPasswordResetUrl } from '../fixtures/email'
 import { TEST_USER } from '../fixtures/seed'
 
 test('user can sign in with email and password and reach the dashboard', async ({ page }) => {
@@ -18,4 +19,39 @@ test('login form shows validation errors when submitted empty', async ({ page })
   await expect(page.getByText('Enter a valid email address')).toBeVisible()
   await expect(page.getByText('Password is required')).toBeVisible()
   await expect(page).toHaveURL(/\/login$/)
+})
+
+test('user can request a password reset from the login screen and sign in with the new password', async ({
+  page,
+}) => {
+  const newPassword = 'ResetPassword123!'
+
+  await page.goto('/login')
+  await expect(page.getByTestId('forgot-password-link')).toBeVisible()
+  await page.getByTestId('forgot-password-link').click()
+
+  await page.waitForURL('**/forgot-password')
+  await page.getByTestId('forgot-password-email').fill(TEST_USER.email)
+  await page.getByTestId('forgot-password-submit').click()
+
+  await expect(page.getByTestId('forgot-password-success')).toContainText(
+    'If an account exists for that email, we sent a password reset link.',
+  )
+
+  const resetUrl = await waitForPasswordResetUrl(TEST_USER.email)
+  await page.goto(resetUrl)
+
+  await page.getByTestId('reset-password-new-password').fill(newPassword)
+  await page.getByTestId('reset-password-confirm-password').fill(newPassword)
+  await page.getByTestId('reset-password-submit').click()
+
+  await page.waitForURL('**/login?reset=1')
+  await expect(page.getByTestId('login-notice')).toContainText('Your password has been reset.')
+
+  await page.getByTestId('login-email').fill(TEST_USER.email)
+  await page.getByTestId('login-password').fill(newPassword)
+  await page.getByTestId('login-submit').click()
+
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
 })

--- a/apps/web/tests/e2e/fixtures/email.ts
+++ b/apps/web/tests/e2e/fixtures/email.ts
@@ -17,6 +17,18 @@ function getCaptureFile(): string {
 }
 
 export async function waitForVerificationUrl(to: string, timeoutMs = 10_000): Promise<string> {
+  return waitForEmailMetadata(to, 'verificationUrl', timeoutMs)
+}
+
+export async function waitForPasswordResetUrl(to: string, timeoutMs = 10_000): Promise<string> {
+  return waitForEmailMetadata(to, 'resetUrl', timeoutMs)
+}
+
+async function waitForEmailMetadata(
+  to: string,
+  key: 'verificationUrl' | 'resetUrl',
+  timeoutMs: number,
+): Promise<string> {
   const deadline = Date.now() + timeoutMs
   const file = getCaptureFile()
 
@@ -30,8 +42,8 @@ export async function waitForVerificationUrl(to: string, timeoutMs = 10_000): Pr
         .map((line) => JSON.parse(line) as CapturedEmail)
 
       const match = [...messages].reverse().find((message) => message.to === to)
-      const verificationUrl = match?.metadata?.verificationUrl
-      if (verificationUrl) return verificationUrl
+      const value = match?.metadata?.[key]
+      if (value) return value
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     }
@@ -39,7 +51,7 @@ export async function waitForVerificationUrl(to: string, timeoutMs = 10_000): Pr
     await new Promise((resolve) => setTimeout(resolve, 200))
   }
 
-  throw new Error(`Timed out waiting for verification email for ${to}`)
+  throw new Error(`Timed out waiting for ${key} email metadata for ${to}`)
 }
 
 export async function countVerificationEmails(to: string): Promise<number> {


### PR DESCRIPTION
## Summary
- add a forgot-password entry point for local account sign-in
- wire Better Auth reset emails into CT-Ops and revoke sessions on password reset
- add reset-flow E2E coverage and record the capability in PROGRESS.md

## Testing
- pnpm --dir apps/web test:e2e tests/e2e/auth/login.spec.ts
- pnpm --dir apps/web type-check

Closes #692