### PR TITLE
fix(web): add stable selectors for directory lookup e2e

### DIFF
--- a/apps/web/app/(dashboard)/directory-lookup/directory-lookup-client.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/directory-lookup-client.tsx
@@ -293,6 +293,7 @@ export function DirectoryLookupClient({
               <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
               <Input
                 id="lookup-username"
+                data-testid="directory-lookup-query-input"
                 value={query}
                 onChange={(e) => handleQueryInput(e.target.value)}
                 onFocus={() => { if (suggestions.length > 0) setShowSuggestions(true) }}

--- a/apps/web/app/(dashboard)/directory-lookup/page.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/page.tsx
@@ -29,7 +29,7 @@ export default async function DirectoryLookupPage() {
           <CardContent className="py-16 text-center">
             <FolderSearch className="size-12 mx-auto text-muted-foreground/40 mb-4" />
             <p className="text-foreground font-medium">No directory configured</p>
-            <p className="text-sm text-muted-foreground mt-1 mb-4">
+            <p className="text-sm text-muted-foreground mt-1 mb-4" data-testid="directory-lookup-empty-description">
               Add an LDAP or Active Directory configuration to enable directory lookups.
             </p>
             <Button asChild size="sm">

--- a/apps/web/tests/e2e/directory-lookup/empty-state.spec.ts
+++ b/apps/web/tests/e2e/directory-lookup/empty-state.spec.ts
@@ -6,6 +6,9 @@ test('authenticated user sees the LDAP setup empty state when no directory is co
   await expect(page.getByTestId('directory-lookup-heading')).toContainText('Directory User Lookup')
   await expect(page.getByTestId('directory-lookup-empty-state')).toBeVisible()
   await expect(page.getByTestId('directory-lookup-empty-state')).toContainText('No directory configured')
+  await expect(page.getByTestId('directory-lookup-empty-description')).toContainText(
+    'Add an LDAP or Active Directory configuration to enable directory lookups.',
+  )
 
   const configureLink = page.getByTestId('directory-lookup-configure-link')
   await expect(configureLink).toHaveAttribute('href', '/settings/integrations')


### PR DESCRIPTION
## Summary
- add a stable selector for the directory lookup empty-state description
- expose a stable selector on the lookup input for future authenticated lookup flows
- keep the directory lookup E2E spec anchored to explicit selectors

## Validation
- pnpm --filter web test:e2e -- tests/e2e/directory-lookup/empty-state.spec.ts