### PR TITLE
fix(web): revoke stale sessions for inactive users

### DIFF
--- a/apps/web/app/api/agent/bundle/route.ts
+++ b/apps/web/app/api/agent/bundle/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { and, eq, isNull } from 'drizzle-orm'
-import { auth } from '@/lib/auth'
 import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema/auth'
 import { agentEnrolmentTokens, parseAgentEnrolmentTokenMetadata } from '@/lib/db/schema/agents'
 import {
   SUPPORTED_OS,
@@ -17,6 +15,7 @@ import { buildInstallBundle } from '@/lib/agent/bundle'
 import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
 import { readFile } from 'node:fs/promises'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
+import { ApiAuthError, getApiOrgAdminSession } from '@/lib/auth/session'
 
 const SERVER_TLS_CERT_PATH = process.env['INGEST_TLS_CERT'] ?? '/etc/ct-ops/tls/server.crt'
 const WEB_TLS_CERT_PATH = process.env['WEB_TLS_CERT'] ?? '/var/lib/ct-ops/server-tls/server.crt'
@@ -72,20 +71,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const session = await auth.api.getSession({ headers: request.headers })
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
+  let session
+  try {
+    session = await getApiOrgAdminSession(request.headers)
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return NextResponse.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user || !user.organisationId) {
-    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
-  }
-  if (user.role !== 'super_admin' && user.role !== 'org_admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const user = session.user
 
   const body = await request.json().catch(() => null)
   const parsed = requestSchema.safeParse(body)

--- a/apps/web/app/api/certificates/counts/route.ts
+++ b/apps/web/app/api/certificates/counts/route.ts
@@ -1,29 +1,23 @@
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getCertificateCounts } from '@/lib/actions/certificates'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 // GET /api/certificates/counts
 export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   try {
-    const counts = await getCertificateCounts(user.organisationId)
+    const counts = await getCertificateCounts(session.user.organisationId)
     return Response.json(counts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/certificates/route.ts
+++ b/apps/web/app/api/certificates/route.ts
@@ -1,28 +1,22 @@
 import { NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getCertificates } from '@/lib/actions/certificates'
 import type { CertificateListFilters } from '@/lib/actions/certificates'
 import type { CertificateStatus } from '@/lib/db/schema'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 // GET /api/certificates?status=valid&host=foo&sortBy=not_after&sortDir=asc&limit=100&offset=0
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   const { searchParams } = request.nextUrl
@@ -36,7 +30,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const certificates = await getCertificates(user.organisationId, filters)
+    const certificates = await getCertificates(session.user.organisationId, filters)
     return Response.json(certificates)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/domain-accounts/counts/route.ts
+++ b/apps/web/app/api/domain-accounts/counts/route.ts
@@ -1,28 +1,22 @@
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getDomainAccountCounts } from '@/lib/actions/domain-accounts'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   try {
-    const counts = await getDomainAccountCounts(user.organisationId)
+    const counts = await getDomainAccountCounts(session.user.organisationId)
     return Response.json(counts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/domain-accounts/route.ts
+++ b/apps/web/app/api/domain-accounts/route.ts
@@ -1,27 +1,21 @@
 import { NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getDomainAccounts } from '@/lib/actions/domain-accounts'
 import type { DomainAccountListFilters } from '@/lib/actions/domain-accounts'
 import type { DomainAccountStatus } from '@/lib/db/schema'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   const { searchParams } = request.nextUrl
@@ -35,7 +29,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accounts = await getDomainAccounts(user.organisationId, filters)
+    const accounts = await getDomainAccounts(session.user.organisationId, filters)
     return Response.json(accounts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/hosts/[id]/queries/[queryId]/route.ts
+++ b/apps/web/app/api/hosts/[id]/queries/[queryId]/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
 import { db } from '@/lib/db'
-import { users, agentQueries } from '@/lib/db/schema'
+import { agentQueries } from '@/lib/db/schema'
 import { and, eq, isNull } from 'drizzle-orm'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,17 +13,16 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string; queryId: string }> }
 ) {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const user = session.user
 
   const { id: hostId, queryId } = await params
 

--- a/apps/web/app/api/hosts/[id]/queries/route.ts
+++ b/apps/web/app/api/hosts/[id]/queries/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
 import { db } from '@/lib/db'
-import { users, hosts, agentQueries } from '@/lib/db/schema'
+import { hosts, agentQueries } from '@/lib/db/schema'
 import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
@@ -26,17 +25,16 @@ export async function POST(
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const user = session.user
 
   const { id: hostId } = await params
 

--- a/apps/web/app/api/hosts/[id]/stream/route.ts
+++ b/apps/web/app/api/hosts/[id]/stream/route.ts
@@ -1,12 +1,8 @@
 import { NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getHost } from '@/lib/actions/agents'
 import { getChecksWithHistory } from '@/lib/actions/checks'
 import { listNotesForHost } from '@/lib/actions/notes'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,16 +10,18 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) return new Response('Unauthorized', { status: 401 })
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) return new Response('Forbidden', { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return new Response(err.message, { status: err.status })
+    }
+    throw err
+  }
 
   const { id: hostId } = await params
-  const orgId = user.organisationId
+  const orgId = session.user.organisationId
 
   const stream = new ReadableStream({
     async start(controller) {

--- a/apps/web/app/api/overview/route.ts
+++ b/apps/web/app/api/overview/route.ts
@@ -1,25 +1,22 @@
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
 import { db } from '@/lib/db'
-import { users, agents, certificates, alertInstances } from '@/lib/db/schema'
+import { agents, certificates, alertInstances } from '@/lib/db/schema'
 import { eq, and, isNull, count } from 'drizzle-orm'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  const orgId = user.organisationId
+  const orgId = session.user.organisationId
 
   const [agentRows, certRows, alertRows] = await Promise.all([
     db

--- a/apps/web/app/api/service-accounts/counts/route.ts
+++ b/apps/web/app/api/service-accounts/counts/route.ts
@@ -1,29 +1,23 @@
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getServiceAccountCounts } from '@/lib/actions/service-accounts'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 // GET /api/service-accounts/counts
 export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   try {
-    const counts = await getServiceAccountCounts(user.organisationId)
+    const counts = await getServiceAccountCounts(session.user.organisationId)
     return Response.json(counts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/service-accounts/route.ts
+++ b/apps/web/app/api/service-accounts/route.ts
@@ -1,28 +1,22 @@
 import { NextRequest } from 'next/server'
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
-import { db } from '@/lib/db'
-import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { getServiceAccounts } from '@/lib/actions/service-accounts'
 import type { ServiceAccountListFilters } from '@/lib/actions/service-accounts'
 import type { ServiceAccountStatus, ServiceAccountType } from '@/lib/db/schema'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 // GET /api/service-accounts?accountType=human&status=active&hostId=xxx&search=deploy&sortBy=username&sortDir=asc&limit=100&offset=0
 export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  let session
+  try {
+    session = await getApiOrgSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
   const { searchParams } = request.nextUrl
@@ -38,7 +32,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accounts = await getServiceAccounts(user.organisationId, filters)
+    const accounts = await getServiceAccounts(session.user.organisationId, filters)
     return Response.json(accounts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/system/health/route.ts
+++ b/apps/web/app/api/system/health/route.ts
@@ -1,7 +1,5 @@
-import { auth } from '@/lib/auth'
-import { headers } from 'next/headers'
 import { db } from '@/lib/db'
-import { users, agents, hosts, organisations } from '@/lib/db/schema'
+import { agents, hosts, organisations } from '@/lib/db/schema'
 import { eq, and, isNull, count, inArray, sql } from 'drizzle-orm'
 import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
 import {
@@ -11,26 +9,22 @@ import {
   type IngestSnapshotSummaryRow,
 } from '@/lib/system/health'
 import pkg from '../../../../package.json'
+import { ApiAuthError, getApiOrgAdminSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) {
-    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  let session
+  try {
+    session = await getApiOrgAdminSession()
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return Response.json({ error: err.message }, { status: err.status })
+    }
+    throw err
   }
 
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  if (!user?.organisationId) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
-  if (user.role !== 'super_admin' && user.role !== 'org_admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  const orgId = user.organisationId
+  const orgId = session.user.organisationId
 
   const [agentRows, org, agentVersionRows, ingestLatestRows, ingestHistoryRows, agentErrorRows] = await Promise.all([
     db

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -16,6 +16,7 @@ import { db } from '@/lib/db'
 import { hosts, taskRunHosts, taskRuns, users } from '@/lib/db/schema'
 import { resolveWarUrl } from '@/lib/jenkins/update-center'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
+import { getApiOrgSession } from '@/lib/auth/session'
 
 export const runtime = 'nodejs'
 export const maxDuration = 900
@@ -645,12 +646,11 @@ async function runTransferJob(job: TransferJob, request: TransferRequest, baseUr
 }
 
 async function getAuthorisedUser(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: request.headers })
-  if (!session) return null
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-  return user?.organisationId ? user : null
+  try {
+    return (await getApiOrgSession(request.headers)).user
+  } catch {
+    return null
+  }
 }
 
 function getRequestOrigin(request: NextRequest) {

--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import * as crypto from 'crypto'
 import * as forge from 'node-forge'
 import { z } from 'zod'
-import { auth } from '@/lib/auth'
 import {
   type ParsedCertificate,
   checkKeyMatch,
@@ -13,6 +12,7 @@ import {
 } from '@/lib/certificates/fetch'
 import { assertAllowedCertificateCheckerTarget } from '@/lib/net/certificate-checker-policy'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 
 export type { ParsedCertificate, ParsedSAN, ChainEntry } from '@/lib/certificates/fetch'
 
@@ -64,9 +64,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ ok: false, error: 'Forbidden' } satisfies CertCheckerResponse, { status: 403 })
   }
 
-  const session = await auth.api.getSession({ headers: req.headers })
-  if (!session) {
-    return NextResponse.json({ ok: false, error: 'Unauthorized' } satisfies CertCheckerResponse, { status: 401 })
+  try {
+    await getApiSession(req.headers)
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return NextResponse.json(
+        { ok: false, error: err.message } satisfies CertCheckerResponse,
+        { status: err.status },
+      )
+    }
+    throw err
   }
 
   let body: unknown

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -5,7 +5,7 @@ import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-au
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
-import { users, invitations } from '@/lib/db/schema'
+import { users, invitations, sessions } from '@/lib/db/schema'
 import { eq, and, isNull, isNotNull, gt } from 'drizzle-orm'
 import type { User, Invitation } from '@/lib/db/schema'
 import { getBetterAuthOrigin } from '@/lib/auth/env'
@@ -210,6 +210,8 @@ export async function deactivateUser(
       .set({ isActive: false, updatedAt: new Date() })
       .where(and(eq(users.id, targetUserId), eq(users.organisationId, orgId)))
 
+    await db.delete(sessions).where(eq(sessions.userId, targetUserId))
+
     return { success: true }
   } catch (err) {
     logError('Failed to deactivate user:', err)
@@ -274,6 +276,8 @@ export async function removeUser(
         .update(users)
         .set({ deletedAt: new Date(), isActive: false, updatedAt: new Date() })
         .where(and(eq(users.id, targetUserId), eq(users.organisationId, orgId)))
+
+      await tx.delete(sessions).where(eq(sessions.userId, targetUserId))
 
       await writeAuditEvent(tx, {
         organisationId: orgId,

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import type { User } from '@/lib/db/schema'
+import { requireActiveUser, requireOrgAdmin } from './guards'
 
 // Re-export User as SessionUser for convenience
 export type { User as SessionUser }
@@ -21,21 +22,88 @@ export type RequiredSession = {
   user: User
 }
 
-export async function getRequiredSession(): Promise<RequiredSession> {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session) redirect('/login')
+export class ApiAuthError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ApiAuthError'
+  }
+}
+
+async function findSessionUser(userId: string): Promise<User | null> {
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+  })
+  return user ?? null
+}
+
+async function loadSessionWithUser(requestHeaders: Headers): Promise<RequiredSession | null> {
+  const session = await auth.api.getSession({ headers: requestHeaders })
+  if (!session) return null
 
   // Better Auth only returns its own base fields in session.user.
   // Fetch the full user row from DB to get our extended fields
   // (organisationId, role, isActive, twoFactorEnabled).
-  const user = await db.query.users.findFirst({
-    where: eq(users.id, session.user.id),
-  })
-
-  if (!user) redirect('/login')
+  const user = await findSessionUser(session.user.id)
+  if (!user) return null
 
   return {
     session: session.session as RequiredSession['session'],
     user,
   }
+}
+
+export async function getRequiredSession(): Promise<RequiredSession> {
+  const session = await loadSessionWithUser(await headers())
+  if (!session) redirect('/login')
+
+  try {
+    requireActiveUser(session.user)
+  } catch {
+    redirect('/login')
+  }
+
+  return session
+}
+
+export async function getApiSession(requestHeaders?: Headers): Promise<RequiredSession> {
+  const session = await loadSessionWithUser(requestHeaders ?? await headers())
+  if (!session) {
+    throw new ApiAuthError(401, 'Unauthorized')
+  }
+
+  try {
+    requireActiveUser(session.user)
+  } catch {
+    throw new ApiAuthError(403, 'Forbidden')
+  }
+
+  return session
+}
+
+export async function getApiOrgSession(
+  requestHeaders?: Headers,
+): Promise<RequiredSession & { user: User & { organisationId: string } }> {
+  const session = await getApiSession(requestHeaders)
+  if (!session.user.organisationId) {
+    throw new ApiAuthError(403, 'Forbidden')
+  }
+
+  return session as RequiredSession & { user: User & { organisationId: string } }
+}
+
+export async function getApiOrgAdminSession(
+  requestHeaders?: Headers,
+): Promise<RequiredSession & { user: User & { organisationId: string } }> {
+  const session = await getApiOrgSession(requestHeaders)
+
+  try {
+    requireOrgAdmin(session.user, session.user.organisationId)
+  } catch {
+    throw new ApiAuthError(403, 'Forbidden')
+  }
+
+  return session
 }

--- a/apps/web/tests/e2e/auth/stale-sessions.spec.ts
+++ b/apps/web/tests/e2e/auth/stale-sessions.spec.ts
@@ -1,0 +1,137 @@
+import { createId } from '@paralleldrive/cuid2'
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+import { createStorageStateForUser } from '../fixtures/auth'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+async function createOrgUser(
+  sql: ReturnType<typeof getTestDb>,
+  orgId: string,
+  input: { email: string; isActive?: boolean; deleted?: boolean },
+): Promise<string> {
+  const userId = createId()
+
+  await sql`
+    INSERT INTO "user" (
+      id,
+      name,
+      email,
+      email_verified,
+      organisation_id,
+      role,
+      is_active,
+      deleted_at
+    )
+    VALUES (
+      ${userId},
+      ${input.email},
+      ${input.email},
+      true,
+      ${orgId},
+      'engineer',
+      ${input.isActive ?? true},
+      ${input.deleted ? new Date() : null}
+    )
+  `
+
+  return userId
+}
+
+async function getSessionCount(
+  sql: ReturnType<typeof getTestDb>,
+  userId: string,
+): Promise<number> {
+  const rows = await sql<Array<{ count: number }>>`
+    SELECT COUNT(*)::int AS count
+    FROM "session"
+    WHERE user_id = ${userId}
+  `
+  return rows[0]?.count ?? 0
+}
+
+test('deactivating a user revokes existing sessions and blocks stale dashboard/api access', async ({
+  authenticatedPage: adminPage,
+  browser,
+  baseURL,
+}) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const userId = await createOrgUser(sql, orgId, {
+    email: 'stale-deactivated@example.com',
+  })
+
+  const storageState = await createStorageStateForUser(baseURL!, userId)
+  const staleContext = await browser.newContext({ storageState })
+  const stalePage = await staleContext.newPage()
+
+  try {
+    await stalePage.goto('/dashboard')
+    await expect(stalePage.getByTestId('dashboard-heading')).toBeVisible()
+
+    await adminPage.goto('/team')
+    const row = adminPage.locator('tr').filter({ hasText: 'stale-deactivated@example.com' })
+    await expect(row).toContainText('Active')
+    await row.getByRole('button', { name: 'Deactivate' }).click()
+    await expect(row).toContainText('Inactive')
+
+    await expect.poll(async () => getSessionCount(sql, userId)).toBe(0)
+
+    const response = await stalePage.request.get('/api/overview')
+    expect(response.status()).toBe(401)
+
+    await stalePage.goto('/dashboard')
+    await expect(stalePage).toHaveURL(/\/login$/)
+  } finally {
+    await staleContext.close()
+  }
+})
+
+test('removing a user clears any leftover sessions', async ({
+  authenticatedPage: adminPage,
+  browser,
+  baseURL,
+}) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const userId = await createOrgUser(sql, orgId, {
+    email: 'stale-removed@example.com',
+    isActive: false,
+  })
+
+  const storageState = await createStorageStateForUser(baseURL!, userId)
+  const staleContext = await browser.newContext({ storageState })
+
+  try {
+    await expect.poll(async () => getSessionCount(sql, userId)).toBe(1)
+
+    await adminPage.goto('/team')
+    const row = adminPage.locator('tr').filter({ hasText: 'stale-removed@example.com' })
+    await expect(row).toContainText('Inactive')
+    await row.getByRole('button', { name: 'Remove' }).click()
+
+    await expect.poll(async () => getSessionCount(sql, userId)).toBe(0)
+    await expect
+      .poll(async () => {
+        const rows = await sql<Array<{ deleted: boolean }>>`
+          SELECT deleted_at IS NOT NULL AS deleted
+          FROM "user"
+          WHERE id = ${userId}
+        `
+        return rows[0]?.deleted ?? false
+      })
+      .toBe(true)
+  } finally {
+    await staleContext.close()
+  }
+})

--- a/apps/web/tests/e2e/fixtures/auth.ts
+++ b/apps/web/tests/e2e/fixtures/auth.ts
@@ -18,6 +18,11 @@ export async function getStorageStatePath(baseURL: string): Promise<string> {
   return createAndCacheStorageState(baseURL)
 }
 
+export async function createStorageStateForUser(baseURL: string, userId: string): Promise<string> {
+  const fileName = `user-${userId}.json`
+  return createStorageState(baseURL, userId, fileName)
+}
+
 async function createAndCacheStorageState(baseURL: string): Promise<string> {
   const sql = getTestDb()
   const rows = await sql<Array<{ id: string }>>`
@@ -27,6 +32,16 @@ async function createAndCacheStorageState(baseURL: string): Promise<string> {
   if (!userId) {
     throw new Error(`E2E test user ${TEST_USER.email} has not been seeded`)
   }
+
+  return createStorageState(baseURL, userId, path.basename(STORAGE_STATE_PATH))
+}
+
+async function createStorageState(
+  baseURL: string,
+  userId: string,
+  fileName: string,
+): Promise<string> {
+  const sql = getTestDb()
 
   const sessionToken = randomBytes(32).toString('hex')
   const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
@@ -38,10 +53,11 @@ async function createAndCacheStorageState(baseURL: string): Promise<string> {
 
   const cookieValue = await makeSessionCookieValue(sessionToken, getBetterAuthSecret())
   const url = new URL(baseURL)
+  const storageStatePath = path.resolve(__dirname, '..', '.auth', fileName)
 
-  await mkdir(path.dirname(STORAGE_STATE_PATH), { recursive: true })
+  await mkdir(path.dirname(storageStatePath), { recursive: true })
   await writeFile(
-    STORAGE_STATE_PATH,
+    storageStatePath,
     JSON.stringify(
       {
         cookies: [
@@ -63,5 +79,5 @@ async function createAndCacheStorageState(baseURL: string): Promise<string> {
     ),
   )
 
-  return STORAGE_STATE_PATH
+  return storageStatePath
 }


### PR DESCRIPTION
## Summary
- revoke Better Auth session rows when org admins deactivate or remove a user
- enforce active-user checks through shared API session helpers instead of route-local session checks
- add E2E coverage proving stale sessions lose dashboard and API access after deactivation/removal

## Testing
- `pnpm --filter web type-check`
- `pnpm --filter web test:unit`
- `E2E_PORT=3201 pnpm --filter web test:e2e -- tests/e2e/auth/stale-sessions.spec.ts`

Closes #742.
