### PR TITLE
fix(web): avoid build-doc editor hydration mismatch

### DIFF
--- a/apps/web/components/build-docs/build-doc-markdown-editor.tsx
+++ b/apps/web/components/build-docs/build-doc-markdown-editor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import {
   BlockTypeSelect,
   BoldItalicUnderlineToggles,
@@ -40,6 +40,10 @@ interface BuildDocMarkdownEditorProps {
   testId?: string
 }
 
+function subscribeToClientSnapshot() {
+  return () => {}
+}
+
 export function BuildDocMarkdownEditor({
   id,
   name,
@@ -53,6 +57,7 @@ export function BuildDocMarkdownEditor({
   const editorRef = useRef<MDXEditorMethods>(null)
   const latestValue = useRef(value)
   const mounted = useRef(false)
+  const isClient = useSyncExternalStore(subscribeToClientSnapshot, () => true, () => false)
 
   const plugins = useMemo(() => {
     const basePlugins = [
@@ -123,21 +128,31 @@ export function BuildDocMarkdownEditor({
       )}
     >
       {name && <textarea name={name} value={value} readOnly hidden />}
-      <MDXEditor
-        ref={editorRef}
-        markdown={value}
-        onChange={handleChange}
-        readOnly={readOnly}
-        placeholder={placeholder}
-        suppressHtmlProcessing
-        trim={false}
-        plugins={plugins}
-        className="build-doc-markdown-editor__root"
-        contentEditableClassName={cn(
-          'build-doc-markdown-editor__content',
-          fullscreen ? 'min-h-[calc(100vh-17rem)]' : 'min-h-[300px]',
-        )}
-      />
+      {isClient ? (
+        <MDXEditor
+          ref={editorRef}
+          markdown={value}
+          onChange={handleChange}
+          readOnly={readOnly}
+          placeholder={placeholder}
+          suppressHtmlProcessing
+          trim={false}
+          plugins={plugins}
+          className="build-doc-markdown-editor__root"
+          contentEditableClassName={cn(
+            'build-doc-markdown-editor__content',
+            fullscreen ? 'min-h-[calc(100vh-17rem)]' : 'min-h-[300px]',
+          )}
+        />
+      ) : (
+        <div
+          aria-hidden="true"
+          className={cn(
+            'build-doc-markdown-editor__content',
+            fullscreen ? 'min-h-[calc(100vh-17rem)]' : 'min-h-[300px]',
+          )}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/tests/e2e/build-docs/build-docs.spec.ts
+++ b/apps/web/tests/e2e/build-docs/build-docs.spec.ts
@@ -26,6 +26,11 @@ async function fillMarkdownSource(editor: Locator, markdown: string) {
 test.setTimeout(60_000)
 
 test('admin can create and export a build document from a template and snippet', async ({ authenticatedPage: page }) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message)
+  })
+
   const sql = getTestDb()
   const { orgId, userId } = await getOrgAndUserIds(sql)
 
@@ -100,6 +105,7 @@ test('admin can create and export a build document from a template and snippet',
 
   await page.reload()
   await expect(page.locator('[data-section-title="Provision VM"]').getByTestId('build-doc-markdown-editor')).toContainText('Captured handover notes')
+  expect(pageErrors).toEqual([])
   const documentUrl = page.url()
 
   await page.goto('/build-docs')


### PR DESCRIPTION
## Summary
- avoid server-rendering the MDX build-doc editor before the client mounts it
- keep the existing build-doc E2E green while asserting the page no longer throws hydration errors

## Evidence
- recent regression introduced in `7db8fd3` (`feat(web): improve build docs markdown editor (#732)`)
- local build-doc E2E previously logged `Uncaught Error: Hydration failed because the server rendered HTML didn't match the client` from `BuildDocMarkdownEditor`
- repro command: `pnpm --dir apps/web test:e2e tests/e2e/build-docs/build-docs.spec.ts`

## Approach
- gate `MDXEditor` rendering behind a client-mounted flag so the server and first client render stay aligned
- record `pageerror` events in the build-doc E2E and assert none are emitted across load and reload

## Validation
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web test:e2e tests/e2e/build-docs/build-docs.spec.ts`
- `pnpm --dir apps/web test:e2e tests/e2e/settings/vulnerabilities.spec.ts`