### PR TITLE
feat(web): add vulnerability detail modal

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 76 — Vulnerability catalog detail modal
+
+**Vulnerability operations UI** (`apps/web/app/(dashboard)/settings/vulnerabilities/`)
+- Added an in-page CVE detail modal to **Administration → Vulnerabilities** so admins can open a catalog vulnerability without leaving the page or losing current catalog filters.
+- The modal shows the full CVE description, title, severity, CVSS score, source, known-exploited/rejected status, affected rule count, open finding count, and published/modified timestamps.
+
+**Validation**
+- Extended database-backed E2E coverage for `/settings/vulnerabilities` to open a filtered CVE detail modal, assert key details, close it, and verify the filter remains applied.
+- Validation run: `pnpm --filter web type-check`, targeted `pnpm --filter web lint -- ...`, and `pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts`.
+- This completes the requested modal-based full vulnerability detail view while preserving user filters on the admin page.
+
 ### Session 75 — Admin ingest and agent health visibility
 
 **System health operations view** (`apps/web/app/(dashboard)/settings/system/`, `apps/web/app/api/system/health/route.ts`)

--- a/apps/web/app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx
+++ b/apps/web/app/(dashboard)/settings/vulnerabilities/vulnerability-management-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -31,6 +31,13 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
   Table,
   TableBody,
   TableCell,
@@ -43,6 +50,7 @@ import {
   getNvdApiKeySettings,
   getVulnerabilityManagementSnapshot,
   saveNvdApiKey,
+  type VulnerabilityCatalogRow,
   type VulnerabilityManagementFilters,
   type VulnerabilitySeverity,
   type VulnerabilitySourceStatus,
@@ -110,8 +118,75 @@ function formatTime(value: Date | string | null) {
   return formatDistanceToNow(new Date(value), { addSuffix: true })
 }
 
+function formatDateTime(value: Date | string | null) {
+  if (!value) return '-'
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}
+
 function sourceOptionValue(source: VulnerabilitySourceStatus) {
   return source.id
+}
+
+function DetailField({ label, value }: { label: string, value: ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs font-medium uppercase text-muted-foreground">{label}</div>
+      <div className="mt-1 break-words text-sm">{value}</div>
+    </div>
+  )
+}
+
+function VulnerabilityDetailDialog({
+  cve,
+  onOpenChange,
+}: {
+  cve: VulnerabilityCatalogRow | null
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog open={Boolean(cve)} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
+        {cve ? (
+          <>
+            <DialogHeader>
+              <div className="flex flex-wrap items-center gap-2 pr-8">
+                <DialogTitle className="font-mono text-lg">{cve.cveId}</DialogTitle>
+                <SeverityBadge severity={cve.severity} />
+                {cve.knownExploited ? (
+                  <Badge className="bg-orange-100 text-orange-800 border-orange-200 hover:bg-orange-100">
+                    <Zap className="size-3 mr-1" />
+                    Known exploited
+                  </Badge>
+                ) : null}
+                {cve.rejected ? <Badge variant="secondary">Rejected</Badge> : null}
+              </div>
+              <DialogDescription>
+                {cve.title ?? 'Untitled CVE'}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-5">
+              <div className="rounded-md border bg-muted/30 p-3 text-sm leading-6">
+                {cve.description ?? 'No vulnerability description is available from the upstream source.'}
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <DetailField label="API source" value={sourceLabel(cve.source)} />
+                <DetailField label="CVSS" value={cve.cvssScore === null ? '-' : `CVSS ${cve.cvssScore}`} />
+                <DetailField label="Affected rules" value={<span className="tabular-nums">{cve.affectedPackageCount}</span>} />
+                <DetailField label="Open findings" value={<span className="tabular-nums">{cve.openFindingCount}</span>} />
+                <DetailField label="Published" value={formatDateTime(cve.publishedAt)} />
+                <DetailField label="Modified" value={formatDateTime(cve.modifiedAt)} />
+              </div>
+            </div>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
 }
 
 export function VulnerabilityManagementClient({ orgId }: Props) {
@@ -120,6 +195,7 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
   const [severity, setSeverity] = useState<VulnerabilitySeverity | 'all'>('all')
   const [source, setSource] = useState(ALL)
   const [kevOnly, setKevOnly] = useState(false)
+  const [selectedCve, setSelectedCve] = useState<VulnerabilityCatalogRow | null>(null)
   const [nvdApiKey, setNvdApiKey] = useState('')
   const [nvdStatusMessage, setNvdStatusMessage] = useState<string | null>(null)
   const [nvdError, setNvdError] = useState<string | null>(null)
@@ -445,7 +521,15 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
                     <TableCell>
                       <div className="flex items-center gap-2">
                         {cve.knownExploited ? <Zap className="size-4 text-orange-600" /> : <ShieldAlert className="size-4 text-muted-foreground" />}
-                        <span className="font-mono text-sm">{cve.cveId}</span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="h-auto p-0 font-mono text-sm hover:bg-transparent"
+                          aria-label={`View ${cve.cveId} details`}
+                          onClick={() => setSelectedCve(cve)}
+                        >
+                          {cve.cveId}
+                        </Button>
                       </div>
                     </TableCell>
                     <TableCell className="max-w-[28rem]">
@@ -464,6 +548,13 @@ export function VulnerabilityManagementClient({ orgId }: Props) {
           )}
         </CardContent>
       </Card>
+
+      <VulnerabilityDetailDialog
+        cve={selectedCve}
+        onOpenChange={(open) => {
+          if (!open) setSelectedCve(null)
+        }}
+      />
     </div>
   )
 }

--- a/apps/web/tests/e2e/settings/vulnerabilities.spec.ts
+++ b/apps/web/tests/e2e/settings/vulnerabilities.spec.ts
@@ -55,6 +55,19 @@ test('admin can monitor vulnerability API sources and pulled CVEs', async ({ aut
   await page.getByLabel('CVE or title').fill('1002')
   await expect(page.getByText('CVE-2026-1001')).toBeHidden()
   await expect(page.getByText('CVE-2026-1002')).toBeVisible()
+
+  await page.getByRole('button', { name: 'View CVE-2026-1002 details' }).click()
+  const detailsDialog = page.getByRole('dialog', { name: 'CVE-2026-1002' })
+  await expect(detailsDialog).toBeVisible()
+  await expect(detailsDialog.getByText('A test CVE from CISA KEV')).toBeVisible()
+  await expect(detailsDialog.getByText('Known exploited', { exact: true })).toBeVisible()
+  await expect(detailsDialog.getByText('CVSS 8.7')).toBeVisible()
+  await expect(detailsDialog.getByText('CISA KEV Catalog')).toBeVisible()
+
+  await page.keyboard.press('Escape')
+  await expect(page.getByLabel('CVE or title')).toHaveValue('1002')
+  await expect(page.getByText('CVE-2026-1001')).toBeHidden()
+  await expect(page.getByText('CVE-2026-1002')).toBeVisible()
 })
 
 test('admin can store and clear an NVD API key without exposing the value', async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary
- add an in-page CVE detail modal to Administration → Vulnerabilities
- expose full catalog-row details including description, source, CVSS, KEV/rejected status, dates, affected rules, and open findings
- extend the vulnerability admin E2E test to verify modal details and preserved filters

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint -- app/''(dashboard)''/settings/vulnerabilities/vulnerability-management-client.tsx tests/e2e/settings/vulnerabilities.spec.ts
- pnpm --filter web test:e2e tests/e2e/settings/vulnerabilities.spec.ts