### PR TITLE
test(web): expand team e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/team/team-client.tsx
@@ -192,14 +192,21 @@ export function TeamClient({
             </thead>
             <tbody className="divide-y divide-border">
               {members.map((member) => (
-                <tr key={member.id} className={cn(!member.isActive && 'opacity-60')}>
+                <tr
+                  key={member.id}
+                  className={cn(!member.isActive && 'opacity-60')}
+                  data-testid={`team-member-row-${member.id}`}
+                >
                   <td className="px-4 py-3 font-medium text-foreground">{member.name}</td>
                   <td className="px-4 py-3 text-muted-foreground">{member.email}</td>
                   <td className="px-4 py-3">
                     {canManage(currentUserRole) && member.id !== currentUserId ? (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <button className="flex items-center gap-1 focus:outline-none">
+                          <button
+                            className="flex items-center gap-1 focus:outline-none"
+                            data-testid={`team-member-role-trigger-${member.id}`}
+                          >
                             <Badge variant={roleBadgeVariant(member.role)} className={roleBadgeClassName(member.role)}>
                               {member.role === 'pending' ? 'Pending Approval' : formatRole(member.role)}
                             </Badge>
@@ -214,6 +221,7 @@ export function TeamClient({
                                 updateRoleMutation.mutate({ userId: member.id, role: r })
                               }
                               className={cn(member.role === r && 'font-medium')}
+                              data-testid={`team-member-role-option-${member.id}-${r}`}
                             >
                               {formatRole(r)}
                             </DropdownMenuItem>
@@ -234,6 +242,7 @@ export function TeamClient({
                           ? 'border-green-600 text-green-700'
                           : 'border-border text-muted-foreground'
                       }
+                      data-testid={`team-member-status-${member.id}`}
                     >
                       {member.isActive ? 'Active' : 'Inactive'}
                     </Badge>
@@ -249,6 +258,7 @@ export function TeamClient({
                               className="text-destructive hover:text-destructive hover:bg-destructive/10"
                               onClick={() => deactivateMutation.mutate(member.id)}
                               disabled={deactivateMutation.isPending}
+                              data-testid={`team-member-deactivate-${member.id}`}
                             >
                               <UserX className="size-4 mr-1" />
                               Deactivate
@@ -261,6 +271,7 @@ export function TeamClient({
                                 className="text-green-700 hover:text-green-700 hover:bg-green-50 dark:hover:bg-green-950"
                                 onClick={() => reactivateMutation.mutate(member.id)}
                                 disabled={reactivateMutation.isPending}
+                                data-testid={`team-member-reactivate-${member.id}`}
                               >
                                 <UserCheck className="size-4 mr-1" />
                                 Reactivate
@@ -271,6 +282,7 @@ export function TeamClient({
                                 className="text-destructive hover:text-destructive hover:bg-destructive/10"
                                 onClick={() => removeMutation.mutate(member.id)}
                                 disabled={removeMutation.isPending}
+                                data-testid={`team-member-remove-${member.id}`}
                               >
                                 <Trash2 className="size-4 mr-1" />
                                 Remove

--- a/apps/web/tests/e2e/team/invitations.spec.ts
+++ b/apps/web/tests/e2e/team/invitations.spec.ts
@@ -97,3 +97,69 @@ test('admin cannot create a duplicate pending invitation for the same email addr
   expect(inviteRows[0]?.role).toBe('engineer')
   expect(inviteRows[0]?.deleted_at).toBeNull()
 })
+
+test('admin re-inviting a removed user restores their membership instead of creating a pending invite', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const removedEmail = 'restored-member@example.com'
+
+  await sql`
+    INSERT INTO "user" (
+      id,
+      name,
+      email,
+      email_verified,
+      organisation_id,
+      role,
+      is_active,
+      deleted_at
+    )
+    VALUES (
+      'removed-team-member',
+      'Restored Member',
+      ${removedEmail},
+      true,
+      ${orgId},
+      'read_only',
+      false,
+      NOW()
+    )
+  `
+
+  await page.goto('/team')
+  await expect(page.getByTestId('team-heading')).toBeVisible()
+
+  await page.getByTestId('team-invite-open').click()
+  await page.getByTestId('team-invite-email').fill(removedEmail)
+  await page.getByTestId('team-invite-role').selectOption('engineer')
+  await page.getByTestId('team-invite-submit').click()
+
+  await expect(page.getByTestId('team-invite-link')).toHaveCount(0)
+  await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Restored Member')
+  await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Engineer')
+  await expect(page.getByTestId('team-member-status-removed-team-member')).toContainText('Active')
+
+  const restoredUserRows = await sql<Array<{ role: string; is_active: boolean; deleted_at: Date | null }>>`
+    SELECT role, is_active, deleted_at
+    FROM "user"
+    WHERE email = ${removedEmail}
+    LIMIT 1
+  `
+
+  expect(restoredUserRows).toEqual([
+    {
+      role: 'engineer',
+      is_active: true,
+      deleted_at: null,
+    },
+  ])
+
+  const inviteRows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM invitations
+    WHERE organisation_id = ${orgId}
+      AND email = ${removedEmail}
+  `
+
+  expect(inviteRows).toHaveLength(0)
+})

--- a/apps/web/tests/e2e/team/members.spec.ts
+++ b/apps/web/tests/e2e/team/members.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can change a team member role and manage their lifecycle', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const memberId = 'team-member-managed'
+
+  await sql`
+    INSERT INTO "user" (
+      id,
+      name,
+      email,
+      email_verified,
+      organisation_id,
+      role,
+      is_active
+    )
+    VALUES (
+      ${memberId},
+      'Managed Team Member',
+      'managed-member@example.com',
+      true,
+      ${orgId},
+      'engineer',
+      true
+    )
+  `
+
+  await page.goto('/team')
+
+  const memberRow = page.getByTestId(`team-member-row-${memberId}`)
+  await expect(page.getByTestId('team-heading')).toBeVisible()
+  await expect(memberRow).toContainText('Managed Team Member')
+  await expect(memberRow).toContainText('Engineer')
+  await expect(page.getByTestId(`team-member-status-${memberId}`)).toContainText('Active')
+
+  await page.getByTestId(`team-member-role-trigger-${memberId}`).click()
+  await page.getByTestId(`team-member-role-option-${memberId}-read_only`).click()
+  await expect(memberRow).toContainText('Read Only')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ role: string }>>`
+        SELECT role
+        FROM "user"
+        WHERE id = ${memberId}
+        LIMIT 1
+      `
+      return rows[0]?.role ?? null
+    })
+    .toBe('read_only')
+
+  await page.getByTestId(`team-member-deactivate-${memberId}`).click()
+  await expect(page.getByTestId(`team-member-status-${memberId}`)).toContainText('Inactive')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ is_active: boolean }>>`
+        SELECT is_active
+        FROM "user"
+        WHERE id = ${memberId}
+        LIMIT 1
+      `
+      return rows[0]?.is_active ?? null
+    })
+    .toBe(false)
+
+  await page.getByTestId(`team-member-reactivate-${memberId}`).click()
+  await expect(page.getByTestId(`team-member-status-${memberId}`)).toContainText('Active')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ is_active: boolean }>>`
+        SELECT is_active
+        FROM "user"
+        WHERE id = ${memberId}
+        LIMIT 1
+      `
+      return rows[0]?.is_active ?? null
+    })
+    .toBe(true)
+
+  await page.getByTestId(`team-member-deactivate-${memberId}`).click()
+  await expect(page.getByTestId(`team-member-status-${memberId}`)).toContainText('Inactive')
+  await page.getByTestId(`team-member-remove-${memberId}`).click()
+  await expect(page.getByTestId(`team-member-row-${memberId}`)).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null; is_active: boolean }>>`
+        SELECT deleted_at, is_active
+        FROM "user"
+        WHERE id = ${memberId}
+        LIMIT 1
+      `
+      return rows[0]
+        ? {
+            deletedAt: Boolean(rows[0].deleted_at),
+            isActive: rows[0].is_active,
+          }
+        : null
+    })
+    .toEqual({
+      deletedAt: true,
+      isActive: false,
+    })
+})


### PR DESCRIPTION
## Summary
- add People page E2E coverage for member role changes, deactivate/reactivate, and removal
- expand invitation coverage to assert re-inviting a removed user restores membership instead of creating a pending invite
- add stable `data-testid` hooks for the People member actions used by the new tests

## Why
The People page had invitation coverage, but member lifecycle actions were untested and the removed-user restore path in the invite flow was not exercised.

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/team/members.spec.ts tests/e2e/team/invitations.spec.ts`
