### PR TITLE
fix(ingest): use canonical agent release repository

### DIFF
--- a/apps/ingest/internal/config/config.go
+++ b/apps/ingest/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const agentReleasesURL = "https://api.github.com/repos/simonjcarr/ct-ops/releases?per_page=20"
+const agentReleasesURL = "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=20"
 
 // Config is the ingest service configuration loaded from a YAML file.
 type Config struct {

--- a/apps/ingest/internal/config/version_poller_test.go
+++ b/apps/ingest/internal/config/version_poller_test.go
@@ -5,8 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestAgentReleasesURLUsesCanonicalRepository(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(agentReleasesURL, "github.com/repos/carrtech-dev/ct-ops/") {
+		t.Fatalf("agentReleasesURL = %q, want canonical carrtech-dev/ct-ops repository", agentReleasesURL)
+	}
+}
 
 func TestLatestAgentVersionFromGitHubReleases(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- update ingest agent release discovery to query `carrtech-dev/ct-ops` instead of the old `simonjcarr/ct-ops` repository
- add a regression test for the canonical release URL

## Investigation notes
- affected host `ct-agent-alma` is running `ct-ops-agent v0.32.0`
- its journal shows update notifications being skipped by the installed binary: `agent update available, but automatic self-update is disabled until release signature verification is implemented`
- current agent changelog shows automatic self-updates were restored in `v0.32.1`, so agents on `v0.32.0` need a one-time manual upgrade before future self-updates can work
- from the affected host, HTTPS download via `https://192.168.8.215` also fails certificate hostname validation because the pinned cert does not include that IP as a SAN; that should be fixed in deployment config for self-update downloads that use the IP URL

## Validation
- `go test ./apps/ingest/internal/config`