### PR TITLE
fix(web): allow certificate checks on private hosts

### DIFF
--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -11,8 +11,7 @@ import {
   parseCertificateBuffer,
   resolveUrlTarget,
 } from '@/lib/certificates/fetch'
-import { assertAllowedCertificateCheckerPort } from '@/lib/net/certificate-checker-policy'
-import { assertPublicHost } from '@/lib/net/ssrf-guard'
+import { assertAllowedCertificateCheckerTarget } from '@/lib/net/certificate-checker-policy'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 
 export type { ParsedCertificate, ParsedSAN, ChainEntry } from '@/lib/certificates/fetch'
@@ -96,8 +95,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     if (data.action === 'fetch-url') {
       const { host, port } = resolveUrlTarget(data.url, data.port)
-      assertAllowedCertificateCheckerPort(port)
-      await assertPublicHost(host)
+      assertAllowedCertificateCheckerTarget(host, port)
       const { certificate } = await fetchCertificateFromUrl(data.url, data.port, data.servername)
       const keyMatch = data.keyPem ? checkKeyMatch(data.keyPem, certificate.pem) : undefined
       return NextResponse.json({ ok: true, certificate, keyMatch } satisfies CertCheckerResponse)

--- a/apps/web/lib/net/certificate-checker-policy.test.mjs
+++ b/apps/web/lib/net/certificate-checker-policy.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  assertAllowedCertificateCheckerTarget,
   assertAllowedCertificateCheckerPort,
   getAllowedCertificateCheckerPorts,
 } from './certificate-checker-policy.ts'
@@ -17,5 +18,11 @@ test('rejects non-TLS and internal-service ports', () => {
       () => assertAllowedCertificateCheckerPort(port),
       /Blocked: port .* is not allowed/,
     )
+  }
+})
+
+test('allows certificate checks against private network hosts on allowed TLS ports', () => {
+  for (const host of ['192.168.8.215', '10.0.0.12', 'ct-ops.carrtech.laptop']) {
+    assert.doesNotThrow(() => assertAllowedCertificateCheckerTarget(host, 443))
   }
 })

--- a/apps/web/lib/net/certificate-checker-policy.ts
+++ b/apps/web/lib/net/certificate-checker-policy.ts
@@ -25,3 +25,14 @@ export function assertAllowedCertificateCheckerPort(port: number): void {
     `Blocked: port ${port} is not allowed. Use one of: ${ALLOWED_CERTIFICATE_CHECKER_PORTS.join(', ')}`,
   )
 }
+
+export function assertAllowedCertificateCheckerTarget(host: string, port: number): void {
+  const normalizedHost = host.trim()
+  if (!normalizedHost) {
+    throw new Error('Blocked: hostname is required.')
+  }
+
+  // Certificate inspection is intentionally used against private infrastructure.
+  // Keep the abuse boundary on authenticated access plus a narrow TLS port allowlist.
+  assertAllowedCertificateCheckerPort(port)
+}


### PR DESCRIPTION
## Summary

- Allows the SSL certificate checker to fetch certificates from private/internal hosts as well as public hosts.
- Keeps the certificate checker constrained by authenticated access, trusted mutation origin checks, and the existing TLS port allowlist.
- Leaves the generic public URL SSRF guard unchanged for other features.

## Root Cause

The certificate checker API reused the generic public-host SSRF guard before fetching a certificate. That blocked RFC1918/private addresses such as `192.168.8.215`, even though the certificate checker is intended for private infrastructure.

## Validation

- `node --experimental-strip-types --test lib/net/certificate-checker-policy.test.mjs lib/net/ssrf-guard.test.mjs`
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `pnpm --filter web test:unit`
