### PR TITLE
fix(agent): restore automatic self-updates

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -22,6 +22,7 @@ import (
 	"github.com/carrtech-dev/ct-ops/agent/internal/checks"
 	"github.com/carrtech-dev/ct-ops/agent/internal/identity"
 	"github.com/carrtech-dev/ct-ops/agent/internal/tasks"
+	"github.com/carrtech-dev/ct-ops/agent/internal/updater"
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
 )
 
@@ -121,9 +122,10 @@ type Runner struct {
 	pinnedServerCertPEM []byte
 	pinnedServerCertFpr string
 
-	// lastSkippedUpdateVersion suppresses duplicate warnings when the server
-	// repeatedly advertises the same release while auto-update is disabled.
-	lastSkippedUpdateVersion string
+	selfUpdateMu       sync.Mutex
+	selfUpdateInFlight bool
+	selfUpdateVersion  string
+	updateFunc         func(latestVersion, downloadURL string, pinnedServerCertPEM []byte) error
 }
 
 // New creates a new heartbeat Runner. dialFunc is called once per stream
@@ -144,6 +146,7 @@ func New(dialFunc func() (*grpc.ClientConn, error), agentID, jwtToken, version s
 		certRotated:  make(chan struct{}, 1),
 		dataDir:      dataDir,
 		keypair:      keypair,
+		updateFunc:   updater.Update,
 	}
 	// Prime the pinned server cert from disk so the first heartbeat sends the
 	// correct fingerprint and preserves any previously pushed trust material.
@@ -389,19 +392,42 @@ func (r *Runner) handleResponse(ctx context.Context, resp *agentv1.HeartbeatResp
 		}
 	}
 	if resp.UpdateAvailable && resp.DownloadUrl != "" {
-		r.noteSkippedSelfUpdate(resp.LatestVersion)
+		r.startSelfUpdate(resp.LatestVersion, resp.DownloadUrl)
 	}
 }
 
-func (r *Runner) noteSkippedSelfUpdate(latestVersion string) {
-	if latestVersion == "" || latestVersion == r.lastSkippedUpdateVersion {
+func (r *Runner) startSelfUpdate(latestVersion, downloadURL string) {
+	if latestVersion == "" || downloadURL == "" || latestVersion == r.version {
 		return
 	}
-	r.lastSkippedUpdateVersion = latestVersion
-	slog.Warn("agent update available, but automatic self-update is disabled until release signature verification is implemented",
+
+	r.selfUpdateMu.Lock()
+	if r.selfUpdateInFlight {
+		r.selfUpdateMu.Unlock()
+		return
+	}
+	r.selfUpdateInFlight = true
+	r.selfUpdateVersion = latestVersion
+	r.selfUpdateMu.Unlock()
+
+	r.pinnedServerCertMu.Lock()
+	pinnedPEM := append([]byte(nil), r.pinnedServerCertPEM...)
+	r.pinnedServerCertMu.Unlock()
+
+	slog.Info("agent update available, starting self-update",
 		"current", r.version,
 		"latest", latestVersion,
 	)
+
+	go func() {
+		if err := r.updateFunc(latestVersion, downloadURL, pinnedPEM); err != nil {
+			r.selfUpdateMu.Lock()
+			r.selfUpdateInFlight = false
+			r.selfUpdateVersion = ""
+			r.selfUpdateMu.Unlock()
+			slog.Warn("agent self-update failed", "current", r.version, "latest", latestVersion, "err", err)
+		}
+	}()
 }
 
 // maybeRenewCert checks the on-disk leaf cert's expiry. If it's within the

--- a/agent/internal/heartbeat/heartbeat_test.go
+++ b/agent/internal/heartbeat/heartbeat_test.go
@@ -4,13 +4,25 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/carrtech-dev/ct-ops/agent/internal/checks"
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
 )
 
-func TestHandleResponseSkipsSelfUpdate(t *testing.T) {
+func TestHandleResponseStartsSelfUpdate(t *testing.T) {
 	runner := New(nil, "agent-id", "jwt", "v1.0.0", 30, checks.NewExecutor(), "", nil)
+	started := make(chan struct{}, 1)
+	runner.updateFunc = func(latestVersion, downloadURL string, pinnedServerCertPEM []byte) error {
+		if latestVersion != "v2.0.0" {
+			t.Errorf("latestVersion = %q, want %q", latestVersion, "v2.0.0")
+		}
+		if downloadURL != "https://example.com/api/agent/download" {
+			t.Errorf("downloadURL = %q, want %q", downloadURL, "https://example.com/api/agent/download")
+		}
+		started <- struct{}{}
+		return nil
+	}
 
 	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
 		Ok:              true,
@@ -19,13 +31,22 @@ func TestHandleResponseSkipsSelfUpdate(t *testing.T) {
 		DownloadUrl:     "https://example.com/api/agent/download",
 	})
 
-	if got := runner.lastSkippedUpdateVersion; got != "v2.0.0" {
-		t.Fatalf("lastSkippedUpdateVersion = %q, want %q", got, "v2.0.0")
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("self-update was not started")
 	}
 }
 
-func TestHandleResponseOnlyNotesEachSkippedVersionOnce(t *testing.T) {
+func TestHandleResponseDeduplicatesSelfUpdateInFlight(t *testing.T) {
 	runner := New(nil, "agent-id", "jwt", "v1.0.0", 30, checks.NewExecutor(), "", nil)
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	runner.updateFunc = func(latestVersion, downloadURL string, pinnedServerCertPEM []byte) error {
+		started <- struct{}{}
+		<-release
+		return nil
+	}
 
 	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
 		Ok:              true,
@@ -40,20 +61,18 @@ func TestHandleResponseOnlyNotesEachSkippedVersionOnce(t *testing.T) {
 		DownloadUrl:     "https://example.com/api/agent/download",
 	})
 
-	if got := runner.lastSkippedUpdateVersion; got != "v2.0.0" {
-		t.Fatalf("lastSkippedUpdateVersion = %q, want %q", got, "v2.0.0")
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("self-update was not started")
 	}
 
-	runner.handleResponse(context.Background(), &agentv1.HeartbeatResponse{
-		Ok:              true,
-		UpdateAvailable: true,
-		LatestVersion:   "v2.1.0",
-		DownloadUrl:     "https://example.com/api/agent/download",
-	})
-
-	if got := runner.lastSkippedUpdateVersion; got != "v2.1.0" {
-		t.Fatalf("lastSkippedUpdateVersion = %q, want %q", got, "v2.1.0")
+	select {
+	case <-started:
+		t.Fatal("duplicate self-update was started while the first update was in flight")
+	default:
 	}
+	close(release)
 }
 
 func TestBufferTaskProgressTruncatesPerTask(t *testing.T) {

--- a/apps/docs/docs/architecture/agent.md
+++ b/apps/docs/docs/architecture/agent.md
@@ -228,9 +228,7 @@ The host record remains in CT-Ops's database (soft-deleted on revocation). You c
 The agent polls the ingest service for the minimum required version. If the running version is below the minimum:
 
 1. Ingest advertises the newer version on heartbeat responses
-2. The current agent logs that a manual upgrade is required
-3. Operators install the newer binary via the download/install bundle flow
-
-Automatic self-update is currently disabled until signed release verification is implemented.
+2. The agent downloads the replacement binary from the CT-Ops web download endpoint
+3. The agent atomically replaces its current executable and re-execs itself
 
 All updates are served from your CT-Ops server — no internet access required.

--- a/apps/ingest/internal/config/config.go
+++ b/apps/ingest/internal/config/config.go
@@ -1,15 +1,20 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+const agentReleasesURL = "https://api.github.com/repos/simonjcarr/ct-ops/releases?per_page=20"
 
 // Config is the ingest service configuration loaded from a YAML file.
 type Config struct {
@@ -89,11 +94,10 @@ func Load(path string) (*Config, error) {
 
 	applyEnv(cfg)
 
-	// If no explicit LatestVersion was supplied via YAML or env, try reading
-	// it from .release-please-manifest.json. release-please updates this file
-	// automatically when it cuts a new agent release, so this keeps the
-	// ingest service in sync without any manual env-var bookkeeping — exactly
-	// the same source of truth the web app uses (apps/web/lib/agent/version.ts).
+	// If no explicit LatestVersion was supplied via YAML or env, seed from the
+	// baked release-please manifest. The VersionPoller refreshes from published
+	// release metadata after startup so long-running ingest processes converge
+	// with the web UI's latest-agent badge without a restart.
 	if cfg.Agent.LatestVersion == "" {
 		if v := loadAgentVersionFromManifest(); v != "" {
 			cfg.Agent.LatestVersion = v
@@ -130,6 +134,91 @@ func loadAgentVersionFromManifest() string {
 		}
 	}
 	return ""
+}
+
+func discoverLatestAgentVersion(ctx context.Context) string {
+	if v, err := latestAgentVersionFromGitHub(ctx, agentReleasesURL, os.Getenv("GITHUB_TOKEN")); err == nil && v != "" {
+		return v
+	}
+	return loadAgentVersionFromManifest()
+}
+
+func latestAgentVersionFromGitHub(ctx context.Context, releasesURL, token string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GitHub releases API returned HTTP %d", resp.StatusCode)
+	}
+
+	var releases []struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return "", err
+	}
+	for _, release := range releases {
+		if version, ok := strings.CutPrefix(release.TagName, "agent/"); ok && strings.HasPrefix(version, "v") {
+			return version, nil
+		}
+	}
+	return "", nil
+}
+
+func shouldStoreCandidateVersion(current, candidate string) bool {
+	if candidate == "" {
+		return false
+	}
+	if current == "" {
+		return true
+	}
+	candidateParts, candidateOK := parseAgentVersion(candidate)
+	currentParts, currentOK := parseAgentVersion(current)
+	if !candidateOK || !currentOK {
+		return candidate != current
+	}
+	for i := range candidateParts {
+		if candidateParts[i] > currentParts[i] {
+			return true
+		}
+		if candidateParts[i] < currentParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func parseAgentVersion(version string) ([3]int, bool) {
+	var out [3]int
+	version = strings.TrimPrefix(version, "agent/")
+	version = strings.TrimPrefix(version, "v")
+	version, _, _ = strings.Cut(version, "-")
+	parts := strings.Split(version, ".")
+	if len(parts) != len(out) {
+		return out, false
+	}
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return out, false
+		}
+		out[i] = n
+	}
+	return out, true
 }
 
 func defaults() *Config {

--- a/apps/ingest/internal/config/version_poller.go
+++ b/apps/ingest/internal/config/version_poller.go
@@ -8,7 +8,7 @@ import (
 )
 
 // VersionPoller holds the current latest agent version and refreshes it from
-// the release-please manifest on a fixed interval. This allows the ingest
+// published release metadata on a fixed interval. This allows the ingest
 // service to pick up new agent releases without restarting.
 type VersionPoller struct {
 	current  atomic.Value // stores string
@@ -29,10 +29,11 @@ func (p *VersionPoller) Get() string {
 	return v
 }
 
-// Start runs a background goroutine that refreshes the version from the
-// manifest on the configured interval. It exits when ctx is cancelled.
+// Start runs a background goroutine that refreshes the version from published
+// release metadata on the configured interval. It exits when ctx is cancelled.
 func (p *VersionPoller) Start(ctx context.Context) {
 	go func() {
+		p.refresh(ctx)
 		ticker := time.NewTicker(p.interval)
 		defer ticker.Stop()
 		for {
@@ -40,14 +41,18 @@ func (p *VersionPoller) Start(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if v := loadAgentVersionFromManifest(); v != "" {
-					prev := p.Get()
-					if v != prev {
-						p.current.Store(v)
-						slog.Info("agent latest version updated", "previous", prev, "current", v)
-					}
-				}
+				p.refresh(ctx)
 			}
 		}
 	}()
+}
+
+func (p *VersionPoller) refresh(ctx context.Context) {
+	if v := discoverLatestAgentVersion(ctx); v != "" {
+		prev := p.Get()
+		if v != prev && shouldStoreCandidateVersion(prev, v) {
+			p.current.Store(v)
+			slog.Info("agent latest version updated", "previous", prev, "current", v)
+		}
+	}
 }

--- a/apps/ingest/internal/config/version_poller_test.go
+++ b/apps/ingest/internal/config/version_poller_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLatestAgentVersionFromGitHubReleases(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Errorf("Accept header = %q, want GitHub JSON media type", got)
+		}
+		fmt.Fprint(w, `[
+			{"tag_name":"web/v0.75.4"},
+			{"tag_name":"agent/v0.31.0"},
+			{"tag_name":"agent/v0.30.8"}
+		]`)
+	}))
+	defer server.Close()
+
+	got, err := latestAgentVersionFromGitHub(context.Background(), server.URL, "")
+	if err != nil {
+		t.Fatalf("latestAgentVersionFromGitHub: %v", err)
+	}
+	if got != "v0.31.0" {
+		t.Fatalf("latestAgentVersionFromGitHub = %q, want %q", got, "v0.31.0")
+	}
+}
+
+func TestLatestAgentVersionFromGitHubUsesToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want bearer token", got)
+		}
+		fmt.Fprint(w, `[{"tag_name":"agent/v0.31.0"}]`)
+	}))
+	defer server.Close()
+
+	got, err := latestAgentVersionFromGitHub(context.Background(), server.URL, "test-token")
+	if err != nil {
+		t.Fatalf("latestAgentVersionFromGitHub: %v", err)
+	}
+	if got != "v0.31.0" {
+		t.Fatalf("latestAgentVersionFromGitHub = %q, want %q", got, "v0.31.0")
+	}
+}
+
+func TestCandidateVersionDoesNotDowngradeCurrent(t *testing.T) {
+	t.Parallel()
+
+	if shouldStoreCandidateVersion("v0.31.0", "v0.30.8") {
+		t.Fatal("older manifest fallback should not downgrade a newer current version")
+	}
+	if !shouldStoreCandidateVersion("v0.30.8", "v0.31.0") {
+		t.Fatal("newer discovered release should update the current version")
+	}
+}


### PR DESCRIPTION
## Summary
- restore agent-side self-update execution when ingest advertises an available agent version
- make ingest refresh latest agent versions from published `agent/v...` releases instead of only rereading the baked release manifest
- update the agent architecture docs to describe the active self-update flow

## Root Cause
Ingest was seeded from the release-please manifest baked into the running image, so the process continued to advertise `v0.30.8` while the web UI showed `v0.31.0` from live GitHub release metadata. Separately, the agent heartbeat receiver intentionally logged update availability without invoking the updater, so even a correct server signal would not apply the new binary.

## Validation
- `go test ./agent/...`
- `go test ./apps/ingest/...`

## Notes
Tracked the separate stuck-task timeout warning from the provided ingest logs in #698.