### PR TITLE
fix(agent): stop leaking enrolment tokens in install URLs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1541,12 +1541,12 @@ _(Built between Sessions 3 and 4; not previously documented)_
 - Already-cached versions skipped; failures logged but never prevent server start
 - Fresh servers are immediately ready to serve installs without a cold-cache delay on first request
 
-**One-command install** (`apps/web/app/api/agent/install/route.ts`, `agent/cmd/agent/main.go`)
-- `curl -fsSL "https://server/api/agent/install?token=TOKEN" | sh` — complete zero-touch setup
-- Shell script detects OS/arch, downloads versioned binary, runs `--install --token TOKEN`
-- Agent `--install` flag: copies binary to system path, writes TOML config, installs service unit, starts service
+**Bootstrap install script** (`apps/web/app/api/agent/install/route.ts`, `agent/cmd/agent/main.go`)
+- `curl -fsSL "https://server/api/agent/install" | sh` downloads the installer without placing enrolment tokens into URLs
+- Shell script detects OS/arch, downloads the versioned binary, and installs when `CT_OPS_ORG_TOKEN` is present in the runtime environment
+- Agent `--install` accepts either `--token` or `CT_OPS_ORG_TOKEN`, then copies the binary to the system path, writes TOML config, installs the service unit, and starts the service
 - Also supports `-address` CLI flag and `CT_OPS_ORG_TOKEN` / `CT_OPS_INGEST_ADDRESS` env vars for config-less operation
-- Enrolment token dialog shows the ready-to-run curl command as the primary action
+- Enrolment token dialog now keeps the token separate from the installer command so the secret is not reflected into copied URLs
 
 **Multi-platform service install** (`agent/internal/install/install.go`, `agent/cmd/agent/service_windows.go`)
 - **Linux:** systemd unit written to `/etc/systemd/system/ct-ops-agent.service`, `systemctl enable --now`

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -105,11 +105,15 @@ func main() {
 
 	// ── Install mode: self-install as a system service, then exit ─────────────
 	if *installFlag {
-		if *tokenFlag == "" {
-			slog.Error("--token is required when using --install")
+		token := strings.TrimSpace(*tokenFlag)
+		if token == "" {
+			token = strings.TrimSpace(os.Getenv("CT_OPS_ORG_TOKEN"))
+		}
+		if token == "" {
+			slog.Error("--token or CT_OPS_ORG_TOKEN is required when using --install")
 			os.Exit(1)
 		}
-		if err := install.Run(*tokenFlag, strings.TrimSpace(*addressFlag), *tlsSkipVerifyFlag, []string(tagFlags)); err != nil {
+		if err := install.Run(token, strings.TrimSpace(*addressFlag), *tlsSkipVerifyFlag, []string(tagFlags)); err != nil {
 			slog.Error("install failed", "err", err)
 			os.Exit(1)
 		}

--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -47,6 +47,7 @@ import {
   DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
   DEFAULT_ENROLMENT_TOKEN_MAX_USES,
 } from '@/lib/agent/enrolment-token-policy'
+import { buildAgentInstallCommand } from '@/lib/agent/install-script'
 
 const createTokenSchema = z.object({
   label: z.string().min(1, 'Label is required').max(100),
@@ -83,16 +84,6 @@ function CopyButton({ text }: { text: string }) {
       )}
     </Button>
   )
-}
-
-function buildInstallCommand(token: string, skipVerify: boolean, appUrl: string): string {
-  const origin = appUrl.replace(/\/$/, '') || window.location.origin
-  const installUrl = new URL(`${origin}/api/agent/install`)
-  installUrl.searchParams.set('token', token)
-  if (skipVerify) {
-    installUrl.searchParams.set('skip_verify', 'true')
-  }
-  return `curl -fsSL "${installUrl.toString()}" | sudo bash`
 }
 
 function tokenStatus(token: EnrolmentTokenSafe): { label: string; className: string } {
@@ -164,7 +155,9 @@ export function AgentsSettingsClient({
       if ('error' in result) return
       queryClient.invalidateQueries({ queryKey: ['enrolment-tokens', orgId] })
       setNewTokenValue(result.token)
-      setNewInstallCommand(buildInstallCommand(result.token, variables.skipVerify, appUrl))
+      setNewInstallCommand(
+        buildAgentInstallCommand(appUrl || window.location.origin, variables.skipVerify),
+      )
       reset()
       setTokenTags([])
     },
@@ -344,14 +337,14 @@ export function AgentsSettingsClient({
             <DialogTitle>Create Enrolment Token</DialogTitle>
             <DialogDescription>
               Agents use this token to register with your organisation. You&apos;ll get a
-              ready-to-run install command.
+              bootstrap command that reads the token from <code>CT_OPS_ORG_TOKEN</code>.
             </DialogDescription>
           </DialogHeader>
 
           {newTokenValue && newInstallCommand ? (
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                Token created. Run this command on each server you want to enrol:
+                Token created. Export the raw token on the target host, then run this command:
               </p>
 
                 <div className="flex items-start gap-2 p-3 bg-muted rounded-md">
@@ -371,7 +364,7 @@ export function AgentsSettingsClient({
                     <CopyButton text={newTokenValue} />
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    This token will not be shown again in full.
+                    This token will not be shown again in full. Export it as <code>CT_OPS_ORG_TOKEN</code> before running the install command.
                   </p>
                 </div>
               </details>

--- a/apps/web/app/api/agent/install/route.ts
+++ b/apps/web/app/api/agent/install/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { buildAgentInstallScript } from '@/lib/agent/install-script'
 import { createRateLimiter } from '@/lib/rate-limit'
 
 // 30 requests per IP per 60 s — generous for CI/CD pipelines but throttles enumeration/DoS.
@@ -10,18 +11,18 @@ const installRateLimit = createRateLimiter({
 
 /**
  * Returns a shell bootstrap script that detects OS/arch, downloads the agent
- * binary from this server, and either runs --install automatically (when a
- * token is provided) or prints the command for the user to complete.
+ * binary from this server, and installs it when CT_OPS_ORG_TOKEN is supplied
+ * in the runtime environment.
  *
- * Usage — one-command install (token from UI):
- *   curl -fsSL "https://ct-ops.example.com/api/agent/install?token=<TOKEN>" | sh
+ * Usage — download and install after exporting a token:
+ *   export CT_OPS_ORG_TOKEN="<TOKEN>"
+ *   curl -fsSL "https://ct-ops.example.com/api/agent/install" | sh
  *
  * Usage — download only, then install manually:
  *   curl -fsSL "https://ct-ops.example.com/api/agent/install" | sh
  *   sudo ./ct-ops-agent --install --token <TOKEN>
  *
  * Query parameters:
- *   token       - Enrolment token from the CT-Ops UI
  *   ingest      - gRPC ingest address host:port (default: <server-hostname>:9443)
  *   skip_verify - Set to "true" to disable TLS certificate verification (for self-signed certs)
  */
@@ -42,15 +43,10 @@ export async function GET(request: NextRequest) {
   const serverURL = `${proto}://${host}`
 
   const { searchParams } = new URL(request.url)
-  const token = searchParams.get('token')
-
   const bareHost = host.split(':')[0]
   const ingestAddress = searchParams.get('ingest') ?? `${bareHost}:9443`
   const skipVerify = searchParams.get('skip_verify') === 'true'
-
-  const script = token
-    ? buildAutoInstallScript(serverURL, token, ingestAddress, skipVerify)
-    : buildDownloadScript(serverURL, ingestAddress, skipVerify)
+  const script = buildAgentInstallScript(serverURL, ingestAddress, skipVerify)
 
   return new NextResponse(script, {
     headers: {
@@ -58,79 +54,4 @@ export async function GET(request: NextRequest) {
       'Cache-Control': 'no-store',
     },
   })
-}
-
-function buildAutoInstallScript(
-  serverURL: string,
-  token: string,
-  ingestAddress: string,
-  skipVerify: boolean,
-): string {
-  const tlsFlag = skipVerify ? ' --tls-skip-verify' : ''
-  // skip_verify=true also relaxes the bootstrap curl that downloads the
-  // binary — without this, operators piping the script through bash hit a
-  // "self-signed certificate" error even after passing -k to the outer
-  // curl, because the outer flag does not propagate to commands in the
-  // downloaded script.
-  const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
-  return `#!/bin/sh
-set -e
-
-# ── Detect platform ────────────────────────────────────────────────────────────
-OS=\$(uname -s | tr '[:upper:]' '[:lower:]')
-case "\$OS" in
-  linux|darwin) ;;
-  *) echo "Unsupported OS: \$OS" >&2; exit 1 ;;
-esac
-
-ARCH=\$(uname -m)
-case "\$ARCH" in
-  x86_64)        ARCH="amd64" ;;
-  aarch64|arm64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: \$ARCH" >&2; exit 1 ;;
-esac
-
-# ── Download binary ────────────────────────────────────────────────────────────
-echo "Downloading ct-ops-agent for \${OS}/\${ARCH}..."
-curl ${curlFlags} "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
-chmod +x ct-ops-agent
-echo "Binary downloaded."
-
-# ── Self-install ───────────────────────────────────────────────────────────────
-sudo ./ct-ops-agent --install --token "${token}" --address "${ingestAddress}"${tlsFlag}
-`
-}
-
-function buildDownloadScript(
-  serverURL: string,
-  ingestAddress: string,
-  skipVerify: boolean,
-): string {
-  const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
-  return `#!/bin/sh
-set -e
-
-# ── Detect platform ────────────────────────────────────────────────────────────
-OS=\$(uname -s | tr '[:upper:]' '[:lower:]')
-case "\$OS" in
-  linux|darwin) ;;
-  *) echo "Unsupported OS: \$OS" >&2; exit 1 ;;
-esac
-
-ARCH=\$(uname -m)
-case "\$ARCH" in
-  x86_64)        ARCH="amd64" ;;
-  aarch64|arm64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: \$ARCH" >&2; exit 1 ;;
-esac
-
-# ── Download binary ────────────────────────────────────────────────────────────
-echo "Downloading ct-ops-agent for \${OS}/\${ARCH}..."
-curl ${curlFlags} "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
-chmod +x ct-ops-agent
-
-echo ""
-echo "Binary downloaded. Now run:"
-echo "  sudo ./ct-ops-agent --install --token <YOUR-TOKEN> --address ${ingestAddress}"
-`
 }

--- a/apps/web/lib/agent/install-script.test.mjs
+++ b/apps/web/lib/agent/install-script.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildAgentInstallCommand,
+  buildAgentInstallScript,
+  buildAgentInstallUrl,
+} from './install-script.ts'
+
+test('buildAgentInstallUrl never places enrolment tokens in the installer URL', () => {
+  const url = buildAgentInstallUrl('https://ct-ops.example.com/', false)
+
+  assert.equal(url, 'https://ct-ops.example.com/api/agent/install')
+  assert.equal(url.includes('token='), false)
+})
+
+test('buildAgentInstallCommand downloads the script without embedding secrets', () => {
+  const command = buildAgentInstallCommand('https://ct-ops.example.com', true)
+
+  assert.equal(command, 'curl -fsSL "https://ct-ops.example.com/api/agent/install?skip_verify=true" | sh')
+  assert.equal(command.includes('token='), false)
+  assert.equal(command.includes('CT_OPS_ORG_TOKEN='), false)
+})
+
+test('buildAgentInstallScript only consumes CT_OPS_ORG_TOKEN from the runtime environment', () => {
+  const script = buildAgentInstallScript('https://ct-ops.example.com', 'ct-ops.example.com:9443', false)
+
+  assert.match(script, /if \[ -n "\$\{CT_OPS_ORG_TOKEN:-\}" \]; then/)
+  assert.match(script, /sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" \.\/ct-ops-agent --install --address "ct-ops\.example\.com:9443"/)
+  assert.equal(script.includes('token='), false)
+})

--- a/apps/web/lib/agent/install-script.ts
+++ b/apps/web/lib/agent/install-script.ts
@@ -1,0 +1,59 @@
+export function buildAgentInstallUrl(appUrl: string, skipVerify: boolean): string {
+  const origin = appUrl.replace(/\/$/, '')
+  const installUrl = new URL(`${origin}/api/agent/install`)
+  if (skipVerify) {
+    installUrl.searchParams.set('skip_verify', 'true')
+  }
+  return installUrl.toString()
+}
+
+export function buildAgentInstallCommand(appUrl: string, skipVerify: boolean): string {
+  return `curl -fsSL "${buildAgentInstallUrl(appUrl, skipVerify)}" | sh`
+}
+
+export function buildAgentInstallScript(
+  serverURL: string,
+  ingestAddress: string,
+  skipVerify: boolean,
+): string {
+  const tlsFlag = skipVerify ? ' --tls-skip-verify' : ''
+  const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
+  const installPath = `/api/agent/install${skipVerify ? '?skip_verify=true' : ''}`
+
+  return `#!/bin/sh
+set -e
+
+# ── Detect platform ────────────────────────────────────────────────────────────
+OS=\$(uname -s | tr '[:upper:]' '[:lower:]')
+case "\$OS" in
+  linux|darwin) ;;
+  *) echo "Unsupported OS: \$OS" >&2; exit 1 ;;
+esac
+
+ARCH=\$(uname -m)
+case "\$ARCH" in
+  x86_64)        ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: \$ARCH" >&2; exit 1 ;;
+esac
+
+# ── Download binary ────────────────────────────────────────────────────────────
+echo "Downloading ct-ops-agent for \${OS}/\${ARCH}..."
+curl ${curlFlags} "${serverURL}/api/agent/download?os=\${OS}&arch=\${ARCH}" -o ct-ops-agent
+chmod +x ct-ops-agent
+echo "Binary downloaded."
+
+# ── Install with runtime-provided token ───────────────────────────────────────
+if [ -n "\${CT_OPS_ORG_TOKEN:-}" ]; then
+  sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" ./ct-ops-agent --install --address "${ingestAddress}"${tlsFlag}
+  exit 0
+fi
+
+echo ""
+echo "Export CT_OPS_ORG_TOKEN with an enrolment token, then rerun this command:"
+echo "  curl ${curlFlags} \\"${serverURL}${installPath}\\" | sh"
+echo ""
+echo "You can also install manually:"
+echo "  sudo ./ct-ops-agent --install --token <YOUR-TOKEN> --address ${ingestAddress}${tlsFlag}"
+`
+}

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -34,12 +34,14 @@ test('admin can create and revoke an enrolment token from agent settings', async
   await page.getByTestId('agent-enrolment-create-submit').click()
 
   const installCommand = page.getByTestId('agent-enrolment-install-command')
-  await expect(installCommand).toContainText('/api/agent/install?token=')
+  await expect(installCommand).toContainText('/api/agent/install')
+  await expect(installCommand).not.toContainText('token=')
   await expect(installCommand).not.toContainText('skip_verify=true')
 
   await page.getByText('Show raw token (for manual config)').click()
   const rawToken = (await page.getByTestId('agent-enrolment-raw-token').textContent())?.trim()
   expect(rawToken).toBeTruthy()
+  await expect(installCommand).not.toContainText(rawToken!)
 
   await expect
     .poll(async () => {


### PR DESCRIPTION
## Summary
- stop generating installer URLs with embedded enrolment tokens
- make the bootstrap script consume CT_OPS_ORG_TOKEN at runtime instead
- allow agent install mode to read CT_OPS_ORG_TOKEN when --token is omitted

## Testing
- `node --experimental-strip-types --test lib/agent/install-script.test.mjs`
- `PATH=/Volumes/MacBookStorage-Dev/dev/carrtech/ct-ops/apps/web/node_modules/.bin:$PATH tsc --noEmit`
- `go build ./agent/...`
- attempted `node tests/e2e/runner.mjs tests/e2e/settings/agent-enrolment.spec.ts` but the Playwright run did not complete in a reasonable window on this machine

Closes #743