### PR TITLE
test(web): add licence and host inventory e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -617,7 +617,7 @@ export function HostsClient({
               value={String(pageSize)}
               onValueChange={(v) => handlePageSizeChange(Number(v))}
             >
-              <SelectTrigger className="w-32">
+              <SelectTrigger className="w-32" data-testid="hosts-page-size">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -755,7 +755,7 @@ export function HostsClient({
 
               {/* ─── Pagination footer ───────────────────────────────────── */}
               <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mt-4">
-                <div className="text-sm text-muted-foreground">
+                <div className="text-sm text-muted-foreground" data-testid="hosts-pagination-summary">
                   Showing <span className="tabular-nums font-medium text-foreground">{rangeFrom.toLocaleString()}</span>–
                   <span className="tabular-nums font-medium text-foreground">{rangeTo.toLocaleString()}</span>{' '}
                   of <span className="tabular-nums font-medium text-foreground">{total.toLocaleString()}</span>
@@ -766,6 +766,7 @@ export function HostsClient({
                     size="sm"
                     onClick={() => setPage(0)}
                     disabled={page === 0}
+                    data-testid="hosts-page-first"
                   >
                     First
                   </Button>
@@ -774,10 +775,11 @@ export function HostsClient({
                     size="sm"
                     onClick={() => setPage((p) => Math.max(0, p - 1))}
                     disabled={page === 0}
+                    data-testid="hosts-page-previous"
                   >
                     Previous
                   </Button>
-                  <span className="text-sm text-muted-foreground px-2 tabular-nums">
+                  <span className="text-sm text-muted-foreground px-2 tabular-nums" data-testid="hosts-page-indicator">
                     Page {page + 1} of {pageCount}
                   </span>
                   <Button
@@ -785,6 +787,7 @@ export function HostsClient({
                     size="sm"
                     onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
                     disabled={page + 1 >= pageCount}
+                    data-testid="hosts-page-next"
                   >
                     Next
                   </Button>
@@ -793,6 +796,7 @@ export function HostsClient({
                     size="sm"
                     onClick={() => setPage(pageCount - 1)}
                     disabled={page + 1 >= pageCount}
+                    data-testid="hosts-page-last"
                   >
                     Last
                   </Button>

--- a/apps/web/tests/e2e/hosts/inventory.spec.ts
+++ b/apps/web/tests/e2e/hosts/inventory.spec.ts
@@ -76,6 +76,7 @@ test('authenticated user can search and filter the host inventory', async ({ aut
   await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
 
   await page.getByTestId('hosts-search-input').fill('10.0.0.20')
+  await expect(page.getByTestId('hosts-pagination-summary')).toContainText('Showing 1–1 of 1')
   await expect(page.getByRole('link', { name: 'Beta Node' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Alpha Node' })).toHaveCount(0)
   await expect(page.getByTestId('hosts-clear-filters')).toBeVisible()
@@ -265,4 +266,68 @@ test('admin can reject a pending agent from the host inventory page', async ({ a
   expect(revokedRows).toHaveLength(1)
   expect(revokedRows[0]?.serial).toBe('reject-serial-1')
   expect(revokedRows[0]?.reason).toBe('Rejected by admin')
+})
+
+test('authenticated user can sort and paginate the host inventory', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId } = await getOrgAndUserIds(sql)
+
+  for (let index = 1; index <= 55; index += 1) {
+    const hostNumber = String(index).padStart(3, '0')
+    const octet = index + 10
+    await sql`
+      INSERT INTO hosts (
+        id,
+        organisation_id,
+        hostname,
+        display_name,
+        os,
+        arch,
+        ip_addresses,
+        status,
+        cpu_percent,
+        memory_percent,
+        disk_percent,
+        last_seen_at
+      )
+      VALUES (
+        ${`host-paged-${hostNumber}`},
+        ${orgId},
+        ${`host-${hostNumber}`},
+        ${`Host ${hostNumber}`},
+        'Ubuntu 24.04',
+        'x86_64',
+        ${JSON.stringify([`10.0.2.${octet}`])}::jsonb,
+        'online',
+        ${index},
+        20,
+        30,
+        NOW() - (${index} * INTERVAL '1 minute')
+      )
+    `
+  }
+
+  await page.goto('/hosts')
+
+  await expect(page.getByTestId('hosts-pagination-summary')).toContainText('Showing 1–50 of 55')
+  await expect(page.getByTestId('hosts-page-indicator')).toContainText('Page 1 of 2')
+  await expect(page.getByRole('link', { name: 'Host 001' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Host 051' })).toHaveCount(0)
+
+  await page.getByTestId('hosts-page-next').click()
+
+  await expect(page.getByTestId('hosts-pagination-summary')).toContainText('Showing 51–55 of 55')
+  await expect(page.getByTestId('hosts-page-indicator')).toContainText('Page 2 of 2')
+  await expect(page.getByRole('link', { name: 'Host 051' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Host 055' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Host 001' })).toHaveCount(0)
+
+  await page.getByTestId('hosts-page-first').click()
+  await expect(page.getByTestId('hosts-page-indicator')).toContainText('Page 1 of 2')
+
+  await page.getByRole('button', { name: 'CPU' }).click()
+
+  const firstRowAfterSort = page.locator('tbody tr').first()
+  await expect(firstRowAfterSort.getByRole('link')).toHaveText('Host 055')
+  await expect(firstRowAfterSort).toContainText('55.0%')
 })

--- a/apps/web/tests/e2e/settings/licence.spec.ts
+++ b/apps/web/tests/e2e/settings/licence.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+import { issueTestLicence } from '../fixtures/licence'
+
+async function getOrg(sql: ReturnType<typeof getTestDb>): Promise<{ id: string; licence_tier: string }> {
+  const rows = await sql<Array<{ id: string; licence_tier: string }>>`
+    SELECT id, licence_tier
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!
+}
+
+test('admin can validate and save a licence key from licence settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const org = await getOrg(sql)
+  const licenceKey = await issueTestLicence({
+    orgId: org.id,
+    tier: 'enterprise',
+    features: ['serviceAccountTracker'],
+  })
+
+  await page.goto('/settings/licence')
+
+  await expect(page.getByTestId('settings-heading')).toContainText('Organisation')
+  await expect(page.getByText('Current tier:')).toBeVisible()
+  await expect(page.getByText('Community', { exact: true })).toBeVisible()
+
+  await page.getByLabel('Licence key').fill('not-a-real-licence')
+  await page.getByRole('button', { name: 'Validate & save' }).click()
+  await expect(page.getByText('Invalid licence key')).toBeVisible()
+
+  await page.getByLabel('Licence key').fill(licenceKey)
+  await page.getByRole('button', { name: 'Validate & save' }).click()
+
+  await expect(page.getByText('Licence activated')).toContainText('Enterprise')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ licence_tier: string; licence_key: string | null }>>`
+        SELECT licence_tier, licence_key
+        FROM organisations
+        WHERE id = ${org.id}
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      licence_tier: 'enterprise',
+      licence_key: licenceKey,
+    })
+})


### PR DESCRIPTION
## Summary
- add a new E2E spec for validating and saving a licence key on `/settings/licence`
- expand host inventory coverage to exercise debounced search, pagination, and CPU sorting
- add stable host inventory pagination test IDs so Playwright can target the server-driven footer reliably

## Testing
- pnpm --filter web test:e2e -- tests/e2e/settings/licence.spec.ts tests/e2e/hosts/inventory.spec.ts