### PR TITLE
test(web): add report e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/software/software-report-client.tsx
@@ -376,13 +376,23 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
     <div className="space-y-6 max-w-5xl">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">Installed Software</h1>
+          <h1
+            className="text-2xl font-semibold text-foreground"
+            data-testid="software-report-heading"
+          >
+            Installed Software
+          </h1>
           <p className="text-sm text-muted-foreground mt-1">
             Search and report on software installed across your host estate.
           </p>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <Button variant="outline" size="sm" onClick={() => setSavedReportsOpen(true)}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSavedReportsOpen(true)}
+            data-testid="software-report-saved-reports-open"
+          >
             <Save className="size-3.5 mr-1.5" />
             Saved reports
             {savedReports.length > 0 && (
@@ -406,6 +416,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
           <button
             key={tab.id}
             onClick={() => setActiveView(tab.id)}
+            data-testid={`software-report-tab-${tab.id}`}
             className={`flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
               activeView === tab.id
                 ? 'border-foreground text-foreground'
@@ -432,6 +443,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                     <div className="relative">
                       <Search className="absolute left-2.5 top-2.5 size-3.5 text-muted-foreground" />
                       <Input
+                        data-testid="software-report-package-name"
                         placeholder="e.g. openssl"
                         className="pl-8 h-8 text-sm"
                         value={nameInput}
@@ -588,7 +600,10 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                     setPage('1')
                   }}
                 >
-                  <SelectTrigger className="h-8 text-sm w-[140px]">
+                  <SelectTrigger
+                    className="h-8 text-sm w-[140px]"
+                    data-testid="software-report-os-filter"
+                  >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -635,6 +650,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                     size="sm"
                     onClick={() => setSaveDialogOpen(true)}
                     disabled={!filters.name}
+                    data-testid="software-report-save-filters-open"
                   >
                     <Save className="size-3.5 mr-1.5" />
                     Save filters
@@ -740,7 +756,10 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                     </TableHeader>
                     <TableBody>
                       {displayedRows.map((row) => (
-                        <TableRow key={`${row.hostId}:${row.version}:${row.architecture ?? ''}`}>
+                        <TableRow
+                          key={`${row.hostId}:${row.version}:${row.architecture ?? ''}`}
+                          data-testid={`software-report-row-${row.hostId}`}
+                        >
                           <TableCell className="font-medium text-sm">
                             <Link
                               href={`/hosts/${row.hostId}`}
@@ -833,7 +852,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                 </TableHeader>
                 <TableBody>
                   {newPackages.map((pkg) => (
-                    <TableRow key={pkg.name}>
+                    <TableRow key={pkg.name} data-testid={`software-report-new-package-${pkg.name}`}>
                       <TableCell className="font-mono text-sm font-medium">{pkg.name}</TableCell>
                       <TableCell>
                         <Badge variant="secondary">{pkg.hostCount}</Badge>
@@ -885,7 +904,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                 </TableHeader>
                 <TableBody>
                   {driftRows.map((row, i) => (
-                    <TableRow key={i}>
+                    <TableRow key={i} data-testid={`software-report-drift-row-${i}`}>
                       <TableCell className="font-mono text-sm font-medium">{row.packageName}</TableCell>
                       <TableCell className="text-sm">{row.groupName}</TableCell>
                       <TableCell>
@@ -933,6 +952,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
               <Label htmlFor="save-name">Report name</Label>
               <Input
                 id="save-name"
+                data-testid="software-report-save-name"
                 placeholder="e.g. OpenSSL < 3.0 exposure"
                 value={saveName}
                 onChange={(e) => setSaveName(e.target.value)}
@@ -946,6 +966,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
             <Button
               disabled={!saveName.trim() || saveMutation.isPending}
               onClick={() => saveMutation.mutate()}
+              data-testid="software-report-save-submit"
             >
               {saveMutation.isPending ? 'Saving…' : 'Save'}
             </Button>
@@ -965,12 +986,13 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
             </p>
           ) : (
             <div className="space-y-2 py-2 max-h-80 overflow-y-auto">
-              {savedReports.map((r) => (
+              {savedReports.map((r, index) => (
                 <div
                   key={r.id}
                   className="flex items-center justify-between gap-2 p-2.5 rounded-md border hover:bg-muted/50"
                 >
                   <button
+                    data-testid={`software-report-saved-report-load-${index}`}
                     className="flex-1 text-left text-sm font-medium text-foreground"
                     onClick={() => loadSavedReport(r.filters as SoftwareReportFilters)}
                   >
@@ -981,6 +1003,7 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
                     size="sm"
                     className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
                     onClick={() => deleteSavedMutation.mutate(r.id)}
+                    data-testid={`software-report-saved-report-delete-${index}`}
                   >
                     <Trash2 className="size-3.5" />
                   </Button>
@@ -989,7 +1012,11 @@ export function SoftwareReportClient({ orgId, orgName, hostGroups }: Props) {
             </div>
           )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setSavedReportsOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setSavedReportsOpen(false)}
+              data-testid="software-report-saved-reports-close"
+            >
               Close
             </Button>
           </DialogFooter>

--- a/apps/web/app/(dashboard)/reports/vulnerabilities/vulnerability-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/vulnerabilities/vulnerability-report-client.tsx
@@ -143,7 +143,7 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
             <div className="space-y-2">
               <Label>Severity</Label>
               <Select value={severity} onValueChange={(value) => setSeverity(value as VulnerabilitySeverity | 'all')}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger data-testid="vulnerability-report-severity-filter"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   {severities.map((value) => <SelectItem key={value} value={value}>{value === 'all' ? 'All severities' : value}</SelectItem>)}
                 </SelectContent>
@@ -152,7 +152,7 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
             <div className="space-y-2">
               <Label>Host group</Label>
               <Select value={hostGroupId} onValueChange={setHostGroupId}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger data-testid="vulnerability-report-host-group-filter"><SelectValue /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value={ALL}>All groups</SelectItem>
                   {hostGroups.map((group) => <SelectItem key={group.id} value={group.id}>{group.name}</SelectItem>)}
@@ -185,11 +185,19 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
               </Select>
             </div>
             <label className="flex items-center gap-2 pt-8 text-sm">
-              <Checkbox checked={kevOnly} onCheckedChange={(value) => setKevOnly(value === true)} />
+              <Checkbox
+                checked={kevOnly}
+                onCheckedChange={(value) => setKevOnly(value === true)}
+                data-testid="vulnerability-report-kev-filter"
+              />
               Known exploited
             </label>
             <label className="flex items-center gap-2 pt-8 text-sm">
-              <Checkbox checked={fixAvailable} onCheckedChange={(value) => setFixAvailable(value === true)} />
+              <Checkbox
+                checked={fixAvailable}
+                onCheckedChange={(value) => setFixAvailable(value === true)}
+                data-testid="vulnerability-report-fix-available-filter"
+              />
               Fix available
             </label>
           </div>
@@ -226,7 +234,10 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
               </TableHeader>
               <TableBody>
                 {report.findings.map((finding) => (
-                  <TableRow key={finding.id}>
+                  <TableRow
+                    key={finding.id}
+                    data-testid={`vulnerability-report-finding-row-${finding.id}`}
+                  >
                     <TableCell>
                       <div className="flex items-center gap-2">
                         {finding.knownExploited ? <Zap className="size-4 text-orange-600" /> : <Bug className="size-4 text-muted-foreground" />}
@@ -305,4 +316,3 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
     </div>
   )
 }
-

--- a/apps/web/tests/e2e/reports/software.spec.ts
+++ b/apps/web/tests/e2e/reports/software.spec.ts
@@ -1,0 +1,237 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+import { issueTestLicence } from '../fixtures/licence'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('software report supports search, saved filters, new packages, and drift views', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const licenceKey = await issueTestLicence({ orgId, tier: 'pro' })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      os_version,
+      arch,
+      status
+    )
+    VALUES
+      (
+        'software-report-host-linux-1',
+        ${orgId},
+        'linux-app-01',
+        'Linux App 01',
+        'linux',
+        'Ubuntu 24.04',
+        'x86_64',
+        'online'
+      ),
+      (
+        'software-report-host-linux-2',
+        ${orgId},
+        'linux-app-02',
+        'Linux App 02',
+        'linux',
+        'Ubuntu 24.04',
+        'x86_64',
+        'online'
+      ),
+      (
+        'software-report-host-windows-1',
+        ${orgId},
+        'windows-edge-01',
+        'Windows Edge 01',
+        'windows',
+        'Windows Server 2022',
+        'x86_64',
+        'online'
+      )
+  `
+
+  await sql`
+    INSERT INTO host_groups (
+      id,
+      organisation_id,
+      name,
+      description
+    )
+    VALUES (
+      'software-report-group-1',
+      ${orgId},
+      'Production Estate',
+      'Hosts used for software report E2E coverage.'
+    )
+  `
+
+  await sql`
+    INSERT INTO host_group_members (
+      id,
+      organisation_id,
+      group_id,
+      host_id
+    )
+    VALUES
+      (
+        'software-report-group-member-1',
+        ${orgId},
+        'software-report-group-1',
+        'software-report-host-linux-1'
+      ),
+      (
+        'software-report-group-member-2',
+        ${orgId},
+        'software-report-group-1',
+        'software-report-host-linux-2'
+      )
+  `
+
+  await sql`
+    INSERT INTO software_packages (
+      id,
+      organisation_id,
+      host_id,
+      name,
+      version,
+      architecture,
+      source,
+      distro_id,
+      distro_version_id,
+      distro_codename,
+      source_name,
+      first_seen_at,
+      last_seen_at
+    )
+    VALUES
+      (
+        'software-report-pkg-linux-1',
+        ${orgId},
+        'software-report-host-linux-1',
+        'openssl',
+        '3.0.2',
+        'x86_64',
+        'dpkg',
+        'ubuntu',
+        '24.04',
+        'noble',
+        'openssl',
+        NOW() - INTERVAL '2 days',
+        NOW() - INTERVAL '1 hour'
+      ),
+      (
+        'software-report-pkg-linux-2',
+        ${orgId},
+        'software-report-host-linux-2',
+        'openssl',
+        '3.0.3',
+        'x86_64',
+        'dpkg',
+        'ubuntu',
+        '24.04',
+        'noble',
+        'openssl',
+        NOW() - INTERVAL '1 day',
+        NOW() - INTERVAL '30 minutes'
+      ),
+      (
+        'software-report-pkg-windows-1',
+        ${orgId},
+        'software-report-host-windows-1',
+        'openssl',
+        '3.0.3',
+        'x86_64',
+        'winreg',
+        'windows',
+        '2022',
+        'server',
+        'openssl',
+        NOW() - INTERVAL '12 hours',
+        NOW() - INTERVAL '15 minutes'
+      ),
+      (
+        'software-report-pkg-windows-2',
+        ${orgId},
+        'software-report-host-windows-1',
+        'git',
+        '2.45.1',
+        'x86_64',
+        'winreg',
+        'windows',
+        '2022',
+        'server',
+        'git',
+        NOW() - INTERVAL '3 days',
+        NOW() - INTERVAL '10 minutes'
+      )
+  `
+
+  await page.goto('/reports/software')
+
+  await expect(page.getByTestId('software-report-heading')).toBeVisible()
+  await page.getByTestId('software-report-package-name').fill('open')
+  await page.getByRole('option', { name: /openssl/i }).click()
+
+  await expect(page.getByTestId('software-report-row-software-report-host-linux-1')).toContainText('Linux App 01')
+  await expect(page.getByTestId('software-report-row-software-report-host-linux-2')).toContainText('Linux App 02')
+  await expect(page.getByTestId('software-report-row-software-report-host-windows-1')).toContainText('Windows Edge 01')
+
+  await page.getByTestId('software-report-os-filter').click()
+  await page.getByRole('option', { name: 'Linux' }).click()
+
+  await expect(page.getByTestId('software-report-row-software-report-host-linux-1')).toBeVisible()
+  await expect(page.getByTestId('software-report-row-software-report-host-linux-2')).toBeVisible()
+  await expect(page.getByTestId('software-report-row-software-report-host-windows-1')).toHaveCount(0)
+
+  await page.getByTestId('software-report-save-filters-open').click()
+  await page.getByTestId('software-report-save-name').fill('Linux OpenSSL')
+  await page.getByTestId('software-report-save-submit').click()
+
+  await page.getByTestId('software-report-os-filter').click()
+  await page.getByRole('option', { name: 'All OS types' }).click()
+  await expect(page.getByTestId('software-report-row-software-report-host-windows-1')).toBeVisible()
+
+  await page.getByTestId('software-report-saved-reports-open').click()
+  await expect(page.getByTestId('software-report-saved-report-load-0')).toContainText('Linux OpenSSL')
+  await page.getByTestId('software-report-saved-report-load-0').click()
+
+  await expect(page.getByTestId('software-report-row-software-report-host-linux-1')).toBeVisible()
+  await expect(page.getByTestId('software-report-row-software-report-host-linux-2')).toBeVisible()
+  await expect(page.getByTestId('software-report-row-software-report-host-windows-1')).toHaveCount(0)
+
+  await page.getByTestId('software-report-saved-reports-open').click()
+  await page.getByTestId('software-report-saved-report-delete-0').click()
+  await expect(page.getByText('No saved reports yet.')).toBeVisible()
+  await page.getByTestId('software-report-saved-reports-close').click()
+
+  await page.getByTestId('software-report-tab-new-packages').click()
+  await expect(page.getByTestId('software-report-new-package-openssl')).toContainText('3')
+  await expect(page.getByTestId('software-report-new-package-git')).toContainText('1')
+
+  await page.getByTestId('software-report-tab-drift').click()
+  const driftRow = page.getByTestId('software-report-drift-row-0')
+  await expect(driftRow).toContainText('openssl')
+  await expect(driftRow).toContainText('Production Estate')
+  await expect(driftRow).toContainText('3.0.2')
+  await expect(driftRow).toContainText('3.0.3')
+})

--- a/apps/web/tests/e2e/reports/vulnerabilities.spec.ts
+++ b/apps/web/tests/e2e/reports/vulnerabilities.spec.ts
@@ -63,3 +63,110 @@ test('vulnerability report filters open findings', async ({ authenticatedPage: p
   await page.getByLabel('Package').fill('does-not-match')
   await expect(page.getByText('CVE-2024-4321')).toBeHidden()
 })
+
+test('vulnerability report applies host group, severity, KEV, and fix filters', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const licenceKey = await issueTestLicence({ orgId, tier: 'pro' })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await sql`
+    INSERT INTO host_groups (
+      id,
+      organisation_id,
+      name,
+      description
+    )
+    VALUES (
+      'report-vuln-group-1',
+      ${orgId},
+      'Critical Linux',
+      'Linux hosts with critical vulnerabilities.'
+    )
+  `
+
+  await sql`
+    INSERT INTO hosts (id, organisation_id, hostname, display_name, os, arch, status)
+    VALUES
+      ('report-vuln-host-2', ${orgId}, 'report-vuln-node-2', 'Critical Linux Node', 'linux', 'x86_64', 'online'),
+      ('report-vuln-host-3', ${orgId}, 'report-vuln-node-3', 'General Linux Node', 'linux', 'x86_64', 'online')
+  `
+
+  await sql`
+    INSERT INTO host_group_members (id, organisation_id, group_id, host_id)
+    VALUES (
+      'report-vuln-group-member-1',
+      ${orgId},
+      'report-vuln-group-1',
+      'report-vuln-host-2'
+    )
+  `
+
+  await sql`
+    INSERT INTO software_packages (
+      id, organisation_id, host_id, name, version, source,
+      distro_id, distro_version_id, distro_codename, source_name,
+      first_seen_at, last_seen_at
+    )
+    VALUES
+      (
+        'report-vuln-pkg-2', ${orgId}, 'report-vuln-host-2', 'openssl', '3.0.1', 'dpkg',
+        'ubuntu', '24.04', 'noble', 'openssl',
+        NOW(), NOW()
+      ),
+      (
+        'report-vuln-pkg-3', ${orgId}, 'report-vuln-host-3', 'curl', '8.5.0', 'apk',
+        'alpine', '3.19', 'edge', 'curl',
+        NOW(), NOW()
+      )
+  `
+
+  await sql`
+    INSERT INTO vulnerability_cves (cve_id, description, severity, known_exploited)
+    VALUES
+      ('CVE-2024-9991', 'Grouped critical vulnerability', 'critical', true),
+      ('CVE-2024-9992', 'Ungrouped medium vulnerability', 'medium', false)
+  `
+
+  await sql`
+    INSERT INTO host_vulnerability_findings (
+      id, organisation_id, host_id, software_package_id, cve_id, status,
+      package_name, installed_version, fixed_version, source, severity, known_exploited,
+      first_seen_at, last_seen_at
+    )
+    VALUES
+      (
+        'report-finding-2', ${orgId}, 'report-vuln-host-2', 'report-vuln-pkg-2', 'CVE-2024-9991', 'open',
+        'openssl', '3.0.1', '3.0.9', 'dpkg', 'critical', true,
+        NOW(), NOW()
+      ),
+      (
+        'report-finding-3', ${orgId}, 'report-vuln-host-3', 'report-vuln-pkg-3', 'CVE-2024-9992', 'open',
+        'curl', '8.5.0', NULL, 'apk', 'medium', false,
+        NOW(), NOW()
+      )
+  `
+
+  await page.goto('/reports/vulnerabilities')
+
+  await expect(page.getByTestId('vulnerability-report-finding-row-report-finding-2')).toBeVisible()
+  await expect(page.getByTestId('vulnerability-report-finding-row-report-finding-3')).toBeVisible()
+
+  await page.getByTestId('vulnerability-report-host-group-filter').click()
+  await page.getByRole('option', { name: 'Critical Linux' }).click()
+
+  await page.getByTestId('vulnerability-report-severity-filter').click()
+  await page.getByRole('option', { name: 'critical' }).click()
+
+  await page.getByTestId('vulnerability-report-kev-filter').click()
+  await page.getByTestId('vulnerability-report-fix-available-filter').click()
+
+  await expect(page.getByTestId('vulnerability-report-finding-row-report-finding-2')).toContainText('CVE-2024-9991')
+  await expect(page.getByTestId('vulnerability-report-finding-row-report-finding-3')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for the software inventory report flows
- expand vulnerability report coverage for host group, severity, KEV, and fix filters
- add stable report test ids used by the Playwright suite

## Testing
- pnpm --filter web test:e2e -- tests/e2e/reports/software.spec.ts tests/e2e/reports/vulnerabilities.spec.ts