### PR TITLE
fix(ingest): enforce inventory JWT expiry

### DIFF
--- a/apps/ingest/internal/handlers/inventory.go
+++ b/apps/ingest/internal/handlers/inventory.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/carrtech-dev/ct-ops/ingest/internal/auth"
 	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
+	"github.com/carrtech-dev/ct-ops/ingest/internal/pki"
 	"github.com/carrtech-dev/ct-ops/ingest/internal/vuln"
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
 )
@@ -285,12 +286,16 @@ func (h *InventoryHandler) authenticateStream(stream agentv1.IngestService_Submi
 	if len(token) > 7 && strings.EqualFold(token[:7], "bearer ") {
 		token = token[7:]
 	}
-	// Accept expired tokens (same as terminal/heartbeat handlers) — the agent
-	// may have a token that hasn't been refreshed yet but is otherwise valid.
-	// The RSA signature is still verified; only the expiry check is relaxed.
-	agentID, _, err := h.issuer.ValidateAgentTokenAllowExpired(token)
+	agentID, orgID, err := h.issuer.ValidateAgentToken(token)
 	if err != nil {
 		return "", status.Error(codes.Unauthenticated, "invalid token")
+	}
+	id, ok := pki.IdentityFromContext(ctx)
+	if !ok || id == nil {
+		return "", status.Error(codes.Unauthenticated, "missing client identity")
+	}
+	if id.AgentID != agentID || id.OrgID != orgID {
+		return "", status.Error(codes.Unauthenticated, "client identity mismatch")
 	}
 	return agentID, nil
 }

--- a/apps/ingest/internal/handlers/inventory_test.go
+++ b/apps/ingest/internal/handlers/inventory_test.go
@@ -1,14 +1,54 @@
 package handlers
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/carrtech-dev/ct-ops/ingest/internal/auth"
+	"github.com/carrtech-dev/ct-ops/ingest/internal/pki"
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
 )
+
+type inventoryAuthTestStream struct {
+	ctx context.Context
+}
+
+func (s *inventoryAuthTestStream) SetHeader(metadata.MD) error {
+	return nil
+}
+
+func (s *inventoryAuthTestStream) SendHeader(metadata.MD) error {
+	return nil
+}
+
+func (s *inventoryAuthTestStream) SetTrailer(metadata.MD) {}
+
+func (s *inventoryAuthTestStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *inventoryAuthTestStream) SendAndClose(*agentv1.SoftwareInventoryAck) error {
+	return nil
+}
+
+func (s *inventoryAuthTestStream) SendMsg(any) error {
+	return nil
+}
+
+func (s *inventoryAuthTestStream) RecvMsg(any) error {
+	return nil
+}
+
+func (s *inventoryAuthTestStream) Recv() (*agentv1.SoftwareInventoryChunk, error) {
+	return nil, context.Canceled
+}
 
 func TestValidateInventoryChunkAllowsConfiguredLimit(t *testing.T) {
 	chunk := &agentv1.SoftwareInventoryChunk{
@@ -33,5 +73,86 @@ func TestValidateInventoryChunkRejectsOversizedChunk(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds maximum") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestInventoryAuthenticateStreamRejectsExpiredJWT(t *testing.T) {
+	t.Parallel()
+
+	issuer, err := auth.NewJWTIssuer(nil, filepath.Join(t.TempDir(), "jwt.pem"), "test-issuer", -time.Minute)
+	if err != nil {
+		t.Fatalf("NewJWTIssuer: %v", err)
+	}
+
+	token, err := issuer.IssueAgentToken("agent-123", "org-123")
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+
+	stream := &inventoryAuthTestStream{
+		ctx: pki.WithIdentity(metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+token)), &pki.Identity{
+			OrgID:   "org-123",
+			AgentID: "agent-123",
+		}),
+	}
+
+	_, err = NewInventoryHandler(nil, issuer).authenticateStream(stream)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("authenticateStream() code = %v, want %v (err=%v)", status.Code(err), codes.Unauthenticated, err)
+	}
+}
+
+func TestInventoryAuthenticateStreamRejectsMTLSJWTMismatch(t *testing.T) {
+	t.Parallel()
+
+	issuer, err := auth.NewJWTIssuer(nil, filepath.Join(t.TempDir(), "jwt.pem"), "test-issuer", time.Hour)
+	if err != nil {
+		t.Fatalf("NewJWTIssuer: %v", err)
+	}
+
+	token, err := issuer.IssueAgentToken("agent-123", "org-123")
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+
+	stream := &inventoryAuthTestStream{
+		ctx: pki.WithIdentity(metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+token)), &pki.Identity{
+			OrgID:   "org-123",
+			AgentID: "agent-999",
+		}),
+	}
+
+	_, err = NewInventoryHandler(nil, issuer).authenticateStream(stream)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("authenticateStream() code = %v, want %v (err=%v)", status.Code(err), codes.Unauthenticated, err)
+	}
+}
+
+func TestInventoryAuthenticateStreamAcceptsMatchingMTLSIdentity(t *testing.T) {
+	t.Parallel()
+
+	issuer, err := auth.NewJWTIssuer(nil, filepath.Join(t.TempDir(), "jwt.pem"), "test-issuer", time.Hour)
+	if err != nil {
+		t.Fatalf("NewJWTIssuer: %v", err)
+	}
+
+	token, err := issuer.IssueAgentToken("agent-123", "org-123")
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+
+	stream := &inventoryAuthTestStream{
+		ctx: pki.WithIdentity(metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+token)), &pki.Identity{
+			OrgID:   "org-123",
+			AgentID: "agent-123",
+		}),
+	}
+
+	agentID, err := NewInventoryHandler(nil, issuer).authenticateStream(stream)
+	if err != nil {
+		t.Fatalf("authenticateStream() unexpected error: %v", err)
+	}
+	if agentID != "agent-123" {
+		t.Fatalf("authenticateStream() agentID = %q, want %q", agentID, "agent-123")
 	}
 }


### PR DESCRIPTION
## Summary
- enforce normal JWT expiry checks for software inventory streams
- require the JWT org/agent identity to match the mTLS SPIFFE identity on the stream context
- add regression tests for expired tokens, mismatched identities, and the matching happy path

## Testing
- go test ./internal/handlers -run 'TestInventoryAuthenticateStream|TestValidateInventoryChunk'
- go test ./...

Closes #745