### PR TITLE
test(web): add task monitor and alerts e2e coverage

### DIFF
--- a/apps/web/tests/e2e/alerts/alerts.spec.ts
+++ b/apps/web/tests/e2e/alerts/alerts.spec.ts
@@ -228,3 +228,82 @@ test('admin can review, filter, acknowledge, and clean up alert settings', async
     },
   ])
 })
+
+test('admin can create a silence and an email notification channel from the alerts page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status
+    )
+    VALUES (
+      'alert-host-create',
+      ${orgId},
+      'app-edge',
+      'App Edge',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.10.1.10"]'::jsonb,
+      'online'
+    )
+  `
+
+  await page.goto('/alerts')
+
+  await expect(page.getByTestId('alerts-heading')).toBeVisible()
+
+  await page.getByTestId('alerts-add-silence').click()
+  await page.getByLabel(/Host/).selectOption('alert-host-create')
+  await page.getByLabel('Reason').fill('E2E maintenance window')
+  await page.getByLabel('Starts at').fill('2026-04-29T09:00')
+  await page.getByLabel('Ends at').fill('2026-04-29T11:00')
+  await page.getByTestId('alert-silence-submit').click()
+
+  const silenceRow = page.getByRole('row').filter({ hasText: 'E2E maintenance window' })
+  await expect(silenceRow).toContainText('app-edge')
+
+  await page.getByTestId('alerts-add-email').click()
+  await page.getByLabel('Name').fill('Escalation Email')
+  await page.getByLabel('Recipients').fill('alerts2@example.com, team@example.com')
+  await page.getByTestId('alert-email-submit').click()
+
+  const channelRow = page.getByRole('row').filter({ hasText: 'Escalation Email' })
+  await expect(channelRow).toContainText('alerts2@example.com')
+  await expect(channelRow).toContainText('team@example.com')
+
+  const createdRows = await sql<Array<{
+    silence_reason: string | null
+    silence_host_id: string | null
+    silence_created_by: string | null
+    channel_name: string | null
+    channel_type: string | null
+    recipients: string[] | null
+  }>>`
+    SELECT
+      (SELECT reason FROM alert_silences WHERE organisation_id = ${orgId} AND reason = 'E2E maintenance window' AND deleted_at IS NULL LIMIT 1) AS silence_reason,
+      (SELECT host_id FROM alert_silences WHERE organisation_id = ${orgId} AND reason = 'E2E maintenance window' AND deleted_at IS NULL LIMIT 1) AS silence_host_id,
+      (SELECT created_by FROM alert_silences WHERE organisation_id = ${orgId} AND reason = 'E2E maintenance window' AND deleted_at IS NULL LIMIT 1) AS silence_created_by,
+      (SELECT name FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS channel_name,
+      (SELECT type FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS channel_type,
+      (SELECT ARRAY(SELECT jsonb_array_elements_text(config->'toAddresses')) FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS recipients
+  `
+
+  expect(createdRows).toEqual([
+    {
+      silence_reason: 'E2E maintenance window',
+      silence_host_id: 'alert-host-create',
+      silence_created_by: userId,
+      channel_name: 'Escalation Email',
+      channel_type: 'smtp',
+      recipients: ['alerts2@example.com', 'team@example.com'],
+    },
+  ])
+})

--- a/apps/web/tests/e2e/tasks/monitor.spec.ts
+++ b/apps/web/tests/e2e/tasks/monitor.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('admin can review a completed grouped task run and switch between host outputs', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO host_groups (
+      id,
+      organisation_id,
+      name,
+      description
+    )
+    VALUES (
+      'task-monitor-group-1',
+      ${orgId},
+      'Task Monitor Group',
+      'Used to verify the task run monitor view'
+    )
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'task-monitor-host-1',
+        ${orgId},
+        'task-monitor-node-1',
+        'Task Monitor Alpha',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.90.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'task-monitor-host-2',
+        ${orgId},
+        'task-monitor-node-2',
+        'Task Monitor Beta',
+        'Ubuntu 24.04',
+        'arm64',
+        '["10.90.0.11"]'::jsonb,
+        'online',
+        NOW()
+      )
+  `
+
+  await sql`
+    INSERT INTO host_group_members (
+      id,
+      organisation_id,
+      group_id,
+      host_id
+    )
+    VALUES
+      (
+        'task-monitor-member-1',
+        ${orgId},
+        'task-monitor-group-1',
+        'task-monitor-host-1'
+      ),
+      (
+        'task-monitor-member-2',
+        ${orgId},
+        'task-monitor-group-1',
+        'task-monitor-host-2'
+      )
+  `
+
+  await sql`
+    INSERT INTO task_runs (
+      id,
+      organisation_id,
+      triggered_by,
+      target_type,
+      target_id,
+      task_type,
+      config,
+      max_parallel,
+      status,
+      started_at,
+      completed_at
+    )
+    VALUES (
+      'task-monitor-run-1',
+      ${orgId},
+      ${userId},
+      'group',
+      'task-monitor-group-1',
+      'patch',
+      '{"mode":"security"}'::jsonb,
+      1,
+      'completed',
+      NOW() - INTERVAL '10 minutes',
+      NOW() - INTERVAL '2 minutes'
+    )
+  `
+
+  await sql`
+    INSERT INTO task_run_hosts (
+      id,
+      organisation_id,
+      task_run_id,
+      host_id,
+      status,
+      exit_code,
+      raw_output,
+      result,
+      started_at,
+      completed_at
+    )
+    VALUES
+      (
+        'task-monitor-run-host-1',
+        ${orgId},
+        'task-monitor-run-1',
+        'task-monitor-host-1',
+        'success',
+        0,
+        'Fetched package lists\nInstalled openssl\nReboot required',
+        '{"packages_updated":[{"name":"openssl","from_version":"3.0.2","to_version":"3.0.3"}],"reboot_required":true}'::jsonb,
+        NOW() - INTERVAL '10 minutes',
+        NOW() - INTERVAL '6 minutes'
+      ),
+      (
+        'task-monitor-run-host-2',
+        ${orgId},
+        'task-monitor-run-1',
+        'task-monitor-host-2',
+        'failed',
+        23,
+        'Failed to lock apt cache',
+        '{"packages_updated":[],"reboot_required":false}'::jsonb,
+        NOW() - INTERVAL '9 minutes',
+        NOW() - INTERVAL '5 minutes'
+      )
+  `
+
+  await page.goto('/tasks/task-monitor-run-1')
+
+  await expect(page.getByRole('link', { name: 'Back to group' })).toHaveAttribute('href', '/hosts/groups/task-monitor-group-1')
+  await expect(page.getByRole('heading', { name: 'Patch — security updates' })).toBeVisible()
+  await expect(page.getByText('Completed', { exact: true })).toBeVisible()
+  await expect(page.getByText('Reboot required', { exact: true }).first()).toBeVisible()
+  await expect(page.getByText(/2 \/ 2 hosts done/)).toBeVisible()
+  await expect(page.getByText(/1 succeeded/)).toBeVisible()
+  await expect(page.getByText(/1 failed/)).toBeVisible()
+  await expect(page.getByText('100%')).toBeVisible()
+
+  await expect(page.getByRole('button', { name: /Task Monitor Alpha/i })).toBeVisible()
+  await expect(page.getByText('Fetched package lists')).toBeVisible()
+  await expect(page.getByText('Installed openssl')).toBeVisible()
+  await expect(page.getByText('1 package updated')).toBeVisible()
+
+  await page.getByRole('button', { name: /Task Monitor Beta/i }).click()
+  await expect(page.getByText('Failed to lock apt cache')).toBeVisible()
+  await expect(page.getByRole('button', { name: /Task Monitor Beta/i })).toContainText('Exit code: 23')
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for the grouped task-run monitor page
- extend alert coverage to create silences and SMTP notification channels
- verify seeded data persists through the expected database-backed UI flows

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/tasks/monitor.spec.ts tests/e2e/alerts/alerts.spec.ts`
