### PR TITLE
feat(vuln): harden confirmed Linux CVE matching

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,23 @@
 
 ## What Has Been Built
 
+### Session 78 — Confirmed Linux CVE matching hardening
+
+**Confirmed finding model and reports** (`apps/web/lib/db/schema/vulnerabilities.ts`, `apps/web/lib/actions/vulnerabilities.ts`, `apps/web/app/(dashboard)/reports/vulnerabilities/`)
+- Added explicit vulnerability finding confidence and match-reason persistence so confirmed Linux package matches are distinguishable from probable/future best-effort matches.
+- Defaulted host and global vulnerability reports to confirmed findings while adding a report confidence filter for operators who want to inspect probable matches.
+- Added a migration for `host_vulnerability_findings.confidence`, `match_reason`, and supporting org/status/confidence lookup.
+
+**Red Hat and matcher accuracy** (`apps/ingest/internal/vuln/`)
+- Hardened Red Hat parsing to prefer structured `affected_release` package data, extracting full RPM EVR from package NEVRA and preserving advisory/product metadata.
+- Marked free-text Red Hat `affected_packages` fallback rows as probable rather than confirmed.
+- Updated RPM matching to report vendor EVR-specific reasons and handle RHEL major-version advisory rules matching minor-version hosts such as `8.9`.
+- Replaced direct unbounded post-scan matching goroutines with a bounded ingest-side vulnerability match scheduler used by inventory completion and feed sync.
+
+**Validation**
+- Added unit coverage for RPM backport release matching, fixed RPM packages resolving, Red Hat structured affected-release parsing, confirmed finding persistence, and unsupported package sources.
+- Validation run: `go test ./internal/vuln`, `go test ./...` from `apps/ingest`, `pnpm --dir apps/web run db:validate`, `pnpm --dir apps/web run type-check`, and `pnpm --dir apps/web run lint` (existing warnings only).
+
 ### Session 77 — Build Docs rich Markdown editor
 
 **Build Docs editing and exports** (`apps/web/app/(dashboard)/build-docs/[id]/`, `apps/web/components/build-docs/`, `apps/web/lib/build-docs/`)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -21,6 +21,7 @@
 - Added explicit vulnerability finding confidence and match-reason persistence so confirmed Linux package matches are distinguishable from probable/future best-effort matches.
 - Defaulted host and global vulnerability reports to confirmed findings while adding a report confidence filter for operators who want to inspect probable matches.
 - Added a migration for `host_vulnerability_findings.confidence`, `match_reason`, and supporting org/status/confidence lookup.
+- Added a host Overview vulnerability assessment card showing affected/clear/stale/not-assessed status, confirmed finding counts, critical/high split, last inventory scan time, last vulnerability feed sync time, and a direct link to host findings.
 
 **Red Hat and matcher accuracy** (`apps/ingest/internal/vuln/`)
 - Hardened Red Hat parsing to prefer structured `affected_release` package data, extracting full RPM EVR from package NEVRA and preserving advisory/product metadata.
@@ -29,8 +30,8 @@
 - Replaced direct unbounded post-scan matching goroutines with a bounded ingest-side vulnerability match scheduler used by inventory completion and feed sync.
 
 **Validation**
-- Added unit coverage for RPM backport release matching, fixed RPM packages resolving, Red Hat structured affected-release parsing, confirmed finding persistence, and unsupported package sources.
-- Validation run: `go test ./internal/vuln`, `go test ./...` from `apps/ingest`, `pnpm --dir apps/web run db:validate`, `pnpm --dir apps/web run type-check`, and `pnpm --dir apps/web run lint` (existing warnings only).
+- Added unit coverage for RPM backport release matching, fixed RPM packages resolving, Red Hat structured affected-release parsing, confirmed finding persistence, unsupported package sources, and host assessment status derivation.
+- Validation run: `go test ./internal/vuln`, `go test ./...` from `apps/ingest`, `node --experimental-strip-types --test lib/vulnerabilities/assessment.test.mjs`, `pnpm --dir apps/web run db:validate`, `pnpm --dir apps/web run type-check`, and `pnpm --dir apps/web run lint` (existing warnings only).
 
 ### Session 77 — Build Docs rich Markdown editor
 

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -115,12 +115,13 @@ func main() {
 	versionPoller := config.NewVersionPoller(cfg.Agent.LatestVersion, 5*time.Minute)
 	versionPoller.Start(ctx)
 	hbHandler := handlers.NewHeartbeatHandler(pool, issuer, q, versionPoller, cfg.Agent.DownloadBaseURL, agentCA, webServerCert)
+	vulnerabilityMatcher := vuln.StartMatchScheduler(ctx, pool, 2, 1000)
 	terminalWSHandler, err := handlers.NewTerminalWSHandler(pool, cfg.Terminal.TrustedOrigins)
 	if err != nil {
 		slog.Error("initialising terminal websocket handler", "err", err)
 		os.Exit(1)
 	}
-	inventoryHandler := handlers.NewInventoryHandler(pool, issuer)
+	inventoryHandler := handlers.NewInventoryHandler(pool, issuer, vulnerabilityMatcher)
 	renewHandler := handlers.NewRenewCertHandler(pool, agentCA)
 
 	// Start the CSR sweeper so admin-approved agents get their certs signed.
@@ -182,7 +183,7 @@ func main() {
 		AlpineBaseURL:  cfg.Vulnerability.AlpineBaseURL,
 		AlpineReleases: cfg.Vulnerability.AlpineReleases,
 		RedHatURL:      cfg.Vulnerability.RedHatURL,
-	})
+	}, vulnerabilityMatcher)
 
 	// Start cert URL refresh sweeper goroutine
 	go handlers.RunCertRefreshSweeper(ctx, pool, 60*time.Second)

--- a/apps/ingest/internal/handlers/inventory.go
+++ b/apps/ingest/internal/handlers/inventory.go
@@ -22,15 +22,20 @@ import (
 
 // InventoryHandler implements the SubmitSoftwareInventory client-streaming RPC.
 type InventoryHandler struct {
-	pool   *pgxpool.Pool
-	issuer *auth.JWTIssuer
+	pool    *pgxpool.Pool
+	issuer  *auth.JWTIssuer
+	matcher *vuln.MatchScheduler
 }
 
 const maxInventoryPackagesPerChunk = 1000
 
 // NewInventoryHandler creates an InventoryHandler.
-func NewInventoryHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer) *InventoryHandler {
-	return &InventoryHandler{pool: pool, issuer: issuer}
+func NewInventoryHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, matcher ...*vuln.MatchScheduler) *InventoryHandler {
+	var scheduler *vuln.MatchScheduler
+	if len(matcher) > 0 {
+		scheduler = matcher[0]
+	}
+	return &InventoryHandler{pool: pool, issuer: issuer, matcher: scheduler}
 }
 
 // SubmitSoftwareInventory receives package chunks from the agent, upserts them
@@ -230,13 +235,19 @@ func (h *InventoryHandler) finalise(
 	if err := queries.UpdateHostLastSoftwareScanAt(streamCtx, h.pool, hostID, completedAt); err != nil {
 		slog.Warn("inventory: updating host lastSoftwareScanAt", "host_id", hostID, "err", err)
 	}
-	go func() {
-		matchCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		if err := vuln.MatchHost(matchCtx, h.pool, hostID); err != nil {
-			slog.Warn("inventory: vulnerability match failed", "host_id", hostID, "err", err)
+	if h.matcher != nil {
+		if !h.matcher.EnqueueHost(hostID) {
+			slog.Warn("inventory: vulnerability match skipped because matcher queue is full", "host_id", hostID)
 		}
-	}()
+	} else {
+		go func() {
+			matchCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			if err := vuln.MatchHost(matchCtx, h.pool, hostID); err != nil {
+				slog.Warn("inventory: vulnerability match failed", "host_id", hostID, "err", err)
+			}
+		}()
+	}
 
 	// Complete the task_run_hosts row.
 	if err := queries.CompleteTaskRunHost(streamCtx, h.pool, taskRunHostID, "success", 0, "", ""); err != nil {

--- a/apps/ingest/internal/vuln/db.go
+++ b/apps/ingest/internal/vuln/db.go
@@ -379,7 +379,8 @@ func upsertFinding(ctx context.Context, tx findingTx, pkg InventoryPackage, affe
 		INSERT INTO host_vulnerability_findings (
 			id, organisation_id, host_id, software_package_id, cve_id, affected_package_id,
 			status, package_name, installed_version, fixed_version, source, severity,
-			cvss_score, known_exploited, first_seen_at, last_seen_at, resolved_at,
+			cvss_score, known_exploited, confidence, match_reason,
+			first_seen_at, last_seen_at, resolved_at,
 			metadata, created_at, updated_at
 		)
 		SELECT
@@ -388,8 +389,9 @@ func upsertFinding(ctx context.Context, tx findingTx, pkg InventoryPackage, affe
 			COALESCE(NULLIF((SELECT severity FROM cve), 'unknown'), $11),
 			(SELECT cvss_score FROM cve),
 			COALESCE((SELECT known_exploited FROM cve), false),
+			$12, $13,
 			NOW(), NOW(), NULL,
-			$12::jsonb, NOW(), NOW()
+			$14::jsonb, NOW(), NOW()
 		ON CONFLICT (organisation_id, host_id, software_package_id, cve_id)
 		DO UPDATE SET
 			affected_package_id = EXCLUDED.affected_package_id,
@@ -401,6 +403,8 @@ func upsertFinding(ctx context.Context, tx findingTx, pkg InventoryPackage, affe
 			severity = EXCLUDED.severity,
 			cvss_score = EXCLUDED.cvss_score,
 			known_exploited = EXCLUDED.known_exploited,
+			confidence = EXCLUDED.confidence,
+			match_reason = EXCLUDED.match_reason,
 			last_seen_at = NOW(),
 			resolved_at = NULL,
 			metadata = EXCLUDED.metadata,
@@ -418,9 +422,21 @@ func upsertFinding(ctx context.Context, tx findingTx, pkg InventoryPackage, affe
 		nullable(affected.FixedVersion),
 		pkg.Source,
 		string(affected.Severity),
-		jsonOrNil(encodeMetadata(map[string]string{"reason": reason})),
+		string(findingConfidenceForAffected(affected)),
+		reason,
+		jsonOrNil(encodeMetadata(map[string]string{
+			"confidence": string(findingConfidenceForAffected(affected)),
+			"reason":     reason,
+		})),
 	)
 	return err
+}
+
+func findingConfidenceForAffected(affected AffectedPackage) FindingConfidence {
+	if affected.PackageState == "probable" {
+		return FindingConfidenceProbable
+	}
+	return FindingConfidenceConfirmed
 }
 
 func nullable(value string) any {

--- a/apps/ingest/internal/vuln/matcher.go
+++ b/apps/ingest/internal/vuln/matcher.go
@@ -9,7 +9,7 @@ func MatchPackage(pkg InventoryPackage, affected AffectedPackage) (bool, string)
 	if affected.DistroID != "" && !strings.EqualFold(pkg.DistroID, affected.DistroID) {
 		return false, "distro mismatch"
 	}
-	if affected.DistroVersionID != "" && pkg.DistroVersionID != "" && affected.DistroVersionID != pkg.DistroVersionID {
+	if affected.DistroVersionID != "" && pkg.DistroVersionID != "" && !distroVersionMatches(pkg, affected) {
 		return false, "distro version mismatch"
 	}
 	if affected.DistroCodename != "" && pkg.DistroCodename != "" && affected.DistroCodename != pkg.DistroCodename {
@@ -33,9 +33,22 @@ func MatchPackage(pkg InventoryPackage, affected AffectedPackage) (bool, string)
 		return false, "no fixed version"
 	}
 	if CompareDistroVersion(pkg.Source, installed, affected.FixedVersion) < 0 {
+		if pkg.Source == "rpm" {
+			return true, "installed rpm evr is below vendor fixed evr"
+		}
 		return true, "installed version is below fixed version"
 	}
 	return false, "installed version is fixed"
+}
+
+func distroVersionMatches(pkg InventoryPackage, affected AffectedPackage) bool {
+	if affected.DistroVersionID == pkg.DistroVersionID {
+		return true
+	}
+	if pkg.Source == "rpm" && strings.EqualFold(affected.DistroID, "rhel") {
+		return !strings.Contains(affected.DistroVersionID, ".") && strings.HasPrefix(pkg.DistroVersionID, affected.DistroVersionID+".")
+	}
+	return false
 }
 
 func supportedInventorySource(source string) bool {

--- a/apps/ingest/internal/vuln/matcher_test.go
+++ b/apps/ingest/internal/vuln/matcher_test.go
@@ -1,6 +1,12 @@
 package vuln
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
 
 func TestPackageMatchesAffectedRange(t *testing.T) {
 	t.Parallel()
@@ -55,4 +61,122 @@ func TestPackageWithUnsupportedSourceIsUnassessed(t *testing.T) {
 	if match || reason != "unsupported inventory source" {
 		t.Fatalf("MatchPackage = %v, %q; want false unsupported inventory source", match, reason)
 	}
+}
+
+func TestRPMBackportReleaseMatch(t *testing.T) {
+	t.Parallel()
+
+	pkg := InventoryPackage{
+		ID:              "pkg1",
+		OrganisationID:  "org1",
+		HostID:          "host1",
+		Name:            "openssl-libs",
+		Version:         "1:1.1.1k-12.el8_9.4",
+		Source:          "rpm",
+		DistroID:        "rhel",
+		DistroVersionID: "8.9",
+		SourceName:      "openssl",
+		SourceVersion:   "1:1.1.1k-12.el8_9.4",
+	}
+	affected := AffectedPackage{
+		CVEID:           "CVE-2025-0001",
+		Source:          "redhat-security-data",
+		DistroID:        "rhel",
+		DistroVersionID: "8",
+		PackageName:     "openssl",
+		FixedVersion:    "1:1.1.1k-12.el8_9.6",
+	}
+
+	match, reason := MatchPackage(pkg, affected)
+	if !match {
+		t.Fatalf("MatchPackage returned false: %s", reason)
+	}
+	if reason != "installed rpm evr is below vendor fixed evr" {
+		t.Fatalf("reason = %q, want RPM EVR-specific reason", reason)
+	}
+}
+
+func TestRPMBackportReleaseDoesNotMatchFixedPackage(t *testing.T) {
+	t.Parallel()
+
+	pkg := InventoryPackage{
+		Name:            "openssl-libs",
+		Version:         "1:1.1.1k-12.el8_9.6",
+		Source:          "rpm",
+		DistroID:        "rhel",
+		DistroVersionID: "8",
+		SourceName:      "openssl",
+		SourceVersion:   "1:1.1.1k-12.el8_9.6",
+	}
+	affected := AffectedPackage{
+		Source:          "redhat-security-data",
+		DistroID:        "rhel",
+		DistroVersionID: "8",
+		PackageName:     "openssl",
+		FixedVersion:    "1:1.1.1k-12.el8_9.6",
+	}
+
+	match, reason := MatchPackage(pkg, affected)
+	if match {
+		t.Fatalf("expected fixed RPM package not to match, reason=%q", reason)
+	}
+	if reason != "installed version is fixed" {
+		t.Fatalf("reason = %q, want fixed package reason", reason)
+	}
+}
+
+func TestUpsertFindingStoresConfirmedConfidenceAndReason(t *testing.T) {
+	t.Parallel()
+
+	tx := &recordingFindingTx{}
+	pkg := InventoryPackage{
+		ID:             "pkg1",
+		OrganisationID: "org1",
+		HostID:         "host1",
+		Name:           "openssl-libs",
+		Version:        "1:1.1.1k-12.el8_9.4",
+		Source:         "rpm",
+	}
+	affected := AffectedPackage{
+		ID:           "affected1",
+		CVEID:        "CVE-2025-0001",
+		FixedVersion: "1:1.1.1k-12.el8_9.6",
+		Severity:     SeverityHigh,
+	}
+
+	if err := upsertFinding(context.Background(), tx, pkg, affected, "installed rpm evr is below vendor fixed evr"); err != nil {
+		t.Fatalf("upsertFinding: %v", err)
+	}
+	if !strings.Contains(tx.query, "confidence") {
+		t.Fatalf("upsert query did not write confidence column:\n%s", tx.query)
+	}
+	if !strings.Contains(tx.query, "match_reason") {
+		t.Fatalf("upsert query did not write match_reason column:\n%s", tx.query)
+	}
+	if !containsArg(tx.args, string(FindingConfidenceConfirmed)) {
+		t.Fatalf("upsert args did not include confirmed confidence: %#v", tx.args)
+	}
+	if !containsArg(tx.args, "installed rpm evr is below vendor fixed evr") {
+		t.Fatalf("upsert args did not include match reason: %#v", tx.args)
+	}
+}
+
+type recordingFindingTx struct {
+	query string
+	args  []any
+}
+
+func (tx *recordingFindingTx) Exec(_ context.Context, query string, args ...any) (pgconn.CommandTag, error) {
+	tx.query = query
+	tx.args = append([]any(nil), args...)
+	return pgconn.CommandTag{}, nil
+}
+
+func containsArg(args []any, want string) bool {
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && s == want {
+			return true
+		}
+	}
+	return false
 }

--- a/apps/ingest/internal/vuln/parsers.go
+++ b/apps/ingest/internal/vuln/parsers.go
@@ -401,6 +401,11 @@ func parseRedHatCVEList(r io.Reader) ([]CVERecord, []AffectedPackage, error) {
 		PublicDate          string   `json:"public_date"`
 		CVSS3Score          string   `json:"cvss3_score"`
 		AffectedPackages    []string `json:"affected_packages"`
+		AffectedRelease     []struct {
+			ProductName string `json:"product_name"`
+			Package     string `json:"package"`
+			Advisory    string `json:"advisory"`
+		} `json:"affected_release"`
 	}
 	if err := json.NewDecoder(r).Decode(&rows); err != nil {
 		return nil, nil, err
@@ -424,6 +429,27 @@ func parseRedHatCVEList(r io.Reader) ([]CVERecord, []AffectedPackage, error) {
 			record.PublishedAt = t
 		}
 		cves = append(cves, record)
+		for _, rel := range row.AffectedRelease {
+			name, fixed := splitRedHatFixedPackage(rel.Package)
+			if name == "" || fixed == "" {
+				continue
+			}
+			affected = append(affected, AffectedPackage{
+				CVEID:           row.CVE,
+				Source:          "redhat-security-data",
+				DistroID:        "rhel",
+				DistroVersionID: redHatProductVersion(rel.ProductName),
+				PackageName:     name,
+				FixedVersion:    fixed,
+				Severity:        record.Severity,
+				PackageState:    "fixed",
+				MetadataJSON: encodeMetadata(map[string]string{
+					"advisory":     rel.Advisory,
+					"product_name": rel.ProductName,
+					"package":      rel.Package,
+				}),
+			})
+		}
 		for _, pkg := range row.AffectedPackages {
 			name, fixed := splitRedHatAffectedPackage(pkg)
 			if name == "" || fixed == "" {
@@ -436,6 +462,11 @@ func parseRedHatCVEList(r io.Reader) ([]CVERecord, []AffectedPackage, error) {
 				PackageName:  name,
 				FixedVersion: fixed,
 				Severity:     record.Severity,
+				PackageState: "probable",
+				MetadataJSON: encodeMetadata(map[string]string{
+					"source": "affected_packages",
+					"raw":    pkg,
+				}),
 			})
 		}
 	}
@@ -460,6 +491,77 @@ func splitRedHatAffectedPackage(value string) (name, fixed string) {
 	name = fields[0]
 	if idx := strings.LastIndex(value, "fixed in "); idx >= 0 {
 		fixed = strings.TrimSpace(value[idx+len("fixed in "):])
+		if parsedName, parsedFixed := splitRedHatFixedPackage(fixed); parsedName != "" && parsedFixed != "" {
+			name = parsedName
+			fixed = parsedFixed
+		}
 	}
 	return name, fixed
+}
+
+func splitRedHatFixedPackage(value string) (name, fixed string) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSuffix(value, ".src.rpm")
+	value = strings.TrimSuffix(value, ".rpm")
+	value = stripRPMArchitecture(value)
+	if value == "" {
+		return "", ""
+	}
+
+	releaseDash := strings.LastIndex(value, "-")
+	if releaseDash <= 0 || releaseDash == len(value)-1 {
+		return "", ""
+	}
+	release := value[releaseDash+1:]
+	beforeRelease := value[:releaseDash]
+
+	versionDash := strings.LastIndex(beforeRelease, "-")
+	if versionDash <= 0 || versionDash == len(beforeRelease)-1 {
+		return "", ""
+	}
+	name = strings.TrimSpace(beforeRelease[:versionDash])
+	version := strings.TrimSpace(beforeRelease[versionDash+1:])
+	if name == "" || version == "" || release == "" {
+		return "", ""
+	}
+	return name, version + "-" + release
+}
+
+func stripRPMArchitecture(value string) string {
+	idx := strings.LastIndex(value, ".")
+	if idx <= 0 || idx == len(value)-1 {
+		return value
+	}
+	switch value[idx+1:] {
+	case "aarch64", "i386", "i486", "i586", "i686", "noarch", "ppc64le", "s390x", "src", "x86_64":
+		return value[:idx]
+	default:
+		return value
+	}
+}
+
+func redHatProductVersion(productName string) string {
+	fields := strings.Fields(productName)
+	for i := len(fields) - 1; i >= 0; i-- {
+		field := strings.Trim(fields[i], "(),")
+		if field == "" {
+			continue
+		}
+		if isVersionLike(field) {
+			return field
+		}
+	}
+	return ""
+}
+
+func isVersionLike(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && r != '.' {
+			return false
+		}
+	}
+	return true
 }

--- a/apps/ingest/internal/vuln/parsers_test.go
+++ b/apps/ingest/internal/vuln/parsers_test.go
@@ -62,3 +62,67 @@ func TestParseAlpineSecDB(t *testing.T) {
 		t.Fatalf("unexpected affected row: %#v", affected[0])
 	}
 }
+
+func TestParseRedHatStructuredAffectedRelease(t *testing.T) {
+	t.Parallel()
+
+	doc := `[{
+	  "CVE": "CVE-2025-0001",
+	  "bugzilla_description": "openssl backport fix",
+	  "severity": "important",
+	  "affected_release": [{
+	    "product_name": "Red Hat Enterprise Linux 8",
+	    "package": "openssl-1:1.1.1k-12.el8_9.6.x86_64",
+	    "advisory": "RHSA-2025:0001"
+	  }]
+	}]`
+	records, affected, err := parseRedHatCVEList(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("parseRedHatCVEList: %v", err)
+	}
+	if len(records) != 1 || records[0].CVEID != "CVE-2025-0001" || records[0].Severity != SeverityHigh {
+		t.Fatalf("unexpected CVE records: %#v", records)
+	}
+	if len(affected) != 1 {
+		t.Fatalf("len(affected) = %d, want 1: %#v", len(affected), affected)
+	}
+	row := affected[0]
+	if row.PackageName != "openssl" {
+		t.Fatalf("PackageName = %q, want openssl", row.PackageName)
+	}
+	if row.FixedVersion != "1:1.1.1k-12.el8_9.6" {
+		t.Fatalf("FixedVersion = %q, want full RPM EVR", row.FixedVersion)
+	}
+	if row.DistroID != "rhel" || row.DistroVersionID != "8" {
+		t.Fatalf("distro = %q %q, want rhel 8", row.DistroID, row.DistroVersionID)
+	}
+	if row.PackageState != "fixed" {
+		t.Fatalf("PackageState = %q, want fixed", row.PackageState)
+	}
+	if !strings.Contains(string(row.MetadataJSON), "RHSA-2025:0001") {
+		t.Fatalf("metadata did not include advisory: %s", string(row.MetadataJSON))
+	}
+}
+
+func TestParseRedHatFreeTextAffectedPackageIsProbable(t *testing.T) {
+	t.Parallel()
+
+	doc := `[{
+	  "CVE": "CVE-2025-0002",
+	  "severity": "moderate",
+	  "affected_packages": ["openssl fixed in openssl-1:1.1.1k-12.el8_9.6.x86_64"]
+	}]`
+	_, affected, err := parseRedHatCVEList(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("parseRedHatCVEList: %v", err)
+	}
+	if len(affected) != 1 {
+		t.Fatalf("len(affected) = %d, want 1: %#v", len(affected), affected)
+	}
+	if affected[0].PackageState != "probable" {
+		t.Fatalf("PackageState = %q, want probable", affected[0].PackageState)
+	}
+	if affected[0].PackageName != "openssl" || affected[0].FixedVersion != "1:1.1.1k-12.el8_9.6" {
+		t.Fatalf("unexpected affected row: %#v", affected[0])
+	}
+}

--- a/apps/ingest/internal/vuln/scheduler.go
+++ b/apps/ingest/internal/vuln/scheduler.go
@@ -1,0 +1,79 @@
+package vuln
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type matchRequest struct {
+	hostID string
+	all    bool
+}
+
+// MatchScheduler bounds asynchronous vulnerability matching work triggered by
+// inventory scans and feed syncs.
+type MatchScheduler struct {
+	pool  *pgxpool.Pool
+	queue chan matchRequest
+}
+
+func StartMatchScheduler(ctx context.Context, pool *pgxpool.Pool, workers, queueSize int) *MatchScheduler {
+	if workers <= 0 {
+		workers = 1
+	}
+	if queueSize <= 0 {
+		queueSize = 100
+	}
+	s := &MatchScheduler{
+		pool:  pool,
+		queue: make(chan matchRequest, queueSize),
+	}
+	for i := 0; i < workers; i++ {
+		go s.runWorker(ctx)
+	}
+	return s
+}
+
+func (s *MatchScheduler) EnqueueHost(hostID string) bool {
+	if s == nil || hostID == "" {
+		return false
+	}
+	return s.enqueue(matchRequest{hostID: hostID})
+}
+
+func (s *MatchScheduler) EnqueueAllHosts() bool {
+	if s == nil {
+		return false
+	}
+	return s.enqueue(matchRequest{all: true})
+}
+
+func (s *MatchScheduler) enqueue(req matchRequest) bool {
+	select {
+	case s.queue <- req:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *MatchScheduler) runWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req := <-s.queue:
+			if req.all {
+				if err := MatchAllHosts(ctx, s.pool); err != nil {
+					slog.Warn("vulnerability matcher: all-host match failed", "err", err)
+				}
+				continue
+			}
+			if err := MatchHost(ctx, s.pool, req.hostID); err != nil {
+				slog.Warn("vulnerability matcher: host match failed", "host_id", req.hostID, "err", err)
+			}
+		}
+	}
+}

--- a/apps/ingest/internal/vuln/sync.go
+++ b/apps/ingest/internal/vuln/sync.go
@@ -49,7 +49,7 @@ func DefaultSyncConfig() SyncConfig {
 	}
 }
 
-func RunSyncer(ctx context.Context, pool *pgxpool.Pool, cfg SyncConfig) {
+func RunSyncer(ctx context.Context, pool *pgxpool.Pool, cfg SyncConfig, matcher *MatchScheduler) {
 	if !cfg.Enabled {
 		slog.Info("vulnerability sync disabled")
 		return
@@ -66,8 +66,14 @@ func RunSyncer(ctx context.Context, pool *pgxpool.Pool, cfg SyncConfig) {
 			slog.Warn("vulnerability sync failed", "err", err)
 			return
 		}
-		if err := MatchAllHosts(ctx, pool); err != nil {
-			slog.Warn("vulnerability matching after sync failed", "err", err)
+		if matcher == nil {
+			if err := MatchAllHosts(ctx, pool); err != nil {
+				slog.Warn("vulnerability matching after sync failed", "err", err)
+			}
+			return
+		}
+		if !matcher.EnqueueAllHosts() {
+			slog.Warn("vulnerability matching after sync skipped: matcher queue full")
 		}
 	}
 	if cfg.SyncOnStartup {

--- a/apps/ingest/internal/vuln/types.go
+++ b/apps/ingest/internal/vuln/types.go
@@ -13,6 +13,14 @@ const (
 	SeverityUnknown  Severity = "unknown"
 )
 
+type FindingConfidence string
+
+const (
+	FindingConfidenceConfirmed   FindingConfidence = "confirmed"
+	FindingConfidenceProbable    FindingConfidence = "probable"
+	FindingConfidenceUnsupported FindingConfidence = "unsupported"
+)
+
 type CVERecord struct {
 	CVEID             string
 	Title             string

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -19,6 +19,7 @@ import {
   Layers,
   Zap,
   User,
+  ShieldAlert,
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
@@ -72,6 +73,8 @@ import { NotesTab } from '@/components/notes/notes-tab'
 import { PinnedNotesCard } from '@/components/notes/pinned-notes-card'
 import { checkTerminalAccess } from '@/lib/actions/terminal'
 import { getAlertInstances } from '@/lib/actions/alerts'
+import { getHostVulnerabilityAssessment } from '@/lib/actions/vulnerabilities'
+import type { HostVulnerabilityAssessmentStatus } from '@/lib/vulnerabilities/assessment'
 import { getHostCollectionSettings } from '@/lib/actions/host-settings'
 import { getServiceAccounts } from '@/lib/actions/service-accounts'
 import { listGroupsForHost, listGroups, addHostToGroup, removeHostFromGroup } from '@/lib/actions/host-groups'
@@ -158,6 +161,11 @@ function formatLastSeen(date: Date | string | null | undefined): string {
   return formatDistanceToNow(new Date(date), { addSuffix: true })
 }
 
+function formatOptionalDate(date: Date | string | null | undefined): string {
+  if (!date) return '—'
+  return formatDistanceToNow(new Date(date), { addSuffix: true })
+}
+
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB', 'TB']
@@ -184,6 +192,39 @@ function MetricCard({ label, value, colorClass }: { label: string; value: string
         <p className={`text-4xl font-bold tabular-nums ${colorClass}`}>{value}</p>
       </CardContent>
     </Card>
+  )
+}
+
+function VulnerabilityStatusBadge({ status }: { status: HostVulnerabilityAssessmentStatus }) {
+  if (status === 'affected') {
+    return (
+      <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">
+        <ShieldAlert className="size-3 mr-1" />
+        Affected
+      </Badge>
+    )
+  }
+  if (status === 'clear') {
+    return (
+      <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">
+        <CheckCircle className="size-3 mr-1" />
+        Clear
+      </Badge>
+    )
+  }
+  if (status === 'stale') {
+    return (
+      <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
+        <Clock className="size-3 mr-1" />
+        Stale
+      </Badge>
+    )
+  }
+  return (
+    <Badge className="bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-100">
+      <AlertTriangle className="size-3 mr-1" />
+      Not assessed
+    </Badge>
   )
 }
 
@@ -308,6 +349,12 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
     refetchInterval: 30_000,
   })
   const activeAlertCount = activeAlerts.length
+
+  const { data: vulnerabilityAssessment } = useQuery({
+    queryKey: ['host-vulnerability-assessment', orgId, initialHost.id],
+    queryFn: () => getHostVulnerabilityAssessment(orgId, initialHost.id),
+    refetchInterval: 60_000,
+  })
 
   const { data: collectionSettings } = useQuery({
     queryKey: ['host-collection-settings', orgId, initialHost.id],
@@ -539,6 +586,67 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
             <MetricCard label="Memory Usage" value={formatPercent(host.memoryPercent)} colorClass={memColor} />
             <MetricCard label="Disk Usage (root)" value={formatPercent(host.diskPercent)} colorClass={diskColor} />
           </div>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <ShieldAlert className="size-4 text-muted-foreground" />
+                Vulnerability Assessment
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {!vulnerabilityAssessment ? (
+                <p className="text-sm text-muted-foreground">Loading vulnerability assessment…</p>
+              ) : (
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <VulnerabilityStatusBadge status={vulnerabilityAssessment.status} />
+                      <span className="text-sm text-muted-foreground">
+                        {vulnerabilityAssessment.reason}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+                      <div>
+                        <p className="text-muted-foreground">Confirmed findings</p>
+                        <p className="font-semibold tabular-nums text-foreground">
+                          {vulnerabilityAssessment.openConfirmedFindings}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Critical / High</p>
+                        <p className="font-semibold tabular-nums text-foreground">
+                          {vulnerabilityAssessment.criticalCount} / {vulnerabilityAssessment.highCount}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Last inventory scan</p>
+                        <p className="font-medium text-foreground">
+                          {formatOptionalDate(vulnerabilityAssessment.lastInventoryScanAt)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-muted-foreground">Last feed sync</p>
+                        <p className="font-medium text-foreground">
+                          {formatOptionalDate(vulnerabilityAssessment.lastFeedSyncAt)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setActiveParentTab('inventory')
+                      setActiveTab('vulnerabilities')
+                    }}
+                  >
+                    View findings
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
           {/* Info cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/apps/web/app/(dashboard)/reports/vulnerabilities/vulnerability-report-client.tsx
+++ b/apps/web/app/(dashboard)/reports/vulnerabilities/vulnerability-report-client.tsx
@@ -27,7 +27,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { getVulnerabilityReport } from '@/lib/actions/vulnerabilities'
-import type { VulnerabilityReportFilters, VulnerabilitySeverity } from '@/lib/actions/vulnerabilities'
+import type { VulnerabilityFindingConfidence, VulnerabilityReportFilters, VulnerabilitySeverity } from '@/lib/actions/vulnerabilities'
 import type { HostGroup } from '@/lib/db/schema'
 
 interface Props {
@@ -37,6 +37,7 @@ interface Props {
 
 const ALL = '__all__'
 const severities: Array<VulnerabilitySeverity | 'all'> = ['all', 'critical', 'high', 'medium', 'low', 'unknown']
+const confidences: Array<VulnerabilityFindingConfidence | 'all'> = ['confirmed', 'probable', 'all']
 
 function SeverityBadge({ severity }: { severity: string }) {
   if (severity === 'critical') return <Badge className="bg-red-100 text-red-800 border-red-200 hover:bg-red-100">Critical</Badge>
@@ -53,6 +54,7 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
   const [hostGroupId, setHostGroupId] = useState(ALL)
   const [distro, setDistro] = useState(ALL)
   const [source, setSource] = useState(ALL)
+  const [confidence, setConfidence] = useState<VulnerabilityFindingConfidence | 'all'>('confirmed')
   const [kevOnly, setKevOnly] = useState(false)
   const [fixAvailable, setFixAvailable] = useState(false)
 
@@ -63,9 +65,10 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
     hostGroupId: hostGroupId === ALL ? undefined : hostGroupId,
     distro: distro === ALL ? undefined : distro,
     source: source === ALL ? undefined : source,
+    confidence,
     kevOnly,
     fixAvailable,
-  }), [cve, distro, fixAvailable, hostGroupId, kevOnly, packageName, severity, source])
+  }), [confidence, cve, distro, fixAvailable, hostGroupId, kevOnly, packageName, severity, source])
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['vulnerability-report', orgId, filters],
@@ -181,6 +184,15 @@ export function VulnerabilityReportClient({ orgId, hostGroups }: Props) {
                   <SelectItem value="dpkg">dpkg</SelectItem>
                   <SelectItem value="rpm">rpm</SelectItem>
                   <SelectItem value="apk">apk</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Confidence</Label>
+              <Select value={confidence} onValueChange={(value) => setConfidence(value as VulnerabilityFindingConfidence | 'all')}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {confidences.map((value) => <SelectItem key={value} value={value}>{value === 'all' ? 'All confidence' : value}</SelectItem>)}
                 </SelectContent>
               </Select>
             </div>

--- a/apps/web/lib/actions/vulnerabilities.ts
+++ b/apps/web/lib/actions/vulnerabilities.ts
@@ -10,6 +10,7 @@ import { requireFeature } from '@/lib/actions/licence-guard'
 import { createRateLimiter } from '@/lib/rate-limit'
 
 export type VulnerabilitySeverity = 'critical' | 'high' | 'medium' | 'low' | 'none' | 'unknown'
+export type VulnerabilityFindingConfidence = 'confirmed' | 'probable' | 'unsupported'
 
 export interface VulnerabilityReportFilters {
   cve?: string
@@ -20,6 +21,7 @@ export interface VulnerabilityReportFilters {
   hostGroupId?: string
   distro?: string
   source?: string
+  confidence?: VulnerabilityFindingConfidence | 'all'
 }
 
 export interface VulnerabilityFindingRow {
@@ -41,6 +43,8 @@ export interface VulnerabilityFindingRow {
   severity: VulnerabilitySeverity
   cvssScore: number | null
   knownExploited: boolean
+  confidence: VulnerabilityFindingConfidence
+  matchReason: string | null
   firstSeenAt: Date
   lastSeenAt: Date
 }
@@ -159,6 +163,7 @@ const filtersSchema = z.object({
   hostGroupId: z.string().trim().max(64).optional(),
   distro: z.string().trim().max(64).optional(),
   source: z.string().trim().max(64).optional(),
+  confidence: z.enum(['confirmed', 'probable', 'unsupported', 'all']).optional(),
 }).strip()
 
 const managementFiltersSchema = z.object({
@@ -244,7 +249,7 @@ export async function getVulnerabilityManagementSnapshot(
         cast(count(*) FILTER (WHERE known_exploited = true) as int) AS "knownExploitedCount",
         cast(count(*) FILTER (WHERE rejected = true) as int) AS "rejectedCount",
         cast((SELECT count(*) FROM vulnerability_affected_packages) as int) AS "affectedPackageRules",
-        cast((SELECT count(*) FROM host_vulnerability_findings WHERE organisation_id = ${orgId} AND status = 'open') as int) AS "openFindings"
+        cast((SELECT count(*) FROM host_vulnerability_findings WHERE organisation_id = ${orgId} AND status = 'open' AND confidence = 'confirmed') as int) AS "openFindings"
       FROM vulnerability_cves
     `),
     db.execute(sql`
@@ -280,6 +285,7 @@ export async function getVulnerabilityManagementSnapshot(
       LEFT JOIN host_vulnerability_findings hvf
         ON hvf.cve_id = vc.cve_id
        AND hvf.organisation_id = ${orgId}
+       AND hvf.confidence = 'confirmed'
       WHERE ${where}
       GROUP BY
         vc.cve_id,
@@ -441,6 +447,8 @@ export async function getVulnerabilityReport(
       hvf.severity,
       hvf.cvss_score AS "cvssScore",
       hvf.known_exploited AS "knownExploited",
+      hvf.confidence,
+      hvf.match_reason AS "matchReason",
       hvf.first_seen_at AS "firstSeenAt",
       hvf.last_seen_at AS "lastSeenAt"
     FROM host_vulnerability_findings hvf
@@ -515,6 +523,8 @@ export async function getHostVulnerabilities(
       hvf.severity,
       hvf.cvss_score AS "cvssScore",
       hvf.known_exploited AS "knownExploited",
+      hvf.confidence,
+      hvf.match_reason AS "matchReason",
       hvf.first_seen_at AS "firstSeenAt",
       hvf.last_seen_at AS "lastSeenAt"
     FROM host_vulnerability_findings hvf
@@ -524,6 +534,7 @@ export async function getHostVulnerabilities(
     WHERE hvf.organisation_id = ${orgId}
       AND hvf.host_id = ${hostId}
       AND hvf.status = 'open'
+      AND hvf.confidence = 'confirmed'
     ORDER BY
       CASE hvf.severity
         WHEN 'critical' THEN 0
@@ -543,6 +554,11 @@ function vulnerabilityWhere(orgId: string, filters: z.infer<typeof filtersSchema
     sql`hvf.organisation_id = ${orgId}`,
     sql`hvf.status = 'open'`,
   ]
+  if (!filters.confidence || filters.confidence === 'confirmed') {
+    conditions.push(sql`hvf.confidence = 'confirmed'`)
+  } else if (filters.confidence !== 'all') {
+    conditions.push(sql`hvf.confidence = ${filters.confidence}`)
+  }
   if (filters.cve) {
     conditions.push(sql`hvf.cve_id ILIKE ${`%${escapeLike(filters.cve)}%`}`)
   }

--- a/apps/web/lib/actions/vulnerabilities.ts
+++ b/apps/web/lib/actions/vulnerabilities.ts
@@ -4,10 +4,15 @@ import { eq, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { systemConfig } from '@/lib/db/schema'
+import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { encrypt } from '@/lib/crypto/encrypt'
 import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 import { requireFeature } from '@/lib/actions/licence-guard'
 import { createRateLimiter } from '@/lib/rate-limit'
+import {
+  deriveHostVulnerabilityAssessmentStatus,
+  type HostVulnerabilityAssessmentStatus,
+} from '@/lib/vulnerabilities/assessment'
 
 export type VulnerabilitySeverity = 'critical' | 'high' | 'medium' | 'low' | 'none' | 'unknown'
 export type VulnerabilityFindingConfidence = 'confirmed' | 'probable' | 'unsupported'
@@ -132,6 +137,22 @@ export interface VulnerabilityReport {
   }
   findings: VulnerabilityFindingRow[]
   sources: VulnerabilitySyncSource[]
+}
+
+export interface HostVulnerabilityAssessment {
+  status: HostVulnerabilityAssessmentStatus
+  reason: string
+  openConfirmedFindings: number
+  criticalCount: number
+  highCount: number
+  knownExploitedCount: number
+  fixAvailableCount: number
+  inventoryStale: boolean
+  feedStale: boolean
+  lastInventoryScanAt: Date | null
+  lastFeedSyncAt: Date | null
+  lastFindingSeenAt: Date | null
+  lastAssessedAt: Date | null
 }
 
 const reportLimiter = createRateLimiter({
@@ -549,6 +570,99 @@ export async function getHostVulnerabilities(
   `)) as unknown as VulnerabilityFindingRow[]
 }
 
+export async function getHostVulnerabilityAssessment(
+  orgId: string,
+  hostId: string,
+): Promise<HostVulnerabilityAssessment> {
+  await requireOrgAccess(orgId)
+
+  const [hostRowsRaw, findingRowsRaw, scanRowsRaw, sourceRowsRaw] = await Promise.all([
+    db.execute(sql`
+      SELECT metadata
+      FROM hosts
+      WHERE id = ${hostId}
+        AND organisation_id = ${orgId}
+        AND deleted_at IS NULL
+      LIMIT 1
+    `),
+    db.execute(sql`
+      SELECT
+        cast(count(*) as int) AS "openConfirmedFindings",
+        cast(count(*) FILTER (WHERE severity = 'critical') as int) AS "criticalCount",
+        cast(count(*) FILTER (WHERE severity = 'high') as int) AS "highCount",
+        cast(count(*) FILTER (WHERE known_exploited = true) as int) AS "knownExploitedCount",
+        cast(count(*) FILTER (WHERE fixed_version IS NOT NULL) as int) AS "fixAvailableCount",
+        max(last_seen_at) AS "lastFindingSeenAt"
+      FROM host_vulnerability_findings
+      WHERE organisation_id = ${orgId}
+        AND host_id = ${hostId}
+        AND status = 'open'
+        AND confidence = 'confirmed'
+    `),
+    db.execute(sql`
+      SELECT completed_at AS "completedAt"
+      FROM software_scans
+      WHERE organisation_id = ${orgId}
+        AND host_id = ${hostId}
+        AND status = 'success'
+      ORDER BY completed_at DESC NULLS LAST, created_at DESC
+      LIMIT 1
+    `),
+    db.execute(sql`
+      SELECT max(last_success_at) AS "lastFeedSyncAt"
+      FROM vulnerability_sources
+      WHERE status = 'success'
+        AND last_success_at IS NOT NULL
+    `),
+  ])
+
+  const hostRows = hostRowsRaw as unknown as Array<{ metadata: unknown }>
+  const findingRows = findingRowsRaw as unknown as Array<{
+    openConfirmedFindings: number
+    criticalCount: number
+    highCount: number
+    knownExploitedCount: number
+    fixAvailableCount: number
+    lastFindingSeenAt: Date | string | null
+  }>
+  const scanRows = scanRowsRaw as unknown as Array<{ completedAt: Date | string | null }>
+  const sourceRows = sourceRowsRaw as unknown as Array<{ lastFeedSyncAt: Date | string | null }>
+
+  const metadata = parseHostMetadata(hostRows[0]?.metadata)
+  const lastInventoryScanAt = coerceDate(scanRows[0]?.completedAt) ?? coerceDate(metadata.lastSoftwareScanAt)
+  const lastFeedSyncAt = coerceDate(sourceRows[0]?.lastFeedSyncAt)
+  const summary = findingRows[0] ?? {
+    openConfirmedFindings: 0,
+    criticalCount: 0,
+    highCount: 0,
+    knownExploitedCount: 0,
+    fixAvailableCount: 0,
+    lastFindingSeenAt: null,
+  }
+  const lastFindingSeenAt = coerceDate(summary.lastFindingSeenAt)
+  const derived = deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: summary.openConfirmedFindings,
+    lastInventoryScanAt,
+    lastFeedSyncAt,
+  })
+
+  return {
+    status: derived.status,
+    reason: derived.reason,
+    openConfirmedFindings: summary.openConfirmedFindings,
+    criticalCount: summary.criticalCount,
+    highCount: summary.highCount,
+    knownExploitedCount: summary.knownExploitedCount,
+    fixAvailableCount: summary.fixAvailableCount,
+    inventoryStale: derived.inventoryStale,
+    feedStale: derived.feedStale,
+    lastInventoryScanAt,
+    lastFeedSyncAt,
+    lastFindingSeenAt,
+    lastAssessedAt: lastFindingSeenAt ?? lastInventoryScanAt,
+  }
+}
+
 function vulnerabilityWhere(orgId: string, filters: z.infer<typeof filtersSchema>) {
   const conditions = [
     sql`hvf.organisation_id = ${orgId}`,
@@ -613,6 +727,12 @@ function vulnerabilityCatalogWhere(filters: z.infer<typeof managementFiltersSche
 
 function escapeLike(value: string) {
   return value.replace(/[\\%_]/g, (match) => `\\${match}`)
+}
+
+function coerceDate(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 function sanitizeSourceError(value: string | null) {

--- a/apps/web/lib/db/migrations/0052_vulnerability_finding_confidence.sql
+++ b/apps/web/lib/db/migrations/0052_vulnerability_finding_confidence.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "host_vulnerability_findings" ADD COLUMN "confidence" text DEFAULT 'confirmed' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "host_vulnerability_findings" ADD COLUMN "match_reason" text;
+--> statement-breakpoint
+CREATE INDEX "host_vuln_findings_confidence_idx" ON "host_vulnerability_findings" USING btree ("organisation_id","status","confidence");

--- a/apps/web/lib/db/migrations/meta/_journal.json
+++ b/apps/web/lib/db/migrations/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1777386000000,
       "tag": "0051_ingest_status",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1777390000000,
+      "tag": "0052_vulnerability_finding_confidence",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/db/schema/software.ts
+++ b/apps/web/lib/db/schema/software.ts
@@ -49,7 +49,7 @@ export const softwarePackages = pgTable(
     lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
     // Set when a later scan no longer reports this package. Cleared on re-appearance.
     removedAt: timestamp('removed_at', { withTimezone: true }),
-    // Reserved for a future CVE matcher; always null in v1.
+    // Legacy per-package CVE cache slot; current findings live in host_vulnerability_findings.
     cveMatches: jsonb('cve_matches'),
     metadata: jsonb('metadata'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/web/lib/db/schema/vulnerabilities.ts
+++ b/apps/web/lib/db/schema/vulnerabilities.ts
@@ -7,6 +7,7 @@ import { softwarePackages } from './software.ts'
 export type VulnerabilitySeverity = 'critical' | 'high' | 'medium' | 'low' | 'none' | 'unknown'
 export type VulnerabilityFindingStatus = 'open' | 'resolved'
 export type VulnerabilitySyncStatus = 'pending' | 'success' | 'error'
+export type VulnerabilityFindingConfidence = 'confirmed' | 'probable' | 'unsupported'
 
 export const vulnerabilityCves = pgTable('vulnerability_cves', {
   cveId: text('cve_id').primaryKey(),
@@ -92,6 +93,8 @@ export const hostVulnerabilityFindings = pgTable('host_vulnerability_findings', 
   severity: text('severity').notNull().default('unknown').$type<VulnerabilitySeverity>(),
   cvssScore: real('cvss_score'),
   knownExploited: boolean('known_exploited').notNull().default(false),
+  confidence: text('confidence').notNull().default('confirmed').$type<VulnerabilityFindingConfidence>(),
+  matchReason: text('match_reason'),
   firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).notNull().defaultNow(),
   lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
   resolvedAt: timestamp('resolved_at', { withTimezone: true }),
@@ -103,10 +106,10 @@ export const hostVulnerabilityFindings = pgTable('host_vulnerability_findings', 
   index('host_vuln_findings_org_status_idx').on(t.organisationId, t.status, t.severity),
   index('host_vuln_findings_host_status_idx').on(t.hostId, t.status),
   index('host_vuln_findings_cve_idx').on(t.cveId),
+  index('host_vuln_findings_confidence_idx').on(t.organisationId, t.status, t.confidence),
 ])
 
 export type VulnerabilityCve = typeof vulnerabilityCves.$inferSelect
 export type VulnerabilitySource = typeof vulnerabilitySources.$inferSelect
 export type VulnerabilityAffectedPackage = typeof vulnerabilityAffectedPackages.$inferSelect
 export type HostVulnerabilityFinding = typeof hostVulnerabilityFindings.$inferSelect
-

--- a/apps/web/lib/vulnerabilities/assessment.test.mjs
+++ b/apps/web/lib/vulnerabilities/assessment.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { deriveHostVulnerabilityAssessmentStatus } from './assessment.ts'
+
+const now = new Date('2026-04-29T12:00:00.000Z')
+const recentInventory = new Date('2026-04-29T10:00:00.000Z')
+const recentFeed = new Date('2026-04-29T09:00:00.000Z')
+
+test('host assessment is affected when confirmed findings are open', () => {
+  const result = deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: 2,
+    lastInventoryScanAt: recentInventory,
+    lastFeedSyncAt: recentFeed,
+    now,
+  })
+
+  assert.equal(result.status, 'affected')
+  assert.equal(result.inventoryStale, false)
+  assert.equal(result.feedStale, false)
+})
+
+test('host assessment is clear when scans are fresh and no confirmed findings are open', () => {
+  const result = deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: 0,
+    lastInventoryScanAt: recentInventory,
+    lastFeedSyncAt: recentFeed,
+    now,
+  })
+
+  assert.equal(result.status, 'clear')
+})
+
+test('host assessment is not assessed without inventory or feed data', () => {
+  assert.equal(deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: 0,
+    lastInventoryScanAt: null,
+    lastFeedSyncAt: recentFeed,
+    now,
+  }).status, 'not_assessed')
+
+  assert.equal(deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: 0,
+    lastInventoryScanAt: recentInventory,
+    lastFeedSyncAt: null,
+    now,
+  }).status, 'not_assessed')
+})
+
+test('host assessment is stale when inventory or feed data is too old', () => {
+  const staleInventory = deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: 0,
+    lastInventoryScanAt: new Date('2026-04-20T12:00:00.000Z'),
+    lastFeedSyncAt: recentFeed,
+    now,
+  })
+  assert.equal(staleInventory.status, 'stale')
+  assert.equal(staleInventory.inventoryStale, true)
+
+  const staleFeed = deriveHostVulnerabilityAssessmentStatus({
+    openConfirmedFindings: 0,
+    lastInventoryScanAt: recentInventory,
+    lastFeedSyncAt: new Date('2026-04-26T12:00:00.000Z'),
+    now,
+  })
+  assert.equal(staleFeed.status, 'stale')
+  assert.equal(staleFeed.feedStale, true)
+})

--- a/apps/web/lib/vulnerabilities/assessment.ts
+++ b/apps/web/lib/vulnerabilities/assessment.ts
@@ -1,0 +1,76 @@
+export type HostVulnerabilityAssessmentStatus = 'affected' | 'clear' | 'stale' | 'not_assessed'
+
+export interface HostVulnerabilityAssessmentInput {
+  openConfirmedFindings: number
+  lastInventoryScanAt: Date | null
+  lastFeedSyncAt: Date | null
+  now?: Date
+  scanStaleAfterMs?: number
+  feedStaleAfterMs?: number
+}
+
+export interface HostVulnerabilityAssessmentStatusResult {
+  status: HostVulnerabilityAssessmentStatus
+  reason: string
+  inventoryStale: boolean
+  feedStale: boolean
+}
+
+const DEFAULT_SCAN_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000
+const DEFAULT_FEED_STALE_AFTER_MS = 2 * 24 * 60 * 60 * 1000
+
+export function deriveHostVulnerabilityAssessmentStatus(
+  input: HostVulnerabilityAssessmentInput,
+): HostVulnerabilityAssessmentStatusResult {
+  const now = input.now ?? new Date()
+  const scanStaleAfterMs = input.scanStaleAfterMs ?? DEFAULT_SCAN_STALE_AFTER_MS
+  const feedStaleAfterMs = input.feedStaleAfterMs ?? DEFAULT_FEED_STALE_AFTER_MS
+
+  if (!input.lastInventoryScanAt) {
+    return {
+      status: 'not_assessed',
+      reason: 'No successful software inventory scan has completed for this host.',
+      inventoryStale: false,
+      feedStale: false,
+    }
+  }
+
+  if (!input.lastFeedSyncAt) {
+    return {
+      status: 'not_assessed',
+      reason: 'Vulnerability feeds have not completed a successful sync yet.',
+      inventoryStale: false,
+      feedStale: false,
+    }
+  }
+
+  const inventoryStale = now.getTime() - input.lastInventoryScanAt.getTime() > scanStaleAfterMs
+  const feedStale = now.getTime() - input.lastFeedSyncAt.getTime() > feedStaleAfterMs
+
+  if (input.openConfirmedFindings > 0) {
+    return {
+      status: 'affected',
+      reason: 'Confirmed Linux package CVE findings are open for this host.',
+      inventoryStale,
+      feedStale,
+    }
+  }
+
+  if (inventoryStale || feedStale) {
+    return {
+      status: 'stale',
+      reason: inventoryStale
+        ? 'The last software inventory scan is stale.'
+        : 'The vulnerability feed data is stale.',
+      inventoryStale,
+      feedStale,
+    }
+  }
+
+  return {
+    status: 'clear',
+    reason: 'No confirmed Linux package CVE findings are open for the latest assessed inventory.',
+    inventoryStale,
+    feedStale,
+  }
+}


### PR DESCRIPTION
## Summary
- add confirmed/probable vulnerability finding confidence and match reasons, with reports defaulting to confirmed findings
- parse structured Red Hat affected-release package data into full RPM EVR rules and mark free-text fallback matches as probable
- add a bounded vulnerability match scheduler used by inventory completion and vulnerability feed sync
- add a host Overview vulnerability assessment card showing affected/clear/stale/not-assessed status, confirmed finding counts, last inventory scan, and last feed sync
- document the completed hardening work in `PROGRESS.md`

## Validation
- `go test ./internal/vuln`
- `go test ./...` from `apps/ingest`
- `node --experimental-strip-types --test lib/vulnerabilities/assessment.test.mjs`
- `pnpm --dir apps/web run db:validate`
- `pnpm --dir apps/web run type-check`
- `pnpm --dir apps/web run lint` (passes with existing warnings)
