### PR TITLE
test(web): add directory lookup and schedule e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/directory-lookup/directory-lookup-client.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/directory-lookup-client.tsx
@@ -263,7 +263,7 @@ export function DirectoryLookupClient({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-foreground">Directory User Lookup</h1>
+        <h1 className="text-2xl font-semibold text-foreground" data-testid="directory-lookup-heading">Directory User Lookup</h1>
         <p className="text-muted-foreground mt-1">
           Search for a user in your connected LDAP or Active Directory. Results are fetched live — nothing is synced or stored.
         </p>

--- a/apps/web/app/(dashboard)/directory-lookup/page.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/page.tsx
@@ -20,12 +20,12 @@ export default async function DirectoryLookupPage() {
     return (
       <div className="space-y-6">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">Directory User Lookup</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="directory-lookup-heading">Directory User Lookup</h1>
           <p className="text-muted-foreground mt-1">
             Search for a user in your connected LDAP or Active Directory.
           </p>
         </div>
-        <Card>
+        <Card data-testid="directory-lookup-empty-state">
           <CardContent className="py-16 text-center">
             <FolderSearch className="size-12 mx-auto text-muted-foreground/40 mb-4" />
             <p className="text-foreground font-medium">No directory configured</p>
@@ -33,7 +33,7 @@ export default async function DirectoryLookupPage() {
               Add an LDAP or Active Directory configuration to enable directory lookups.
             </p>
             <Button asChild size="sm">
-              <Link href="/settings/integrations">Configure LDAP</Link>
+              <Link href="/settings/integrations" data-testid="directory-lookup-configure-link">Configure LDAP</Link>
             </Button>
           </CardContent>
         </Card>

--- a/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
@@ -298,7 +298,7 @@ export function ScheduleForm({
                 <div>
                   <Label>Interpreter</Label>
                   <Select value={interpreter} onValueChange={(v) => setInterpreter(v as 'sh' | 'bash' | 'python3')}>
-                    <SelectTrigger>
+                    <SelectTrigger data-testid="task-schedule-script-interpreter">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -312,6 +312,7 @@ export function ScheduleForm({
                   <Label htmlFor="script">Script</Label>
                   <Textarea
                     id="script"
+                    data-testid="task-schedule-script-body"
                     value={script}
                     onChange={(e) => setScript(e.target.value)}
                     rows={8}
@@ -323,6 +324,7 @@ export function ScheduleForm({
                   <Label htmlFor="timeout">Timeout in seconds (optional)</Label>
                   <Input
                     id="timeout"
+                    data-testid="task-schedule-script-timeout"
                     type="number"
                     min={1}
                     value={timeoutSeconds}

--- a/apps/web/tests/e2e/directory-lookup/empty-state.spec.ts
+++ b/apps/web/tests/e2e/directory-lookup/empty-state.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '../fixtures/test'
+
+test('authenticated user sees the LDAP setup empty state when no directory is configured', async ({ authenticatedPage: page }) => {
+  await page.goto('/directory-lookup')
+
+  await expect(page.getByTestId('directory-lookup-heading')).toContainText('Directory User Lookup')
+  await expect(page.getByTestId('directory-lookup-empty-state')).toBeVisible()
+  await expect(page.getByTestId('directory-lookup-empty-state')).toContainText('No directory configured')
+
+  const configureLink = page.getByTestId('directory-lookup-configure-link')
+  await expect(configureLink).toHaveAttribute('href', '/settings/integrations')
+
+  await configureLink.click()
+  await expect(page).toHaveURL(/\/settings\/integrations$/)
+  await expect(page.getByTestId('ldap-settings-heading')).toBeVisible()
+})

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -344,3 +344,96 @@ test('admin can create a security-only patch schedule for a host group', async (
       config: { mode: 'security' },
     })
 })
+
+test('admin can create a custom script schedule for a single host', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'schedule-script-host-1',
+      ${orgId},
+      'schedule-script-host-1',
+      'Schedule Script Host',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.60.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await page.goto('/tasks/schedules/new')
+
+  await expect(page.getByTestId('task-schedule-heading-create')).toBeVisible()
+  await page.getByLabel('Name').fill('Daily diagnostics script')
+  await page.getByLabel('Description (optional)').fill('Collect host diagnostics every morning.')
+
+  await page.getByTestId('task-schedule-task-type').click()
+  await page.getByRole('option', { name: 'Custom script' }).click()
+  await page.getByTestId('task-schedule-script-interpreter').click()
+  await page.getByRole('option', { name: 'python3' }).click()
+  await page.getByTestId('task-schedule-script-body').fill('print(\"diagnostics\")')
+  await page.getByTestId('task-schedule-script-timeout').fill('120')
+
+  await page.getByTestId('task-schedule-target-id').click()
+  await page.getByRole('option', { name: /schedule-script-host-1/i }).click()
+
+  await page.getByLabel('Cron expression (5 fields: minute hour dom month dow)').fill('30 6 * * *')
+  await page.getByTestId('task-schedule-timezone').click()
+  await page.getByRole('option', { name: 'America/New_York' }).click()
+
+  await expect(page.getByTestId('task-schedule-preview-list')).toBeVisible()
+
+  await page.getByTestId('task-schedule-submit-create').click()
+
+  await expect(page).toHaveURL(/\/tasks$/)
+  const scheduleRow = page.getByRole('row', { name: /Daily diagnostics script/i })
+  await expect(scheduleRow).toContainText('Custom script')
+  await expect(scheduleRow).toContainText('schedule-script-host-1')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        name: string
+        cron_expression: string
+        timezone: string
+        target_type: string
+        target_id: string
+        task_type: string
+        config: { script?: string; interpreter?: string; timeout_seconds?: number }
+      }>>`
+        SELECT name, cron_expression, timezone, target_type, target_id, task_type, config
+        FROM task_schedules
+        WHERE organisation_id = ${orgId}
+          AND name = 'Daily diagnostics script'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      name: 'Daily diagnostics script',
+      cron_expression: '30 6 * * *',
+      timezone: 'America/New_York',
+      target_type: 'host',
+      target_id: 'schedule-script-host-1',
+      task_type: 'custom_script',
+      config: {
+        script: 'print("diagnostics")',
+        interpreter: 'python3',
+        timeout_seconds: 120,
+      },
+    })
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for the directory lookup empty state and LDAP setup link
- expand scheduled task coverage with a custom script schedule scenario
- add stable selectors for the new assertions

## Validation
- pnpm --filter web test:e2e -- tests/e2e/directory-lookup/empty-state.spec.ts tests/e2e/tasks/schedules.spec.ts