### PR TITLE
feat(vuln): match rhel-compatible rpm hosts

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -41,10 +41,11 @@
 - Hardened Red Hat parsing to prefer structured `affected_release` package data, extracting full RPM EVR from package NEVRA and preserving advisory/product metadata.
 - Marked free-text Red Hat `affected_packages` fallback rows as probable rather than confirmed.
 - Updated RPM matching to report vendor EVR-specific reasons and handle RHEL major-version advisory rules matching minor-version hosts such as `8.9`.
+- Added RHEL-compatible distro matching for RPM hosts, so AlmaLinux/Rocky/CentOS/Oracle-style inventory with `ID_LIKE=rhel` can match structured Red Hat advisory rows by full EVR.
 - Replaced direct unbounded post-scan matching goroutines with a bounded ingest-side vulnerability match scheduler used by inventory completion and feed sync.
 
 **Validation**
-- Added unit coverage for RPM backport release matching, fixed RPM packages resolving, Red Hat structured affected-release parsing, confirmed finding persistence, unsupported package sources, and host assessment status derivation.
+- Added unit coverage for RPM backport release matching, RHEL-compatible distro matching, fixed RPM packages resolving, Red Hat structured affected-release parsing, confirmed finding persistence, unsupported package sources, and host assessment status derivation.
 - Validation run: `go test ./internal/vuln`, `go test ./...` from `apps/ingest`, `node --experimental-strip-types --test lib/vulnerabilities/assessment.test.mjs`, `pnpm --dir apps/web run db:validate`, `pnpm --dir apps/web run type-check`, and `pnpm --dir apps/web run lint` (existing warnings only).
 
 ### Session 77 — Build Docs rich Markdown editor

--- a/apps/ingest/internal/vuln/db.go
+++ b/apps/ingest/internal/vuln/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"strings"
 	"time"
 
 	ctcrypto "github.com/carrtech-dev/ct-ops/ingest/internal/crypto"
@@ -298,7 +299,8 @@ func loadHostPackages(ctx context.Context, pool *pgxpool.Pool, hostID string) ([
 		SELECT id, organisation_id, host_id, name, version, source,
 		       COALESCE(distro_id, ''), COALESCE(distro_version_id, ''),
 		       COALESCE(distro_codename, ''), COALESCE(source_name, ''),
-		       COALESCE(source_version, ''), COALESCE(repository, '')
+		       COALESCE(source_version, ''), COALESCE(repository, ''),
+		       COALESCE(distro_id_like, '[]'::jsonb)::text
 		FROM software_packages
 		WHERE host_id = $1
 		  AND deleted_at IS NULL
@@ -313,13 +315,15 @@ func loadHostPackages(ctx context.Context, pool *pgxpool.Pool, hostID string) ([
 	var pkgs []InventoryPackage
 	for rows.Next() {
 		var pkg InventoryPackage
+		var distroIDLikeJSON string
 		if err := rows.Scan(
 			&pkg.ID, &pkg.OrganisationID, &pkg.HostID, &pkg.Name, &pkg.Version, &pkg.Source,
 			&pkg.DistroID, &pkg.DistroVersionID, &pkg.DistroCodename,
-			&pkg.SourceName, &pkg.SourceVersion, &pkg.Repository,
+			&pkg.SourceName, &pkg.SourceVersion, &pkg.Repository, &distroIDLikeJSON,
 		); err != nil {
 			return nil, err
 		}
+		_ = json.Unmarshal([]byte(distroIDLikeJSON), &pkg.DistroIDLike)
 		pkgs = append(pkgs, pkg)
 	}
 	return pkgs, rows.Err()
@@ -330,6 +334,8 @@ func loadAffectedCandidates(ctx context.Context, pool *pgxpool.Pool, pkg Invento
 	if pkg.SourceName != "" && pkg.SourceName != pkg.Name {
 		nameCandidates = append(nameCandidates, pkg.SourceName)
 	}
+	distroCandidates := affectedDistroCandidates(pkg)
+	majorVersion := majorRHELDistroVersion(pkg)
 	rows, err := pool.Query(ctx, `
 		SELECT vap.id, vap.cve_id, vap.source, vap.distro_id,
 		       COALESCE(vap.distro_version_id, ''), COALESCE(vap.distro_codename, ''),
@@ -337,11 +343,11 @@ func loadAffectedCandidates(ctx context.Context, pool *pgxpool.Pool, pkg Invento
 		       COALESCE(vap.fixed_version, ''), COALESCE(vap.affected_versions, '[]'::jsonb)::text,
 		       COALESCE(vap.repository, ''), vap.severity, COALESCE(vap.package_state, '')
 		FROM vulnerability_affected_packages vap
-		WHERE vap.distro_id = $1
-		  AND (vap.distro_version_id IS NULL OR vap.distro_version_id = $2)
-		  AND (vap.distro_codename IS NULL OR vap.distro_codename = $3)
-		  AND vap.package_name = ANY($4::text[])
-	`, pkg.DistroID, pkg.DistroVersionID, pkg.DistroCodename, nameCandidates)
+		WHERE vap.distro_id = ANY($1::text[])
+		  AND (vap.distro_version_id IS NULL OR vap.distro_version_id = $2 OR ($3 <> '' AND vap.distro_version_id = $3))
+		  AND (vap.distro_codename IS NULL OR vap.distro_codename = $4)
+		  AND vap.package_name = ANY($5::text[])
+	`, distroCandidates, pkg.DistroVersionID, majorVersion, pkg.DistroCodename, nameCandidates)
 	if err != nil {
 		return nil, err
 	}
@@ -363,6 +369,24 @@ func loadAffectedCandidates(ctx context.Context, pool *pgxpool.Pool, pkg Invento
 		out = append(out, row)
 	}
 	return out, rows.Err()
+}
+
+func affectedDistroCandidates(pkg InventoryPackage) []string {
+	candidates := []string{pkg.DistroID}
+	if pkg.Source == "rpm" && isRHELCompatibleDistro(pkg) && !strings.EqualFold(pkg.DistroID, "rhel") {
+		candidates = append(candidates, "rhel")
+	}
+	return candidates
+}
+
+func majorRHELDistroVersion(pkg InventoryPackage) string {
+	if pkg.Source != "rpm" || !isRHELCompatibleDistro(pkg) || pkg.DistroVersionID == "" {
+		return ""
+	}
+	if idx := strings.Index(pkg.DistroVersionID, "."); idx > 0 {
+		return pkg.DistroVersionID[:idx]
+	}
+	return ""
 }
 
 type findingTx interface {

--- a/apps/ingest/internal/vuln/matcher.go
+++ b/apps/ingest/internal/vuln/matcher.go
@@ -6,7 +6,7 @@ func MatchPackage(pkg InventoryPackage, affected AffectedPackage) (bool, string)
 	if !supportedInventorySource(pkg.Source) {
 		return false, "unsupported inventory source"
 	}
-	if affected.DistroID != "" && !strings.EqualFold(pkg.DistroID, affected.DistroID) {
+	if affected.DistroID != "" && !distroMatches(pkg, affected) {
 		return false, "distro mismatch"
 	}
 	if affected.DistroVersionID != "" && pkg.DistroVersionID != "" && !distroVersionMatches(pkg, affected) {
@@ -41,12 +41,35 @@ func MatchPackage(pkg InventoryPackage, affected AffectedPackage) (bool, string)
 	return false, "installed version is fixed"
 }
 
+func distroMatches(pkg InventoryPackage, affected AffectedPackage) bool {
+	if strings.EqualFold(pkg.DistroID, affected.DistroID) {
+		return true
+	}
+	if pkg.Source == "rpm" && strings.EqualFold(affected.DistroID, "rhel") {
+		return isRHELCompatibleDistro(pkg)
+	}
+	return false
+}
+
 func distroVersionMatches(pkg InventoryPackage, affected AffectedPackage) bool {
 	if affected.DistroVersionID == pkg.DistroVersionID {
 		return true
 	}
-	if pkg.Source == "rpm" && strings.EqualFold(affected.DistroID, "rhel") {
+	if pkg.Source == "rpm" && strings.EqualFold(affected.DistroID, "rhel") && isRHELCompatibleDistro(pkg) {
 		return !strings.Contains(affected.DistroVersionID, ".") && strings.HasPrefix(pkg.DistroVersionID, affected.DistroVersionID+".")
+	}
+	return false
+}
+
+func isRHELCompatibleDistro(pkg InventoryPackage) bool {
+	switch strings.ToLower(pkg.DistroID) {
+	case "rhel", "redhat", "redhatenterpriseserver", "almalinux", "rocky", "centos", "ol", "oraclelinux", "miraclelinux":
+		return true
+	}
+	for _, like := range pkg.DistroIDLike {
+		if strings.EqualFold(like, "rhel") {
+			return true
+		}
 	}
 	return false
 }

--- a/apps/ingest/internal/vuln/matcher_test.go
+++ b/apps/ingest/internal/vuln/matcher_test.go
@@ -125,6 +125,63 @@ func TestRPMBackportReleaseDoesNotMatchFixedPackage(t *testing.T) {
 	}
 }
 
+func TestRPMRHELCompatibleDistroMatchesRedHatAdvisory(t *testing.T) {
+	t.Parallel()
+
+	pkg := InventoryPackage{
+		Name:            "openssl-libs",
+		Version:         "1:3.5.1-5.el9_7",
+		Source:          "rpm",
+		DistroID:        "almalinux",
+		DistroIDLike:    []string{"rhel", "centos", "fedora"},
+		DistroVersionID: "9.7",
+		SourceName:      "openssl",
+		SourceVersion:   "1:3.5.1-5.el9_7",
+	}
+	affected := AffectedPackage{
+		Source:          "redhat-security-data",
+		DistroID:        "rhel",
+		DistroVersionID: "9",
+		PackageName:     "openssl",
+		FixedVersion:    "1:3.5.1-7.el9_7",
+	}
+
+	match, reason := MatchPackage(pkg, affected)
+	if !match {
+		t.Fatalf("MatchPackage returned false: %s", reason)
+	}
+	if reason != "installed rpm evr is below vendor fixed evr" {
+		t.Fatalf("reason = %q, want RPM EVR-specific reason", reason)
+	}
+}
+
+func TestRPMNonRHELCompatibleDistroDoesNotMatchRedHatAdvisory(t *testing.T) {
+	t.Parallel()
+
+	pkg := InventoryPackage{
+		Name:            "openssl-libs",
+		Version:         "1:3.5.1-5.el9_7",
+		Source:          "rpm",
+		DistroID:        "suse",
+		DistroIDLike:    []string{"suse"},
+		DistroVersionID: "9.7",
+		SourceName:      "openssl",
+		SourceVersion:   "1:3.5.1-5.el9_7",
+	}
+	affected := AffectedPackage{
+		Source:          "redhat-security-data",
+		DistroID:        "rhel",
+		DistroVersionID: "9",
+		PackageName:     "openssl",
+		FixedVersion:    "1:3.5.1-7.el9_7",
+	}
+
+	match, reason := MatchPackage(pkg, affected)
+	if match || reason != "distro mismatch" {
+		t.Fatalf("MatchPackage = %v, %q; want distro mismatch", match, reason)
+	}
+}
+
 func TestUpsertFindingStoresConfirmedConfidenceAndReason(t *testing.T) {
 	t.Parallel()
 

--- a/apps/ingest/internal/vuln/types.go
+++ b/apps/ingest/internal/vuln/types.go
@@ -73,6 +73,7 @@ type InventoryPackage struct {
 	Version         string
 	Source          string
 	DistroID        string
+	DistroIDLike    []string
 	DistroVersionID string
 	DistroCodename  string
 	SourceName      string


### PR DESCRIPTION
## Summary
- match RHEL-compatible RPM hosts such as AlmaLinux, Rocky, CentOS, and Oracle Linux against structured Red Hat advisory rows
- carry `distro_id_like` from software inventory into vulnerability matching
- expand affected-package candidate lookup so minor-version hosts like AlmaLinux 9.7 can use RHEL major-version advisory rows

## Why
AlmaLinux inventory reports `distro_id=almalinux` with `ID_LIKE=rhel`, while Red Hat advisory data is keyed as `rhel`. Without compatibility matching, confirmed RPM CVE findings can be missed even when the installed EVR is below the vendor fixed EVR.

## Validation
- `go test ./internal/vuln`
