### PR TITLE
test(web): add certificate checker and host task history e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -96,10 +96,10 @@ function InfoRow({ label, value, mono = false, copyable = false }: {
 
 function StatusBadge({ cert }: { cert: ParsedCertificate }) {
   if (cert.isExpired)
-    return <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100"><ShieldX className="size-3 mr-1" />Expired</Badge>
+    return <Badge data-testid="certificate-checker-status" className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100"><ShieldX className="size-3 mr-1" />Expired</Badge>
   if (cert.isExpiringSoon)
-    return <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100"><ShieldAlert className="size-3 mr-1" />Expiring Soon</Badge>
-  return <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100"><ShieldCheck className="size-3 mr-1" />Valid</Badge>
+    return <Badge data-testid="certificate-checker-status" className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100"><ShieldAlert className="size-3 mr-1" />Expiring Soon</Badge>
+  return <Badge data-testid="certificate-checker-status" className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100"><ShieldCheck className="size-3 mr-1" />Valid</Badge>
 }
 
 function Section({ title, children, defaultOpen = true }: {
@@ -417,12 +417,12 @@ function CertificateResults({ cert, keyMatch, onDownload, orgId, source }: {
     : `${daysAbs} day${daysAbs !== 1 ? 's' : ''} remaining`
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-testid="certificate-checker-result">
       {/* Header summary */}
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <div className="flex items-center gap-3 flex-wrap">
-            <h2 className="text-xl font-semibold">{cert.commonName || cert.subject}</h2>
+            <h2 className="text-xl font-semibold" data-testid="certificate-checker-result-title">{cert.commonName || cert.subject}</h2>
             <StatusBadge cert={cert} />
             {cert.isSelfSigned && <Badge variant="outline" className="text-xs">Self-Signed</Badge>}
             {cert.isCA && <Badge variant="outline" className="text-xs">CA Certificate</Badge>}
@@ -484,7 +484,7 @@ function CertificateResults({ cert, keyMatch, onDownload, orgId, source }: {
 
       {/* Key match result */}
       {keyMatch !== undefined && (
-        <div className={`flex items-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium ${
+        <div data-testid="certificate-checker-key-match" className={`flex items-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium ${
           keyMatch
             ? 'border-green-200 bg-green-50 text-green-800'
             : 'border-red-200 bg-red-50 text-red-800'
@@ -575,6 +575,7 @@ function CertificateResults({ cert, keyMatch, onDownload, orgId, source }: {
       {/* SANs */}
       {cert.sans.length > 0 && (
         <Section title={`Subject Alternative Names (${cert.sans.length})`}>
+          <p className="sr-only" data-testid="certificate-checker-san-count">{cert.sans.length}</p>
           <div className="flex flex-wrap gap-1.5">
             {cert.sans.map((san, i) => (
               <Badge key={i} variant="secondary" className="font-mono text-xs">
@@ -834,6 +835,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && submit()}
+          data-testid="certificate-checker-url-input"
         />
       </div>
 
@@ -848,6 +850,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
             placeholder="443"
             value={port}
             onChange={(e) => setPort(e.target.value)}
+            data-testid="certificate-checker-port-input"
           />
           <p className="text-xs text-muted-foreground">Allowed TLS ports: {allowedPorts}</p>
         </div>
@@ -858,6 +861,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
             placeholder="Same as hostname"
             value={servername}
             onChange={(e) => setServername(e.target.value)}
+            data-testid="certificate-checker-sni-input"
           />
         </div>
       </div>
@@ -876,7 +880,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
         </div>
       )}
 
-      <Button className="w-full" disabled={!url.trim() || loading} onClick={submit}>
+      <Button className="w-full" disabled={!url.trim() || loading} onClick={submit} data-testid="certificate-checker-url-submit">
         {loading ? <Loader2 className="size-4 mr-2 animate-spin" /> : <Globe className="size-4 mr-2" />}
         {loading ? 'Fetching...' : 'Fetch Certificate'}
       </Button>
@@ -936,13 +940,13 @@ export function CertificateCheckerClient({ orgId }: { orgId: string }) {
     <div className="space-y-6 max-w-4xl">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-foreground">SSL Certificate Checker</h1>
+          <h1 className="text-2xl font-semibold text-foreground" data-testid="certificate-checker-heading">SSL Certificate Checker</h1>
           <p className="text-muted-foreground mt-1 text-sm">
             Inspect, validate, and convert X.509 certificates from files or live endpoints.
           </p>
         </div>
         {cert && (
-          <Button variant="outline" size="sm" onClick={reset}>
+          <Button variant="outline" size="sm" onClick={reset} data-testid="certificate-checker-clear">
             <X className="size-4 mr-2" />
             Clear
           </Button>
@@ -954,11 +958,11 @@ export function CertificateCheckerClient({ orgId }: { orgId: string }) {
         <CardContent className="pt-5">
           <Tabs defaultValue="upload">
             <TabsList className="mb-4">
-              <TabsTrigger value="upload">
+              <TabsTrigger value="upload" data-testid="certificate-checker-tab-upload">
                 <Upload className="size-4 mr-2" />
                 Upload / Paste
               </TabsTrigger>
-              <TabsTrigger value="url">
+              <TabsTrigger value="url" data-testid="certificate-checker-tab-url">
                 <Globe className="size-4 mr-2" />
                 Check URL
               </TabsTrigger>
@@ -976,7 +980,7 @@ export function CertificateCheckerClient({ orgId }: { orgId: string }) {
       {cert ? (
         <CertificateResults cert={cert} keyMatch={keyMatch} onDownload={handleDownload} orgId={orgId} source={source} />
       ) : (
-        <div className="flex flex-col items-center justify-center py-20 text-center text-muted-foreground">
+        <div className="flex flex-col items-center justify-center py-20 text-center text-muted-foreground" data-testid="certificate-checker-empty-state">
           <ShieldCheck className="size-16 mb-4 opacity-20" />
           <p className="font-medium">No certificate loaded</p>
           <p className="text-sm mt-1">Upload a certificate file, paste PEM text, or enter a URL above to begin.</p>

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -400,7 +400,10 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
 
         {/* Selection toolbar */}
         {selectedRunIds.size > 0 && (
-          <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2">
+          <div
+            className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2"
+            data-testid="host-group-task-runs-selection"
+          >
             <span className="text-sm text-muted-foreground">
               {selectedRunIds.size} selected
             </span>
@@ -409,6 +412,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
               size="sm"
               onClick={() => doDeleteRuns()}
               disabled={isDeletingRuns}
+              data-testid="host-group-task-runs-delete-selected"
             >
               {isDeletingRuns ? (
                 <Loader2 className="size-3.5 mr-1.5 animate-spin" />
@@ -421,7 +425,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
         )}
 
         {taskRuns.length === 0 ? (
-          <div className="rounded-lg border border-dashed p-8 text-center">
+          <div className="rounded-lg border border-dashed p-8 text-center" data-testid="host-group-task-runs-empty">
             <Terminal className="size-7 mx-auto text-muted-foreground mb-3" />
             <p className="text-sm font-medium text-foreground">No task runs yet</p>
             <p className="text-xs text-muted-foreground mt-1">
@@ -463,7 +467,11 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
                   const pendingCount = run.hosts.filter((h) => h.status === 'pending').length
 
                   return (
-                    <TableRow key={run.id} data-state={selectedRunIds.has(run.id) ? 'selected' : undefined}>
+                    <TableRow
+                      key={run.id}
+                      data-state={selectedRunIds.has(run.id) ? 'selected' : undefined}
+                      data-testid={`host-group-task-run-row-${run.id}`}
+                    >
                       <TableCell>
                         <Checkbox
                           checked={selectedRunIds.has(run.id)}

--- a/apps/web/tests/e2e/certificate-checker/url-check.spec.ts
+++ b/apps/web/tests/e2e/certificate-checker/url-check.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '../fixtures/test'
+
+test('authenticated user can analyse a pasted certificate and clear the result', async ({ authenticatedPage: page }) => {
+  let capturedBody: Record<string, unknown> | null = null
+
+  await page.route('**/api/tools/certificate-checker', async (route) => {
+    const body = route.request().postDataJSON() as Record<string, unknown>
+    capturedBody = body
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        keyMatch: true,
+        certificate: {
+          pem: '-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----',
+          subject: 'CN=api.example.com, O=Example Corp, C=GB',
+          issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+          commonName: 'api.example.com',
+          organization: 'Example Corp',
+          organizationalUnit: 'Platform',
+          country: 'GB',
+          state: 'London',
+          locality: 'London',
+          issuerCommonName: 'Example Issuing CA',
+          issuerOrganization: 'Example PKI',
+          notBefore: '2026-01-01T00:00:00.000Z',
+          notAfter: '2027-01-01T00:00:00.000Z',
+          daysRemaining: 200,
+          isExpired: false,
+          isExpiringSoon: false,
+          isSelfSigned: false,
+          isCA: false,
+          pathLength: null,
+          serialNumber: '01AB23CD45EF',
+          fingerprintSha256: 'AA:BB:CC:DD',
+          fingerprintSha512: '11:22:33:44',
+          keyAlgorithm: 'RSA',
+          keySize: 2048,
+          curve: null,
+          signatureAlgorithm: 'sha256WithRSAEncryption',
+          subjectKeyId: 'subject-key-id',
+          authorityKeyId: 'authority-key-id',
+          keyUsage: ['Digital Signature', 'Key Encipherment'],
+          extendedKeyUsage: ['TLS Web Server Authentication'],
+          certificatePolicies: ['2.23.140.1.2.1'],
+          sans: [
+            { type: 'DNS', value: 'api.example.com' },
+            { type: 'DNS', value: 'www.api.example.com' },
+          ],
+          ocspUrls: ['http://ocsp.example.com'],
+          caIssuers: ['http://crt.example.com/issuer.crt'],
+          crlUrls: ['http://crl.example.com/root.crl'],
+          chain: [
+            {
+              subject: 'CN=api.example.com, O=Example Corp, C=GB',
+              issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+              notAfter: '2027-01-01T00:00:00.000Z',
+              isCA: false,
+              fingerprintSha256: 'AA:BB:CC:DD',
+            },
+            {
+              subject: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+              issuer: 'CN=Example Root CA, O=Example PKI, C=GB',
+              notAfter: '2028-01-01T00:00:00.000Z',
+              isCA: true,
+              fingerprintSha256: 'EE:FF:GG:HH',
+            },
+          ],
+        },
+      }),
+    })
+  })
+
+  await page.goto('/certificate-checker')
+
+  await expect(page.getByTestId('certificate-checker-heading')).toBeVisible()
+
+  await page.locator('#cert-input').fill(
+    '-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----',
+  )
+  await page.locator('#key-input').fill(
+    'matching-key-placeholder',
+  )
+  await page.getByRole('button', { name: 'Analyse Certificate' }).click()
+
+  await expect
+    .poll(() => capturedBody)
+    .toMatchObject({
+      action: 'parse',
+      pemText: '-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----',
+      keyPem: 'matching-key-placeholder',
+    })
+
+  await expect(page.getByTestId('certificate-checker-result')).toBeVisible()
+  await expect(page.getByTestId('certificate-checker-result-title')).toContainText('api.example.com')
+  await expect(page.getByTestId('certificate-checker-status')).toContainText('Valid')
+  await expect(page.getByTestId('certificate-checker-key-match')).toContainText(
+    'Private key matches this certificate',
+  )
+  await expect(page.getByTestId('certificate-checker-san-count')).toContainText('2')
+
+  await page.getByTestId('certificate-checker-clear').click()
+  await expect(page.getByTestId('certificate-checker-result')).toHaveCount(0)
+  await expect(page.getByTestId('certificate-checker-empty-state')).toBeVisible()
+})

--- a/apps/web/tests/e2e/hosts/group-task-history.spec.ts
+++ b/apps/web/tests/e2e/hosts/group-task-history.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('authenticated user can bulk delete task history from a host group', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO host_groups (id, organisation_id, name, description)
+    VALUES (
+      'group-task-history',
+      ${orgId},
+      'Task History Group',
+      'Used to verify task history cleanup'
+    )
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'group-task-history-host',
+      ${orgId},
+      'ops-01',
+      'Ops Host 01',
+      'linux',
+      'x86_64',
+      '["10.80.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`
+    INSERT INTO host_group_members (id, organisation_id, group_id, host_id)
+    VALUES (
+      'group-task-history-member',
+      ${orgId},
+      'group-task-history',
+      'group-task-history-host'
+    )
+  `
+
+  await sql`
+    INSERT INTO task_runs (
+      id,
+      organisation_id,
+      triggered_by,
+      target_type,
+      target_id,
+      task_type,
+      config,
+      max_parallel,
+      status,
+      started_at,
+      completed_at
+    )
+    VALUES
+      (
+        'group-task-run-patch',
+        ${orgId},
+        ${userId},
+        'group',
+        'group-task-history',
+        'patch',
+        '{"mode":"all"}'::jsonb,
+        1,
+        'completed',
+        NOW() - INTERVAL '2 hours',
+        NOW() - INTERVAL '110 minutes'
+      ),
+      (
+        'group-task-run-service',
+        ${orgId},
+        ${userId},
+        'group',
+        'group-task-history',
+        'service',
+        '{"service_name":"nginx","action":"restart"}'::jsonb,
+        1,
+        'failed',
+        NOW() - INTERVAL '1 hour',
+        NOW() - INTERVAL '50 minutes'
+      )
+  `
+
+  await sql`
+    INSERT INTO task_run_hosts (
+      id,
+      organisation_id,
+      task_run_id,
+      host_id,
+      status,
+      result,
+      started_at,
+      completed_at
+    )
+    VALUES
+      (
+        'group-task-run-host-patch',
+        ${orgId},
+        'group-task-run-patch',
+        'group-task-history-host',
+        'success',
+        '{"packages_updated":[],"reboot_required":false}'::jsonb,
+        NOW() - INTERVAL '2 hours',
+        NOW() - INTERVAL '110 minutes'
+      ),
+      (
+        'group-task-run-host-service',
+        ${orgId},
+        'group-task-run-service',
+        'group-task-history-host',
+        'failed',
+        '{"service_name":"nginx","action":"restart","is_active":false}'::jsonb,
+        NOW() - INTERVAL '1 hour',
+        NOW() - INTERVAL '50 minutes'
+      )
+  `
+
+  await page.goto('/hosts/groups/group-task-history')
+
+  await expect(page.getByTestId('host-group-detail-heading')).toContainText('Task History Group')
+  await expect(page.getByTestId('host-group-task-run-row-group-task-run-patch')).toBeVisible()
+  await expect(page.getByTestId('host-group-task-run-row-group-task-run-service')).toBeVisible()
+
+  await page.getByLabel('Select all').click()
+  await expect(page.getByTestId('host-group-task-runs-selection')).toContainText('2 selected')
+  await page.getByTestId('host-group-task-runs-delete-selected').click()
+
+  await expect(page.getByTestId('host-group-task-run-row-group-task-run-patch')).toHaveCount(0)
+  await expect(page.getByTestId('host-group-task-run-row-group-task-run-service')).toHaveCount(0)
+  await expect(page.getByTestId('host-group-task-runs-empty')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        id: string
+        deleted_at: string | null
+        host_deleted_at: string | null
+      }>>`
+        SELECT
+          task_runs.id,
+          task_runs.deleted_at::text,
+          task_run_hosts.deleted_at::text AS host_deleted_at
+        FROM task_runs
+        JOIN task_run_hosts ON task_run_hosts.task_run_id = task_runs.id
+        WHERE task_runs.id IN ('group-task-run-patch', 'group-task-run-service')
+        ORDER BY task_runs.id
+      `
+
+      return rows
+    })
+    .toEqual([
+      {
+        id: 'group-task-run-patch',
+        deleted_at: expect.any(String),
+        host_deleted_at: expect.any(String),
+      },
+      {
+        id: 'group-task-run-service',
+        deleted_at: expect.any(String),
+        host_deleted_at: expect.any(String),
+      },
+    ])
+})


### PR DESCRIPTION
## Summary
- add certificate checker e2e coverage for pasted certificate analysis and clear/reset behavior
- expand host group e2e coverage to verify bulk task-history deletion
- add stable test ids needed by the new e2e assertions

## Testing
- pnpm --filter web test:e2e -- tests/e2e/certificate-checker/url-check.spec.ts tests/e2e/hosts/group-task-history.spec.ts