### PR TITLE
fix(web): refresh filtered certificate results

### DIFF
--- a/apps/web/app/(dashboard)/certificates/certificates-client.tsx
+++ b/apps/web/app/(dashboard)/certificates/certificates-client.tsx
@@ -106,6 +106,7 @@ export function CertificatesClient({
     sortDir: 'asc',
     limit: 100,
   }
+  const useServerInitialCertificates = statusFilter === 'all' && hostFilter === '' && sortBy === 'not_after'
 
   const { data: certs = initialCertificates } = useQuery({
     queryKey: ['certificates', orgId, filters],
@@ -121,7 +122,7 @@ export function CertificatesClient({
       if (!res.ok) throw new Error('Failed to fetch certificates')
       return res.json() as Promise<Certificate[]>
     },
-    initialData: initialCertificates,
+    initialData: useServerInitialCertificates ? initialCertificates : undefined,
     staleTime: 30_000,
   })
 
@@ -150,7 +151,7 @@ export function CertificatesClient({
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">Certificates</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="certificates-heading">Certificates</h1>
           <p className="text-muted-foreground mt-1">
             {totalCerts} certificate{totalCerts !== 1 ? 's' : ''} tracked across your infrastructure
           </p>
@@ -223,13 +224,14 @@ export function CertificatesClient({
             className="pl-9 w-56"
             value={hostFilter}
             onChange={(e) => setHostFilter(e.target.value)}
+            data-testid="certificates-filter-host"
           />
         </div>
         <Select
           value={statusFilter}
           onValueChange={(v) => setStatusFilter(v as CertificateStatus | 'all')}
         >
-          <SelectTrigger className="w-44">
+          <SelectTrigger className="w-44" data-testid="certificates-status-filter">
             <SelectValue placeholder="All statuses" />
           </SelectTrigger>
           <SelectContent>
@@ -244,7 +246,7 @@ export function CertificatesClient({
           value={sortBy}
           onValueChange={(v) => setSortBy(v as CertificateListFilters['sortBy'])}
         >
-          <SelectTrigger className="w-44">
+          <SelectTrigger className="w-44" data-testid="certificates-sort-filter">
             <SelectValue placeholder="Sort by" />
           </SelectTrigger>
           <SelectContent>
@@ -284,6 +286,7 @@ export function CertificatesClient({
                   key={cert.id}
                   className="cursor-pointer"
                   onClick={() => router.push(`/certificates/${cert.id}`)}
+                  data-testid={`certificate-row-${cert.id}`}
                 >
                   <TableCell className="font-medium max-w-48 truncate">{cert.commonName}</TableCell>
                   <TableCell className="text-muted-foreground max-w-40 truncate">{cert.issuer}</TableCell>
@@ -305,6 +308,7 @@ export function CertificatesClient({
                       variant="ghost"
                       size="icon"
                       className="size-8 text-muted-foreground hover:text-destructive"
+                      data-testid={`certificate-delete-${cert.id}`}
                       onClick={(e) => {
                         e.stopPropagation()
                         deleteMutation.mutate(cert.id)

--- a/apps/web/tests/e2e/certificates/inventory.spec.ts
+++ b/apps/web/tests/e2e/certificates/inventory.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { issueTestLicence } from '../fixtures/licence'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can review, filter, and delete tracked certificates', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const licenceKey = await issueTestLicence({
+    orgId,
+    features: ['certExpiryTracker'],
+  })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await sql`
+    INSERT INTO certificates (
+      id,
+      organisation_id,
+      source,
+      host,
+      port,
+      server_name,
+      common_name,
+      issuer,
+      sans,
+      not_before,
+      not_after,
+      fingerprint_sha256,
+      status,
+      details,
+      last_seen_at
+    )
+    VALUES
+      (
+        'cert-e2e-valid',
+        ${orgId},
+        'discovered',
+        'api.example.com',
+        443,
+        'api.example.com',
+        'api.example.com',
+        'CT Test CA',
+        '["api.example.com"]'::jsonb,
+        NOW() - INTERVAL '10 days',
+        NOW() + INTERVAL '45 days',
+        'sha256-valid',
+        'valid',
+        '{"subject":"CN=api.example.com","issuer":"CN=CT Test CA","serialNumber":"1001","signatureAlgorithm":"sha256WithRSAEncryption","keyAlgorithm":"RSA-2048","isSelfSigned":false,"chain":[]}'::jsonb,
+        NOW() - INTERVAL '5 minutes'
+      ),
+      (
+        'cert-e2e-expiring',
+        ${orgId},
+        'discovered',
+        'edge.example.com',
+        8443,
+        'edge.example.com',
+        'edge.example.com',
+        'CT Test CA',
+        '["edge.example.com"]'::jsonb,
+        NOW() - INTERVAL '20 days',
+        NOW() + INTERVAL '3 days',
+        'sha256-expiring',
+        'expiring_soon',
+        '{"subject":"CN=edge.example.com","issuer":"CN=CT Test CA","serialNumber":"1002","signatureAlgorithm":"sha256WithRSAEncryption","keyAlgorithm":"RSA-2048","isSelfSigned":false,"chain":[]}'::jsonb,
+        NOW() - INTERVAL '10 minutes'
+      ),
+      (
+        'cert-e2e-expired',
+        ${orgId},
+        'discovered',
+        'legacy.example.com',
+        443,
+        'legacy.example.com',
+        'legacy.example.com',
+        'Legacy CA',
+        '["legacy.example.com"]'::jsonb,
+        NOW() - INTERVAL '90 days',
+        NOW() - INTERVAL '1 day',
+        'sha256-expired',
+        'expired',
+        '{"subject":"CN=legacy.example.com","issuer":"CN=Legacy CA","serialNumber":"1003","signatureAlgorithm":"sha256WithRSAEncryption","keyAlgorithm":"RSA-2048","isSelfSigned":false,"chain":[]}'::jsonb,
+        NOW() - INTERVAL '30 minutes'
+      )
+  `
+
+  await page.goto('/certificates')
+
+  await expect(page.getByTestId('certificates-heading')).toBeVisible()
+  await expect(page.getByTestId('certificate-row-cert-e2e-valid')).toContainText('api.example.com')
+  await expect(page.getByTestId('certificate-row-cert-e2e-expiring')).toContainText('edge.example.com')
+  await expect(page.getByTestId('certificate-row-cert-e2e-expired')).toContainText('legacy.example.com')
+
+  await page.getByTestId('certificates-filter-host').fill('edge')
+  await expect(page.getByTestId('certificate-row-cert-e2e-expiring')).toBeVisible()
+  await expect(page.getByTestId('certificate-row-cert-e2e-valid')).toHaveCount(0)
+  await expect(page.getByTestId('certificate-row-cert-e2e-expired')).toHaveCount(0)
+
+  await page.getByTestId('certificates-filter-host').fill('')
+  await page.getByTestId('certificates-status-filter').click()
+  await page.getByRole('option', { name: 'Expired' }).click()
+
+  await expect(page.getByTestId('certificate-row-cert-e2e-expired')).toBeVisible()
+  await expect(page.getByTestId('certificate-row-cert-e2e-valid')).toHaveCount(0)
+  await expect(page.getByTestId('certificate-row-cert-e2e-expiring')).toHaveCount(0)
+
+  await page.getByTestId('certificate-delete-cert-e2e-expired').click()
+  await expect(page.getByTestId('certificate-row-cert-e2e-expired')).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM certificates
+        WHERE id = 'cert-e2e-expired'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .toBeTruthy()
+})

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -203,3 +203,144 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
       config: { mode: 'all' },
     })
 })
+
+test('admin can create a security-only patch schedule for a host group', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'schedule-group-host-1',
+        ${orgId},
+        'schedule-group-host-1',
+        'Schedule Group Host 1',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.50.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'schedule-group-host-2',
+        ${orgId},
+        'schedule-group-host-2',
+        'Schedule Group Host 2',
+        'Ubuntu 24.04',
+        'arm64',
+        '["10.50.0.11"]'::jsonb,
+        'online',
+        NOW()
+      )
+  `
+
+  await sql`
+    INSERT INTO host_groups (
+      id,
+      organisation_id,
+      name,
+      description
+    )
+    VALUES (
+      'schedule-host-group-1',
+      ${orgId},
+      'Production Linux',
+      'Production patch window group'
+    )
+  `
+
+  await sql`
+    INSERT INTO host_group_members (
+      id,
+      organisation_id,
+      group_id,
+      host_id
+    )
+    VALUES
+      (
+        'schedule-group-member-1',
+        ${orgId},
+        'schedule-host-group-1',
+        'schedule-group-host-1'
+      ),
+      (
+        'schedule-group-member-2',
+        ${orgId},
+        'schedule-host-group-1',
+        'schedule-group-host-2'
+      )
+  `
+
+  await page.goto('/tasks/schedules/new')
+
+  await expect(page.getByTestId('task-schedule-heading-create')).toBeVisible()
+  await page.getByLabel('Name').fill('Weekly security patch wave')
+  await page.getByLabel('Description (optional)').fill('Apply security-only updates to the production group.')
+
+  await page.getByTestId('task-schedule-task-type').click()
+  await page.getByRole('option', { name: 'Patch' }).click()
+  await page.getByTestId('task-schedule-patch-mode').click()
+  await page.getByRole('option', { name: 'Security updates only' }).click()
+
+  await page.getByTestId('task-schedule-target-type').click()
+  await page.getByRole('option', { name: 'Host group' }).click()
+  await page.getByTestId('task-schedule-target-id').click()
+  await page.getByRole('option', { name: 'Production Linux' }).click()
+  await page.getByLabel('Max parallel hosts').fill('2')
+
+  await page.getByLabel('Cron expression (5 fields: minute hour dom month dow)').fill('0 1 * * 1')
+  await page.getByTestId('task-schedule-timezone').click()
+  await page.getByRole('option', { name: 'UTC' }).click()
+
+  await expect(page.getByTestId('task-schedule-preview-list')).toBeVisible()
+
+  await page.getByTestId('task-schedule-submit-create').click()
+
+  await expect(page).toHaveURL(/\/tasks$/)
+  const scheduleRow = page.getByRole('row', { name: /Weekly security patch wave/i })
+  await expect(scheduleRow).toContainText('Patch')
+  await expect(scheduleRow).toContainText('Production Linux')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        name: string
+        cron_expression: string
+        timezone: string
+        target_type: string
+        target_id: string
+        max_parallel: number
+        task_type: string
+        config: { mode?: string }
+      }>>`
+        SELECT name, cron_expression, timezone, target_type, target_id, max_parallel, task_type, config
+        FROM task_schedules
+        WHERE organisation_id = ${orgId}
+          AND name = 'Weekly security patch wave'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      name: 'Weekly security patch wave',
+      cron_expression: '0 1 * * 1',
+      timezone: 'UTC',
+      target_type: 'group',
+      target_id: 'schedule-host-group-1',
+      max_parallel: 2,
+      task_type: 'patch',
+      config: { mode: 'security' },
+    })
+})


### PR DESCRIPTION
## What changed
- added Playwright E2E coverage for the certificates dashboard, including seeded certificate rows, filtering, and delete behavior
- expanded scheduled task coverage to create a security-only patch schedule for a host group
- fixed the certificates dashboard query so filtered views do not keep reusing the unfiltered server snapshot

## Why
- the certificates area had no E2E coverage despite shipping filter and delete behavior
- scheduled task coverage did not exercise host-group targets or security-only patch mode
- the new certificates test exposed a real bug: changing filters kept the original list for up to 30 seconds because `initialData` was applied to every query key

## Impact
- certificate filters now update immediately in the dashboard
- regressions in certificates and richer schedule creation paths are covered by E2E tests

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/certificates/inventory.spec.ts tests/e2e/tasks/schedules.spec.ts`
