### PR TITLE
test(web): add retention and agent defaults e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -495,7 +495,7 @@ export function SettingsClient({
                   onValueChange={setRetentionDays}
                   disabled={retentionMutation.isPending}
                 >
-                  <SelectTrigger id="retention-select" className="w-48">
+                  <SelectTrigger id="retention-select" className="w-48" data-testid="settings-retention-select">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -524,11 +524,12 @@ export function SettingsClient({
                   size="sm"
                   disabled={retentionMutation.isPending || retentionDays === String(org.metricRetentionDays ?? 30)}
                   onClick={() => retentionMutation.mutate(Number(retentionDays))}
+                  data-testid="settings-retention-save"
                 >
                   {retentionMutation.isPending ? 'Saving…' : 'Save'}
                 </Button>
                 {retentionSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span className="flex items-center gap-1 text-sm text-green-700" data-testid="settings-retention-success">
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>
@@ -566,6 +567,7 @@ export function SettingsClient({
                 </div>
                 <Switch
                   checked={currentCollectionSettings.cpu}
+                  data-testid="settings-collection-cpu-toggle"
                   onCheckedChange={(checked) =>
                     setLocalCollectionSettings({ ...currentCollectionSettings, cpu: checked })
                   }
@@ -578,6 +580,7 @@ export function SettingsClient({
                 </div>
                 <Switch
                   checked={currentCollectionSettings.memory}
+                  data-testid="settings-collection-memory-toggle"
                   onCheckedChange={(checked) =>
                     setLocalCollectionSettings({ ...currentCollectionSettings, memory: checked })
                   }
@@ -590,6 +593,7 @@ export function SettingsClient({
                 </div>
                 <Switch
                   checked={currentCollectionSettings.disk}
+                  data-testid="settings-collection-disk-toggle"
                   onCheckedChange={(checked) =>
                     setLocalCollectionSettings({ ...currentCollectionSettings, disk: checked })
                   }
@@ -602,6 +606,7 @@ export function SettingsClient({
                 </div>
                 <Switch
                   checked={currentCollectionSettings.localUsers}
+                  data-testid="settings-collection-local-users-toggle"
                   onCheckedChange={(checked) =>
                     setLocalCollectionSettings({ ...currentCollectionSettings, localUsers: checked })
                   }
@@ -612,11 +617,12 @@ export function SettingsClient({
                   size="sm"
                   disabled={!collectionDirty || collectionMutation.isPending}
                   onClick={() => collectionMutation.mutate(currentCollectionSettings)}
+                  data-testid="settings-collection-save"
                 >
                   {collectionMutation.isPending ? 'Saving...' : 'Save'}
                 </Button>
                 {collectionSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span className="flex items-center gap-1 text-sm text-green-700" data-testid="settings-collection-success">
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>
@@ -1188,6 +1194,7 @@ export function SettingsClient({
                 </div>
                 <Switch
                   checked={currentSwInvSettings.enabled}
+                  data-testid="settings-software-enabled-toggle"
                   onCheckedChange={(checked) =>
                     setLocalSwInvSettings({ ...currentSwInvSettings, enabled: checked })
                   }
@@ -1208,6 +1215,7 @@ export function SettingsClient({
                       min={1}
                       max={720}
                       className="w-32"
+                      data-testid="settings-software-interval-input"
                       value={currentSwInvSettings.intervalHours}
                       onChange={(e) => {
                         const n = parseInt(e.target.value, 10)
@@ -1224,6 +1232,7 @@ export function SettingsClient({
                         <Checkbox
                           id="sw-inv-snap"
                           checked={currentSwInvSettings.includeSnapFlatpak ?? false}
+                          data-testid="settings-software-snap-toggle"
                           onCheckedChange={(checked) =>
                             setLocalSwInvSettings({
                               ...currentSwInvSettings,
@@ -1239,6 +1248,7 @@ export function SettingsClient({
                         <Checkbox
                           id="sw-inv-winstore"
                           checked={currentSwInvSettings.includeWindowsStore ?? false}
+                          data-testid="settings-software-windows-store-toggle"
                           onCheckedChange={(checked) =>
                             setLocalSwInvSettings({
                               ...currentSwInvSettings,
@@ -1259,11 +1269,12 @@ export function SettingsClient({
                   size="sm"
                   disabled={!swInvDirty || swInvMutation.isPending}
                   onClick={() => swInvMutation.mutate(currentSwInvSettings)}
+                  data-testid="settings-software-save"
                 >
                   {swInvMutation.isPending ? 'Saving…' : 'Save'}
                 </Button>
                 {swInvSaveSuccess && (
-                  <span className="flex items-center gap-1 text-sm text-green-700">
+                  <span className="flex items-center gap-1 text-sm text-green-700" data-testid="settings-software-success">
                     <CheckCircle2 className="size-4" />
                     Saved
                   </span>

--- a/apps/web/tests/e2e/settings/retention-and-agent-defaults.spec.ts
+++ b/apps/web/tests/e2e/settings/retention-and-agent-defaults.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+test('admin can update metric retention from monitoring settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings/monitoring/retention')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  await page.getByTestId('settings-retention-select').click()
+  await page.getByRole('option', { name: '14 days' }).click()
+  await page.getByTestId('settings-retention-save').click()
+  await expect(page.getByTestId('settings-retention-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ metric_retention_days: number }>>`
+        SELECT metric_retention_days
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return rows[0]?.metric_retention_days ?? null
+    })
+    .toBe(14)
+})
+
+test('admin can update default host collection settings from agent defaults', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings/agents/defaults')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  await page.getByTestId('settings-collection-cpu-toggle').click()
+  await page.getByTestId('settings-collection-local-users-toggle').click()
+  await page.getByTestId('settings-collection-save').click()
+  await expect(page.getByTestId('settings-collection-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: {
+          defaultCollectionSettings?: {
+            cpu?: boolean
+            memory?: boolean
+            disk?: boolean
+            localUsers?: boolean
+          }
+        } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return rows[0]?.metadata?.defaultCollectionSettings ?? null
+    })
+    .toEqual({
+      cpu: false,
+      memory: true,
+      disk: true,
+      localUsers: true,
+    })
+})
+
+test('admin can update software inventory defaults from agent settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings/agents/software')
+  await expect(page.getByTestId('settings-heading')).toBeVisible()
+
+  await page.getByTestId('settings-software-enabled-toggle').click()
+  await page.getByTestId('settings-software-interval-input').fill('48')
+  await page.getByTestId('settings-software-snap-toggle').click()
+  await page.getByTestId('settings-software-windows-store-toggle').click()
+  await page.getByTestId('settings-software-save').click()
+  await expect(page.getByTestId('settings-software-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        metadata: {
+          softwareInventorySettings?: {
+            enabled?: boolean
+            intervalHours?: number
+            includeSnapFlatpak?: boolean
+            includeWindowsStore?: boolean
+          }
+        } | null
+      }>>`
+        SELECT metadata
+        FROM organisations
+        WHERE slug = ${TEST_ORG.slug}
+        LIMIT 1
+      `
+
+      return rows[0]?.metadata?.softwareInventorySettings ?? null
+    })
+    .toEqual({
+      enabled: true,
+      intervalHours: 48,
+      includeSnapFlatpak: true,
+      includeWindowsStore: true,
+    })
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for monitoring retention settings
- add E2E coverage for agent default host collection settings
- add E2E coverage for software inventory defaults under agent settings
- add stable `data-testid` hooks for the new settings interactions and success states

## Why
These settings routes existed on `main`, but the E2E suite only covered adjacent settings flows. That left retention and newer agent defaults behavior unverified end-to-end.

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/settings/retention-and-agent-defaults.spec.ts`
