### PR TITLE
test(web): add security and certificate-checker e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -772,7 +772,10 @@ function UploadTab({ onResult }: { onResult: (cert: ParsedCertificate, source: T
       />
 
       {error && (
-        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+        <div
+          className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+          data-testid="certificate-checker-url-error"
+        >
           <AlertCircle className="size-4 shrink-0 mt-0.5" />
           <span>{error}</span>
         </div>
@@ -874,7 +877,10 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
       />
 
       {error && (
-        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+        <div
+          className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+          data-testid="certificate-checker-url-error"
+        >
           <AlertCircle className="size-4 shrink-0 mt-0.5" />
           <span>{error}</span>
         </div>

--- a/apps/web/app/(dashboard)/settings/security/security-client.tsx
+++ b/apps/web/app/(dashboard)/settings/security/security-client.tsx
@@ -78,7 +78,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
   return (
     <div className="p-6 space-y-6 max-w-4xl">
       <div>
-        <h1 className="text-2xl font-semibold flex items-center gap-2">
+        <h1 className="text-2xl font-semibold flex items-center gap-2" data-testid="security-settings-heading">
           <ShieldCheck className="size-6" />
           Security — mTLS &amp; Agent CA
         </h1>
@@ -88,7 +88,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
         </p>
       </div>
 
-      <Card>
+      <Card data-testid="security-server-tls-card">
         <CardHeader>
           <CardTitle>Server TLS certificate</CardTitle>
           <CardDescription>
@@ -118,7 +118,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card data-testid="security-agent-ca-card">
         <CardHeader>
           <CardTitle>Agent CA</CardTitle>
           <CardDescription>
@@ -131,7 +131,10 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
           {data.agentCa ? (
             <>
               <div className="flex gap-2 items-center">
-                <Badge variant={data.agentCa.source === 'byo' ? 'default' : 'secondary'}>
+                <Badge
+                  variant={data.agentCa.source === 'byo' ? 'default' : 'secondary'}
+                  data-testid="security-agent-ca-source"
+                >
                   {data.agentCa.source === 'byo' ? 'Customer-provided' : 'Auto-generated'}
                 </Badge>
                 {data.agentCa.byoEnvConfigured && (
@@ -140,7 +143,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
               </div>
               <dl className="grid grid-cols-[140px,1fr] gap-y-1 mt-2">
                 <dt className="text-muted-foreground">Subject</dt>
-                <dd className="font-mono text-xs">{data.agentCa.subject}</dd>
+                <dd className="font-mono text-xs" data-testid="security-agent-ca-subject">{data.agentCa.subject}</dd>
                 <dt className="text-muted-foreground">Issuer</dt>
                 <dd className="font-mono text-xs">{data.agentCa.issuer}</dd>
                 <dt className="text-muted-foreground">Valid from</dt>
@@ -148,7 +151,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
                 <dt className="text-muted-foreground">Valid to</dt>
                 <dd>{formatIsoDate(data.agentCa.notAfter)}</dd>
                 <dt className="text-muted-foreground">SHA-256</dt>
-                <dd className="font-mono text-xs break-all">{data.agentCa.fingerprintSha256}</dd>
+                <dd className="font-mono text-xs break-all" data-testid="security-agent-ca-fingerprint">{data.agentCa.fingerprintSha256}</dd>
               </dl>
             </>
           ) : (
@@ -157,7 +160,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card data-testid="security-upload-card">
         <CardHeader>
           <CardTitle>Upload a custom CA</CardTitle>
           <CardDescription>
@@ -177,6 +180,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
               placeholder="-----BEGIN CERTIFICATE-----..."
               rows={8}
               className="font-mono text-xs"
+              data-testid="security-upload-cert"
             />
           </div>
           <div>
@@ -188,6 +192,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
               placeholder="-----BEGIN EC PRIVATE KEY-----..."
               rows={8}
               className="font-mono text-xs"
+              data-testid="security-upload-key"
             />
           </div>
           {uploadError && (
@@ -205,6 +210,7 @@ export function SecuritySettingsClient({ initialOverview }: Props) {
           <Button
             onClick={() => uploadMutation.mutate()}
             disabled={uploadMutation.isPending || !certPem.trim() || !keyPem.trim()}
+            data-testid="security-upload-submit"
           >
             <Upload className="size-4 mr-2" />
             {uploadMutation.isPending ? 'Uploading…' : 'Upload CA'}

--- a/apps/web/tests/e2e/certificate-checker/url-port-validation.spec.ts
+++ b/apps/web/tests/e2e/certificate-checker/url-port-validation.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '../fixtures/test'
+
+test('authenticated user sees a safe validation error for blocked certificate-checker ports', async ({ authenticatedPage: page }) => {
+  await page.goto('/certificate-checker')
+
+  await expect(page.getByTestId('certificate-checker-heading')).toBeVisible()
+  await page.getByTestId('certificate-checker-tab-url').click()
+  await page.getByTestId('certificate-checker-url-input').fill('https://example.com')
+  await page.getByTestId('certificate-checker-port-input').fill('22')
+  await page.getByTestId('certificate-checker-url-submit').click()
+
+  await expect(page.getByTestId('certificate-checker-url-error')).toContainText(
+    'Blocked: port 22 is not allowed. Use one of: 443, 465, 587, 636, 853, 993, 995, 8443, 9443',
+  )
+  await expect(page.getByTestId('certificate-checker-result')).toHaveCount(0)
+  await expect(page.getByTestId('certificate-checker-empty-state')).toBeVisible()
+})

--- a/apps/web/tests/e2e/fixtures/db.ts
+++ b/apps/web/tests/e2e/fixtures/db.ts
@@ -27,6 +27,7 @@ const APP_TABLES = [
   'alert_instances',
   'alert_rules',
   'alert_silences',
+  'certificate_authorities',
   'certificate_events',
   'certificates',
   'check_results',

--- a/apps/web/tests/e2e/settings/security-overview.spec.ts
+++ b/apps/web/tests/e2e/settings/security-overview.spec.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process'
+import { X509Certificate } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+
+const E2E_AGENT_CA_FORM_VALUE = 'placeholder'
+
+function createAgentCaFixture() {
+  const fixtureDir = mkdtempSync(join(tmpdir(), 'ct-ops-security-ca-'))
+  const keyPath = join(fixtureDir, 'agent-ca.key')
+  const certPath = join(fixtureDir, 'agent-ca.crt')
+
+  try {
+    execFileSync('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-nodes',
+      '-keyout',
+      keyPath,
+      '-out',
+      certPath,
+      '-subj',
+      '/CN=E2E Agent CA/O=Carrtech Test/C=GB',
+      '-days',
+      '3650',
+    ], { stdio: 'ignore' })
+
+    const certPem = readFileSync(certPath, 'utf8')
+    const cert = new X509Certificate(certPem)
+
+    return {
+      certPem,
+      subject: cert.subject,
+      fingerprintSha256: cert.fingerprint256.replace(/:/g, '').toLowerCase(),
+      notBefore: new Date(cert.validFrom).toISOString(),
+      notAfter: new Date(cert.validTo).toISOString(),
+    }
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+}
+
+const E2E_AGENT_CA = createAgentCaFixture()
+
+test('admin can review the current agent CA and upload form readiness in security settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await sql`
+    INSERT INTO certificate_authorities (
+      id,
+      organisation_id,
+      purpose,
+      cert_pem,
+      key_pem_encrypted,
+      source,
+      fingerprint_sha256,
+      not_before,
+      not_after,
+      metadata
+    )
+    VALUES (
+      'e2e-agent-ca-current',
+      NULL,
+      'agent_ca',
+      ${E2E_AGENT_CA.certPem},
+      'encrypted-placeholder',
+      'auto',
+      ${E2E_AGENT_CA.fingerprintSha256},
+      ${E2E_AGENT_CA.notBefore}::timestamptz,
+      ${E2E_AGENT_CA.notAfter}::timestamptz,
+      '{}'::jsonb
+    )
+  `
+
+  await page.goto('/settings/security')
+
+  await expect(page.getByTestId('security-settings-heading')).toBeVisible()
+  await expect(page.getByTestId('security-agent-ca-card')).toBeVisible()
+  await expect(page.getByTestId('security-agent-ca-source')).toContainText('Auto-generated')
+  await expect(page.getByTestId('security-agent-ca-subject')).toContainText(E2E_AGENT_CA.subject)
+  await expect(page.getByTestId('security-agent-ca-fingerprint')).toContainText(
+    E2E_AGENT_CA.fingerprintSha256,
+  )
+
+  const uploadButton = page.getByTestId('security-upload-submit')
+  await expect(uploadButton).toBeDisabled()
+
+  await page.getByTestId('security-upload-cert').fill(E2E_AGENT_CA.certPem)
+  await expect(uploadButton).toBeDisabled()
+
+  await page.getByTestId('security-upload-key').fill(E2E_AGENT_CA_FORM_VALUE)
+  await expect(uploadButton).toBeEnabled()
+
+  await expect(page.getByRole('link', { name: 'Terminal access' })).toHaveAttribute(
+    'href',
+    '/settings/security/terminal',
+  )
+})


### PR DESCRIPTION
## What changed
- added a new DB-backed E2E spec for the security settings Agent CA overview and upload form readiness
- added certificate-checker URL-mode E2E coverage for blocked-port validation
- extended the shared E2E truncate list to include `certificate_authorities` so the new security coverage stays isolated

## Why
- the security settings overview had no E2E coverage
- certificate-checker coverage did not exercise the real URL validation path for disallowed ports
- without truncating `certificate_authorities`, CA rows created by security tests could leak between specs

## Validation
- `E2E_PORT=3202 node tests/e2e/runner.mjs tests/e2e/settings/security-overview.spec.ts tests/e2e/certificate-checker/url-port-validation.spec.ts`
