### PR TITLE
fix(web): add network and enrolment e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
@@ -142,6 +142,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
         <Link
           href="/hosts/networks"
           className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          data-testid="network-detail-back"
         >
           <ArrowLeft className="size-4" />
           All Networks
@@ -152,7 +153,9 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
           <div className="flex items-center gap-3">
             <Network className="size-6 text-muted-foreground shrink-0 mt-0.5" />
             <div>
-              <h1 className="text-2xl font-semibold text-foreground">{network.name}</h1>
+              <h1 className="text-2xl font-semibold text-foreground" data-testid="network-detail-heading">
+                {network.name}
+              </h1>
               <div className="flex items-center gap-2 mt-1">
                 <code className="text-sm bg-muted px-2 py-0.5 rounded font-mono">{network.cidr}</code>
                 {network.description && (
@@ -169,6 +172,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                 variant={viewMode === 'table' ? 'secondary' : 'ghost'}
                 className="h-7 px-2 text-xs"
                 onClick={() => setViewMode('table')}
+                data-testid="network-detail-view-table"
               >
                 <LayoutGrid className="size-3.5 mr-1" />
                 Table
@@ -178,12 +182,13 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                 variant={viewMode === 'graph' ? 'secondary' : 'ghost'}
                 className="h-7 px-2 text-xs"
                 onClick={() => setViewMode('graph')}
+                data-testid="network-detail-view-graph"
               >
                 <GitBranch className="size-3.5 mr-1" />
                 Graph
               </Button>
             </div>
-            <Button onClick={() => setAddOpen(true)}>
+            <Button onClick={() => setAddOpen(true)} data-testid="network-detail-add-open">
               <Plus className="size-4 mr-1" />
               Add Host
             </Button>
@@ -198,14 +203,14 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
         {/* Table view */}
         {viewMode === 'table' && (
           network.members.length === 0 ? (
-            <div className="rounded-lg border border-dashed p-12 text-center">
+            <div className="rounded-lg border border-dashed p-12 text-center" data-testid="network-detail-empty-state">
               <Server className="size-8 mx-auto text-muted-foreground mb-3" />
               <p className="text-sm font-medium text-foreground">No hosts in this network</p>
               <p className="text-xs text-muted-foreground mt-1">
                 Hosts are added automatically when their IP falls within{' '}
                 <code className="font-mono">{network.cidr}</code>, or you can add them manually.
               </p>
-              <Button className="mt-4" onClick={() => setAddOpen(true)}>
+              <Button className="mt-4" onClick={() => setAddOpen(true)} data-testid="network-detail-empty-add-open">
                 <Plus className="size-4 mr-1" />
                 Add Host
               </Button>
@@ -227,7 +232,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                   {network.members.map((host) => {
                     const isAuto = autoAssignedMap.get(host.id) ?? false
                     return (
-                      <TableRow key={host.id}>
+                      <TableRow key={host.id} data-testid={`network-detail-member-${host.id}`}>
                         <TableCell>
                           <Link
                             href={`/hosts/${host.id}`}
@@ -279,6 +284,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                             size="icon"
                             className="size-8 text-destructive hover:text-destructive"
                             onClick={() => setRemoveTarget(host)}
+                            data-testid={`network-detail-remove-${host.id}`}
                           >
                             <Trash2 className="size-3.5" />
                           </Button>
@@ -314,6 +320,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                   className="pl-8"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
+                  data-testid="network-detail-add-search"
                 />
               </div>
               <div className="max-h-72 overflow-y-auto rounded-md border divide-y">
@@ -330,6 +337,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                       className="w-full flex items-center justify-between px-3 py-2.5 text-left hover:bg-muted/50 disabled:opacity-50 disabled:cursor-not-allowed"
                       onClick={() => doAdd(host.id)}
                       disabled={isAdding}
+                      data-testid={`network-detail-add-${host.id}`}
                     >
                       <span className="flex items-center gap-2">
                         <HostStatusIcon status={host.status ?? 'unknown'} />
@@ -375,6 +383,7 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 onClick={() => removeTarget && doRemove(removeTarget.id)}
                 disabled={isRemoving}
+                data-testid="network-detail-remove-confirm"
               >
                 {isRemoving && <Loader2 className="size-4 mr-1 animate-spin" />}
                 Remove

--- a/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
@@ -121,7 +121,11 @@ function NetworkForm({
         <Button type="button" variant="outline" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" disabled={isPending}>
+        <Button
+          type="submit"
+          disabled={isPending}
+          data-testid={submitLabel === 'Create Network' ? 'networks-create-submit' : 'networks-edit-submit'}
+        >
           {isPending && <Loader2 className="size-4 mr-1 animate-spin" />}
           {submitLabel}
         </Button>
@@ -192,7 +196,9 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
         <div className="flex items-center gap-3">
           <Network className="size-6 text-muted-foreground" />
           <div>
-            <h1 className="text-2xl font-semibold text-foreground">Networks</h1>
+            <h1 className="text-2xl font-semibold text-foreground" data-testid="networks-heading">
+              Networks
+            </h1>
             <p className="text-sm text-muted-foreground">
               Define IP subnets and automatically group hosts by network
             </p>
@@ -206,6 +212,7 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
               variant={viewMode === 'table' ? 'secondary' : 'ghost'}
               className="h-7 px-2 text-xs"
               onClick={() => setViewMode('table')}
+              data-testid="networks-view-table"
             >
               <LayoutGrid className="size-3.5 mr-1" />
               Table
@@ -215,12 +222,13 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
               variant={viewMode === 'graph' ? 'secondary' : 'ghost'}
               className="h-7 px-2 text-xs"
               onClick={() => setViewMode('graph')}
+              data-testid="networks-view-graph"
             >
               <GitBranch className="size-3.5 mr-1" />
               Graph
             </Button>
           </div>
-          <Button onClick={() => setCreateOpen(true)}>
+          <Button onClick={() => setCreateOpen(true)} data-testid="networks-create-open">
             <Plus className="size-4 mr-1" />
             New Network
           </Button>
@@ -234,13 +242,13 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
 
       {/* Table */}
       {viewMode === 'table' && (networkList.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-12 text-center">
+        <div className="rounded-lg border border-dashed p-12 text-center" data-testid="networks-empty-state">
           <Network className="size-8 mx-auto text-muted-foreground mb-3" />
           <p className="text-sm font-medium text-foreground">No networks yet</p>
           <p className="text-xs text-muted-foreground mt-1">
             Create a network to automatically group hosts by their IP subnet.
           </p>
-          <Button className="mt-4" onClick={() => setCreateOpen(true)}>
+          <Button className="mt-4" onClick={() => setCreateOpen(true)} data-testid="networks-empty-create-open">
             <Plus className="size-4 mr-1" />
             New Network
           </Button>
@@ -260,7 +268,7 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
             </TableHeader>
             <TableBody>
               {networkList.map((network) => (
-                <TableRow key={network.id}>
+                <TableRow key={network.id} data-testid={`network-row-${network.id}`}>
                   <TableCell>
                     <Link
                       href={`/hosts/networks/${network.id}`}
@@ -293,6 +301,7 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
                         size="icon"
                         className="size-8"
                         onClick={() => setEditNetwork(network)}
+                        data-testid={`network-edit-${network.id}`}
                       >
                         <Pencil className="size-3.5" />
                       </Button>
@@ -301,6 +310,7 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
                         size="icon"
                         className="size-8 text-destructive hover:text-destructive"
                         onClick={() => setDeleteTarget(network)}
+                        data-testid={`network-delete-${network.id}`}
                       >
                         <Trash2 className="size-3.5" />
                       </Button>
@@ -373,16 +383,17 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={() => deleteTarget && doDelete(deleteTarget.id)}
-              disabled={isDeleting}
-            >
-              {isDeleting && <Loader2 className="size-4 mr-1 animate-spin" />}
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={() => deleteTarget && doDelete(deleteTarget.id)}
+                disabled={isDeleting}
+                data-testid="network-delete-confirm"
+              >
+                {isDeleting && <Loader2 className="size-4 mr-1 animate-spin" />}
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </div>

--- a/apps/web/tests/e2e/hosts/networks.spec.ts
+++ b/apps/web/tests/e2e/hosts/networks.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can create, edit, and delete a network and manage its hosts', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'network-host-1',
+        ${orgId},
+        'edge-node-1',
+        'Edge Node 1',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.55.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'network-host-2',
+        ${orgId},
+        'edge-node-2',
+        'Edge Node 2',
+        'Ubuntu 24.04',
+        'arm64',
+        '["10.55.0.11"]'::jsonb,
+        'offline',
+        NOW() - INTERVAL '2 hours'
+      )
+  `
+
+  await page.goto('/hosts/networks')
+
+  await expect(page.getByTestId('networks-heading')).toBeVisible()
+  await expect(page.getByTestId('networks-empty-state')).toBeVisible()
+
+  await page.getByTestId('networks-create-open').click()
+  await page.getByLabel('Name').fill('Branch Office')
+  await page.getByLabel('CIDR').fill('10.55.0.0/24')
+  await page.getByLabel('Description (optional)').fill('Branch office LAN')
+  await page.getByTestId('networks-create-submit').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ id: string | null }>>`
+        SELECT id
+        FROM networks
+        WHERE organisation_id = ${orgId}
+          AND name = 'Branch Office'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+
+      return rows[0]?.id ?? null
+    })
+    .not.toBeNull()
+
+  const createdRows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM networks
+    WHERE organisation_id = ${orgId}
+      AND name = 'Branch Office'
+      AND deleted_at IS NULL
+    LIMIT 1
+  `
+
+  expect(createdRows).toHaveLength(1)
+  const networkId = createdRows[0]!.id
+  const networkRow = page.getByTestId(`network-row-${networkId}`)
+  await expect(networkRow).toContainText('Branch Office')
+  await expect(networkRow).toContainText('10.55.0.0/24')
+  await expect(networkRow).toContainText('Branch office LAN')
+
+  await networkRow.getByRole('link', { name: 'Branch Office' }).click()
+
+  await expect(page).toHaveURL(new RegExp(`/hosts/networks/${networkId}$`))
+  await expect(page.getByTestId('network-detail-heading')).toContainText('Branch Office')
+  await expect(page.getByTestId('network-detail-empty-state')).toBeVisible()
+
+  await page.getByTestId('network-detail-add-open').click()
+  await page.getByTestId('network-detail-add-search').fill('edge-node-1')
+  await page.getByTestId('network-detail-add-network-host-1').click()
+
+  const memberRow = page.getByTestId('network-detail-member-network-host-1')
+  await expect(memberRow).toContainText('Edge Node 1')
+  await expect(memberRow).toContainText('online')
+  await expect(page.getByTestId('network-detail-empty-state')).toHaveCount(0)
+
+  const membershipRows = await sql<Array<{ deleted_at: string | null; auto_assigned: boolean }>>`
+    SELECT deleted_at, auto_assigned
+    FROM host_network_memberships
+    WHERE organisation_id = ${orgId}
+      AND network_id = ${networkId}
+      AND host_id = 'network-host-1'
+    LIMIT 1
+  `
+
+  expect(membershipRows).toEqual([
+    {
+      deleted_at: null,
+      auto_assigned: false,
+    },
+  ])
+
+  await page.getByTestId(`network-detail-remove-network-host-1`).click()
+  await page.getByTestId('network-detail-remove-confirm').click()
+
+  await expect(memberRow).toHaveCount(0)
+  await expect(page.getByTestId('network-detail-empty-state')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at
+        FROM host_network_memberships
+        WHERE organisation_id = ${orgId}
+          AND network_id = ${networkId}
+          AND host_id = 'network-host-1'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .not.toBeNull()
+
+  await page.goto('/hosts/networks')
+
+  await page.getByTestId(`network-edit-${networkId}`).click()
+  await page.getByLabel('Name').fill('Branch Office Updated')
+  await page.getByLabel('CIDR').fill('10.55.1.0/24')
+  await page.getByLabel('Description (optional)').fill('Updated branch office LAN')
+  await page.getByTestId('networks-edit-submit').click()
+
+  const updatedRow = page.getByTestId(`network-row-${networkId}`)
+  await expect(updatedRow).toContainText('Branch Office Updated')
+  await expect(updatedRow).toContainText('10.55.1.0/24')
+  await expect(updatedRow).toContainText('Updated branch office LAN')
+
+  await page.getByTestId(`network-delete-${networkId}`).click()
+  await page.getByTestId('network-delete-confirm').click()
+
+  await expect(updatedRow).toHaveCount(0)
+  await expect(page.getByTestId('networks-empty-state')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at
+        FROM networks
+        WHERE id = ${networkId}
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .not.toBeNull()
+})

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -104,3 +104,31 @@ test('admin can create and revoke an enrolment token from agent settings', async
     })
     .toBeTruthy()
 })
+
+test('admin can create an auto-approved token that skips TLS verification', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  await page.goto('/settings/agents')
+
+  await expect(page.getByTestId('agent-enrolment-heading')).toBeVisible()
+  await page.getByTestId('agent-enrolment-create-open').click()
+
+  await page.getByTestId('agent-enrolment-label').fill('Remote Edge')
+  await page.getByTestId('agent-enrolment-auto-approve').click()
+  await page.getByTestId('agent-enrolment-max-uses').fill('2')
+  await page.getByTestId('agent-enrolment-expires-days').fill('30')
+  await page.getByTestId('agent-enrolment-create-submit').click()
+
+  await expect(page.getByText('Only super_admin users may create auto-approve enrolment tokens.')).toBeVisible()
+
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM agent_enrolment_tokens
+    WHERE organisation_id = ${orgId}
+      AND label = 'Remote Edge'
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- add first E2E coverage for the networks management flow, including create, membership add/remove, edit, and delete
- expand agent enrolment coverage to assert non-super-admin users are blocked from creating auto-approve tokens
- add stable `data-testid` hooks for the networks UI to support database-backed E2E interactions

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/hosts/networks.spec.ts tests/e2e/settings/agent-enrolment.spec.ts`
