### PR TITLE
test(web): cover pending approval and tooling redirects

### DIFF
--- a/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
+++ b/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
@@ -15,9 +15,9 @@ export function PendingApprovalCard() {
   }
 
   return (
-    <Card>
+    <Card data-testid="pending-approval-card">
       <CardHeader>
-        <CardTitle>Account pending approval</CardTitle>
+        <CardTitle data-testid="pending-approval-heading">Account pending approval</CardTitle>
         <CardDescription>
           Your account has been created but needs to be approved by an administrator.
           You&apos;ll be able to access the dashboard once a role has been assigned to you.
@@ -29,7 +29,12 @@ export function PendingApprovalCard() {
         </p>
       </CardContent>
       <CardFooter>
-        <Button variant="outline" className="w-full" onClick={handleSignOut}>
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={handleSignOut}
+          data-testid="pending-approval-signout"
+        >
           Sign out
         </Button>
       </CardFooter>

--- a/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
+++ b/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
@@ -1,8 +1,39 @@
 import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_USER } from '../fixtures/seed'
 
 test('authenticated user visiting login is redirected to the dashboard', async ({ authenticatedPage: page }) => {
   await page.goto('/login')
 
   await page.waitForURL('**/dashboard')
   await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+})
+
+test('pending users are redirected to approval and can sign out', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const rows = await sql`
+    SELECT id AS user_id
+    FROM "user"
+    WHERE email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  const userId = rows[0].user_id
+
+  await sql`UPDATE "user" SET role = 'pending', updated_at = NOW() WHERE id = ${userId}`
+
+  try {
+    await page.goto('/dashboard')
+
+    await page.waitForURL('**/pending-approval')
+    await expect(page.getByTestId('pending-approval-card')).toBeVisible()
+    await expect(page.getByTestId('pending-approval-heading')).toContainText('Account pending approval')
+    await expect(page.getByText('needs to be approved by an administrator.')).toBeVisible()
+
+    await page.getByTestId('pending-approval-signout').click()
+    await page.waitForURL('**/login')
+    await expect(page.getByTestId('login-submit')).toBeVisible()
+  } finally {
+    await sql`UPDATE "user" SET role = 'org_admin', updated_at = NOW() WHERE id = ${userId}`
+  }
 })

--- a/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
+++ b/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
@@ -18,7 +18,8 @@ test('pending users are redirected to approval and can sign out', async ({ authe
     LIMIT 1
   `
   expect(rows).toHaveLength(1)
-  const userId = rows[0].user_id
+  const userId = rows[0]?.user_id
+  expect(userId).toBeTruthy()
 
   await sql`UPDATE "user" SET role = 'pending', updated_at = NOW() WHERE id = ${userId}`
 

--- a/apps/web/tests/e2e/tooling/access-control.spec.ts
+++ b/apps/web/tests/e2e/tooling/access-control.spec.ts
@@ -24,8 +24,10 @@ test('read-only users cannot access tooling pages or certificate checker API', a
     await expect(page.getByText('Tooling')).toHaveCount(0)
     await expect(page.getByRole('link', { name: 'SSL Certificate Checker' })).toHaveCount(0)
 
-    await page.goto('/certificate-checker')
-    await expect(page).toHaveURL(/\/dashboard$/)
+    for (const path of ['/certificate-checker', '/directory-lookup', '/tasks', '/build-docs']) {
+      await page.goto(path)
+      await expect(page).toHaveURL(/\/dashboard$/)
+    }
 
     const response = await page.request.post(`${baseURL}/api/tools/certificate-checker`, {
       headers: {


### PR DESCRIPTION
## Summary
- add E2E coverage for pending users redirecting to the approval screen and signing out
- expand tooling access-control coverage to assert read-only redirects for additional protected pages
- add stable pending-approval test ids used by the E2E assertions

## Testing
- pnpm --filter web test:e2e -- tests/e2e/auth/authenticated-redirects.spec.ts tests/e2e/tooling/access-control.spec.ts