### PR TITLE
test(web): cover LDAP settings and host group membership e2e

### DIFF
--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -300,7 +300,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
         </Link>
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-foreground">{group.name}</h1>
+            <h1 className="text-2xl font-semibold text-foreground" data-testid="host-group-detail-heading">{group.name}</h1>
             {group.description && (
               <p className="text-sm text-muted-foreground mt-1">{group.description}</p>
             )}
@@ -318,7 +318,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
               <Shield className="size-4 mr-1" />
               Patch Group
             </Button>
-            <Button onClick={() => setAddOpen(true)}>
+            <Button onClick={() => setAddOpen(true)} data-testid="host-group-add-open">
               <Plus className="size-4 mr-1" />
               Add Hosts
             </Button>
@@ -328,7 +328,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
 
       {/* Members table */}
       {group.members.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-12 text-center">
+        <div className="rounded-lg border border-dashed p-12 text-center" data-testid="host-group-empty-state">
           <Server className="size-8 mx-auto text-muted-foreground mb-3" />
           <p className="text-sm font-medium text-foreground">No hosts in this group</p>
           <p className="text-xs text-muted-foreground mt-1">
@@ -353,7 +353,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
             </TableHeader>
             <TableBody>
               {group.members.map((host) => (
-                <TableRow key={host.id}>
+                <TableRow key={host.id} data-testid={`host-group-member-${host.id}`}>
                   <TableCell>
                     <Link
                       href={`/hosts/${host.id}`}
@@ -382,6 +382,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
                       size="icon"
                       className="size-8 text-destructive hover:text-destructive"
                       onClick={() => setRemoveTarget(host)}
+                      data-testid={`host-group-remove-${host.id}`}
                     >
                       <Trash2 className="size-3.5" />
                     </Button>
@@ -742,6 +743,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="pl-9"
+                data-testid="host-group-add-search"
               />
             </div>
             <div className="max-h-80 overflow-y-auto rounded-lg border divide-y">
@@ -770,6 +772,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
                       variant="outline"
                       disabled={isAdding}
                       onClick={() => doAdd(host.id)}
+                      data-testid={`host-group-add-${host.id}`}
                     >
                       {isAdding ? <Loader2 className="size-3.5 animate-spin" /> : 'Add'}
                     </Button>
@@ -883,6 +886,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={() => removeTarget && doRemove(removeTarget.id)}
               disabled={isRemoving}
+              data-testid="host-group-remove-confirm"
             >
               {isRemoving && <Loader2 className="size-4 mr-1 animate-spin" />}
               Remove

--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -242,14 +242,14 @@ export function LdapSettingsClient({
     <div className="space-y-6 max-w-3xl">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">LDAP / Directory</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="ldap-settings-heading">LDAP / Directory</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Configure LDAP or Active Directory connections for directory lookup and optional domain login.
           </p>
         </div>
         <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
           <DialogTrigger asChild>
-            <Button size="sm">
+            <Button size="sm" data-testid="ldap-settings-add-open">
               <Plus className="size-4 mr-1.5" />
               Add Configuration
             </Button>
@@ -268,6 +268,7 @@ export function LdapSettingsClient({
                   value={addForm.name}
                   onChange={(e) => setAddForm({ ...addForm, name: e.target.value })}
                   placeholder="e.g. Corporate AD"
+                  data-testid="ldap-settings-add-name"
                 />
               </div>
               <div className="grid grid-cols-3 gap-3">
@@ -277,6 +278,7 @@ export function LdapSettingsClient({
                     value={addForm.host}
                     onChange={(e) => setAddForm({ ...addForm, host: e.target.value })}
                     placeholder="ldap.example.com"
+                    data-testid="ldap-settings-add-host"
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -316,6 +318,7 @@ export function LdapSettingsClient({
                   value={addForm.baseDn}
                   onChange={(e) => setAddForm({ ...addForm, baseDn: e.target.value })}
                   placeholder="dc=example,dc=com"
+                  data-testid="ldap-settings-add-base-dn"
                 />
               </div>
               <div className="space-y-1.5">
@@ -324,6 +327,7 @@ export function LdapSettingsClient({
                   value={addForm.bindDn}
                   onChange={(e) => setAddForm({ ...addForm, bindDn: e.target.value })}
                   placeholder="cn=admin,dc=example,dc=com"
+                  data-testid="ldap-settings-add-bind-dn"
                 />
               </div>
               <div className="space-y-1.5">
@@ -332,6 +336,7 @@ export function LdapSettingsClient({
                   type="password"
                   value={addForm.bindPassword}
                   onChange={(e) => setAddForm({ ...addForm, bindPassword: e.target.value })}
+                  data-testid="ldap-settings-add-bind-password"
                 />
               </div>
               <div className="space-y-1.5">
@@ -364,6 +369,7 @@ export function LdapSettingsClient({
               <Button
                 onClick={() => addMutation.mutate()}
                 disabled={addMutation.isPending || !addForm.name || !addForm.host || !addForm.baseDn || !addForm.bindDn || !addForm.bindPassword}
+                data-testid="ldap-settings-add-submit"
               >
                 {addMutation.isPending ? 'Adding...' : 'Add'}
               </Button>
@@ -374,7 +380,7 @@ export function LdapSettingsClient({
 
       {configs.length === 0 ? (
         <Card>
-          <CardContent className="py-16 text-center">
+          <CardContent className="py-16 text-center" data-testid="ldap-settings-empty-state">
             <FolderTree className="size-12 mx-auto text-muted-foreground/40 mb-4" />
             <p className="text-muted-foreground font-medium">No LDAP configurations</p>
             <p className="text-sm text-muted-foreground mt-1">
@@ -385,7 +391,7 @@ export function LdapSettingsClient({
       ) : (
         <div className="space-y-4">
           {configs.map((config) => (
-            <Card key={config.id}>
+            <Card key={config.id} data-testid={`ldap-config-row-${config.id}`}>
               <CardHeader>
                 <div className="flex items-center justify-between">
                   <div>
@@ -404,6 +410,7 @@ export function LdapSettingsClient({
                     <Switch
                       checked={config.enabled}
                       onCheckedChange={(checked) => toggleMutation.mutate({ id: config.id, enabled: checked })}
+                      data-testid={`ldap-config-enabled-${config.id}`}
                     />
                   </div>
                 </div>
@@ -429,6 +436,7 @@ export function LdapSettingsClient({
                     <Switch
                       checked={config.allowLogin}
                       onCheckedChange={(checked) => toggleLoginMutation.mutate({ id: config.id, allowLogin: checked })}
+                      data-testid={`ldap-config-allow-login-${config.id}`}
                     />
                     Allow Web UI Login
                   </label>
@@ -460,6 +468,7 @@ export function LdapSettingsClient({
                     variant="outline"
                     size="sm"
                     onClick={() => openEditDialog(config)}
+                    data-testid={`ldap-config-edit-${config.id}`}
                   >
                     <Pencil className="size-4 mr-1.5" />
                     Edit
@@ -470,6 +479,7 @@ export function LdapSettingsClient({
                     className="text-destructive hover:text-destructive ml-auto"
                     onClick={() => deleteMutation.mutate(config.id)}
                     disabled={deleteMutation.isPending}
+                    data-testid={`ldap-config-delete-${config.id}`}
                   >
                     <Trash2 className="size-4 mr-1.5" />
                     Delete
@@ -502,19 +512,21 @@ export function LdapSettingsClient({
             <div className="grid grid-cols-3 gap-3">
               <div className="col-span-2 space-y-1.5">
                 <Label>Host</Label>
-                <Input
-                  value={editForm.host}
-                  onChange={(e) => setEditForm({ ...editForm, host: e.target.value })}
-                  placeholder="ldap.example.com"
-                />
+              <Input
+                value={editForm.host}
+                onChange={(e) => setEditForm({ ...editForm, host: e.target.value })}
+                placeholder="ldap.example.com"
+                data-testid="ldap-settings-edit-host"
+              />
               </div>
               <div className="space-y-1.5">
                 <Label>Port</Label>
-                <Input
-                  type="number"
-                  value={editForm.port}
-                  onChange={(e) => setEditForm({ ...editForm, port: Number(e.target.value) })}
-                />
+              <Input
+                type="number"
+                value={editForm.port}
+                onChange={(e) => setEditForm({ ...editForm, port: Number(e.target.value) })}
+                data-testid="ldap-settings-edit-port"
+              />
               </div>
             </div>
             <div className="flex items-center gap-6">
@@ -578,6 +590,7 @@ export function LdapSettingsClient({
                 value={editForm.userSearchFilter}
                 onChange={(e) => setEditForm({ ...editForm, userSearchFilter: e.target.value })}
                 placeholder="(uid={{username}})"
+                data-testid="ldap-settings-edit-user-filter"
               />
             </div>
             <div className="grid grid-cols-3 gap-3">
@@ -633,6 +646,7 @@ export function LdapSettingsClient({
             <Button
               onClick={() => editMutation.mutate()}
               disabled={editMutation.isPending || !editForm.name || !editForm.host || !editForm.baseDn || !editForm.bindDn}
+              data-testid="ldap-settings-edit-save"
             >
               {editMutation.isPending ? 'Saving...' : 'Save Changes'}
             </Button>

--- a/apps/web/tests/e2e/hosts/groups.spec.ts
+++ b/apps/web/tests/e2e/hosts/groups.spec.ts
@@ -43,6 +43,73 @@ test('authenticated user can create, edit, and delete a host group', async ({ au
 
   const groupId = createdRows[0]!.id
 
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'group-host-1',
+      ${orgId},
+      'app-01',
+      'App Server 01',
+      'Ubuntu',
+      'x86_64',
+      '["10.40.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await page.goto(`/hosts/groups/${groupId}`)
+  await expect(page.getByTestId('host-group-detail-heading')).toContainText('Linux Servers')
+
+  await page.getByTestId('host-group-add-open').click()
+  await page.getByTestId('host-group-add-search').fill('App Server 01')
+  await page.getByTestId('host-group-add-group-host-1').click()
+
+  const memberRow = page.getByTestId('host-group-member-group-host-1')
+  await expect(memberRow).toBeVisible()
+  await expect(memberRow).toContainText('App Server 01')
+  await page.keyboard.press('Escape')
+
+  const activeMembershipRows = await sql<Array<{ deleted_at: string | null }>>`
+    SELECT deleted_at
+    FROM host_group_members
+    WHERE group_id = ${groupId}
+      AND host_id = 'group-host-1'
+    LIMIT 1
+  `
+
+  expect(activeMembershipRows).toHaveLength(1)
+  expect(activeMembershipRows[0]?.deleted_at).toBeNull()
+
+  await page.getByTestId('host-group-remove-group-host-1').click()
+  await page.getByTestId('host-group-remove-confirm').click()
+
+  await expect(memberRow).toHaveCount(0)
+  await expect(page.getByTestId('host-group-empty-state')).toBeVisible()
+
+  const removedMembershipRows = await sql<Array<{ deleted_at: string | null }>>`
+    SELECT deleted_at
+    FROM host_group_members
+    WHERE group_id = ${groupId}
+      AND host_id = 'group-host-1'
+    LIMIT 1
+  `
+
+  expect(removedMembershipRows).toHaveLength(1)
+  expect(removedMembershipRows[0]?.deleted_at).not.toBeNull()
+
+  await page.goto('/hosts/groups')
+
   await page.getByTestId(`host-groups-edit-${groupId}`).click()
   await page.getByTestId('host-groups-form-name').fill('Linux Estate')
   await page.getByTestId('host-groups-form-description').fill('Linux production and staging fleet')

--- a/apps/web/tests/e2e/settings/ldap.spec.ts
+++ b/apps/web/tests/e2e/settings/ldap.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug} LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can create, edit, toggle, and delete an LDAP configuration', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await page.goto('/settings/integrations')
+
+  await expect(page.getByTestId('ldap-settings-heading')).toBeVisible()
+  await expect(page.getByTestId('ldap-settings-empty-state')).toBeVisible()
+
+  await page.getByTestId('ldap-settings-add-open').click()
+  await page.getByTestId('ldap-settings-add-name').fill('Corporate AD')
+  await page.getByTestId('ldap-settings-add-host').fill('ldap.internal.example')
+  await page.getByTestId('ldap-settings-add-base-dn').fill('dc=internal,dc=example')
+  await page.getByTestId('ldap-settings-add-bind-dn').fill('cn=svc-ldap,dc=internal,dc=example')
+  await page.getByTestId('ldap-settings-add-bind-password').fill('SuperSecret123!')
+  await page.getByTestId('ldap-settings-add-submit').click()
+  await expect(page.getByText('Corporate AD')).toBeVisible()
+
+  const createdRows = await sql<Array<{
+    id: string
+    host: string
+    port: number
+    allow_login: boolean
+    enabled: boolean
+    deleted_at: string | null
+  }>>`
+    SELECT id, host, port, allow_login, enabled, deleted_at
+    FROM ldap_configurations
+    WHERE organisation_id = ${orgId}
+      AND name = 'Corporate AD'
+    LIMIT 1
+  `
+
+  expect(createdRows).toHaveLength(1)
+  expect(createdRows[0]?.host).toBe('ldap.internal.example')
+  expect(createdRows[0]?.port).toBe(389)
+  expect(createdRows[0]?.allow_login).toBe(false)
+  expect(createdRows[0]?.enabled).toBe(true)
+  expect(createdRows[0]?.deleted_at).toBeNull()
+
+  const configId = createdRows[0]!.id
+  const configRow = page.getByTestId(`ldap-config-row-${configId}`)
+
+  await expect(configRow).toBeVisible()
+  await expect(configRow).toContainText('Corporate AD')
+  await expect(configRow).toContainText('ldap://ldap.internal.example:389')
+
+  await page.getByTestId(`ldap-config-edit-${configId}`).click()
+  await page.getByTestId('ldap-settings-edit-host').fill('directory.internal.example')
+  await page.getByTestId('ldap-settings-edit-port').fill('636')
+  await page.getByTestId('ldap-settings-edit-user-filter').fill('(mail={{username}})')
+  await page.getByTestId('ldap-settings-edit-save').click()
+
+  await expect(configRow).toContainText('ldap://directory.internal.example:636')
+  await expect(configRow).toContainText('(mail={{username}})')
+
+  await page.getByTestId(`ldap-config-enabled-${configId}`).click()
+  await expect(configRow).toContainText('Disabled')
+
+  await page.getByTestId(`ldap-config-allow-login-${configId}`).click()
+
+  await expect.poll(async () => {
+    const rows = await sql<Array<{
+      host: string
+      port: number
+      user_search_filter: string
+      allow_login: boolean
+      enabled: boolean
+    }>>`
+      SELECT host, port, user_search_filter, allow_login, enabled
+      FROM ldap_configurations
+      WHERE id = ${configId}
+      LIMIT 1
+    `
+
+    return rows[0] ?? null
+  }).toMatchObject({
+    host: 'directory.internal.example',
+    port: 636,
+    user_search_filter: '(mail={{username}})',
+    allow_login: true,
+    enabled: false,
+  })
+
+  await page.getByTestId(`ldap-config-delete-${configId}`).click()
+
+  await expect(configRow).toHaveCount(0)
+  await expect(page.getByTestId('ldap-settings-empty-state')).toBeVisible()
+
+  const deletedRows = await sql<Array<{ deleted_at: string | null }>>`
+    SELECT deleted_at
+    FROM ldap_configurations
+    WHERE id = ${configId}
+    LIMIT 1
+  `
+
+  expect(deletedRows).toHaveLength(1)
+  expect(deletedRows[0]?.deleted_at).not.toBeNull()
+})


### PR DESCRIPTION
## Summary
- add LDAP settings end-to-end coverage for create, edit, toggle, and delete flows on the integrations page
- expand host group E2E coverage to exercise member add/remove flows from the group detail page
- add stable test ids needed for the new Playwright coverage

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/settings/ldap.spec.ts tests/e2e/hosts/groups.spec.ts`
