### PR TITLE
test(web): add bundlers and certificate tracking e2e coverage

### DIFF
--- a/apps/web/tests/e2e/bundlers/bundlers.spec.ts
+++ b/apps/web/tests/e2e/bundlers/bundlers.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect } from '../fixtures/test'
+
+test('authenticated user can resolve Jenkins and GitLab air-gap bundles', async ({ authenticatedPage: page }) => {
+  const jenkinsBodies: Array<Record<string, unknown>> = []
+  const gitlabBodies: Array<Record<string, unknown>> = []
+
+  await page.route('**/api/tools/jenkins-bundler', async (route) => {
+    const body = route.request().postDataJSON() as Record<string, unknown>
+    jenkinsBodies.push(body)
+
+    if (body.action === 'latest-lts') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          version: '2.504.3',
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        coreVersion: '2.504.3',
+        coreMinimumJava: 17,
+        coreJavaSource: 'updates.jenkins.io',
+        javaCompatible: true,
+        warUrl: 'https://get.jenkins.io/war-stable/2.504.3/jenkins.war',
+        plugins: [
+          {
+            name: 'credentials',
+            requested: 'credentials',
+            status: 'compatible',
+            version: '1389.vd7a_b_f5fa_50a_2',
+            url: 'https://updates.jenkins.io/download/plugins/credentials/1389.vd7a_b_f5fa_50a_2/credentials.hpi',
+            requiredCore: '2.479.1',
+            minimumJavaVersion: '17',
+            size: 123456,
+            sha256: 'sha-credentials',
+            origin: 'requested',
+          },
+          {
+            name: 'git',
+            requested: 'git',
+            status: 'compatible',
+            version: '5.7.0',
+            url: 'https://updates.jenkins.io/download/plugins/git/5.7.0/git.hpi',
+            requiredCore: '2.479.3',
+            minimumJavaVersion: '17',
+            size: 654321,
+            sha256: 'sha-git',
+            origin: 'requested',
+          },
+        ],
+        transitivePlugins: [],
+      }),
+    })
+  })
+
+  await page.route('**/api/tools/gitlab-bundler', async (route) => {
+    const body = route.request().postDataJSON() as Record<string, unknown>
+    gitlabBodies.push(body)
+
+    if (body.action === 'latest') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          version: '18.6.1',
+          edition: 'ee',
+          packageTarget: {
+            key: 'ubuntu-jammy',
+            label: 'Ubuntu 22.04 Jammy',
+            arch: 'amd64',
+            kind: 'deb',
+          },
+          sources: {
+            packages: 'https://packages.gitlab.com/gitlab/gitlab-ee/packages/ubuntu/jammy',
+          },
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        currentVersion: '17.11.5',
+        targetVersion: '18.6.1',
+        edition: 'ee',
+        packageTarget: {
+          key: 'ubuntu-jammy',
+          label: 'Ubuntu 22.04 Jammy',
+          arch: 'amd64',
+          kind: 'deb',
+        },
+        generatedAt: '2026-04-29T12:00:00.000Z',
+        sources: {
+          upgradePath: 'https://gitlab.com/gitlab-org/gitlab/-/raw/master/doc/update/upgrade_paths.md',
+          packages: 'https://packages.gitlab.com/gitlab/gitlab-ee/packages/ubuntu/jammy',
+        },
+        steps: [
+          {
+            id: 'gitlab-step-stop',
+            role: 'required-stop',
+            version: '18.2.3',
+            majorMinor: '18.2',
+            sourceVersion: '18.2.0',
+            conditional: false,
+            note: 'Required GitLab 18.2 upgrade stop.',
+            packageName: 'gitlab-ee',
+            filename: 'gitlab-ee_18.2.3-ee.0_amd64.deb',
+            url: 'https://packages.gitlab.com/gitlab/gitlab-ee/packages/ubuntu/jammy/gitlab-ee_18.2.3-ee.0_amd64.deb/download.deb',
+            sizeBytes: 1048576,
+            sizeLabel: '1.0 MB',
+            status: 'available',
+          },
+          {
+            id: 'gitlab-step-target',
+            role: 'target',
+            version: '18.6.1',
+            majorMinor: '18.6',
+            sourceVersion: '18.6.1',
+            conditional: false,
+            note: null,
+            packageName: 'gitlab-ee',
+            filename: 'gitlab-ee_18.6.1-ee.0_amd64.deb',
+            url: 'https://packages.gitlab.com/gitlab/gitlab-ee/packages/ubuntu/jammy/gitlab-ee_18.6.1-ee.0_amd64.deb/download.deb',
+            sizeBytes: 2097152,
+            sizeLabel: '2.0 MB',
+            status: 'available',
+          },
+        ],
+      }),
+    })
+  })
+
+  await page.goto('/bundlers')
+
+  await expect(page.getByRole('heading', { name: 'Air-gap Bundlers' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Jenkins' })).toHaveAttribute('aria-selected', 'true')
+
+  await page.getByLabel('Jenkins WAR version').fill('2.504.3')
+  await page.getByLabel('Your Java version (optional)').fill('17')
+  await page.getByLabel('Plugin list').fill('git\ncredentials')
+  await page.getByRole('button', { name: 'Resolve compatibility' }).click()
+
+  await expect
+    .poll(() => jenkinsBodies.at(-1))
+    .toMatchObject({
+      action: 'resolve',
+      coreVersion: '2.504.3',
+      javaVersion: 17,
+      plugins: ['git', 'credentials'],
+      includeTransitiveDeps: false,
+    })
+
+  await expect(page.getByText('Compatibility report')).toBeVisible()
+  await expect(page.getByText('2 compatible')).toBeVisible()
+  await expect(page.getByText('https://get.jenkins.io/war-stable/2.504.3/jenkins.war')).toBeVisible()
+  await expect(page.getByRole('cell', { name: 'credentials' })).toBeVisible()
+  await expect(page.getByRole('cell', { name: 'git' })).toBeVisible()
+
+  await page.getByRole('tab', { name: 'GitLab' }).click()
+  await page.getByRole('button', { name: /use latest/i }).click()
+  await expect(page.getByLabel('Target GitLab version')).toHaveValue('18.6.1')
+
+  await page.getByLabel('Current GitLab version').fill('17.11.5')
+  await page.getByRole('button', { name: 'Find upgrade packages' }).click()
+
+  await expect
+    .poll(() => gitlabBodies.at(-1))
+    .toMatchObject({
+      action: 'resolve',
+      currentVersion: '17.11.5',
+      targetVersion: '18.6.1',
+      edition: 'ee',
+      packageTarget: 'ubuntu-jammy',
+      arch: 'amd64',
+    })
+
+  await expect(page.getByText('Resolved upgrade sequence')).toBeVisible()
+  await expect(page.getByText('2 packages')).toBeVisible()
+  await expect(page.getByRole('row', { name: /18\.2\.3/ })).toBeVisible()
+  await expect(page.getByRole('row', { name: /18\.6\.1/ })).toBeVisible()
+  await expect(page.getByText('Required GitLab 18.2 upgrade stop.')).toBeVisible()
+})

--- a/apps/web/tests/e2e/certificate-checker/url-check.spec.ts
+++ b/apps/web/tests/e2e/certificate-checker/url-check.spec.ts
@@ -1,4 +1,40 @@
 import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+import { issueTestLicence } from '../fixtures/licence'
+
+const TRACKING_TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIDZTCCAk2gAwIBAgIUGqljnkaJw0tIYv9uPQ+dGmImmaMwDQYJKoZIhvcNAQEL
+BQAwQjEcMBoGA1UEAwwTdHJhY2tlci5leGFtcGxlLmNvbTEVMBMGA1UECgwMRXhh
+bXBsZSBDb3JwMQswCQYDVQQGEwJHQjAeFw0yNjA0MjkwMDA4MTFaFw0yNzA0Mjkw
+MDA4MTFaMEIxHDAaBgNVBAMME3RyYWNrZXIuZXhhbXBsZS5jb20xFTATBgNVBAoM
+DEV4YW1wbGUgQ29ycDELMAkGA1UEBhMCR0IwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCls/uua3AkgxheOFlZG4TpgyT6NWbDXedxyBQAJAfEZZI5+/g+
+PWiBH2ZMMUXV79KPPYTXoXc7w63s6OWpysqD7b0jT1bv1JX3dTbYcW685yTE4exA
+9OSnKUJTwxAPEZUrDfbGh8bzsjpPu6D1NMs59Qn/kd8TAbeZBbXbqj6dPXDxxnPY
+8yHzRHwgmGoAm8ouE8es6DZhg27sD4ZSDxUz55tji/+4cDSsvaPsPhW+tfVMKr8j
+3X/LViGPfOujd8fG78RPfFP/ETFTwRPd52vsEK/oTZOizThlhoVG3ZgZGyjnzrE9
+59JqijoBDa/Kia7lqyDQGR3L+sAoXDhoRgMvAgMBAAGjUzBRMB0GA1UdDgQWBBTA
+LVY9CMCJdYuFDBPdSLFM9oB8NjAfBgNVHSMEGDAWgBTALVY9CMCJdYuFDBPdSLFM
+9oB8NjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBwb3aowTP+
+z7AoqRDS1EHQYxHGdWkm3vFHJF0eoeGPcehlvI0Lag93l29GN183fSAY9Qs0ISTI
+pw7les3KQwcHdf2k2aO5qEYaB5486dR1f9bA0BEDlbS35g0a14JmW7XHx59VvjbK
+l17ftMPzQG2jbyffyQFluw1Ld/JcLCmioqUN9KKPEK1hYOj2ibBNCsVXnsHM3BKZ
+AxPNuJ5L9aQj88sI0jQWcqiZLXT6JDV3IeV3S89LVi8nVAWp2mZDlVyEPBGVOP9H
+z9EhcxayTDhI7Oo2n2yorFz7WHBpytSIN1vQTrhRAUPbNXAcOaUie5TserTteazP
+sNone70z9cF/
+-----END CERTIFICATE-----`
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
 
 test('authenticated user can analyse a pasted certificate and clear the result', async ({ authenticatedPage: page }) => {
   let capturedBody: Record<string, unknown> | null = null
@@ -14,7 +50,7 @@ test('authenticated user can analyse a pasted certificate and clear the result',
         ok: true,
         keyMatch: true,
         certificate: {
-          pem: '-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----',
+          pem: TRACKING_TEST_CERT_PEM,
           subject: 'CN=api.example.com, O=Example Corp, C=GB',
           issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
           commonName: 'api.example.com',
@@ -104,4 +140,117 @@ test('authenticated user can analyse a pasted certificate and clear the result',
   await page.getByTestId('certificate-checker-clear').click()
   await expect(page.getByTestId('certificate-checker-result')).toHaveCount(0)
   await expect(page.getByTestId('certificate-checker-empty-state')).toBeVisible()
+})
+
+test('authenticated user can track an uploaded certificate after analysis', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const licenceKey = await issueTestLicence({
+    orgId,
+    features: ['certExpiryTracker'],
+  })
+
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+
+  await page.route('**/api/tools/certificate-checker', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        keyMatch: true,
+        certificate: {
+          pem: TRACKING_TEST_CERT_PEM,
+          subject: 'CN=tracker.example.com, O=Example Corp, C=GB',
+          issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+          commonName: 'tracker.example.com',
+          organization: 'Example Corp',
+          organizationalUnit: 'Platform',
+          country: 'GB',
+          state: 'London',
+          locality: 'London',
+          issuerCommonName: 'Example Issuing CA',
+          issuerOrganization: 'Example PKI',
+          notBefore: '2026-01-01T00:00:00.000Z',
+          notAfter: '2027-01-01T00:00:00.000Z',
+          daysRemaining: 200,
+          isExpired: false,
+          isExpiringSoon: false,
+          isSelfSigned: false,
+          isCA: false,
+          pathLength: null,
+          serialNumber: 'TRACKER12345',
+          fingerprintSha256: 'TRACKER:AA:BB:CC:DD',
+          fingerprintSha512: 'TRACKER:11:22:33:44',
+          keyAlgorithm: 'RSA',
+          keySize: 2048,
+          curve: null,
+          signatureAlgorithm: 'sha256WithRSAEncryption',
+          subjectKeyId: 'tracker-subject-key-id',
+          authorityKeyId: 'tracker-authority-key-id',
+          keyUsage: ['Digital Signature', 'Key Encipherment'],
+          extendedKeyUsage: ['TLS Web Server Authentication'],
+          certificatePolicies: ['2.23.140.1.2.1'],
+          sans: [
+            { type: 'DNS', value: 'tracker.example.com' },
+          ],
+          ocspUrls: [],
+          caIssuers: [],
+          crlUrls: [],
+          chain: [
+            {
+              subject: 'CN=tracker.example.com, O=Example Corp, C=GB',
+              issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+              notBefore: '2026-01-01T00:00:00.000Z',
+              notAfter: '2027-01-01T00:00:00.000Z',
+              isCA: false,
+              fingerprintSha256: 'TRACKER:AA:BB:CC:DD',
+            },
+          ],
+        },
+      }),
+    })
+  })
+
+  await page.goto('/certificate-checker')
+
+  await page.locator('#cert-input').fill(TRACKING_TEST_CERT_PEM)
+  await page.getByRole('button', { name: 'Analyse Certificate' }).click()
+
+  await expect(page.getByTestId('certificate-checker-result')).toBeVisible()
+  await page.getByRole('button', { name: 'Track this certificate' }).click()
+
+  await expect(page.getByText('Added to tracker')).toBeVisible()
+  await expect(page.getByRole('link', { name: 'View in Certificate Tracker' })).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        host: string
+        port: number
+        server_name: string
+        common_name: string | null
+        tracked_url: string | null
+      }>>`
+        SELECT host, port, server_name, common_name, tracked_url
+        FROM certificates
+        WHERE organisation_id = ${orgId}
+          AND host = 'tracker.example.com'
+          AND deleted_at IS NULL
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({
+      host: 'tracker.example.com',
+      port: 0,
+      server_name: 'tracker.example.com',
+      common_name: 'tracker.example.com',
+      tracked_url: null,
+    })
 })


### PR DESCRIPTION
## Summary
- add E2E coverage for Jenkins and GitLab air-gap bundler resolution flows
- extend certificate checker coverage to track an analysed uploaded certificate into the certificate tracker
- validate the new coverage against the database-backed Playwright harness

## Validation
- pnpm --filter web test:e2e -- tests/e2e/bundlers/bundlers.spec.ts
- pnpm --filter web test:e2e -- tests/e2e/certificate-checker/url-check.spec.ts