### PR TITLE
test(web): add setup email and reset callback e2e coverage

### DIFF
--- a/apps/web/app/(setup)/setup-email/setup-email-form.tsx
+++ b/apps/web/app/(setup)/setup-email/setup-email-form.tsx
@@ -56,7 +56,7 @@ export function SetupEmailForm({ userId, username }: SetupEmailFormProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Set your email address</CardTitle>
+        <CardTitle data-testid="setup-email-heading">Set your email address</CardTitle>
         <CardDescription>
           Welcome, {username}. Your directory account does not have an email address configured.
           Please provide one to continue.
@@ -65,7 +65,7 @@ export function SetupEmailForm({ userId, username }: SetupEmailFormProps) {
       <form onSubmit={handleSubmit((values) => mutate(values))}>
         <CardContent className="space-y-4">
           {serverError && (
-            <p className="text-sm text-destructive">{serverError}</p>
+            <p className="text-sm text-destructive" data-testid="setup-email-error">{serverError}</p>
           )}
           <div className="space-y-1.5">
             <Label htmlFor="email">Email address</Label>
@@ -74,15 +74,18 @@ export function SetupEmailForm({ userId, username }: SetupEmailFormProps) {
               type="email"
               autoComplete="email"
               placeholder="you@example.com"
+              data-testid="setup-email-input"
               {...register('email')}
             />
             {errors.email && (
-              <p className="text-xs text-destructive">{errors.email.message}</p>
+              <p className="text-xs text-destructive" data-testid="setup-email-validation-error">
+                {errors.email.message}
+              </p>
             )}
           </div>
         </CardContent>
         <CardFooter>
-          <Button type="submit" className="w-full" disabled={isPending}>
+          <Button type="submit" className="w-full" disabled={isPending} data-testid="setup-email-submit">
             {isPending ? 'Saving...' : 'Continue'}
           </Button>
         </CardFooter>

--- a/apps/web/tests/e2e/auth/login.spec.ts
+++ b/apps/web/tests/e2e/auth/login.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
 import { waitForPasswordResetUrl } from '../fixtures/email'
 import { TEST_USER } from '../fixtures/seed'
 
@@ -49,6 +51,58 @@ test('user can request a password reset from the login screen and sign in with t
   await expect(page.getByTestId('login-notice')).toContainText('Your password has been reset.')
 
   await page.getByTestId('login-email').fill(TEST_USER.email)
+  await page.getByTestId('login-password').fill(newPassword)
+  await page.getByTestId('login-submit').click()
+
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+})
+
+test('password reset ignores unsafe callback urls and returns to the login notice', async ({ page }) => {
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const email = `reset-callback-${suffix}@example.com`
+  const password = 'TestPassword123!'
+  const newPassword = 'SafeCallbackReset123!'
+
+  const signUpResponse = await page.request.post('/api/auth/sign-up/email', {
+    data: {
+      email,
+      password,
+      name: 'Reset Callback User',
+    },
+  })
+  expect(signUpResponse.ok()).toBeTruthy()
+
+  await sql`
+    UPDATE "user"
+    SET organisation_id = (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+        email_verified = true,
+        role = 'org_admin',
+        is_active = true
+    WHERE email = ${email}
+  `
+
+  await page.request.post('/api/auth/request-password-reset', {
+    data: {
+      email,
+      redirectTo: '/login?reset=1',
+    },
+  })
+
+  const resetUrl = await waitForPasswordResetUrl(email)
+  const unsafeResetUrl = new URL(resetUrl)
+  unsafeResetUrl.searchParams.set('callbackURL', 'https://evil.example/phish')
+
+  await page.goto(unsafeResetUrl.toString())
+  await page.getByTestId('reset-password-new-password').fill(newPassword)
+  await page.getByTestId('reset-password-confirm-password').fill(newPassword)
+  await page.getByTestId('reset-password-submit').click()
+
+  await page.waitForURL('**/login?reset=1')
+  await expect(page.getByTestId('login-notice')).toContainText('Your password has been reset.')
+
+  await page.getByTestId('login-email').fill(email)
   await page.getByTestId('login-password').fill(newPassword)
   await page.getByTestId('login-submit').click()
 

--- a/apps/web/tests/e2e/setup/setup-email.spec.ts
+++ b/apps/web/tests/e2e/setup/setup-email.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+test('ldap placeholder users must set a real email before reaching the dashboard', async ({ page }) => {
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const placeholderEmail = `ldap-user-${suffix}@ldap.local`
+  const realEmail = `ldap-user-${suffix}@example.com`
+  const password = 'TestPassword123!'
+
+  const signUpResponse = await page.request.post('/api/auth/sign-up/email', {
+    data: {
+      email: placeholderEmail,
+      password,
+      name: 'LDAP Placeholder User',
+    },
+  })
+  expect(signUpResponse.ok()).toBeTruthy()
+
+  await sql`
+    UPDATE "user"
+    SET organisation_id = (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+        email_verified = true,
+        role = 'org_admin',
+        is_active = true
+    WHERE email = ${placeholderEmail}
+  `
+
+  await page.goto('/login')
+  await page.getByTestId('login-email').fill(placeholderEmail)
+  await page.getByTestId('login-password').fill(password)
+  await page.getByTestId('login-submit').click()
+
+  await page.waitForURL('**/setup-email')
+  await expect(page.getByTestId('setup-email-heading')).toBeVisible()
+
+  await page.getByTestId('setup-email-input').fill(placeholderEmail)
+  await page.getByTestId('setup-email-submit').click()
+  await expect(page.getByTestId('setup-email-validation-error')).toContainText(
+    'Please enter a real email address',
+  )
+
+  await page.getByTestId('setup-email-input').fill(realEmail)
+  await page.getByTestId('setup-email-submit').click()
+
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+
+  const rows = await sql<Array<{ email: string }>>`
+    SELECT email
+    FROM "user"
+    WHERE email = ${realEmail}
+    LIMIT 1
+  `
+  expect(rows).toEqual([{ email: realEmail }])
+})


### PR DESCRIPTION
## What changed
- added a new E2E spec for the `/setup-email` flow so placeholder `@ldap.local` users must provide a real email before reaching the dashboard
- expanded the existing auth login E2E coverage to verify password reset ignores unsafe external `callbackURL` values
- added stable `data-testid` hooks to the setup-email form to keep the E2E selectors aligned with the harness guidance

## Why
These flows were either untested or only partially covered on `main`, despite being security- and onboarding-sensitive paths.

## Impact
This raises coverage for onboarding and auth recovery behavior without changing application logic.

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/setup/setup-email.spec.ts tests/e2e/auth/login.spec.ts`
- The targeted E2E assertions were exercised successfully, but the local runner did not emit a stable final summary line before teardown in this environment.
