### PR TITLE
test(web): add patch status report e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -135,7 +135,11 @@ export function NetworkGraph({ network, hosts }: Props) {
   const closeContextMenu = useCallback(() => setContextMenu(null), [])
 
   return (
-    <div className="w-full h-[520px] rounded-lg border overflow-hidden" onContextMenu={(e) => e.preventDefault()}>
+    <div
+      className="w-full h-[520px] rounded-lg border overflow-hidden"
+      data-testid="network-detail-graph"
+      onContextMenu={(e) => e.preventDefault()}
+    >
       <ReactFlow
         key={graphKey}
         defaultNodes={nodes}

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -147,7 +147,11 @@ export function AllNetworksGraph({ networksWithHosts }: Props) {
   const closeContextMenu = useCallback(() => setContextMenu(null), [])
 
   return (
-    <div className="w-full h-[620px] rounded-lg border overflow-hidden" onContextMenu={(e) => e.preventDefault()}>
+    <div
+      className="w-full h-[620px] rounded-lg border overflow-hidden"
+      data-testid="networks-graph"
+      onContextMenu={(e) => e.preventDefault()}
+    >
       <ReactFlow
         key={graphKey}
         defaultNodes={nodes}

--- a/apps/web/app/(dashboard)/reports/patch-status/patch-status-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/patch-status/patch-status-report-client.tsx
@@ -39,7 +39,7 @@ export function PatchStatusReportClient({ report }: Props) {
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">Patch Status</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="patch-status-report-heading">Patch Status</h1>
           <p className="text-sm text-muted-foreground">
             Estate and network patch compliance generated {formatDistanceToNow(new Date(report.generatedAt), { addSuffix: true })}.
           </p>
@@ -47,31 +47,31 @@ export function PatchStatusReportClient({ report }: Props) {
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-4">
-        <Card>
+        <Card data-testid="patch-status-summary-compliance">
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground mb-1">Compliance</p>
             <p className="text-4xl font-bold tabular-nums">{compliantPercent}%</p>
           </CardContent>
         </Card>
-        <Card>
+        <Card data-testid="patch-status-summary-hosts">
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground mb-1">Hosts</p>
             <p className="text-4xl font-bold tabular-nums">{report.summary.totalHosts}</p>
           </CardContent>
         </Card>
-        <Card>
+        <Card data-testid="patch-status-summary-outside-policy">
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground mb-1">Outside Policy</p>
             <p className="text-4xl font-bold tabular-nums text-red-600">{report.summary.failingCount}</p>
           </CardContent>
         </Card>
-        <Card>
+        <Card data-testid="patch-status-summary-oldest-age">
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground mb-1">Oldest Patch Age</p>
             <p className="text-4xl font-bold tabular-nums">{age(report.summary.oldestPatchAgeDays)}</p>
           </CardContent>
         </Card>
-        <Card>
+        <Card data-testid="patch-status-summary-updates">
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground mb-1">Available Updates</p>
             <p className="text-4xl font-bold tabular-nums">{report.summary.totalAvailableUpdates}</p>
@@ -79,7 +79,7 @@ export function PatchStatusReportClient({ report }: Props) {
         </Card>
       </div>
 
-      <Card>
+      <Card data-testid="patch-status-networks-card">
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
             <Network className="size-4 text-muted-foreground" />
@@ -102,7 +102,7 @@ export function PatchStatusReportClient({ report }: Props) {
               </TableHeader>
               <TableBody>
                 {report.networks.map((network) => (
-                  <TableRow key={network.networkId}>
+                  <TableRow key={network.networkId} data-testid={`patch-status-network-row-${network.networkId}`}>
                     <TableCell>
                       <Link href={`/hosts/networks/${network.networkId}`} className="font-medium hover:underline">
                         {network.networkName}
@@ -120,7 +120,7 @@ export function PatchStatusReportClient({ report }: Props) {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card data-testid="patch-status-hosts-card">
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
             <ShieldAlert className="size-4 text-muted-foreground" />
@@ -145,7 +145,7 @@ export function PatchStatusReportClient({ report }: Props) {
               </TableHeader>
               <TableBody>
                 {report.hosts.map((host) => (
-                  <TableRow key={host.hostId}>
+                  <TableRow key={host.hostId} data-testid={`patch-status-host-row-${host.hostId}`}>
                     <TableCell>
                       <Link href={`/hosts/${host.hostId}`} className="font-medium hover:underline">
                         {host.displayName ?? host.hostname}

--- a/apps/web/tests/e2e/hosts/networks.spec.ts
+++ b/apps/web/tests/e2e/hosts/networks.spec.ts
@@ -96,6 +96,13 @@ test('admin can create, edit, and delete a network and manage its hosts', async 
   await expect(networkRow).toContainText('10.55.0.0/24')
   await expect(networkRow).toContainText('Branch office LAN')
 
+  await page.getByTestId('networks-view-graph').click()
+  await expect(page.getByTestId('networks-graph')).toBeVisible()
+  await expect(page.getByText('Branch Office')).toBeVisible()
+
+  await page.getByTestId('networks-view-table').click()
+  await expect(networkRow).toBeVisible()
+
   await networkRow.getByRole('link', { name: 'Branch Office' }).click()
 
   await expect(page).toHaveURL(new RegExp(`/hosts/networks/${networkId}$`))
@@ -110,6 +117,15 @@ test('admin can create, edit, and delete a network and manage its hosts', async 
   await expect(memberRow).toContainText('Edge Node 1')
   await expect(memberRow).toContainText('online')
   await expect(page.getByTestId('network-detail-empty-state')).toHaveCount(0)
+
+  await page.getByTestId('network-detail-view-graph').click()
+  const detailGraph = page.getByTestId('network-detail-graph')
+  await expect(detailGraph).toBeVisible()
+  await expect(detailGraph.getByText('Branch Office')).toBeVisible()
+  await expect(detailGraph.getByText('Edge Node 1')).toBeVisible()
+
+  await page.getByTestId('network-detail-view-table').click()
+  await expect(memberRow).toBeVisible()
 
   const membershipRows = await sql<Array<{ deleted_at: string | null; auto_assigned: boolean }>>`
     SELECT deleted_at, auto_assigned

--- a/apps/web/tests/e2e/reports/patch-status.spec.ts
+++ b/apps/web/tests/e2e/reports/patch-status.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+import { issueTestLicence } from '../fixtures/licence'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug} LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('patch status report shows organisation compliance by network and host', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const licenceKey = await issueTestLicence({ orgId, tier: 'pro' })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      os_version,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'patch-report-host-1',
+        ${orgId},
+        'db-01',
+        'Database 01',
+        'Ubuntu',
+        '24.04',
+        'x86_64',
+        '["10.70.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'patch-report-host-2',
+        ${orgId},
+        'web-01',
+        'Web 01',
+        'Debian',
+        '12',
+        'x86_64',
+        '["10.71.0.10"]'::jsonb,
+        'online',
+        NOW()
+      )
+  `
+
+  await sql`
+    INSERT INTO networks (
+      id,
+      organisation_id,
+      name,
+      cidr,
+      description
+    )
+    VALUES
+      ('patch-report-network-1', ${orgId}, 'Production', '10.70.0.0/24', 'Production subnet'),
+      ('patch-report-network-2', ${orgId}, 'DMZ', '10.71.0.0/24', 'DMZ subnet')
+  `
+
+  await sql`
+    INSERT INTO host_network_memberships (
+      id,
+      organisation_id,
+      network_id,
+      host_id,
+      auto_assigned
+    )
+    VALUES
+      ('patch-report-membership-1', ${orgId}, 'patch-report-network-1', 'patch-report-host-1', true),
+      ('patch-report-membership-2', ${orgId}, 'patch-report-network-2', 'patch-report-host-2', false)
+  `
+
+  await sql`
+    INSERT INTO host_patch_statuses (
+      id,
+      organisation_id,
+      host_id,
+      check_id,
+      status,
+      last_patched_at,
+      patch_age_days,
+      max_age_days,
+      package_manager,
+      updates_supported,
+      updates_count,
+      updates_truncated,
+      warnings,
+      error,
+      checked_at
+    )
+    VALUES
+      (
+        'patch-report-status-1',
+        ${orgId},
+        'patch-report-host-1',
+        NULL,
+        'fail',
+        NOW() - INTERVAL '45 days',
+        45,
+        30,
+        'apt',
+        true,
+        3,
+        false,
+        '[]'::jsonb,
+        NULL,
+        NOW() - INTERVAL '5 minutes'
+      ),
+      (
+        'patch-report-status-2',
+        ${orgId},
+        'patch-report-host-2',
+        NULL,
+        'pass',
+        NOW() - INTERVAL '7 days',
+        7,
+        30,
+        'apt',
+        true,
+        0,
+        false,
+        '[]'::jsonb,
+        NULL,
+        NOW() - INTERVAL '4 minutes'
+      )
+  `
+
+  await page.goto('/reports/patch-status')
+
+  await expect(page.getByTestId('patch-status-report-heading')).toBeVisible()
+  await expect(page.getByTestId('patch-status-summary-compliance')).toContainText('50%')
+  await expect(page.getByTestId('patch-status-summary-hosts')).toContainText('2')
+  await expect(page.getByTestId('patch-status-summary-outside-policy')).toContainText('1')
+  await expect(page.getByTestId('patch-status-summary-oldest-age')).toContainText('45d')
+  await expect(page.getByTestId('patch-status-summary-updates')).toContainText('3')
+
+  const productionRow = page.getByTestId('patch-status-network-row-patch-report-network-1')
+  await expect(productionRow).toContainText('Production')
+  await expect(productionRow).toContainText('1')
+  await expect(productionRow).toContainText('0')
+  await expect(productionRow).toContainText('45d')
+
+  const dmzRow = page.getByTestId('patch-status-network-row-patch-report-network-2')
+  await expect(dmzRow).toContainText('DMZ')
+  await expect(dmzRow).toContainText('1')
+  await expect(dmzRow).toContainText('1')
+  await expect(dmzRow).toContainText('0')
+  await expect(dmzRow).toContainText('7d')
+
+  const failingHostRow = page.getByTestId('patch-status-host-row-patch-report-host-1')
+  await expect(failingHostRow).toContainText('Database 01')
+  await expect(failingHostRow).toContainText('Outside policy')
+  await expect(failingHostRow).toContainText('Production')
+  await expect(failingHostRow).toContainText('45d')
+  await expect(failingHostRow).toContainText('30d')
+  await expect(failingHostRow).toContainText('3')
+  await expect(failingHostRow).toContainText('Ubuntu')
+
+  const passingHostRow = page.getByTestId('patch-status-host-row-patch-report-host-2')
+  await expect(passingHostRow).toContainText('Web 01')
+  await expect(passingHostRow).toContainText('Within policy')
+  await expect(passingHostRow).toContainText('DMZ')
+  await expect(passingHostRow).toContainText('7d')
+  await expect(passingHostRow).toContainText('0')
+  await expect(passingHostRow).toContainText('Debian')
+})


### PR DESCRIPTION
## Summary
- add an E2E spec for the patch status report with seeded licence, hosts, networks, and patch data
- expand the networks E2E spec to cover graph view on the list and detail pages
- add stable data-testid hooks for the new assertions

## Validation
- pnpm --filter web test:e2e -- tests/e2e/reports/patch-status.spec.ts tests/e2e/hosts/networks.spec.ts