### PR TITLE
feat(install): add support data bundle

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -184,6 +184,7 @@ jobs:
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example
           cp deploy/customer-bundle/README.md dist/ct-ops/README.md
+          cp deploy/customer-bundle/generate_support_data dist/ct-ops/generate_support_data
           cp deploy/nginx/nginx.conf          dist/ct-ops/deploy/nginx/nginx.conf
           echo "$VERSION" > dist/ct-ops/VERSION
 
@@ -546,6 +547,9 @@ jobs:
           cp deploy/customer-bundle/build-offline-installer.sh dist/ct-ops/build-offline-installer.sh
           chmod +x dist/ct-ops/build-offline-installer.sh
           bash -n dist/ct-ops/build-offline-installer.sh
+
+          chmod +x dist/ct-ops/generate_support_data
+          bash -n dist/ct-ops/generate_support_data
 
           (cd dist && zip -r "../ct-ops-single-${VERSION}.zip" ct-ops)
           cp "ct-ops-single-${VERSION}.zip" ct-ops-single.zip

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/customer-bundle-check.yml"
       - "deploy/customer-bundle/**"
       - "deploy/scripts/test-install.sh"
+      - "deploy/scripts/test-support-data.sh"
       - "deploy/nginx/nginx.conf"
       - "docker-compose.single.yml"
       - ".env.example"
@@ -31,11 +32,12 @@ jobs:
           cp deploy/customer-bundle/README.md dist/ct-ops/README.md
           cp deploy/customer-bundle/start.sh dist/ct-ops/start.sh
           cp deploy/customer-bundle/build-offline-installer.sh dist/ct-ops/build-offline-installer.sh
+          cp deploy/customer-bundle/generate_support_data dist/ct-ops/generate_support_data
           cp deploy/nginx/nginx.conf dist/ct-ops/deploy/nginx/nginx.conf
           echo "test" > dist/ct-ops/VERSION
           perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml
           perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m' dist/ct-ops/.env.example
-          chmod +x dist/ct-ops/start.sh dist/ct-ops/build-offline-installer.sh
+          chmod +x dist/ct-ops/start.sh dist/ct-ops/build-offline-installer.sh dist/ct-ops/generate_support_data
 
       - name: Validate scripts and required files
         working-directory: dist/ct-ops
@@ -44,14 +46,17 @@ jobs:
           test -f docker-compose.yml
           test -f deploy/nginx/nginx.conf
           test -f .env.example
+          test -x generate_support_data
           bash -n start.sh
           bash -n build-offline-installer.sh
+          bash -n generate_support_data
 
       - name: Validate installer script
         run: |
           set -euo pipefail
           bash -n install.sh
           bash deploy/scripts/test-install.sh
+          bash deploy/scripts/test-support-data.sh
 
       - name: Render compose config
         working-directory: dist/ct-ops

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 71 — Customer support data bundle
+
+**Support diagnostics tooling** (`deploy/customer-bundle/generate_support_data`, `.github/workflows/`, `apps/docs/docs/`)
+- Added a customer-bundle `generate_support_data` executable that writes a timestamped `ct-ops-support-data-*.tar.gz` beside `docker-compose.yml`.
+- The archive includes sanitized `.env`/compose data, Docker status, recent compose logs, host information, file metadata, and TLS certificate fingerprints while excluding raw `.env` files, private keys, and database dumps.
+- Release and customer-bundle checks now stage and syntax-check the executable so it ships with the install bundle at the same level as `docker-compose.yml`.
+
+**Validation**
+- Added `deploy/scripts/test-support-data.sh` to verify support bundle generation and redaction of env secrets, compose-rendered secrets, and log bearer/password values.
+
 ### Session 70 — Patch status monitoring and management reporting
 
 **Patch status check** (`agent/internal/checks/patch_status.go`, `apps/web/lib/actions/checks.ts`, `apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx`)

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -31,6 +31,13 @@ nano .env
 
 When `docker compose ps` shows all containers as `healthy`, open the web UI at `https://<your-server>`. The bundle ships a self-signed certificate — your browser will warn on first visit. To replace it with a certificate from your own CA, see [Replacing the TLS certificate](#replacing-the-tls-certificate) below.
 
+If you need to open a support request, run `./generate_support_data` from the
+bundle directory. It creates `ct-ops-support-data-<timestamp>.tar.gz` next to
+`docker-compose.yml` with sanitized settings, Docker status, recent logs, host
+information, file metadata, and TLS certificate fingerprints. Raw `.env` files,
+private keys, and database dumps are not included; review the archive before
+attaching it to a ticket.
+
 If ports 80 or 443 are already in use on the host, set `NGINX_HTTP_PORT` and
 `NGINX_HTTPS_PORT` in `.env` before the second `./start.sh` run. Include the
 external HTTPS port in `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, and

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -45,6 +45,11 @@ CT_OPS_VERSION=v0.3.0 curl -fsSL ... | bash
 
 It then pulls images from GHCR and starts the stack. Database migrations run in a one-shot migration container before web and ingest start.
 
+The release bundle also includes `./generate_support_data`. Run it from the
+same directory as `docker-compose.yml` when opening a support request; it
+creates a redacted support archive with sanitized settings, Docker status,
+recent logs, host information, file metadata, and TLS certificate fingerprints.
+
 When all containers show `healthy` in `docker compose ps`, continue to [Create your account](#create-your-account).
 
 If ports 80 or 443 are already in use, set `NGINX_HTTP_PORT` and
@@ -212,3 +217,7 @@ docker compose -f docker-compose.single.yml down -v
 | Agent stays in pending state | Approve it in the Hosts page pending panel |
 | Migrations failed | Ensure the `db` container is healthy before running migrations |
 | `certificate signed by unknown authority` | Set `ca_cert_file` to point to `deploy/dev-tls/server.crt` |
+
+For support tickets from a release-bundle install, run `./generate_support_data`
+and review the generated `ct-ops-support-data-<timestamp>.tar.gz` before
+attaching it.

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -68,6 +68,7 @@ the external HTTPS port and `9443` to the instance.
 ./start.sh --down     # stop the stack (data is preserved)
 ./start.sh --version  # show bundle version, app version and licence tier
 ./start.sh --help     # links to documentation and support
+./generate_support_data  # create a redacted support archive
 ```
 
 ## Installing the agent
@@ -112,6 +113,18 @@ docker compose ps                       # container status
 docker compose logs web ingest db       # last logs
 cat VERSION                             # bundle version
 ```
+
+When opening a support request, run:
+
+```sh
+./generate_support_data
+```
+
+This creates `ct-ops-support-data-<timestamp>.tar.gz` next to
+`docker-compose.yml`. It includes sanitized settings, Docker status, recent
+logs, host information, file metadata, and TLS certificate fingerprints. It
+does not include raw `.env` files, private keys, or database dumps. Review the
+archive before attaching it to a ticket.
 
 Data lives in named Docker volumes (`db_data`, `ingest_data`, `agent_dist`).
 

--- a/deploy/customer-bundle/generate_support_data
+++ b/deploy/customer-bundle/generate_support_data
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collects a best-effort CT-Ops support bundle for customer installations.
+# The output intentionally avoids raw .env files, private keys, database dumps,
+# and docker inspect output. Logs and rendered config are redacted before they
+# are written to disk.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+LOG_LINES="${CT_OPS_SUPPORT_LOG_LINES:-300}"
+OUTPUT_DIR="${CT_OPS_SUPPORT_OUTPUT_DIR:-$SCRIPT_DIR}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ct-ops-support-data.XXXXXX")"
+BUNDLE_NAME="ct-ops-support-data-${TIMESTAMP}"
+BUNDLE_DIR="${WORK_DIR}/${BUNDLE_NAME}"
+ARCHIVE="${OUTPUT_DIR}/${BUNDLE_NAME}.tar.gz"
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$BUNDLE_DIR" "$OUTPUT_DIR"
+
+redact_stream() {
+  awk '
+    BEGIN { IGNORECASE = 1 }
+    function lower(s) { return tolower(s) }
+    function redact_kv(line,    eq, colon, pos, prefix, suffix) {
+      eq = index(line, "=")
+      colon = index(line, ":")
+      if (eq == 0 || (colon > 0 && colon < eq)) {
+        pos = colon
+      } else {
+        pos = eq
+      }
+      if (pos == 0) {
+        return "[REDACTED]"
+      }
+      prefix = substr(line, 1, pos)
+      suffix = substr(line, pos + 1)
+      if (suffix ~ /^[[:space:]]/) {
+        return prefix " [REDACTED]"
+      }
+      return prefix "[REDACTED]"
+    }
+    {
+      line = $0
+
+      if (line ~ /-----BEGIN .*PRIVATE[[:space:]]+KEY-----/) {
+        private_key = 1
+        print "[REDACTED PEM KEY BLOCK]"
+        next
+      }
+      if (private_key) {
+        if (line ~ /-----END .*PRIVATE[[:space:]]+KEY-----/) {
+          print "[END REDACTED PEM KEY BLOCK]"
+          private_key = 0
+        }
+        next
+      }
+
+      gsub(/Bearer[[:space:]]+[^[:space:]]+/, "Bearer [REDACTED]", line)
+      gsub(/Basic[[:space:]]+[^[:space:]]+/, "Basic [REDACTED]", line)
+      gsub(/:\/\/[^\/@[:space:]]+:[^\/@[:space:]]+@/, "://[REDACTED]@", line)
+
+      lowered = lower(line)
+      if (lowered ~ /(password|secret|token|credential|private|jwt|cookie|session|loadtest_admin_key|encryption_key)/ && line ~ /[:=]/) {
+        print redact_kv(line)
+        next
+      }
+
+      print line
+    }
+  '
+}
+
+write_section() {
+  local title="$1"
+  printf '\n## %s\n\n' "$title"
+}
+
+run_command() {
+  local path="$1"
+  shift
+  {
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n\n'
+    set +e
+    "$@"
+    status=$?
+    set -e
+    printf '\n(exit status: %s)\n' "$status"
+    exit "$status"
+  } 2>&1 | redact_stream > "${BUNDLE_DIR}/${path}" || true
+}
+
+copy_redacted_file() {
+  local source="$1"
+  local target="$2"
+  if [ -f "$source" ]; then
+    redact_stream < "$source" > "${BUNDLE_DIR}/${target}"
+  else
+    printf '%s not found\n' "$source" > "${BUNDLE_DIR}/${target}"
+  fi
+}
+
+collect_manifest() {
+  {
+    echo "CT-Ops support data"
+    echo "Generated UTC: ${TIMESTAMP}"
+    echo "Bundle directory: ${SCRIPT_DIR}"
+    echo "Log lines per service: ${LOG_LINES}"
+    if [ -f VERSION ]; then
+      echo "Bundle version: $(cat VERSION)"
+    else
+      echo "Bundle version: unknown"
+    fi
+    echo ""
+    echo "Redaction policy:"
+    echo "- Raw .env files are not included."
+    echo "- Values whose names contain password, secret, token, key, credential, JWT,"
+    echo "  cookie, session, or load-test admin key markers are replaced with [REDACTED]."
+    echo "- Bearer/Basic authorization values and URL userinfo are replaced with [REDACTED]."
+    echo "- Private key PEM blocks are replaced with redacted placeholders."
+  } > "${BUNDLE_DIR}/manifest.txt"
+}
+
+collect_host_info() {
+  {
+    write_section "Host"
+    echo "Hostname: $(hostname 2>/dev/null || echo unknown)"
+    echo "User: $(id 2>/dev/null || echo unknown)"
+    echo "Date UTC: $(date -u 2>/dev/null || echo unknown)"
+    echo "Uname: $(uname -a 2>/dev/null || echo unknown)"
+
+    if [ -f /etc/os-release ]; then
+      write_section "OS Release"
+      sed -n '1,80p' /etc/os-release
+    fi
+
+    write_section "Disk"
+    df -h 2>/dev/null || true
+
+    write_section "Memory"
+    if command -v free >/dev/null 2>&1; then
+      free -h
+    elif command -v vm_stat >/dev/null 2>&1; then
+      vm_stat
+    else
+      echo "memory command unavailable"
+    fi
+
+    write_section "Uptime"
+    uptime 2>/dev/null || true
+  } | redact_stream > "${BUNDLE_DIR}/host-info.txt"
+}
+
+collect_file_inventory() {
+  {
+    write_section "Bundle Files"
+    find . -maxdepth 3 \
+      \( -path './.git' -o -path './images.tar.gz' -o -name 'ct-ops-support-data-*.tar.gz' \) -prune \
+      -o -type f -printf '%M %s %p\n' 2>/dev/null || find . -maxdepth 3 -type f -print
+
+    write_section "Key Directory Listing"
+    for dir in . deploy deploy/tls deploy/dev-tls deploy/nginx; do
+      [ -e "$dir" ] || continue
+      echo "# ${dir}"
+      ls -la "$dir" 2>/dev/null || true
+      echo ""
+    done
+  } | redact_stream > "${BUNDLE_DIR}/file-inventory.txt"
+}
+
+collect_tls_info() {
+  {
+    for cert in deploy/tls/server.crt deploy/dev-tls/server.crt; do
+      write_section "$cert"
+      if [ ! -f "$cert" ]; then
+        echo "not found"
+        continue
+      fi
+      if command -v openssl >/dev/null 2>&1; then
+        openssl x509 -in "$cert" -noout -subject -issuer -dates -fingerprint -sha256 2>&1 || true
+        openssl x509 -in "$cert" -noout -ext subjectAltName 2>/dev/null || true
+      else
+        echo "openssl not available; certificate metadata not collected"
+      fi
+    done
+  } | redact_stream > "${BUNDLE_DIR}/tls-info.txt"
+}
+
+collect_docker_info() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker not found in PATH" > "${BUNDLE_DIR}/docker-info.txt"
+    return 0
+  fi
+
+  run_command docker-info.txt docker version
+
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "docker compose plugin not available" >> "${BUNDLE_DIR}/docker-info.txt"
+    return 0
+  fi
+
+  run_command docker-compose-version.txt docker compose version
+
+  if [ -f docker-compose.yml ]; then
+    # Prevent known required secrets from being interpolated into rendered
+    # config. The rendered file still goes through the generic redactor.
+    (
+      export BETTER_AUTH_SECRET=support-redacted
+      export POSTGRES_PASSWORD=support-redacted
+      export LDAP_ENCRYPTION_KEY=support-redacted
+      export CT_OPS_LOADTEST_ADMIN_KEY=support-redacted
+      docker compose -f docker-compose.yml config
+    ) 2>&1 | redact_stream > "${BUNDLE_DIR}/docker-compose-config.txt" || true
+  else
+    echo "docker-compose.yml not found" > "${BUNDLE_DIR}/docker-compose-config.txt"
+  fi
+
+  run_command docker-compose-ps.txt docker compose ps
+  run_command docker-compose-images.txt docker compose images
+  run_command docker-system-df.txt docker system df
+
+  {
+    echo "$ docker compose logs --no-color --timestamps --tail ${LOG_LINES}"
+    echo ""
+    set +e
+    docker compose logs --no-color --timestamps --tail "$LOG_LINES"
+    status=$?
+    set -e
+    echo ""
+    echo "(exit status: ${status})"
+    exit "$status"
+  } 2>&1 | redact_stream > "${BUNDLE_DIR}/docker-logs.txt" || true
+}
+
+collect_manifest
+collect_host_info
+collect_file_inventory
+collect_tls_info
+copy_redacted_file .env environment.env
+copy_redacted_file .env.example environment-example.env
+copy_redacted_file docker-compose.yml docker-compose.yml.txt
+collect_docker_info
+
+cat > "${BUNDLE_DIR}/README.txt" <<'EOF'
+This archive contains best-effort diagnostic data for CT-Ops support.
+
+Before sending it to support, you may inspect the text files inside the archive.
+The generator redacts common secret formats, but customer environments can use
+custom naming conventions, so review the archive according to your own data
+handling policy.
+EOF
+
+tar -czf "$ARCHIVE" -C "$WORK_DIR" "$BUNDLE_NAME"
+
+echo "Wrote support archive: $ARCHIVE"
+echo "Review the archive before attaching it to a support request."

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -45,6 +45,7 @@ Commands:
   ./start.sh --down      Stop the stack (named volumes are preserved)
   ./start.sh --version   Show bundle version, app version and licence tier
   ./start.sh --help      Show this message
+  ./generate_support_data  Create a redacted support archive for tickets
 
 Documentation: ${DOCS_URL}
 Support:       ${SUPPORT_URL}

--- a/deploy/scripts/test-support-data.sh
+++ b/deploy/scripts/test-support-data.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SUPPORT_SCRIPT="${REPO_ROOT}/deploy/customer-bundle/generate_support_data"
+
+make_mock_docker() {
+  local dir="$1"
+
+  cat > "${dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+case "$1" in
+  version)
+    cat <<'OUT'
+Client: Docker Engine - Community
+ Version: 27.0.0
+Server: Docker Engine - Community
+ Version: 27.0.0
+OUT
+    ;;
+  system)
+    if [ "${2:-}" = "df" ]; then
+      cat <<'OUT'
+TYPE            TOTAL     ACTIVE    SIZE
+Images          5         3         2GB
+Volumes         3         3         1GB
+OUT
+    fi
+    ;;
+  compose)
+    case "${2:-}" in
+      version)
+        echo "Docker Compose version v2.29.0"
+        ;;
+      config)
+        cat <<'OUT'
+services:
+  web:
+    environment:
+      BETTER_AUTH_URL: https://ct-ops.example.com
+      BETTER_AUTH_SECRET: compose-secret-value
+      POSTGRES_PASSWORD: compose-postgres-value
+OUT
+        ;;
+      ps)
+        echo "NAME          SERVICE   STATUS"
+        echo "ct-ops-web-1  web       running"
+        ;;
+      images)
+        echo "SERVICE   IMAGE"
+        echo "web       ghcr.io/carrtech-dev/ct-ops/web@sha256:abc"
+        ;;
+      logs)
+        cat <<'OUT'
+web-1  | ready BETTER_AUTH_URL=https://ct-ops.example.com
+web-1  | leaked POSTGRES_PASSWORD=log-postgres-value
+ingest | Authorization: Bearer log-bearer-token
+OUT
+        ;;
+      *)
+        exit 0
+        ;;
+    esac
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+
+  chmod +x "${dir}/docker"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "unexpected sensitive value '$needle' found in $file" >&2
+    sed -n '1,160p' "$file" >&2
+    exit 1
+  fi
+}
+
+main() {
+  local tmpdir bundle mockbin out extract archive
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "'"$tmpdir"'"' EXIT
+
+  bundle="${tmpdir}/ct-ops"
+  mockbin="${tmpdir}/mockbin"
+  mkdir -p "$bundle" "$mockbin"
+  make_mock_docker "$mockbin"
+
+  cat > "${bundle}/.env" <<'EOF'
+BETTER_AUTH_URL=https://ct-ops.example.com
+BETTER_AUTH_TRUSTED_ORIGINS=https://ct-ops.example.com
+BETTER_AUTH_SECRET=env-better-auth-secret
+POSTGRES_PASSWORD=env-postgres-password
+CT_OPS_LOADTEST_ADMIN_KEY=env-loadtest-key
+WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:abc
+EOF
+
+  cat > "${bundle}/docker-compose.yml" <<'EOF'
+services:
+  web:
+    image: ${WEB_IMAGE}
+EOF
+  echo "1.2.3" > "${bundle}/VERSION"
+  cp "$SUPPORT_SCRIPT" "${bundle}/generate_support_data"
+  chmod +x "${bundle}/generate_support_data"
+
+  out="$(
+    cd "$bundle" &&
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" ./generate_support_data
+  )"
+
+  archive="$(find "$bundle" -maxdepth 1 -name 'ct-ops-support-data-*.tar.gz' -print | head -n1)"
+  if [ -z "$archive" ]; then
+    echo "support archive was not created" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+
+  extract="${tmpdir}/extract"
+  mkdir -p "$extract"
+  tar -xzf "$archive" -C "$extract"
+
+  local root
+  root="$(find "$extract" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+  test -f "${root}/environment.env"
+  test -f "${root}/docker-compose-config.txt"
+  test -f "${root}/docker-logs.txt"
+  test -f "${root}/manifest.txt"
+
+  grep -Fq "BETTER_AUTH_URL=https://ct-ops.example.com" "${root}/environment.env"
+  grep -Fq "BETTER_AUTH_SECRET=[REDACTED]" "${root}/environment.env"
+  grep -Fq "POSTGRES_PASSWORD=[REDACTED]" "${root}/environment.env"
+  grep -Fq "CT_OPS_LOADTEST_ADMIN_KEY=[REDACTED]" "${root}/environment.env"
+
+  assert_not_contains "${root}/environment.env" "env-better-auth-secret"
+  assert_not_contains "${root}/environment.env" "env-postgres-password"
+  assert_not_contains "${root}/environment.env" "env-loadtest-key"
+  assert_not_contains "${root}/docker-compose-config.txt" "compose-secret-value"
+  assert_not_contains "${root}/docker-compose-config.txt" "compose-postgres-value"
+  assert_not_contains "${root}/docker-logs.txt" "log-postgres-value"
+  assert_not_contains "${root}/docker-logs.txt" "log-bearer-token"
+
+  if tar -tzf "$archive" | grep -Eq '(^|/)\.env$'; then
+    echo "archive must not include raw .env" >&2
+    tar -tzf "$archive" >&2
+    exit 1
+  fi
+
+  echo "support data redaction tests passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- add a customer-bundle `generate_support_data` executable beside `docker-compose.yml`
- collect sanitized environment/config, Docker status, recent compose logs, host info, file metadata, and TLS certificate fingerprints
- wire the executable into release and bundle-check staging, with docs and redaction tests

## Validation

- `bash -n deploy/customer-bundle/generate_support_data deploy/customer-bundle/start.sh deploy/customer-bundle/build-offline-installer.sh install.sh`
- `bash deploy/scripts/test-support-data.sh`
- `bash deploy/scripts/test-install.sh`
- local customer bundle staging check including `docker compose config --images` digest validation
- `git diff --check`

Shellcheck was not run because it is not installed in this environment.