### PR TITLE
fix(ingest): repair stuck task timeout interval encoding

### DIFF
--- a/apps/ingest/internal/db/queries/task_runs.sql.go
+++ b/apps/ingest/internal/db/queries/task_runs.sql.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+type taskRunExec interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
 
 // PendingAgentTask represents a task_run_hosts row that is ready to be dispatched
 // to an agent, along with the parent task_run config.
@@ -168,6 +173,10 @@ func CompleteTaskRunHost(
 // 'running' status for longer than maxAge as 'failed', then closes any parent
 // task_run whose all hosts are now in a terminal state.
 func TimeoutStuckTaskRunHosts(ctx context.Context, pool *pgxpool.Pool, maxAge time.Duration) error {
+	return timeoutStuckTaskRunHosts(ctx, pool, maxAge)
+}
+
+func timeoutStuckTaskRunHosts(ctx context.Context, exec taskRunExec, maxAge time.Duration) error {
 	const q = `
 		WITH timed_out AS (
 		  UPDATE task_run_hosts
@@ -177,7 +186,7 @@ func TimeoutStuckTaskRunHosts(ctx context.Context, pool *pgxpool.Pool, maxAge ti
 		      updated_at   = NOW()
 		  WHERE status     IN ('running', 'cancelling')
 		    AND deleted_at IS NULL
-		    AND started_at < NOW() - ($1 || ' seconds')::interval
+		    AND started_at < NOW() - make_interval(secs => $1::int)
 		  RETURNING task_run_id
 		),
 		affected AS (
@@ -207,8 +216,8 @@ func TimeoutStuckTaskRunHosts(ctx context.Context, pool *pgxpool.Pool, maxAge ti
 		  AND rc.still_active   = 0
 		  AND tr.status NOT IN ('completed', 'failed', 'cancelled')
 	`
-	secs := int64(maxAge.Seconds())
-	_, err := pool.Exec(ctx, q, secs)
+	secs := int32(maxAge / time.Second)
+	_, err := exec.Exec(ctx, q, secs)
 	return err
 }
 

--- a/apps/ingest/internal/db/queries/task_runs_test.go
+++ b/apps/ingest/internal/db/queries/task_runs_test.go
@@ -1,0 +1,50 @@
+package queries
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakeTaskRunExec struct {
+	sql  string
+	args []any
+	tag  pgconn.CommandTag
+	err  error
+}
+
+func (f *fakeTaskRunExec) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.sql = sql
+	f.args = args
+	return f.tag, f.err
+}
+
+func TestTimeoutStuckTaskRunHostsUsesTypedInterval(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeTaskRunExec{tag: pgconn.NewCommandTag("UPDATE 2")}
+
+	if err := timeoutStuckTaskRunHosts(context.Background(), exec, 90*time.Minute); err != nil {
+		t.Fatalf("timeoutStuckTaskRunHosts: %v", err)
+	}
+
+	if !strings.Contains(exec.sql, "make_interval(secs => $1::int)") {
+		t.Fatalf("query does not build a typed interval: %s", exec.sql)
+	}
+	if strings.Contains(exec.sql, "|| ' seconds'") {
+		t.Fatalf("query still concatenates seconds into text: %s", exec.sql)
+	}
+	if len(exec.args) != 1 {
+		t.Fatalf("args = %#v, want exactly one argument", exec.args)
+	}
+	secs, ok := exec.args[0].(int32)
+	if !ok {
+		t.Fatalf("arg type = %T, want int32", exec.args[0])
+	}
+	if secs != 5400 {
+		t.Fatalf("secs = %d, want 5400", secs)
+	}
+}


### PR DESCRIPTION
## Summary
- replace text concatenation interval building in `TimeoutStuckTaskRunHosts` with `make_interval(secs => $1::int)`
- pass a whole-second integer argument to avoid pgx text encoding failures
- add a regression test covering the typed interval SQL shape

## Testing
- go test ./internal/db/queries

Closes #698