### PR TITLE
feat(web): add NVD API key administration

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -35,14 +35,15 @@
 ### Session 74 — Vulnerability management interface
 
 **Vulnerability operations UI** (`apps/web/app/(dashboard)/settings/vulnerabilities/`, `apps/web/lib/actions/vulnerabilities.ts`)
-- Added an admin-only **Administration → Vulnerabilities** page that shows vulnerability feed/API connection status, last attempt/success times, pulled record counts, and recent connection errors without exposing configured upstream URLs or secrets.
+- Added an admin-only **Administration → Vulnerabilities** page that shows vulnerability feed/API connection status, upstream API URLs, last attempt/success times, pulled record counts, and recent connection errors without exposing secrets.
 - Added a live CVE catalog view backed by `vulnerability_cves`, including pulled CVE counts, severity/KEV summaries, affected-package rule counts, source filtering, and CVE/title search so users can confirm API data is present independently of host findings.
 - Added a bounded, rate-limited server action for the management snapshot, with organisation admin authorization and org-scoped open finding counts.
 - Added sync policy visibility plus expected feed rows for NVD, CISA KEV, Debian, Ubuntu OSV, Alpine SecDB, and Red Hat, so the page shows the APIs CT-Ops is supposed to contact even before the first sync attempt. Ingest now stores the attempted upstream URL in source metadata for accurate display after environment overrides.
+- Added an admin NVD API key control to **Administration → Vulnerabilities**. The key is stored encrypted in `system_config` as `vulnerability_nvd_api_key`; ingest uses it when `NVD_API_KEY` is not set, while keeping the environment variable as the deployment-level override.
 
 **Validation**
-- Added database-backed E2E coverage for seeded API source states and pulled CVEs at `/settings/vulnerabilities`.
-- Validation run: `pnpm --filter web type-check`, targeted `pnpm --filter web lint -- ...`, `pnpm --filter web db:validate`, `pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts`, and `go test ./apps/ingest/internal/vuln`.
+- Added database-backed E2E coverage for seeded API source states, pulled CVEs, and NVD API key save/clear behavior at `/settings/vulnerabilities`.
+- Validation run: `pnpm --filter web type-check`, targeted `pnpm --filter web lint -- ...`, `pnpm --filter web db:validate`, `pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts`, and `go test ./apps/ingest/internal/vuln ./apps/ingest/internal/crypto ./apps/ingest/internal/config`.
 - This completes the requested visibility for CVEs being pulled from vulnerability APIs and the status of vulnerability API connections. Manual sync triggering remains outside this interface.
 
 ### Session 72 — Linux OS package CVE checking

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -38,10 +38,11 @@
 - Added an admin-only **Administration → Vulnerabilities** page that shows vulnerability feed/API connection status, last attempt/success times, pulled record counts, and recent connection errors without exposing configured upstream URLs or secrets.
 - Added a live CVE catalog view backed by `vulnerability_cves`, including pulled CVE counts, severity/KEV summaries, affected-package rule counts, source filtering, and CVE/title search so users can confirm API data is present independently of host findings.
 - Added a bounded, rate-limited server action for the management snapshot, with organisation admin authorization and org-scoped open finding counts.
+- Added sync policy visibility plus expected feed rows for NVD, CISA KEV, Debian, Ubuntu OSV, Alpine SecDB, and Red Hat, so the page shows the APIs CT-Ops is supposed to contact even before the first sync attempt. Ingest now stores the attempted upstream URL in source metadata for accurate display after environment overrides.
 
 **Validation**
 - Added database-backed E2E coverage for seeded API source states and pulled CVEs at `/settings/vulnerabilities`.
-- Validation run: `pnpm --filter web type-check`, targeted `pnpm --filter web lint -- ...`, `pnpm --filter web db:validate`, and `pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts`.
+- Validation run: `pnpm --filter web type-check`, targeted `pnpm --filter web lint -- ...`, `pnpm --filter web db:validate`, `pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts`, and `go test ./apps/ingest/internal/vuln`.
 - This completes the requested visibility for CVEs being pulled from vulnerability APIs and the status of vulnerability API connections. Manual sync triggering remains outside this interface.
 
 ### Session 72 — Linux OS package CVE checking

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -158,13 +158,23 @@ func main() {
 	// Start software inventory sweeper goroutine
 	go handlers.RunSoftwareSweeper(ctx, pool)
 
+	vulnerabilityNVDAPIKey := cfg.Vulnerability.NVDAPIKey
+	if vulnerabilityNVDAPIKey == "" {
+		storedKey, err := vuln.GetStoredNVDAPIKey(ctx, pool)
+		if err != nil {
+			slog.Warn("failed to load stored NVD API key", "err", err)
+		} else if storedKey != "" {
+			vulnerabilityNVDAPIKey = storedKey
+		}
+	}
+
 	// Start vulnerability feed sync and matching goroutine
 	go vuln.RunSyncer(ctx, pool, vuln.SyncConfig{
 		Enabled:        cfg.Vulnerability.Enabled,
 		Interval:       cfg.Vulnerability.Interval,
 		SyncOnStartup:  cfg.Vulnerability.SyncOnStartup,
 		RequestTimeout: cfg.Vulnerability.RequestTimeout,
-		NVDAPIKey:      cfg.Vulnerability.NVDAPIKey,
+		NVDAPIKey:      vulnerabilityNVDAPIKey,
 		NVDDaysBack:    cfg.Vulnerability.NVDDaysBack,
 		CISAURL:        cfg.Vulnerability.CISAURL,
 		DebianURL:      cfg.Vulnerability.DebianURL,

--- a/apps/ingest/internal/vuln/db.go
+++ b/apps/ingest/internal/vuln/db.go
@@ -132,17 +132,18 @@ func UpsertAffectedPackage(ctx context.Context, pool *pgxpool.Pool, row Affected
 	return id, err
 }
 
-func MarkSourceAttempt(ctx context.Context, pool *pgxpool.Pool, id string) error {
+func MarkSourceAttempt(ctx context.Context, pool *pgxpool.Pool, id, sourceURL string) error {
 	const q = `
-		INSERT INTO vulnerability_sources (id, status, last_attempt_at, created_at, updated_at)
-		VALUES ($1, 'pending', NOW(), NOW(), NOW())
+		INSERT INTO vulnerability_sources (id, status, last_attempt_at, metadata, created_at, updated_at)
+		VALUES ($1, 'pending', NOW(), jsonb_build_object('url', $2::text), NOW(), NOW())
 		ON CONFLICT (id) DO UPDATE SET
 			status = 'pending',
 			last_attempt_at = NOW(),
 			last_error = NULL,
+			metadata = COALESCE(vulnerability_sources.metadata, '{}'::jsonb) || jsonb_build_object('url', $2::text),
 			updated_at = NOW()
 	`
-	_, err := pool.Exec(ctx, q, id)
+	_, err := pool.Exec(ctx, q, id, sourceURL)
 	return err
 }
 
@@ -161,7 +162,7 @@ func MarkSourceSuccess(ctx context.Context, pool *pgxpool.Pool, id, etag, lastMo
 			last_success_at = NOW(),
 			last_error = NULL,
 			records_upserted = $4,
-			metadata = COALESCE($5::jsonb, vulnerability_sources.metadata),
+			metadata = COALESCE(vulnerability_sources.metadata, '{}'::jsonb) || COALESCE($5::jsonb, '{}'::jsonb),
 			updated_at = NOW()
 	`
 	_, err := pool.Exec(ctx, q, id, nullable(etag), nullable(lastModified), records, jsonOrNil(metadata))

--- a/apps/ingest/internal/vuln/db.go
+++ b/apps/ingest/internal/vuln/db.go
@@ -6,10 +6,29 @@ import (
 	"encoding/json"
 	"time"
 
+	ctcrypto "github.com/carrtech-dev/ct-ops/ingest/internal/crypto"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const NVDAPIKeyConfigKey = "vulnerability_nvd_api_key"
+
+func GetStoredNVDAPIKey(ctx context.Context, pool *pgxpool.Pool) (string, error) {
+	var encrypted string
+	err := pool.QueryRow(ctx, `SELECT value FROM system_config WHERE key = $1`, NVDAPIKeyConfigKey).Scan(&encrypted)
+	if err == pgx.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	plaintext, err := ctcrypto.Decrypt(encrypted)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}
 
 func UpsertCVE(ctx context.Context, pool *pgxpool.Pool, record CVERecord) error {
 	const q = `

--- a/apps/ingest/internal/vuln/sync.go
+++ b/apps/ingest/internal/vuln/sync.go
@@ -234,6 +234,10 @@ func syncAlpine(ctx context.Context, pool *pgxpool.Pool, client *http.Client, cf
 
 func syncNVD(ctx context.Context, pool *pgxpool.Pool, client *http.Client, cfg SyncConfig) error {
 	sourceID := "nvd"
+	const sourceURL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+	if err := MarkSourceAttempt(ctx, pool, sourceID, sourceURL); err != nil {
+		return err
+	}
 	state, err := GetSourceState(ctx, pool, sourceID)
 	if err != nil {
 		return err
@@ -247,7 +251,7 @@ func syncNVD(ctx context.Context, pool *pgxpool.Pool, client *http.Client, cfg S
 		start = end.Add(-120 * 24 * time.Hour)
 	}
 
-	base, _ := url.Parse("https://services.nvd.nist.gov/rest/json/cves/2.0")
+	base, _ := url.Parse(sourceURL)
 	values := base.Query()
 	values.Set("lastModStartDate", nvdTime(start))
 	values.Set("lastModEndDate", nvdTime(end))
@@ -350,7 +354,7 @@ type fetchMeta struct {
 }
 
 func fetchSource(ctx context.Context, pool *pgxpool.Pool, client *http.Client, sourceID, sourceURL string) ([]byte, fetchMeta, error) {
-	if err := MarkSourceAttempt(ctx, pool, sourceID); err != nil {
+	if err := MarkSourceAttempt(ctx, pool, sourceID, sourceURL); err != nil {
 		return nil, fetchMeta{}, err
 	}
 	state, err := GetSourceState(ctx, pool, sourceID)

--- a/apps/web/app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx
+++ b/apps/web/app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
   AlertTriangle,
@@ -10,8 +10,10 @@ import {
   Filter,
   Loader2,
   RefreshCw,
+  Save,
   Search,
   ShieldAlert,
+  Trash2,
   XCircle,
   Zap,
 } from 'lucide-react'
@@ -37,7 +39,10 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import {
+  clearNvdApiKey,
+  getNvdApiKeySettings,
   getVulnerabilityManagementSnapshot,
+  saveNvdApiKey,
   type VulnerabilityManagementFilters,
   type VulnerabilitySeverity,
   type VulnerabilitySourceStatus,
@@ -110,10 +115,14 @@ function sourceOptionValue(source: VulnerabilitySourceStatus) {
 }
 
 export function VulnerabilityManagementClient({ orgId }: Props) {
+  const queryClient = useQueryClient()
   const [query, setQuery] = useState('')
   const [severity, setSeverity] = useState<VulnerabilitySeverity | 'all'>('all')
   const [source, setSource] = useState(ALL)
   const [kevOnly, setKevOnly] = useState(false)
+  const [nvdApiKey, setNvdApiKey] = useState('')
+  const [nvdStatusMessage, setNvdStatusMessage] = useState<string | null>(null)
+  const [nvdError, setNvdError] = useState<string | null>(null)
 
   const filters = useMemo<VulnerabilityManagementFilters>(() => ({
     query: query || undefined,
@@ -127,6 +136,42 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
     queryFn: () => getVulnerabilityManagementSnapshot(orgId, filters),
     refetchInterval: 30_000,
     staleTime: 15_000,
+  })
+
+  const { data: nvdSettings } = useQuery({
+    queryKey: ['nvd-api-key-settings', orgId],
+    queryFn: () => getNvdApiKeySettings(orgId),
+    staleTime: 30_000,
+  })
+
+  const saveNvdMutation = useMutation({
+    mutationFn: () => saveNvdApiKey(orgId, nvdApiKey),
+    onSuccess: (result) => {
+      if ('error' in result) {
+        setNvdError(result.error)
+        setNvdStatusMessage(null)
+        return
+      }
+      setNvdApiKey('')
+      setNvdError(null)
+      setNvdStatusMessage('NVD API key saved. Restart ingest to use it.')
+      queryClient.invalidateQueries({ queryKey: ['nvd-api-key-settings', orgId] })
+    },
+  })
+
+  const clearNvdMutation = useMutation({
+    mutationFn: () => clearNvdApiKey(orgId),
+    onSuccess: (result) => {
+      if ('error' in result) {
+        setNvdError(result.error)
+        setNvdStatusMessage(null)
+        return
+      }
+      setNvdApiKey('')
+      setNvdError(null)
+      setNvdStatusMessage('NVD API key cleared. Restart ingest to remove it from active sync.')
+      queryClient.invalidateQueries({ queryKey: ['nvd-api-key-settings', orgId] })
+    },
   })
 
   return (
@@ -249,6 +294,72 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
               </TableBody>
             </Table>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <ShieldAlert className="size-4 text-muted-foreground" />
+            NVD API Key
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                {nvdSettings?.hasKey ? (
+                  <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">Stored in app settings</Badge>
+                ) : (
+                  <Badge variant="outline">No key stored</Badge>
+                )}
+                {nvdSettings?.updatedAt ? (
+                  <span className="text-xs text-muted-foreground">
+                    Updated {formatDistanceToNow(new Date(nvdSettings.updatedAt), { addSuffix: true })}
+                  </span>
+                ) : null}
+              </div>
+              <Label htmlFor="nvd-api-key">NVD API key</Label>
+              <Input
+                id="nvd-api-key"
+                type="password"
+                autoComplete="off"
+                value={nvdApiKey}
+                onChange={(event) => {
+                  setNvdApiKey(event.target.value)
+                  setNvdError(null)
+                  setNvdStatusMessage(null)
+                }}
+                placeholder={nvdSettings?.hasKey ? 'Leave blank to keep stored key' : 'Paste NVD API key'}
+              />
+              <p className="text-xs text-muted-foreground">
+                Stored encrypted. Ingest uses this key when the NVD_API_KEY environment variable is not set.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                disabled={nvdApiKey.trim().length === 0 || saveNvdMutation.isPending}
+                onClick={() => saveNvdMutation.mutate()}
+              >
+                <Save className="size-4" />
+                {saveNvdMutation.isPending ? 'Saving...' : 'Save key'}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={!nvdSettings?.hasKey || clearNvdMutation.isPending}
+                onClick={() => clearNvdMutation.mutate()}
+              >
+                <Trash2 className="size-4" />
+                {clearNvdMutation.isPending ? 'Clearing...' : 'Clear key'}
+              </Button>
+            </div>
+          </div>
+          {nvdError ? <p className="mt-3 text-sm text-destructive">{nvdError}</p> : null}
+          {nvdStatusMessage ? <p className="mt-3 text-sm text-green-700">{nvdStatusMessage}</p> : null}
         </CardContent>
       </Card>
 

--- a/apps/web/app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx
+++ b/apps/web/app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx
@@ -91,6 +91,7 @@ function SourceStatusBadge({ status }: { status: string }) {
       </Badge>
     )
   }
+  if (status === 'not_attempted') return <Badge variant="secondary">Not attempted</Badge>
   return (
     <Badge variant="outline">
       <Loader2 className="size-3 mr-1" />
@@ -165,8 +166,8 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
         </Card>
         <Card>
           <CardContent className="pt-6">
-            <p className="text-sm text-muted-foreground mb-1">API Errors</p>
-            <p className="text-4xl font-bold tabular-nums text-red-600">{data?.sourceSummary.error ?? 0}</p>
+            <p className="text-sm text-muted-foreground mb-1">Not Attempted</p>
+            <p className="text-4xl font-bold tabular-nums">{data?.sourceSummary.notAttempted ?? 0}</p>
           </CardContent>
         </Card>
         <Card>
@@ -191,19 +192,38 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
           </CardTitle>
         </CardHeader>
         <CardContent>
+          <div className="mb-4 grid grid-cols-1 gap-3 text-sm md:grid-cols-4">
+            <div>
+              <div className="text-muted-foreground">Sync cadence</div>
+              <div className="font-medium">Every {data?.syncPolicy.interval ?? '6h'}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Startup sync</div>
+              <div className="font-medium">{data?.syncPolicy.syncOnStartup ?? true ? 'Enabled' : 'Disabled'}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Request timeout</div>
+              <div className="font-medium">{data?.syncPolicy.requestTimeout ?? '45s'}</div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">API errors</div>
+              <div className="font-medium text-red-600">{data?.sourceSummary.error ?? 0}</div>
+            </div>
+          </div>
           {isLoading ? (
             <p className="text-sm text-muted-foreground">Loading API connection status...</p>
           ) : !data || data.sources.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No vulnerability API sources have attempted to sync yet.</p>
+            <p className="text-sm text-muted-foreground">No vulnerability API sources are configured.</p>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>API Source</TableHead>
+                  <TableHead>API Endpoint</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Last Attempt</TableHead>
                   <TableHead>Last Success</TableHead>
-                  <TableHead className="text-right">Pulled</TableHead>
+                  <TableHead className="text-right">Fetched</TableHead>
                   <TableHead>Connection Detail</TableHead>
                 </TableRow>
               </TableHeader>
@@ -213,6 +233,9 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
                     <TableCell>
                       <div className="font-medium">{sourceLabel(sourceRow.id)}</div>
                       <div className="font-mono text-xs text-muted-foreground">{sourceRow.id}</div>
+                    </TableCell>
+                    <TableCell className="max-w-[22rem] truncate font-mono text-xs text-muted-foreground">
+                      {sourceRow.apiUrl}
                     </TableCell>
                     <TableCell><SourceStatusBadge status={sourceRow.status} /></TableCell>
                     <TableCell>{formatTime(sourceRow.lastAttemptAt)}</TableCell>

--- a/apps/web/lib/actions/vulnerabilities.ts
+++ b/apps/web/lib/actions/vulnerabilities.ts
@@ -74,9 +74,11 @@ export interface VulnerabilityCatalogRow {
   openFindingCount: number
 }
 
-export interface VulnerabilitySourceStatus extends VulnerabilitySyncSource {
+export interface VulnerabilitySourceStatus extends Omit<VulnerabilitySyncSource, 'status'> {
+  status: VulnerabilitySyncSource['status'] | 'not_attempted'
   lastModified: string | null
   hasCacheValidator: boolean
+  apiUrl: string
 }
 
 export interface VulnerabilityManagementSnapshot {
@@ -95,6 +97,13 @@ export interface VulnerabilityManagementSnapshot {
     connected: number
     pending: number
     error: number
+    notAttempted: number
+  }
+  syncPolicy: {
+    enabledByDefault: boolean
+    interval: string
+    syncOnStartup: boolean
+    requestTimeout: string
   }
   sources: VulnerabilitySourceStatus[]
   cves: VulnerabilityCatalogRow[]
@@ -144,6 +153,54 @@ const managementFiltersSchema = z.object({
   kevOnly: z.boolean().optional(),
 }).strip()
 
+type ExpectedVulnerabilitySource = {
+  id: string
+  label: string
+  apiUrl: string
+}
+
+const ALPINE_RELEASES = ['v3.18', 'v3.19', 'v3.20', 'v3.21', 'v3.22', 'v3.23']
+
+const EXPECTED_VULNERABILITY_SOURCES: ExpectedVulnerabilitySource[] = [
+  {
+    id: 'nvd',
+    label: 'NVD CVE API',
+    apiUrl: 'https://services.nvd.nist.gov/rest/json/cves/2.0',
+  },
+  {
+    id: 'cisa-kev',
+    label: 'CISA KEV Catalog',
+    apiUrl: 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json',
+  },
+  {
+    id: 'debian-tracker',
+    label: 'Debian Security Tracker',
+    apiUrl: 'https://security-tracker.debian.org/tracker/data/json',
+  },
+  {
+    id: 'ubuntu-osv',
+    label: 'Ubuntu OSV Feed',
+    apiUrl: 'https://security-metadata.canonical.com/osv/osv-all.tar.xz',
+  },
+  ...ALPINE_RELEASES.flatMap((release) => ([
+    {
+      id: `alpine-secdb-${release}-main`,
+      label: `Alpine SecDB ${release} main`,
+      apiUrl: `https://secdb.alpinelinux.org/${release}/main.json`,
+    },
+    {
+      id: `alpine-secdb-${release}-community`,
+      label: `Alpine SecDB ${release} community`,
+      apiUrl: `https://secdb.alpinelinux.org/${release}/community.json`,
+    },
+  ])),
+  {
+    id: 'redhat-security-data',
+    label: 'Red Hat Security Data',
+    apiUrl: 'https://access.redhat.com/hydra/rest/securitydata/cve.json',
+  },
+]
+
 export async function getVulnerabilityManagementSnapshot(
   orgId: string,
   filters: VulnerabilityManagementFilters = {},
@@ -178,6 +235,7 @@ export async function getVulnerabilityManagementSnapshot(
         last_success_at AS "lastSuccessAt",
         last_error AS "lastError",
         records_upserted AS "recordsUpserted",
+        COALESCE(metadata->>'url', '') AS "apiUrl",
         (etag IS NOT NULL OR last_modified IS NOT NULL) AS "hasCacheValidator"
       FROM vulnerability_sources
       ORDER BY id ASC
@@ -220,7 +278,7 @@ export async function getVulnerabilityManagementSnapshot(
   ])
 
   const summaryRows = summaryRowsRaw as unknown as Array<VulnerabilityManagementSnapshot['summary']>
-  const sourceRows = sourceRowsRaw as unknown as VulnerabilitySourceStatus[]
+  const sourceRows = sourceRowsRaw as unknown as Array<VulnerabilitySourceStatus & { apiUrl: string | null }>
   const cveRows = cveRowsRaw as unknown as VulnerabilityCatalogRow[]
 
   const summary = summaryRows[0] ?? {
@@ -233,19 +291,25 @@ export async function getVulnerabilityManagementSnapshot(
     openFindings: 0,
   }
 
+  const sources = mergeVulnerabilitySources(sourceRows)
+
   return {
     generatedAt: new Date(),
     summary,
     sourceSummary: {
-      total: sourceRows.length,
-      connected: sourceRows.filter((row) => row.status === 'success').length,
-      pending: sourceRows.filter((row) => row.status === 'pending').length,
-      error: sourceRows.filter((row) => row.status === 'error').length,
+      total: sources.length,
+      connected: sources.filter((row) => row.status === 'success').length,
+      pending: sources.filter((row) => row.status === 'pending').length,
+      error: sources.filter((row) => row.status === 'error').length,
+      notAttempted: sources.filter((row) => row.status === 'not_attempted').length,
     },
-    sources: sourceRows.map((row) => ({
-      ...row,
-      lastError: sanitizeSourceError(row.lastError),
-    })),
+    syncPolicy: {
+      enabledByDefault: true,
+      interval: '6h',
+      syncOnStartup: true,
+      requestTimeout: '45s',
+    },
+    sources,
     cves: cveRows,
   }
 }
@@ -462,4 +526,40 @@ function sanitizeSourceError(value: string | null) {
     return 'Response parsing failed'
   }
   return 'Sync failed'
+}
+
+function mergeVulnerabilitySources(rows: Array<VulnerabilitySourceStatus & { apiUrl: string | null }>): VulnerabilitySourceStatus[] {
+  const byId = new Map(rows.map((row) => [row.id, row]))
+  const merged = EXPECTED_VULNERABILITY_SOURCES.map((source) => {
+    const row = byId.get(source.id)
+    byId.delete(source.id)
+    return normalizeVulnerabilitySource(source, row)
+  })
+
+  for (const row of byId.values()) {
+    merged.push(normalizeVulnerabilitySource({
+      id: row.id,
+      label: row.id,
+      apiUrl: row.apiUrl || 'Configured upstream URL',
+    }, row))
+  }
+
+  return merged
+}
+
+function normalizeVulnerabilitySource(
+  source: ExpectedVulnerabilitySource,
+  row?: VulnerabilitySourceStatus & { apiUrl: string | null },
+): VulnerabilitySourceStatus {
+  return {
+    id: source.id,
+    status: row?.status ?? 'not_attempted',
+    lastAttemptAt: row?.lastAttemptAt ?? null,
+    lastSuccessAt: row?.lastSuccessAt ?? null,
+    lastError: sanitizeSourceError(row?.lastError ?? null),
+    recordsUpserted: row?.recordsUpserted ?? 0,
+    lastModified: row?.lastModified ?? null,
+    hasCacheValidator: row?.hasCacheValidator ?? false,
+    apiUrl: row?.apiUrl || source.apiUrl,
+  }
 }

--- a/apps/web/lib/actions/vulnerabilities.ts
+++ b/apps/web/lib/actions/vulnerabilities.ts
@@ -1,8 +1,10 @@
 'use server'
 
-import { sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { db } from '@/lib/db'
+import { systemConfig } from '@/lib/db/schema'
+import { encrypt } from '@/lib/crypto/encrypt'
 import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 import { requireFeature } from '@/lib/actions/licence-guard'
 import { createRateLimiter } from '@/lib/rate-limit'
@@ -57,6 +59,11 @@ export interface VulnerabilityManagementFilters {
   severity?: VulnerabilitySeverity | 'all'
   source?: string
   kevOnly?: boolean
+}
+
+export interface NvdApiKeySettings {
+  hasKey: boolean
+  updatedAt: Date | null
 }
 
 export interface VulnerabilityCatalogRow {
@@ -135,6 +142,14 @@ const managementLimiter = createRateLimiter({
   max: 30,
 })
 
+const nvdApiKeyUpdateLimiter = createRateLimiter({
+  scope: 'vulnerabilities:nvd-api-key-update',
+  windowMs: 60_000,
+  max: 5,
+})
+
+const NVD_API_KEY_CONFIG_KEY = 'vulnerability_nvd_api_key'
+
 const filtersSchema = z.object({
   cve: z.string().trim().max(32).optional(),
   packageName: z.string().trim().max(120).optional(),
@@ -152,6 +167,12 @@ const managementFiltersSchema = z.object({
   source: z.string().trim().max(80).optional(),
   kevOnly: z.boolean().optional(),
 }).strip()
+
+const nvdApiKeySchema = z.string()
+  .trim()
+  .min(8, 'NVD API key must be at least 8 characters')
+  .max(256, 'NVD API key must be at most 256 characters')
+  .refine((value) => !/\s/.test(value), 'NVD API key must not contain whitespace')
 
 type ExpectedVulnerabilitySource = {
   id: string
@@ -311,6 +332,78 @@ export async function getVulnerabilityManagementSnapshot(
     },
     sources,
     cves: cveRows,
+  }
+}
+
+export async function getNvdApiKeySettings(orgId: string): Promise<NvdApiKeySettings> {
+  await requireOrgAdminAccess(orgId)
+
+  const row = await db.query.systemConfig.findFirst({
+    where: eq(systemConfig.key, NVD_API_KEY_CONFIG_KEY),
+    columns: { updatedAt: true },
+  })
+
+  return {
+    hasKey: Boolean(row),
+    updatedAt: row?.updatedAt ?? null,
+  }
+}
+
+export async function saveNvdApiKey(
+  orgId: string,
+  apiKey: unknown,
+): Promise<{ success: true } | { error: string }> {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
+    return { error: 'You do not have permission to update vulnerability settings' }
+  }
+  if (!await nvdApiKeyUpdateLimiter.check(orgId)) {
+    return { error: 'Too many NVD API key updates. Please wait before trying again.' }
+  }
+
+  const parsed = nvdApiKeySchema.safeParse(apiKey)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid NVD API key' }
+  }
+
+  try {
+    const encryptedApiKey = encrypt(parsed.data)
+    await db
+      .insert(systemConfig)
+      .values({
+        key: NVD_API_KEY_CONFIG_KEY,
+        value: encryptedApiKey,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: systemConfig.key,
+        set: {
+          value: encryptedApiKey,
+          updatedAt: new Date(),
+        },
+      })
+    return { success: true }
+  } catch {
+    return { error: 'Failed to save NVD API key' }
+  }
+}
+
+export async function clearNvdApiKey(orgId: string): Promise<{ success: true } | { error: string }> {
+  try {
+    await requireOrgAdminAccess(orgId)
+  } catch {
+    return { error: 'You do not have permission to update vulnerability settings' }
+  }
+  if (!await nvdApiKeyUpdateLimiter.check(orgId)) {
+    return { error: 'Too many NVD API key updates. Please wait before trying again.' }
+  }
+
+  try {
+    await db.delete(systemConfig).where(eq(systemConfig.key, NVD_API_KEY_CONFIG_KEY))
+    return { success: true }
+  } catch {
+    return { error: 'Failed to clear NVD API key' }
   }
 }
 

--- a/apps/web/tests/e2e/settings/vulnerabilities.spec.ts
+++ b/apps/web/tests/e2e/settings/vulnerabilities.spec.ts
@@ -56,3 +56,31 @@ test('admin can monitor vulnerability API sources and pulled CVEs', async ({ aut
   await expect(page.getByText('CVE-2026-1001')).toBeHidden()
   await expect(page.getByText('CVE-2026-1002')).toBeVisible()
 })
+
+test('admin can store and clear an NVD API key without exposing the value', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  await sql`DELETE FROM system_config WHERE key = 'vulnerability_nvd_api_key'`
+
+  await page.goto('/settings/vulnerabilities')
+
+  await expect(page.getByLabel('NVD API key')).toBeVisible()
+  await expect(page.getByText('No key stored')).toBeVisible()
+
+  await page.getByLabel('NVD API key').fill('test-nvd-key-123456')
+  await page.getByRole('button', { name: 'Save key' }).click()
+
+  await expect(page.getByText('NVD API key saved. Restart ingest to use it.')).toBeVisible()
+  await expect(page.getByText('Stored in app settings')).toBeVisible()
+  await expect(page.getByLabel('NVD API key')).toHaveValue('')
+  await expect(page.getByText('test-nvd-key-123456')).toHaveCount(0)
+
+  const rows = await sql<Array<{ value: string }>>`
+    SELECT value FROM system_config WHERE key = 'vulnerability_nvd_api_key'
+  `
+  expect(rows).toHaveLength(1)
+  expect(rows[0]!.value).not.toContain('test-nvd-key-123456')
+
+  await page.getByRole('button', { name: 'Clear key' }).click()
+  await expect(page.getByText('NVD API key cleared. Restart ingest to remove it from active sync.')).toBeVisible()
+  await expect(page.getByText('No key stored')).toBeVisible()
+})

--- a/apps/web/tests/e2e/settings/vulnerabilities.spec.ts
+++ b/apps/web/tests/e2e/settings/vulnerabilities.spec.ts
@@ -37,10 +37,15 @@ test('admin can monitor vulnerability API sources and pulled CVEs', async ({ aut
 
   await expect(page.getByRole('heading', { name: 'Vulnerability Management' })).toBeVisible()
   await expect(page.getByText('API Connections')).toBeVisible()
+  await expect(page.getByText('Every 6h')).toBeVisible()
   await expect(page.getByRole('cell', { name: 'NVD CVE API nvd' })).toBeVisible()
   await expect(page.getByRole('cell', { name: 'CISA KEV Catalog cisa-kev' })).toBeVisible()
+  await expect(page.getByText('https://services.nvd.nist.gov/rest/json/cves/2.0')).toBeVisible()
+  await expect(page.getByText('https://security-tracker.debian.org/tracker/data/json')).toBeVisible()
   await expect(page.getByText('Connected').first()).toBeVisible()
   await expect(page.getByText('Error').first()).toBeVisible()
+  await expect(page.getByText('Not attempted').first()).toBeVisible()
+  await expect(page.getByRole('cell', { name: '42' })).toBeVisible()
 
   await expect(page.getByText('CVE Catalog')).toBeVisible()
   await expect(page.getByText('CVE-2026-1001')).toBeVisible()


### PR DESCRIPTION
## Summary
- Add an admin-only NVD API key control under Administration -> Vulnerabilities.
- Store the NVD API key encrypted in system_config and never echo the plaintext back to the browser.
- Let ingest use the stored key when NVD_API_KEY is not set, while keeping the environment variable as the deployment-level override.
- Extend vulnerability settings E2E coverage for save, clear, and secret non-disclosure behavior.

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint -- app/(dashboard)/settings/vulnerabilities/page.tsx app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx lib/actions/vulnerabilities.ts tests/e2e/settings/vulnerabilities.spec.ts
- pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts
- go test ./apps/ingest/internal/vuln ./apps/ingest/internal/crypto ./apps/ingest/internal/config
- git diff --check