### PR TITLE
fix(web): send auth emails via SMTP relay

### DIFF
--- a/apps/web/lib/auth/email.test.mjs
+++ b/apps/web/lib/auth/email.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { encrypt } from '../crypto/encrypt.ts'
+import {
+  getAuthEmailConfigFromEnv,
+  getAuthEmailConfigFromOrgSettings,
+} from './email.ts'
+
+test('getAuthEmailConfigFromEnv returns null without required SMTP env vars', () => {
+  assert.equal(getAuthEmailConfigFromEnv({}), null)
+})
+
+test('getAuthEmailConfigFromEnv maps AUTH_EMAIL_* vars into SMTP config', () => {
+  assert.deepEqual(
+    getAuthEmailConfigFromEnv({
+      AUTH_EMAIL_SMTP_HOST: 'smtp.example.com',
+      AUTH_EMAIL_SMTP_PORT: '465',
+      AUTH_EMAIL_SMTP_SECURE: 'true',
+      AUTH_EMAIL_SMTP_USER: 'mailer',
+      AUTH_EMAIL_SMTP_PASSWORD: 'secret',
+      AUTH_EMAIL_FROM: 'noreply@example.com',
+      AUTH_EMAIL_FROM_NAME: 'CT-Ops Mailer',
+    }),
+    {
+      host: 'smtp.example.com',
+      port: 465,
+      encryption: 'tls',
+      username: 'mailer',
+      password: 'secret',
+      fromAddress: 'noreply@example.com',
+      fromName: 'CT-Ops Mailer',
+    },
+  )
+})
+
+test('getAuthEmailConfigFromOrgSettings uses the enabled central relay and decrypts its password', () => {
+  process.env.BETTER_AUTH_SECRET = '01234567890123456789012345678901'
+  const encryptedPassword = encrypt('relay-secret')
+
+  assert.deepEqual(
+    getAuthEmailConfigFromOrgSettings({
+      smtpRelay: {
+        enabled: true,
+        host: 'relay.example.com',
+        port: 587,
+        encryption: 'starttls',
+        username: 'relay-user',
+        passwordEncrypted: encryptedPassword,
+        fromAddress: 'alerts@example.com',
+        fromName: 'CT-Ops Alerts',
+      },
+    }),
+    {
+      host: 'relay.example.com',
+      port: 587,
+      encryption: 'starttls',
+      username: 'relay-user',
+      password: 'relay-secret',
+      fromAddress: 'alerts@example.com',
+      fromName: 'CT-Ops Alerts',
+    },
+  )
+})
+
+test('getAuthEmailConfigFromOrgSettings ignores disabled or missing relays', () => {
+  assert.equal(getAuthEmailConfigFromOrgSettings(undefined), null)
+  assert.equal(
+    getAuthEmailConfigFromOrgSettings({
+      smtpRelay: {
+        enabled: false,
+        host: 'relay.example.com',
+        port: 587,
+        encryption: 'starttls',
+        fromAddress: 'alerts@example.com',
+      },
+    }),
+    null,
+  )
+})

--- a/apps/web/lib/auth/email.ts
+++ b/apps/web/lib/auth/email.ts
@@ -1,6 +1,9 @@
 import { appendFile, mkdir } from 'node:fs/promises'
 import path from 'node:path'
 import nodemailer from 'nodemailer'
+import { decrypt } from '../crypto/encrypt.ts'
+import type { OrgNotificationSettings } from '../db/schema/organisations.ts'
+import type { SmtpSendConfig } from '../notifications/smtp-send.ts'
 
 type AuthEmailInput = {
   to: string
@@ -15,6 +18,42 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   return value === '1' || value.toLowerCase() === 'true'
 }
 
+export function getAuthEmailConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): SmtpSendConfig | null {
+  const host = env['AUTH_EMAIL_SMTP_HOST']
+  const fromAddress = env['AUTH_EMAIL_FROM']
+  if (!host || !fromAddress) return null
+
+  const port = Number(env['AUTH_EMAIL_SMTP_PORT'] ?? '587')
+  return {
+    host,
+    port,
+    encryption: parseBoolean(env['AUTH_EMAIL_SMTP_SECURE'], port === 465) ? 'tls' : 'none',
+    username: env['AUTH_EMAIL_SMTP_USER'] || undefined,
+    password: env['AUTH_EMAIL_SMTP_PASSWORD'] || undefined,
+    fromAddress,
+    fromName: env['AUTH_EMAIL_FROM_NAME'] ?? 'CT-Ops',
+  }
+}
+
+export function getAuthEmailConfigFromOrgSettings(
+  notificationSettings: OrgNotificationSettings | undefined,
+): SmtpSendConfig | null {
+  const relay = notificationSettings?.smtpRelay
+  if (!relay?.enabled) return null
+
+  return {
+    host: relay.host,
+    port: relay.port,
+    encryption: relay.encryption,
+    username: relay.username || undefined,
+    password: relay.passwordEncrypted ? decrypt(relay.passwordEncrypted) : undefined,
+    fromAddress: relay.fromAddress,
+    fromName: relay.fromName || undefined,
+  }
+}
+
 async function captureEmail(input: AuthEmailInput): Promise<void> {
   const file = process.env['AUTH_EMAIL_CAPTURE_FILE']
   if (!file) return
@@ -24,25 +63,23 @@ async function captureEmail(input: AuthEmailInput): Promise<void> {
 `, 'utf8')
 }
 
-export async function sendAuthEmail(input: AuthEmailInput): Promise<void> {
-  const host = process.env['AUTH_EMAIL_SMTP_HOST']
-  const port = Number(process.env['AUTH_EMAIL_SMTP_PORT'] ?? '587')
-  const secure = parseBoolean(process.env['AUTH_EMAIL_SMTP_SECURE'], port === 465)
-  const user = process.env['AUTH_EMAIL_SMTP_USER']
-  const password = process.env['AUTH_EMAIL_SMTP_PASSWORD']
-  const fromAddress = process.env['AUTH_EMAIL_FROM']
-  const fromName = process.env['AUTH_EMAIL_FROM_NAME'] ?? 'CT-Ops'
+export async function sendAuthEmail(
+  input: AuthEmailInput,
+  smtpConfig: SmtpSendConfig | null = null,
+): Promise<void> {
+  const config = smtpConfig ?? getAuthEmailConfigFromEnv()
 
-  if (host && fromAddress) {
+  if (config) {
     const transporter = nodemailer.createTransport({
-      host,
-      port,
-      secure,
-      ...(user ? { auth: { user, pass: password ?? '' } } : {}),
+      host: config.host,
+      port: config.port,
+      secure: config.encryption === 'tls',
+      requireTLS: config.encryption === 'starttls',
+      ...(config.username ? { auth: { user: config.username, pass: config.password ?? '' } } : {}),
     })
 
     await transporter.sendMail({
-      from: fromName ? `"${fromName}" <${fromAddress}>` : fromAddress,
+      from: config.fromName ? `"${config.fromName}" <${config.fromAddress}>` : config.fromAddress,
       to: input.to,
       subject: input.subject,
       text: input.text,
@@ -67,6 +104,7 @@ export async function sendVerificationEmail(input: {
   email: string
   name: string
   verificationUrl: string
+  smtpConfig?: SmtpSendConfig | null
 }): Promise<void> {
   const subject = 'Verify your CT-Ops email address'
   const text = [
@@ -92,13 +130,14 @@ export async function sendVerificationEmail(input: {
     text,
     html,
     metadata: { verificationUrl: input.verificationUrl },
-  })
+  }, input.smtpConfig ?? null)
 }
 
 export async function sendPasswordResetEmail(input: {
   email: string
   name: string
   resetUrl: string
+  smtpConfig?: SmtpSendConfig | null
 }): Promise<void> {
   const subject = 'Reset your CT-Ops password'
   const text = [
@@ -125,5 +164,5 @@ export async function sendPasswordResetEmail(input: {
     text,
     html,
     metadata: { resetUrl: input.resetUrl },
-  })
+  }, input.smtpConfig ?? null)
 }

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -4,7 +4,12 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor } from 'better-auth/plugins'
 import { db } from '@/lib/db'
 import * as schema from '@/lib/db/schema'
-import { sendPasswordResetEmail, sendVerificationEmail } from './email'
+import { parseOrgMetadata } from '@/lib/db/schema/organisations'
+import {
+  getAuthEmailConfigFromOrgSettings,
+  sendPasswordResetEmail,
+  sendVerificationEmail,
+} from './email'
 import {
   getBetterAuthOrigin,
   getBetterAuthSecret,
@@ -20,6 +25,24 @@ import { passwordLoginAttemptGuard } from './login-attempts'
 
 const LOGIN_THROTTLED_MESSAGE = 'Too many login attempts — please wait before trying again.'
 const requireEmailVerification = getRequireEmailVerification()
+
+async function getAuthEmailConfigForUser(userId: string) {
+  const user = await db.query.users.findFirst({
+    where: (users, { eq }) => eq(users.id, userId),
+    columns: { organisationId: true },
+  })
+  const organisationId = user?.organisationId
+  if (!organisationId) return null
+
+  const organisation = await db.query.organisations.findFirst({
+    where: (organisations, { eq }) => eq(organisations.id, organisationId),
+    columns: { metadata: true },
+  })
+  if (!organisation) return null
+
+  const metadata = parseOrgMetadata(organisation.metadata)
+  return getAuthEmailConfigFromOrgSettings(metadata.notificationSettings)
+}
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -39,6 +62,7 @@ export const auth = betterAuth({
     sendResetPassword: async ({ user, url, token }) => {
       const appResetUrl = new URL(`/reset-password/${token}`, getBetterAuthOrigin())
       const callbackURL = new URL(url).searchParams.get('callbackURL')
+      const smtpConfig = await getAuthEmailConfigForUser(user.id)
       if (callbackURL) {
         appResetUrl.searchParams.set('callbackURL', callbackURL)
       }
@@ -47,6 +71,7 @@ export const auth = betterAuth({
         email: user.email,
         name: user.name,
         resetUrl: appResetUrl.toString(),
+        smtpConfig,
       })
     },
     revokeSessionsOnPasswordReset: true,
@@ -54,10 +79,12 @@ export const auth = betterAuth({
   emailVerification: {
     autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, url }) => {
+      const smtpConfig = await getAuthEmailConfigForUser(user.id)
       await sendVerificationEmail({
         email: user.email,
         name: user.name,
         verificationUrl: url,
+        smtpConfig,
       })
     },
   },


### PR DESCRIPTION
## Summary
- route Better Auth verification and password reset emails through the org SMTP relay when available
- keep env-based auth mail as the fallback for users without an org relay
- add unit coverage for relay-vs-env auth mail transport selection

## Testing
- pnpm --dir apps/web exec node --experimental-strip-types --test lib/auth/email.test.mjs
- pnpm --dir apps/web type-check

Fixes the reported password reset mail regression.