### PR TITLE
fix(web): restrict tooling access to engineer roles

### DIFF
--- a/apps/web/app/(dashboard)/build-docs/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/build-docs/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import {
   getBuildDoc,
   getBuildDocRenderModel,
@@ -19,6 +20,7 @@ interface Props {
 export default async function BuildDocPage({ params }: Props) {
   const { id } = await params
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
   const [detail, model, snippets] = await Promise.all([
     getBuildDoc(orgId, id),

--- a/apps/web/app/(dashboard)/build-docs/page.tsx
+++ b/apps/web/app/(dashboard)/build-docs/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import {
   listBuildDocs,
   listBuildDocSnippets,
@@ -14,6 +16,7 @@ export const metadata: Metadata = {
 
 export default async function BuildDocsPage() {
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
   const [docs, templates, snippets, storageSettings] = await Promise.all([
     listBuildDocs(orgId),

--- a/apps/web/app/(dashboard)/bundlers/page.tsx
+++ b/apps/web/app/(dashboard)/bundlers/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { BundlersClient } from './bundlers-client'
 
 export const metadata: Metadata = {
@@ -8,6 +10,7 @@ export const metadata: Metadata = {
 
 export default async function BundlersPage() {
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
 
   return (

--- a/apps/web/app/(dashboard)/certificate-checker/page.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { CertificateCheckerClient } from './certificate-checker-client'
 
 export const metadata: Metadata = {
@@ -8,6 +10,7 @@ export const metadata: Metadata = {
 
 export default async function CertificateCheckerPage() {
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
   return <CertificateCheckerClient orgId={orgId} />
 }

--- a/apps/web/app/(dashboard)/directory-lookup/page.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { FolderSearch } from 'lucide-react'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { getLookupConfigOptions } from '@/lib/actions/ldap'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -13,6 +15,7 @@ export const metadata: Metadata = {
 
 export default async function DirectoryLookupPage() {
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
   const configs = await getLookupConfigOptions(orgId)
 

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -26,10 +26,10 @@ export default async function DashboardLayout({ children }: { children: React.Re
   const licence = await getEffectiveLicence(orgId)
 
   return (
-    <CommandPaletteProvider orgId={orgId}>
+    <CommandPaletteProvider orgId={orgId} userRole={session.user.role}>
       <TerminalProviderWrapper>
         <SidebarProvider className="h-svh overflow-hidden">
-          <AppSidebar orgId={orgId} tier={licence.tier} />
+          <AppSidebar orgId={orgId} tier={licence.tier} userRole={session.user.role} />
           <TerminalContentWrapper orgId={orgId}>
             <Topbar orgId={orgId} />
             <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>

--- a/apps/web/app/(dashboard)/tasks/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { getTaskRun } from '@/lib/actions/task-runs'
 import { TaskMonitorClient } from './task-monitor-client'
 
@@ -15,6 +16,7 @@ interface Props {
 export default async function TaskRunPage({ params }: Props) {
   const { id } = await params
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
 
   const taskRun = await getTaskRun(orgId, id)

--- a/apps/web/app/(dashboard)/tasks/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { listSchedules } from '@/lib/actions/task-schedules'
 import { SchedulesClient } from './schedules-client'
 
@@ -9,6 +11,7 @@ export const metadata: Metadata = {
 
 export default async function ScheduledTasksPage() {
   const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
 
   const schedules = await listSchedules(orgId)

--- a/apps/web/app/(dashboard)/tasks/schedules/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { db } from '@/lib/db'
 import { hosts, hostGroups } from '@/lib/db/schema'
 import { and, eq, isNull, asc } from 'drizzle-orm'
@@ -18,7 +19,7 @@ interface Props {
 export default async function SchedulePage({ params }: Props) {
   const { id } = await params
   const session = await getRequiredSession()
-  if (session.user.role === 'read_only') redirect('/tasks')
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
 
   const result = await getSchedule(orgId, id)

--- a/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { db } from '@/lib/db'
 import { hosts, hostGroups } from '@/lib/db/schema'
 import { and, eq, isNull, asc } from 'drizzle-orm'
@@ -12,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function NewSchedulePage() {
   const session = await getRequiredSession()
-  if (session.user.role === 'read_only') redirect('/tasks')
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
   const orgId = session.user.organisationId!
 
   const [hostRows, groupRows] = await Promise.all([

--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -17,6 +17,7 @@ import { hosts, taskRunHosts, taskRuns, users } from '@/lib/db/schema'
 import { resolveWarUrl } from '@/lib/jenkins/update-center'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 import { getApiOrgSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
 
 export const runtime = 'nodejs'
 export const maxDuration = 900
@@ -647,7 +648,8 @@ async function runTransferJob(job: TransferJob, request: TransferRequest, baseUr
 
 async function getAuthorisedUser(request: NextRequest) {
   try {
-    return (await getApiOrgSession(request.headers)).user
+    const user = (await getApiOrgSession(request.headers)).user
+    return canAccessTooling(user) ? user : null
   } catch {
     return null
   }
@@ -666,6 +668,10 @@ function getRequestOrigin(request: NextRequest) {
 
 async function serveBundleDownload(request: NextRequest) {
   cleanupOldJobs()
+  const user = await getAuthorisedUser(request)
+  if (!user?.organisationId) {
+    return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
+  }
   const jobId = request.nextUrl.searchParams.get('jobId')
   const token = request.nextUrl.searchParams.get('token')
   if (!jobId || !token) {
@@ -673,7 +679,14 @@ async function serveBundleDownload(request: NextRequest) {
   }
 
   const job = transferJobs.get(jobId)
-  if (!job || job.downloadToken !== token || !job.archivePath || job.phase !== 'transferring') {
+  if (
+    !job ||
+    job.userId !== user.id ||
+    job.organisationId !== user.organisationId ||
+    job.downloadToken !== token ||
+    !job.archivePath ||
+    job.phase !== 'transferring'
+  ) {
     return NextResponse.json({ error: 'Bundle download not found' }, { status: 404 })
   }
 

--- a/apps/web/app/api/tools/certificate-checker/route.ts
+++ b/apps/web/app/api/tools/certificate-checker/route.ts
@@ -13,6 +13,7 @@ import {
 import { assertAllowedCertificateCheckerTarget } from '@/lib/net/certificate-checker-policy'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 import { ApiAuthError, getApiSession } from '@/lib/auth/session'
+import { requireToolingAccess } from '@/lib/auth/tooling'
 
 export type { ParsedCertificate, ParsedSAN, ChainEntry } from '@/lib/certificates/fetch'
 
@@ -65,12 +66,19 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    await getApiSession(req.headers)
+    const session = await getApiSession(req.headers)
+    requireToolingAccess(session.user)
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return NextResponse.json(
         { ok: false, error: err.message } satisfies CertCheckerResponse,
         { status: err.status },
+      )
+    }
+    if (err instanceof Error && err.message === 'forbidden: tooling role required') {
+      return NextResponse.json(
+        { ok: false, error: 'Forbidden' } satisfies CertCheckerResponse,
+        { status: 403 },
       )
     }
     throw err

--- a/apps/web/app/api/tools/gitlab-bundler/route.ts
+++ b/apps/web/app/api/tools/gitlab-bundler/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { compareVersions } from '@/lib/version-compare'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
+import { requireToolingAccess } from '@/lib/auth/tooling'
 
 export const runtime = 'nodejs'
 
@@ -387,6 +389,9 @@ function createStep(
 
 export async function POST(req: NextRequest): Promise<NextResponse<GitLabBundlerResponse | GitLabLatestVersionResponse>> {
   try {
+    const session = await getApiSession(req.headers)
+    requireToolingAccess(session.user)
+
     const raw = await req.json()
     const parsed = BodySchema.safeParse(raw)
     if (!parsed.success) {
@@ -503,12 +508,31 @@ export async function POST(req: NextRequest): Promise<NextResponse<GitLabBundler
       steps: deduped,
     })
   } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: err.status })
+    }
+    if (err instanceof Error && err.message === 'forbidden: tooling role required') {
+      return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+    }
     const message = err instanceof Error ? err.message : 'Failed to resolve GitLab packages'
     return NextResponse.json({ ok: false, error: message }, { status: 502 })
   }
 }
 
 export async function GET(req: NextRequest): Promise<NextResponse | Response> {
+  try {
+    const session = await getApiSession(req.headers)
+    requireToolingAccess(session.user)
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: err.status })
+    }
+    if (err instanceof Error && err.message === 'forbidden: tooling role required') {
+      return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+    }
+    throw err
+  }
+
   const params = Object.fromEntries(req.nextUrl.searchParams.entries())
   const parsed = QuerySchema.safeParse(params)
   if (!parsed.success) {

--- a/apps/web/app/api/tools/jenkins-bundler/route.ts
+++ b/apps/web/app/api/tools/jenkins-bundler/route.ts
@@ -8,6 +8,8 @@ import {
   resolveWarUrl,
 } from '@/lib/jenkins/update-center'
 import { compareVersions } from '@/lib/version-compare'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
+import { requireToolingAccess } from '@/lib/auth/tooling'
 
 export const runtime = 'nodejs'
 
@@ -318,6 +320,19 @@ function resolveTree(
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getApiSession(req.headers)
+    requireToolingAccess(session.user)
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: err.status })
+    }
+    if (err instanceof Error && err.message === 'forbidden: tooling role required') {
+      return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+    }
+    throw err
+  }
+
   let body: unknown
   try {
     body = await req.json()
@@ -414,6 +429,19 @@ const PluginQuerySchema = z.object({
 const QuerySchema = z.discriminatedUnion('kind', [WarQuerySchema, PluginQuerySchema])
 
 export async function GET(req: NextRequest): Promise<NextResponse | Response> {
+  try {
+    const session = await getApiSession(req.headers)
+    requireToolingAccess(session.user)
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: err.status })
+    }
+    if (err instanceof Error && err.message === 'forbidden: tooling role required') {
+      return NextResponse.json({ ok: false, error: 'Forbidden' }, { status: 403 })
+    }
+    throw err
+  }
+
   const params = Object.fromEntries(req.nextUrl.searchParams.entries())
   const parsed = QuerySchema.safeParse(params)
   if (!parsed.success) {

--- a/apps/web/components/shared/command-palette/command-palette.tsx
+++ b/apps/web/components/shared/command-palette/command-palette.tsx
@@ -65,10 +65,11 @@ function writeRecents(ids: string[]): void {
 
 interface CommandPaletteProviderProps {
   orgId: string
+  userRole: string
   children: React.ReactNode
 }
 
-export function CommandPaletteProvider({ orgId, children }: CommandPaletteProviderProps) {
+export function CommandPaletteProvider({ orgId, userRole, children }: CommandPaletteProviderProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   const open = useCallback(() => setIsOpen(true), [])
@@ -96,20 +97,21 @@ export function CommandPaletteProvider({ orgId, children }: CommandPaletteProvid
   return (
     <CommandPaletteContext.Provider value={value}>
       {children}
-      <CommandPaletteDialog orgId={orgId} isOpen={isOpen} onOpenChange={setIsOpen} />
+      <CommandPaletteDialog orgId={orgId} userRole={userRole} isOpen={isOpen} onOpenChange={setIsOpen} />
     </CommandPaletteContext.Provider>
   )
 }
 
 interface CommandPaletteDialogProps {
   orgId: string
+  userRole: string
   isOpen: boolean
   onOpenChange: (next: boolean) => void
 }
 
-function CommandPaletteDialog({ orgId, isOpen, onOpenChange }: CommandPaletteDialogProps) {
+function CommandPaletteDialog({ orgId, userRole, isOpen, onOpenChange }: CommandPaletteDialogProps) {
   const router = useRouter()
-  const navItems = useNavigationItems()
+  const navItems = useNavigationItems(userRole)
   const hostItems = useHostItems(orgId, isOpen)
 
   const allItems = useMemo(() => [...navItems, ...hostItems], [navItems, hostItems])

--- a/apps/web/components/shared/command-palette/providers.tsx
+++ b/apps/web/components/shared/command-palette/providers.tsx
@@ -24,6 +24,7 @@ import {
   Users,
 } from 'lucide-react'
 import { listHosts } from '@/lib/actions/agents'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import type { CommandPaletteItem } from './types'
 
 const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
@@ -53,10 +54,20 @@ const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
   { id: 'nav-system-health', label: 'System', icon: HeartPulse, href: '/settings/system', keywords: ['health'] },
 ]
 
-export function useNavigationItems(): CommandPaletteItem[] {
+const TOOLING_ITEM_IDS = new Set([
+  'nav-cert-checker',
+  'nav-dir-lookup',
+  'nav-bundlers',
+  'nav-build-docs',
+  'nav-tasks',
+])
+
+export function useNavigationItems(userRole: string): CommandPaletteItem[] {
   return useMemo(
-    () => NAV_ITEMS.map((item) => ({ ...item, group: 'Navigation' })),
-    [],
+    () => NAV_ITEMS
+      .filter((item) => canAccessTooling({ role: userRole }) || !TOOLING_ITEM_IDS.has(item.id))
+      .map((item) => ({ ...item, group: 'Navigation' })),
+    [userRole],
   )
 }
 

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -43,6 +43,7 @@ import {
 import { cn } from '@/lib/utils'
 import { TerminalPanelTrigger } from '@/components/terminal'
 import { hasFeature, type Feature, type LicenceTier } from '@/lib/features'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import pkg from '../../package.json'
 
 const WEB_VERSION = `v${pkg.version}`
@@ -269,7 +270,9 @@ const TIER_LABEL: Record<LicenceTier, string> = {
   enterprise: 'Enterprise Edition',
 }
 
-export function AppSidebar({ orgId, tier }: { orgId: string; tier: LicenceTier }) {
+export function AppSidebar({ orgId, tier, userRole }: { orgId: string; tier: LicenceTier; userRole: string }) {
+  const showTooling = canAccessTooling({ role: userRole })
+
   return (
     <Sidebar>
       <SidebarHeader className="border-b border-sidebar-border px-4 py-3">
@@ -283,17 +286,19 @@ export function AppSidebar({ orgId, tier }: { orgId: string; tier: LicenceTier }
       <SidebarContent>
         <NavGroup label="Monitoring" items={primaryNav} tier={tier} />
         <NavGroup label="Reporting" items={reportingNav} tier={tier} />
-        <SidebarGroup>
-          <SidebarGroupLabel>Tooling</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <NavGroupItems items={toolingNav} tier={tier} />
-              <SidebarMenuItem>
-                <TerminalPanelTrigger orgId={orgId} />
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+        {showTooling ? (
+          <SidebarGroup>
+            <SidebarGroupLabel>Tooling</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <NavGroupItems items={toolingNav} tier={tier} />
+                <SidebarMenuItem>
+                  <TerminalPanelTrigger orgId={orgId} />
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null}
         <NavGroup label="Administration" items={adminNav} tier={tier} />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border p-2">

--- a/apps/web/lib/actions/action-auth.ts
+++ b/apps/web/lib/actions/action-auth.ts
@@ -1,5 +1,6 @@
 import { getRequiredSession, type RequiredSession } from '@/lib/auth/session'
 import { assertOrgAccess, assertOrgAdminAccess } from '@/lib/actions/action-auth-core'
+import { requireToolingAccess } from '@/lib/auth/tooling'
 
 export async function requireOrgAccess(orgId: string): Promise<RequiredSession> {
   const session = await getRequiredSession()
@@ -10,5 +11,11 @@ export async function requireOrgAccess(orgId: string): Promise<RequiredSession> 
 export async function requireOrgAdminAccess(orgId: string): Promise<RequiredSession> {
   const session = await getRequiredSession()
   assertOrgAdminAccess(session.user, orgId)
+  return session
+}
+
+export async function requireOrgToolingAccess(orgId: string): Promise<RequiredSession> {
+  const session = await requireOrgAccess(orgId)
+  requireToolingAccess(session.user)
   return session
 }

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
+import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -264,7 +264,7 @@ export async function searchLdapDirectory(
   configId: string,
   query: string,
 ): Promise<{ success: true; users: LdapUserResult[] } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   if (!query.trim()) return { success: true, users: [] }
 
   const config = await db.query.ldapConfigurations.findFirst({
@@ -294,7 +294,7 @@ export type LookupConfigOption = {
 export async function getLookupConfigOptions(
   orgId: string,
 ): Promise<LookupConfigOption[]> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const rows = await db.query.ldapConfigurations.findMany({
     where: and(
       eq(ldapConfigurations.organisationId, orgId),
@@ -316,7 +316,7 @@ export async function lookupDirectoryUser(
   configId: string,
   dn: string,
 ): Promise<{ success: true; user: LdapUserDetailResult } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const config = await db.query.ldapConfigurations.findFirst({
     where: and(
       eq(ldapConfigurations.id, configId),

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import {
@@ -101,7 +101,7 @@ export async function getTaskRun(
   orgId: string,
   taskRunId: string,
 ): Promise<TaskRunWithHosts | null> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const run = await db.query.taskRuns.findFirst({
     where: and(
       eq(taskRuns.id, taskRunId),
@@ -152,7 +152,7 @@ export async function listTaskRunsForHost(
   hostId: string,
   taskType?: string,
 ): Promise<TaskRunWithHosts[]> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   // Find task_run_hosts rows for this host
   const hostRunRows = await db.query.taskRunHosts.findMany({
     where: and(
@@ -192,7 +192,7 @@ export async function listAutomatedRunsForHost(
   hostId: string,
   taskType?: string,
 ): Promise<TaskRunWithHosts[]> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const hostRunRows = await db.query.taskRunHosts.findMany({
     where: and(
       eq(taskRunHosts.hostId, hostId),
@@ -230,7 +230,7 @@ export async function listTaskRunsForGroup(
   groupId: string,
   taskType?: string,
 ): Promise<TaskRunWithHosts[]> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const runs = await db.query.taskRuns.findMany({
     where: and(
       eq(taskRuns.organisationId, orgId),
@@ -260,7 +260,7 @@ export async function cancelTaskRun(
   orgId: string,
   taskRunId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   try {
     return await db.transaction(async (tx) => {
       // Verify ownership and that the run is still active.
@@ -346,7 +346,7 @@ export async function triggerCustomScriptRun(
   interpreter: 'sh' | 'bash' | 'python3',
   timeoutSeconds?: number,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
     return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
   }
@@ -373,7 +373,7 @@ export async function triggerGroupCustomScriptRun(
   maxParallel: number,
   timeoutSeconds?: number,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
     return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
   }
@@ -405,7 +405,7 @@ export async function triggerServiceAction(
   serviceName: string,
   action: 'start' | 'stop' | 'restart' | 'status',
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })
@@ -432,7 +432,7 @@ export async function triggerGroupServiceAction(
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const members = await db.query.hostGroupMembers.findMany({
     where: and(
       eq(hostGroupMembers.groupId, groupId),
@@ -503,7 +503,7 @@ export async function triggerAgentUninstall(
   userId: string,
   hostId: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })
@@ -524,7 +524,7 @@ export async function deleteTaskRuns(
   orgId: string,
   taskRunIds: string[],
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   if (taskRunIds.length === 0) return { success: true }
   try {
     const now = new Date()
@@ -569,7 +569,7 @@ export async function triggerPatchRun(
   hostId: string,
   mode: 'security' | 'all',
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(
       eq(hosts.id, hostId),
@@ -600,7 +600,7 @@ export async function triggerGroupPatchRun(
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   // Fetch all members of the group
   const members = await db.query.hostGroupMembers.findMany({
     where: and(

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -1,14 +1,12 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import { taskSchedules, taskRuns, hostGroups, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, desc, inArray } from 'drizzle-orm'
 import { CronExpressionParser } from 'cron-parser'
-import { MEMBERSHIP_ROLES } from '@/lib/auth/roles'
-import { hasRole } from '@/lib/auth/guards'
 import { z } from 'zod'
 import type { TaskSchedule, TaskType, TaskConfig } from '@/lib/db/schema'
 import {
@@ -112,7 +110,7 @@ async function verifyTargetExists(
 // ── Read queries ──────────────────────────────────────────────────────────────
 
 export async function listSchedules(orgId: string): Promise<ScheduleWithTargetName[]> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const rows = await db.query.taskSchedules.findMany({
     where: and(eq(taskSchedules.organisationId, orgId), isNull(taskSchedules.deletedAt)),
     orderBy: [desc(taskSchedules.createdAt)],
@@ -160,7 +158,7 @@ export async function getSchedule(
   orgId: string,
   id: string,
 ): Promise<{ schedule: TaskSchedule; recentRuns: Awaited<ReturnType<typeof recentRunsForSchedule>> } | null> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   const schedule = await db.query.taskSchedules.findFirst({
     where: and(
       eq(taskSchedules.id, id),
@@ -192,8 +190,7 @@ export async function createSchedule(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
-  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
+  const session = await requireOrgToolingAccess(orgId)
 
   const parsed = scheduleInputSchema.safeParse(input)
   if (!parsed.success) {
@@ -244,8 +241,7 @@ export async function updateSchedule(
   id: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
-  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
+  const session = await requireOrgToolingAccess(orgId)
 
   const existing = await db.query.taskSchedules.findFirst({
     where: and(
@@ -305,8 +301,7 @@ export async function setScheduleEnabled(
   id: string,
   enabled: boolean,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
-  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
+  const session = await requireOrgToolingAccess(orgId)
 
   const existing = await db.query.taskSchedules.findFirst({
     where: and(
@@ -343,8 +338,7 @@ export async function deleteSchedule(
   orgId: string,
   id: string,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
-  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
+  const session = await requireOrgToolingAccess(orgId)
 
   try {
     await db
@@ -373,8 +367,7 @@ export async function runScheduleNow(
   orgId: string,
   id: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
-  if (!hasRole(session.user, MEMBERSHIP_ROLES)) return { error: 'Insufficient permissions' }
+  const session = await requireOrgToolingAccess(orgId)
 
   const schedule = await db.query.taskSchedules.findFirst({
     where: and(

--- a/apps/web/lib/auth/tooling.test.mjs
+++ b/apps/web/lib/auth/tooling.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { canAccessTooling, requireToolingAccess } from './tooling.ts'
+
+const baseUser = {
+  organisationId: 'org-1',
+  isActive: true,
+  deletedAt: null,
+}
+
+test('canAccessTooling allows engineer and admin roles', () => {
+  assert.equal(canAccessTooling({ ...baseUser, role: 'engineer' }), true)
+  assert.equal(canAccessTooling({ ...baseUser, role: 'org_admin' }), true)
+  assert.equal(canAccessTooling({ ...baseUser, role: 'super_admin' }), true)
+})
+
+test('requireToolingAccess rejects read-only and pending roles', () => {
+  assert.equal(canAccessTooling({ ...baseUser, role: 'read_only' }), false)
+  assert.equal(canAccessTooling({ ...baseUser, role: 'pending' }), false)
+  assert.throws(
+    () => requireToolingAccess({ ...baseUser, role: 'read_only' }),
+    /forbidden: tooling role required/,
+  )
+})

--- a/apps/web/lib/auth/tooling.ts
+++ b/apps/web/lib/auth/tooling.ts
@@ -1,0 +1,13 @@
+import { hasRole } from './guards.ts'
+import { MEMBERSHIP_ROLES } from './roles.ts'
+import type { SessionUser } from './session.ts'
+
+export function canAccessTooling(user: Pick<SessionUser, 'role'>): boolean {
+  return hasRole(user, MEMBERSHIP_ROLES)
+}
+
+export function requireToolingAccess(user: Pick<SessionUser, 'role'>): void {
+  if (!canAccessTooling(user)) {
+    throw new Error('forbidden: tooling role required')
+  }
+}

--- a/apps/web/lib/build-docs/permissions.ts
+++ b/apps/web/lib/build-docs/permissions.ts
@@ -1,14 +1,15 @@
 import type { SessionUser } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { canAccessTooling } from '@/lib/auth/tooling'
 
 export function canManageBuildDocAdministration(user: SessionUser): boolean {
   return ADMIN_ROLES.includes(user.role)
 }
 
 export function canWriteBuildDocs(user: SessionUser): boolean {
-  return user.role !== 'read_only' && user.role !== 'pending'
+  return canAccessTooling(user)
 }
 
 export function canReadBuildDocs(user: SessionUser): boolean {
-  return user.role !== 'pending'
+  return canAccessTooling(user)
 }

--- a/apps/web/tests/e2e/tooling/access-control.spec.ts
+++ b/apps/web/tests/e2e/tooling/access-control.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_USER } from '../fixtures/seed'
+
+async function getUserId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ user_id: string }>>`
+    SELECT id AS user_id
+    FROM "user"
+    WHERE email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.user_id
+}
+
+test('read-only users cannot access tooling pages or certificate checker API', async ({ authenticatedPage: page, baseURL }) => {
+  const sql = getTestDb()
+  const userId = await getUserId(sql)
+
+  await sql`UPDATE "user" SET role = 'read_only', updated_at = NOW() WHERE id = ${userId}`
+
+  try {
+    await page.goto('/dashboard')
+    await expect(page.getByText('Tooling')).toHaveCount(0)
+    await expect(page.getByRole('link', { name: 'SSL Certificate Checker' })).toHaveCount(0)
+
+    await page.goto('/certificate-checker')
+    await expect(page).toHaveURL(/\/dashboard$/)
+
+    const response = await page.request.post(`${baseURL}/api/tools/certificate-checker`, {
+      headers: {
+        origin: baseURL!,
+      },
+      data: {
+        action: 'parse',
+        pemText: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----',
+      },
+    })
+    expect(response.status()).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: 'Forbidden' })
+  } finally {
+    await sql`UPDATE "user" SET role = 'org_admin', updated_at = NOW() WHERE id = ${userId}`
+  }
+})


### PR DESCRIPTION
## Summary
- centralise tooling role checks for engineer and admin users
- hide tooling navigation and command-palette entries from disallowed roles
- block tooling pages plus LDAP, task, build-doc, and tooling API access for read-only users

## Testing
- node --experimental-strip-types --test lib/auth/guards.test.mjs lib/auth/tooling.test.mjs
- pnpm type-check
- pnpm test:e2e tests/e2e/tooling/access-control.spec.ts

Closes #760