### PR TITLE
fix(web): end terminal sessions on logout

### DIFF
--- a/apps/web/components/terminal/terminal-pane-tree.tsx
+++ b/apps/web/components/terminal/terminal-pane-tree.tsx
@@ -17,6 +17,7 @@ interface PaneTreeProps {
   activePaneId: string
   fontSize: number
   onSessionStatusChange: (paneId: string, status: TerminalSessionStatus) => void
+  onSessionEnded: () => void
   onFocusPane: (paneId: string) => void
   onSplitPane: (paneId: string, direction: 'row' | 'column') => void
   onClosePane: (paneId: string) => void
@@ -43,6 +44,7 @@ function PaneLeaf({
   fontSize,
   onSessionStatusChange,
   onFocusPane,
+  onSessionEnded,
   onSplitPane,
   onClosePane,
 }: PaneTreeProps & { node: { type: 'leaf'; id: string } }) {
@@ -61,6 +63,7 @@ function PaneLeaf({
         isFocused={isActive}
         fontSize={fontSize}
         onStatusChange={onSessionStatusChange}
+        onSessionEnded={onSessionEnded}
         onFocus={() => onFocusPane(node.id)}
       />
       {/* Per-pane action toolbar (top-right) */}

--- a/apps/web/components/terminal/terminal-panel-context.tsx
+++ b/apps/web/components/terminal/terminal-panel-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useCallback, useEffect } from 'react'
 import { createId } from '@paralleldrive/cuid2'
+import { clearTerminalPasswordForTab } from '@/lib/terminal/tab-state'
 
 export type TerminalTabColor =
   | 'slate'
@@ -76,6 +77,7 @@ interface TerminalPanelActions {
   setActivePane: (tabId: string, paneId: string) => void
   setSplitRatio: (tabId: string, splitId: string, ratio: number) => void
   setTabFontSize: (tabId: string, fontSize: number | null) => void
+  clearTabPassword: (tabId: string) => void
 }
 
 type TerminalPanelContextValue = TerminalPanelState & TerminalPanelActions
@@ -503,6 +505,13 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
     }))
   }, [])
 
+  const clearTabPassword = useCallback((tabId: string) => {
+    setState((prev) => ({
+      ...prev,
+      tabs: clearTerminalPasswordForTab(prev.tabs, tabId),
+    }))
+  }, [])
+
   return (
     <TerminalPanelContext.Provider
       value={{
@@ -522,6 +531,7 @@ export function TerminalPanelProvider({ children }: { children: React.ReactNode 
         setActivePane,
         setSplitRatio,
         setTabFontSize,
+        clearTabPassword,
       }}
     >
       {children}

--- a/apps/web/components/terminal/terminal-panel.tsx
+++ b/apps/web/components/terminal/terminal-panel.tsx
@@ -87,6 +87,7 @@ export function TerminalPanel({ orgId }: Props) {
     setActivePane,
     setSplitRatio,
     setTabFontSize,
+    clearTabPassword,
   } = useTerminalPanel()
   const { preferences, setFontSize: setGlobalFontSize } = useTerminalPreferences()
 
@@ -293,6 +294,7 @@ export function TerminalPanel({ orgId }: Props) {
                   fontSize={tab.fontSize ?? preferences.fontSize}
                   onSessionStatusChange={handleSessionStatusChange}
                   onFocusPane={(paneId) => setActivePane(tab.id, paneId)}
+                  onSessionEnded={() => clearTabPassword(tab.id)}
                   onSplitPane={(paneId, dir) => splitPane(tab.id, paneId, dir)}
                   onClosePane={(paneId) => closePane(tab.id, paneId)}
                   onSplitRatioChange={(splitId, ratio) =>

--- a/apps/web/components/terminal/terminal-session.tsx
+++ b/apps/web/components/terminal/terminal-session.tsx
@@ -13,6 +13,7 @@ interface Props {
   isFocused: boolean
   fontSize: number
   onStatusChange?: (paneId: string, status: TerminalSessionStatus) => void
+  onSessionEnded?: () => void
   onFocus?: () => void
 }
 
@@ -23,6 +24,7 @@ export function TerminalSession({
   isFocused,
   fontSize,
   onStatusChange,
+  onSessionEnded,
   onFocus,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -158,7 +160,7 @@ export function TerminalSession({
 
         if (!binding.password) {
           term.writeln('\x1b[31mError: host password is required. Open a new terminal session.\x1b[0m')
-          updateStatus('error')
+          updateStatus('closed')
           return
         }
 
@@ -200,14 +202,11 @@ export function TerminalSession({
           }
         }, 5000)
 
-        const promptReconnect = () => {
+        const endSession = () => {
           if (sessionEnded) return
           sessionEnded = true
-          term.writeln('\r\n\x1b[90mPress any key to reconnect...\x1b[0m')
-          const reconnectDisposable = term.onData(() => {
-            reconnectDisposable.dispose()
-            connectSession()
-          })
+          onSessionEnded?.()
+          term.writeln('\r\n\x1b[90mOpen a new terminal session to reconnect.\x1b[0m')
         }
 
         ws.onopen = () => {
@@ -243,12 +242,11 @@ export function TerminalSession({
               clearTimeout(waitingTimer)
               term.writeln('\r\n\x1b[90mSession ended.\x1b[0m')
               updateStatus('closed')
-              promptReconnect()
+              endSession()
             } else if (msg.type === 'error' && msg.message) {
               clearTimeout(waitingTimer)
               term.writeln(`\r\n\x1b[31mError: ${msg.message}\x1b[0m`)
               updateStatus('error')
-              promptReconnect()
             }
           } catch {
             // ignore malformed messages
@@ -262,7 +260,9 @@ export function TerminalSession({
         ws.onclose = (e) => {
           if (e.code !== 1000) {
             updateStatus('closed')
-            promptReconnect()
+            if (!sessionEnded) {
+              term.writeln('\r\n\x1b[90mConnection closed. Open a new terminal session to reconnect.\x1b[0m')
+            }
           }
         }
 

--- a/apps/web/lib/terminal/tab-state.test.mjs
+++ b/apps/web/lib/terminal/tab-state.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { clearTerminalPasswordForTab } from './tab-state.ts'
+
+test('clearTerminalPasswordForTab removes the cached password from the ended tab only', () => {
+  const tabs = [
+    {
+      id: 'tab-1',
+      binding: {
+        hostId: 'host-1',
+        hostname: 'alpha.internal',
+        username: 'alice',
+        password: 'secret-one',
+        orgId: 'org-1',
+        directAccess: false,
+      },
+    },
+    {
+      id: 'tab-2',
+      binding: {
+        hostId: 'host-2',
+        hostname: 'beta.internal',
+        username: 'bob',
+        password: 'secret-two',
+        orgId: 'org-1',
+        directAccess: false,
+      },
+    },
+  ]
+
+  const next = clearTerminalPasswordForTab(tabs, 'tab-1')
+
+  assert.equal(next[0]?.binding.password, undefined)
+  assert.equal(next[1]?.binding.password, 'secret-two')
+  assert.equal(next[0]?.binding.username, 'alice')
+  assert.equal(next[1]?.binding.username, 'bob')
+})

--- a/apps/web/lib/terminal/tab-state.ts
+++ b/apps/web/lib/terminal/tab-state.ts
@@ -1,0 +1,24 @@
+interface TerminalBindingWithPassword {
+  password?: string
+}
+
+interface TerminalTabWithBinding<TBinding extends TerminalBindingWithPassword = TerminalBindingWithPassword> {
+  id: string
+  binding: TBinding
+}
+
+export function clearTerminalPasswordForTab<TTab extends TerminalTabWithBinding>(
+  tabs: readonly TTab[],
+  tabId: string,
+): TTab[] {
+  return tabs.map((tab) => {
+    if (tab.id !== tabId || tab.binding.password === undefined) return tab
+    return {
+      ...tab,
+      binding: {
+        ...tab.binding,
+        password: undefined,
+      },
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- stop the terminal panel from offering in-place reconnect after a shell exits
- clear the tab's cached SSH password when a terminal session ends
- add a focused regression test for terminal tab credential clearing

## Testing
- cd apps/web && node --experimental-strip-types --test ./lib/terminal/tab-state.test.mjs
- pnpm --filter web type-check

Closes #719