### PR TITLE
test(web): add alerts and service schedule e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -289,7 +289,7 @@ function AddSmtpDialog({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} data-testid="alert-email-submit">
               Add Channel
             </Button>
           </DialogFooter>
@@ -970,7 +970,7 @@ function AddSilenceDialog({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} data-testid="alert-silence-submit">
               Create Silence
             </Button>
           </DialogFooter>
@@ -1115,7 +1115,7 @@ export function AlertsClient({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-foreground">Alerts</h1>
+        <h1 className="text-2xl font-semibold text-foreground" data-testid="alerts-heading">Alerts</h1>
         <p className="text-muted-foreground mt-1">
           {activeAlerts.length} active alert{activeAlerts.length !== 1 ? 's' : ''}
         </p>
@@ -1124,11 +1124,11 @@ export function AlertsClient({
       {/* Filters */}
       <div className="flex items-center gap-3">
         <Label className="text-sm text-muted-foreground shrink-0">Severity</Label>
-        <Select
+          <Select
           value={severityFilter}
           onValueChange={(v) => setSeverityFilter(v as SeverityFilter)}
         >
-          <SelectTrigger className="w-36">
+          <SelectTrigger className="w-36" data-testid="alerts-severity-filter">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -1173,7 +1173,7 @@ export function AlertsClient({
               </TableHeader>
               <TableBody>
                 {filteredActive.map((alert) => (
-                  <TableRow key={alert.id}>
+                  <TableRow key={alert.id} data-testid={`alert-row-${alert.id}`}>
                     <TableCell>
                       <SeverityBadge severity={alert.ruleSeverity} />
                     </TableCell>
@@ -1198,6 +1198,7 @@ export function AlertsClient({
                         variant="outline"
                         onClick={() => acknowledgeMutation.mutate(alert.id)}
                         disabled={acknowledgeMutation.isPending}
+                        data-testid={`alert-acknowledge-${alert.id}`}
                       >
                         Acknowledge
                       </Button>
@@ -1282,7 +1283,7 @@ export function AlertsClient({
                 </TableHeader>
                 <TableBody>
                   {historyAlerts.map((alert) => (
-                    <TableRow key={alert.id}>
+                    <TableRow key={alert.id} data-testid={`alert-history-row-${alert.id}`}>
                       <TableCell>
                         <SeverityBadge severity={alert.ruleSeverity} />
                       </TableCell>
@@ -1356,6 +1357,7 @@ export function AlertsClient({
             variant="outline"
             className="shrink-0"
             onClick={() => setAddSilenceOpen(true)}
+            data-testid="alerts-add-silence"
           >
             <Plus className="size-3.5 mr-1" />
             Add Silence
@@ -1386,7 +1388,7 @@ export function AlertsClient({
                   const isActive = start <= now && end >= now
                   const isExpired = end < now
                   return (
-                    <TableRow key={s.id}>
+                    <TableRow key={s.id} data-testid="alert-silence-row">
                       <TableCell className="font-medium">
                         {s.hostname ? (
                           <Link href={`/hosts/${s.hostId}`} className="hover:underline text-foreground">
@@ -1466,6 +1468,7 @@ export function AlertsClient({
               size="sm"
               variant="outline"
               onClick={() => setAddSmtpOpen(true)}
+              data-testid="alerts-add-email"
             >
               <Plus className="size-3.5 mr-1" />
               Add Email
@@ -1505,7 +1508,7 @@ export function AlertsClient({
               </TableHeader>
               <TableBody>
                 {channels.map((ch) => (
-                  <TableRow key={ch.id}>
+                  <TableRow key={ch.id} data-testid="alert-channel-row">
                     <TableCell className="font-medium">{ch.name}</TableCell>
                     <TableCell>
                       {ch.type === 'smtp' ? (

--- a/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
@@ -350,7 +350,7 @@ export function ScheduleForm({
                 <div>
                   <Label>Action</Label>
                   <Select value={serviceAction} onValueChange={(v) => setServiceAction(v as typeof serviceAction)}>
-                    <SelectTrigger>
+                    <SelectTrigger data-testid="task-schedule-service-action">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>

--- a/apps/web/tests/e2e/alerts/alerts.spec.ts
+++ b/apps/web/tests/e2e/alerts/alerts.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('admin can filter, acknowledge, and configure alerting from the alerts page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'alerts-host-critical',
+        ${orgId},
+        'alerts-host-critical',
+        'Alerts Host Critical',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.70.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'alerts-host-warning',
+        ${orgId},
+        'alerts-host-warning',
+        'Alerts Host Warning',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.70.0.11"]'::jsonb,
+        'online',
+        NOW()
+      )
+  `
+
+  await sql`
+    INSERT INTO alert_rules (
+      id,
+      organisation_id,
+      host_id,
+      name,
+      condition_type,
+      config,
+      severity,
+      enabled,
+      is_global_default
+    )
+    VALUES
+      (
+        'alerts-rule-critical',
+        ${orgId},
+        'alerts-host-critical',
+        'CPU saturation',
+        'metric_threshold',
+        '{"metric":"cpu","operator":"gt","threshold":95}'::jsonb,
+        'critical',
+        true,
+        false
+      ),
+      (
+        'alerts-rule-warning',
+        ${orgId},
+        'alerts-host-warning',
+        'Disk usage warning',
+        'metric_threshold',
+        '{"metric":"disk","operator":"gt","threshold":80}'::jsonb,
+        'warning',
+        true,
+        false
+      )
+  `
+
+  await sql`
+    INSERT INTO alert_instances (
+      id,
+      rule_id,
+      host_id,
+      organisation_id,
+      status,
+      message,
+      triggered_at
+    )
+    VALUES
+      (
+        'alerts-instance-critical',
+        'alerts-rule-critical',
+        'alerts-host-critical',
+        ${orgId},
+        'firing',
+        'CPU has exceeded 95% for 10 minutes',
+        NOW() - INTERVAL '10 minutes'
+      ),
+      (
+        'alerts-instance-warning',
+        'alerts-rule-warning',
+        'alerts-host-warning',
+        ${orgId},
+        'firing',
+        'Disk usage has exceeded 80%',
+        NOW() - INTERVAL '5 minutes'
+      )
+  `
+
+  await page.goto('/alerts')
+
+  await expect(page.getByTestId('alerts-heading')).toBeVisible()
+  await expect(page.getByTestId('alert-row-alerts-instance-critical')).toContainText('alerts-host-critical')
+  await expect(page.getByTestId('alert-row-alerts-instance-warning')).toContainText('alerts-host-warning')
+
+  await page.getByTestId('alerts-severity-filter').click()
+  await page.getByRole('option', { name: 'Critical' }).click()
+
+  await expect(page.getByTestId('alert-row-alerts-instance-critical')).toBeVisible()
+  await expect(page.getByTestId('alert-row-alerts-instance-warning')).toHaveCount(0)
+
+  await page.getByTestId('alert-acknowledge-alerts-instance-critical').click()
+
+  await expect(page.getByTestId('alert-row-alerts-instance-critical')).toHaveCount(0)
+  await expect(page.getByTestId('alert-history-row-alerts-instance-critical')).toContainText('Acknowledged')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ status: string; acknowledged_at: string | null }>>`
+        SELECT status, acknowledged_at::text
+        FROM alert_instances
+        WHERE id = 'alerts-instance-critical'
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      status: 'acknowledged',
+      acknowledged_at: expect.any(String),
+    })
+
+  await page.getByTestId('alerts-add-silence').click()
+  await page.getByLabel('Host (leave blank for org-wide)').selectOption('alerts-host-warning')
+  await page.getByLabel('Reason').fill('Scheduled maintenance')
+  await page.getByTestId('alert-silence-submit').click()
+
+  await expect(page.getByTestId('alert-silence-row')).toContainText('alerts-host-warning')
+  await expect(page.getByTestId('alert-silence-row')).toContainText('Scheduled maintenance')
+
+  await page.getByTestId('alerts-add-email').click()
+  await page.getByLabel('Name').fill('Ops Email')
+  await page.getByLabel('Recipients').fill('ops@example.com, team@example.com')
+  await page.getByTestId('alert-email-submit').click()
+
+  const emailRow = page.getByTestId('alert-channel-row').filter({ hasText: 'Ops Email' })
+  await expect(emailRow).toContainText('ops@example.com, team@example.com')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ name: string; type: string; config: { toAddresses: string[] } }>>`
+        SELECT name, type, config
+        FROM notification_channels
+        WHERE organisation_id = ${orgId}
+          AND name = 'Ops Email'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      name: 'Ops Email',
+      type: 'smtp',
+      config: {
+        toAddresses: ['ops@example.com', 'team@example.com'],
+      },
+    })
+})

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -437,3 +437,128 @@ test('admin can create a custom script schedule for a single host', async ({ aut
       },
     })
 })
+
+test('admin can create a service action schedule for a host group', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'schedule-service-host-1',
+      ${orgId},
+      'schedule-service-host-1',
+      'Schedule Service Host',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.60.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`
+    INSERT INTO host_groups (
+      id,
+      organisation_id,
+      name,
+      description
+    )
+    VALUES (
+      'schedule-service-group-1',
+      ${orgId},
+      'Frontend Fleet',
+      'Hosts for scheduled service restarts'
+    )
+  `
+
+  await sql`
+    INSERT INTO host_group_members (
+      id,
+      organisation_id,
+      group_id,
+      host_id
+    )
+    VALUES (
+      'schedule-service-group-member-1',
+      ${orgId},
+      'schedule-service-group-1',
+      'schedule-service-host-1'
+    )
+  `
+
+  await page.goto('/tasks/schedules/new')
+
+  await expect(page.getByTestId('task-schedule-heading-create')).toBeVisible()
+  await page.getByLabel('Name').fill('Restart nginx weekly')
+  await page.getByLabel('Description (optional)').fill('Restart the frontend service window every week.')
+
+  await page.getByTestId('task-schedule-task-type').click()
+  await page.getByRole('option', { name: 'Service action' }).click()
+
+  await page.getByLabel('Service name').fill('nginx')
+  await page.getByTestId('task-schedule-service-action').click()
+  await page.getByRole('option', { name: 'restart' }).click()
+
+  await page.getByTestId('task-schedule-target-type').click()
+  await page.getByRole('option', { name: 'Host group' }).click()
+  await page.getByTestId('task-schedule-target-id').click()
+  await page.getByRole('option', { name: 'Frontend Fleet' }).click()
+
+  await page.getByLabel('Max parallel hosts').fill('3')
+  await page.getByLabel('Cron expression (5 fields: minute hour dom month dow)').fill('30 4 * * 1')
+  await page.getByTestId('task-schedule-timezone').click()
+  await page.getByRole('option', { name: 'UTC' }).click()
+
+  await page.getByTestId('task-schedule-submit-create').click()
+
+  await expect(page).toHaveURL(/\/tasks$/)
+  const scheduleRow = page.getByRole('row', { name: /Restart nginx weekly/i })
+  await expect(scheduleRow).toContainText('Service action')
+  await expect(scheduleRow).toContainText('Frontend Fleet')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        name: string
+        cron_expression: string
+        timezone: string
+        target_type: string
+        target_id: string
+        max_parallel: number
+        task_type: string
+        config: { service_name: string; action: string }
+      }>>`
+        SELECT name, cron_expression, timezone, target_type, target_id, max_parallel, task_type, config
+        FROM task_schedules
+        WHERE organisation_id = ${orgId}
+          AND name = 'Restart nginx weekly'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      name: 'Restart nginx weekly',
+      cron_expression: '30 4 * * 1',
+      timezone: 'UTC',
+      target_type: 'group',
+      target_id: 'schedule-service-group-1',
+      max_parallel: 3,
+      task_type: 'service',
+      config: {
+        service_name: 'nginx',
+        action: 'restart',
+      },
+    })
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for the alerts page, including severity filtering, acknowledgement, silences, and email channels
- extend scheduled task E2E coverage with a service action schedule for a host group
- add stable data-testid hooks for the new E2E interactions

## Validation
- pnpm --filter web test:e2e -- tests/e2e/alerts/alerts.spec.ts tests/e2e/tasks/schedules.spec.ts