### PR TITLE
fix(web): add host groups and networks e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -935,12 +935,17 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
 
       {/* Host Networks Tab */}
       {activeTab === 'host-networks' && (
-        <div className="space-y-4">
+        <div className="space-y-4" data-testid="host-networks-tab">
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               Networks this host belongs to.
             </p>
-            <Button size="sm" onClick={() => setAddNetworkOpen(true)} disabled={allNetworks.length === hostNetworksList.length}>
+            <Button
+              size="sm"
+              onClick={() => setAddNetworkOpen(true)}
+              disabled={allNetworks.length === hostNetworksList.length}
+              data-testid="host-networks-add-trigger"
+            >
               <Network className="size-4 mr-1" />
               Add to Network
             </Button>
@@ -960,7 +965,11 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
           ) : (
             <div className="rounded-lg border divide-y">
               {hostNetworksList.map((network) => (
-                <div key={network.id} className="flex items-center gap-3 px-4 py-3">
+                <div
+                  key={network.id}
+                  className="flex items-center gap-3 px-4 py-3"
+                  data-testid={`host-network-row-${network.id}`}
+                >
                   <Network className="size-4 text-muted-foreground shrink-0" />
                   <div className="flex-1 min-w-0">
                     <Link
@@ -972,12 +981,18 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
                     <div className="flex items-center gap-2 mt-0.5">
                       <code className="text-xs font-mono text-muted-foreground">{network.cidr}</code>
                       {network.autoAssigned ? (
-                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <span
+                          className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                          data-testid={`host-network-membership-${network.id}`}
+                        >
                           <Zap className="size-3" />
                           Auto
                         </span>
                       ) : (
-                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <span
+                          className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                          data-testid={`host-network-membership-${network.id}`}
+                        >
                           <User className="size-3" />
                           Manual
                         </span>
@@ -990,6 +1005,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
                     className="size-8 text-destructive hover:text-destructive shrink-0"
                     disabled={isRemovingFromNetwork}
                     onClick={() => doRemoveFromNetwork(network.id)}
+                    data-testid={`host-networks-remove-${network.id}`}
                   >
                     <Trash2 className="size-3.5" />
                   </Button>
@@ -1026,6 +1042,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
                           variant="outline"
                           disabled={isAddingToNetwork}
                           onClick={() => doAddToNetwork(network.id)}
+                          data-testid={`host-networks-add-${network.id}`}
                         >
                           {isAddingToNetwork ? <Loader2 className="size-3.5 animate-spin" /> : 'Add'}
                         </Button>

--- a/apps/web/app/(dashboard)/hosts/groups/groups-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/groups-client.tsx
@@ -55,6 +55,14 @@ interface Props {
   initialGroups: HostGroupWithCount[]
 }
 
+function toTestIdSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
 function GroupForm({
   defaultValues,
   onSubmit,
@@ -81,7 +89,12 @@ function GroupForm({
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       <div className="space-y-1.5">
         <Label htmlFor="name">Name</Label>
-        <Input id="name" placeholder="e.g. Production Web Servers" {...register('name')} />
+        <Input
+          id="name"
+          placeholder="e.g. Production Web Servers"
+          data-testid="host-groups-form-name"
+          {...register('name')}
+        />
         {errors.name && (
           <p className="text-destructive text-sm">{errors.name.message}</p>
         )}
@@ -95,6 +108,7 @@ function GroupForm({
           id="description"
           rows={3}
           placeholder="What hosts belong in this group and why?"
+          data-testid="host-groups-form-description"
           className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           {...register('description')}
         />
@@ -106,7 +120,11 @@ function GroupForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" disabled={isPending}>
+        <Button
+          type="submit"
+          disabled={isPending}
+          data-testid={submitLabel === 'Create Group' ? 'host-groups-create-submit' : 'host-groups-edit-submit'}
+        >
           {isPending && <Loader2 className="size-4 mr-1 animate-spin" />}
           {submitLabel}
         </Button>
@@ -162,13 +180,18 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
         <div className="flex items-center gap-3">
           <Layers className="size-6 text-muted-foreground" />
           <div>
-            <h1 className="text-2xl font-semibold text-foreground">Host Groups</h1>
+            <h1
+              className="text-2xl font-semibold text-foreground"
+              data-testid="host-groups-heading"
+            >
+              Host Groups
+            </h1>
             <p className="text-sm text-muted-foreground">
               Organise hosts into named groups for batch operations
             </p>
           </div>
         </div>
-        <Button onClick={() => setCreateOpen(true)}>
+        <Button onClick={() => setCreateOpen(true)} data-testid="host-groups-create-trigger">
           <Plus className="size-4 mr-1" />
           New Group
         </Button>
@@ -176,7 +199,10 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
 
       {/* Table */}
       {groups.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-12 text-center">
+        <div
+          className="rounded-lg border border-dashed p-12 text-center"
+          data-testid="host-groups-empty-state"
+        >
           <Layers className="size-8 mx-auto text-muted-foreground mb-3" />
           <p className="text-sm font-medium text-foreground">No groups yet</p>
           <p className="text-xs text-muted-foreground mt-1">
@@ -201,7 +227,10 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
             </TableHeader>
             <TableBody>
               {groups.map((group) => (
-                <TableRow key={group.id}>
+                <TableRow
+                  key={group.id}
+                  data-testid={`host-groups-row-${toTestIdSlug(group.name)}`}
+                >
                   <TableCell>
                     <Link
                       href={`/hosts/groups/${group.id}`}
@@ -229,6 +258,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
                         size="icon"
                         className="size-8"
                         onClick={() => setEditGroup(group)}
+                        data-testid={`host-groups-edit-${group.id}`}
                       >
                         <Pencil className="size-3.5" />
                       </Button>
@@ -237,6 +267,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
                         size="icon"
                         className="size-8 text-destructive hover:text-destructive"
                         onClick={() => setDeleteTarget(group)}
+                        data-testid={`host-groups-delete-${group.id}`}
                       >
                         <Trash2 className="size-3.5" />
                       </Button>
@@ -255,6 +286,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
           <DialogHeader>
             <DialogTitle>Create Group</DialogTitle>
           </DialogHeader>
+          <div data-testid="host-groups-create-dialog">
           <GroupForm
             defaultValues={{ name: '', description: '' }}
             onSubmit={(d) => doCreate(d)}
@@ -262,6 +294,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
             isPending={isCreating}
             submitLabel="Create Group"
           />
+          </div>
         </DialogContent>
       </Dialog>
 
@@ -275,6 +308,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
             <DialogTitle>Edit Group</DialogTitle>
           </DialogHeader>
           {editGroup && (
+            <div data-testid="host-groups-edit-dialog">
             <GroupForm
               defaultValues={{ name: editGroup.name, description: editGroup.description ?? '' }}
               onSubmit={(d) => doUpdate(d)}
@@ -282,6 +316,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
               isPending={isUpdating}
               submitLabel="Save Changes"
             />
+            </div>
           )}
         </DialogContent>
       </Dialog>
@@ -304,6 +339,7 @@ export function GroupsClient({ orgId, initialGroups }: Props) {
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={() => deleteTarget && doDelete(deleteTarget.id)}
               disabled={isDeleting}
+              data-testid="host-groups-delete-confirm"
             >
               {isDeleting && <Loader2 className="size-4 mr-1 animate-spin" />}
               Delete

--- a/apps/web/tests/e2e/hosts/groups.spec.ts
+++ b/apps/web/tests/e2e/hosts/groups.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug} LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('authenticated user can create, edit, and delete a host group', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await page.goto('/hosts/groups')
+
+  await expect(page.getByTestId('host-groups-heading')).toBeVisible()
+  await expect(page.getByTestId('host-groups-empty-state')).toBeVisible()
+
+  await page.getByTestId('host-groups-create-trigger').click()
+  await page.getByTestId('host-groups-form-name').fill('Linux Servers')
+  await page.getByTestId('host-groups-form-description').fill('Linux production fleet')
+  await page.getByTestId('host-groups-create-submit').click()
+
+  const initialRow = page.getByTestId('host-groups-row-linux-servers')
+  await expect(initialRow).toBeVisible()
+  await expect(initialRow).toContainText('Linux Servers')
+  await expect(initialRow).toContainText('Linux production fleet')
+  await expect(initialRow).toContainText('0')
+
+  const createdRows = await sql<Array<{ id: string; deleted_at: string | null }>>`
+    SELECT id, deleted_at
+    FROM host_groups
+    WHERE organisation_id = ${orgId}
+      AND name = 'Linux Servers'
+    LIMIT 1
+  `
+
+  expect(createdRows).toHaveLength(1)
+  expect(createdRows[0]?.deleted_at).toBeNull()
+
+  const groupId = createdRows[0]!.id
+
+  await page.getByTestId(`host-groups-edit-${groupId}`).click()
+  await page.getByTestId('host-groups-form-name').fill('Linux Estate')
+  await page.getByTestId('host-groups-form-description').fill('Linux production and staging fleet')
+  await page.getByTestId('host-groups-edit-submit').click()
+
+  const updatedRow = page.getByTestId('host-groups-row-linux-estate')
+  await expect(updatedRow).toBeVisible()
+  await expect(updatedRow).toContainText('Linux production and staging fleet')
+
+  await page.getByTestId(`host-groups-delete-${groupId}`).click()
+  await page.getByTestId('host-groups-delete-confirm').click()
+
+  await expect(updatedRow).toHaveCount(0)
+  await expect(page.getByTestId('host-groups-empty-state')).toBeVisible()
+
+  const deletedRows = await sql<Array<{ deleted_at: string | null }>>`
+    SELECT deleted_at
+    FROM host_groups
+    WHERE id = ${groupId}
+    LIMIT 1
+  `
+
+  expect(deletedRows).toHaveLength(1)
+  expect(deletedRows[0]?.deleted_at).not.toBeNull()
+})

--- a/apps/web/tests/e2e/hosts/patch-status.spec.ts
+++ b/apps/web/tests/e2e/hosts/patch-status.spec.ts
@@ -10,7 +10,7 @@ async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
   return rows[0]!.id
 }
 
-test('host infrastructure tab shows patch status for the selected host', async ({ authenticatedPage: page }) => {
+test('host infrastructure tab shows network memberships and patch status for the selected host', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const orgId = await getOrgId(sql)
 
@@ -92,8 +92,53 @@ test('host infrastructure tab shows patch status for the selected host', async (
       ('patch-update-2', ${orgId}, 'patch-host-1', 'libssl3', '3.0.2-1', '3.0.2-2', 'apt', 'current', NOW(), NOW())
   `
 
+  await sql`
+    INSERT INTO networks (
+      id,
+      organisation_id,
+      name,
+      cidr,
+      description
+    )
+    VALUES
+      ('network-auto-1', ${orgId}, 'Office LAN', '10.20.0.0/24', 'Auto-discovered office subnet'),
+      ('network-manual-1', ${orgId}, 'DMZ', '10.30.0.0/24', 'Manually managed network')
+  `
+
+  await sql`
+    INSERT INTO host_network_memberships (
+      id,
+      organisation_id,
+      network_id,
+      host_id,
+      auto_assigned
+    )
+    VALUES (
+      'membership-auto-1',
+      ${orgId},
+      'network-auto-1',
+      'patch-host-1',
+      true
+    )
+  `
+
   await page.goto('/hosts/patch-host-1')
   await page.getByRole('button', { name: 'Infrastructure' }).click()
+  await page.getByRole('button', { name: 'Networks' }).click()
+
+  await expect(page.getByTestId('host-networks-tab')).toBeVisible()
+  await expect(page.getByTestId('host-network-row-network-auto-1')).toContainText('Office LAN')
+  await expect(page.getByTestId('host-network-membership-network-auto-1')).toContainText('Auto')
+
+  await page.getByTestId('host-networks-add-trigger').click()
+  await page.getByTestId('host-networks-add-network-manual-1').click()
+
+  await expect(page.getByTestId('host-network-row-network-manual-1')).toContainText('DMZ')
+  await expect(page.getByTestId('host-network-membership-network-manual-1')).toContainText('Manual')
+
+  await page.getByTestId('host-networks-remove-network-manual-1').click()
+  await expect(page.getByTestId('host-network-row-network-manual-1')).toHaveCount(0)
+
   await page.getByRole('button', { name: 'Patch Status' }).click()
 
   await expect(page.getByTestId('host-patch-status-tab')).toBeVisible()
@@ -101,4 +146,15 @@ test('host infrastructure tab shows patch status for the selected host', async (
   await expect(page.getByText('2 updates available')).toBeVisible()
   await expect(page.getByText('openssl')).toBeVisible()
   await expect(page.getByText('libssl3')).toBeVisible()
+
+  const membershipRows = await sql<Array<{ deleted_at: string | null }>>`
+    SELECT deleted_at
+    FROM host_network_memberships
+    WHERE network_id = 'network-manual-1'
+      AND host_id = 'patch-host-1'
+    LIMIT 1
+  `
+
+  expect(membershipRows).toHaveLength(1)
+  expect(membershipRows[0]?.deleted_at).not.toBeNull()
 })


### PR DESCRIPTION
## Summary
- add a new E2E spec covering host group create, edit, and delete flows
- expand the host infrastructure E2E spec to cover network memberships alongside patch status
- add stable test ids for the host groups page and host network management UI

## Testing
- pnpm --filter web test:e2e -- tests/e2e/hosts/groups.spec.ts tests/e2e/hosts/patch-status.spec.ts