### PR TITLE
test(web): add host compare and security CA e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/compare/compare-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/compare/compare-client.tsx
@@ -29,7 +29,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
 
   if (!hostIdB) {
     return (
-      <div className="max-w-2xl space-y-4">
+      <div className="max-w-2xl space-y-4" data-testid="host-compare-empty-state">
         <Link
           href={`/hosts/${hostIdA}`}
           className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
@@ -55,7 +55,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
           <ArrowLeft className="size-3.5" />
           Back
         </Link>
-        <h1 className="text-xl font-semibold flex items-center gap-2">
+        <h1 className="text-xl font-semibold flex items-center gap-2" data-testid="host-compare-heading">
           <GitCompare className="size-5" />
           Package comparison
         </h1>
@@ -73,7 +73,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
       {data && (
         <div className="space-y-6">
           {data.differentVersion.length > 0 && (
-            <div>
+            <div data-testid="host-compare-different-versions">
               <h2 className="text-sm font-semibold mb-2 flex items-center gap-2">
                 Different versions
                 <Badge variant="secondary">{data.differentVersion.length}</Badge>
@@ -89,7 +89,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
                   </TableHeader>
                   <TableBody>
                     {data.differentVersion.map((row) => (
-                      <TableRow key={row.name}>
+                      <TableRow key={row.name} data-testid={`host-compare-different-row-${row.name}`}>
                         <TableCell className="font-mono text-sm">{row.name}</TableCell>
                         <TableCell className="font-mono text-sm text-amber-700">
                           {row.versionA}
@@ -106,7 +106,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
           )}
 
           {data.onlyInA.length > 0 && (
-            <div>
+            <div data-testid="host-compare-only-in-a">
               <h2 className="text-sm font-semibold mb-2 flex items-center gap-2">
                 Only in host A
                 <Badge variant="secondary">{data.onlyInA.length}</Badge>
@@ -121,7 +121,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
                   </TableHeader>
                   <TableBody>
                     {data.onlyInA.map((pkg) => (
-                      <TableRow key={pkg.id}>
+                      <TableRow key={pkg.id} data-testid={`host-compare-only-in-a-row-${pkg.name}`}>
                         <TableCell className="font-mono text-sm">{pkg.name}</TableCell>
                         <TableCell className="font-mono text-sm text-muted-foreground">
                           {pkg.version}
@@ -135,7 +135,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
           )}
 
           {data.onlyInB.length > 0 && (
-            <div>
+            <div data-testid="host-compare-only-in-b">
               <h2 className="text-sm font-semibold mb-2 flex items-center gap-2">
                 Only in host B
                 <Badge variant="secondary">{data.onlyInB.length}</Badge>
@@ -150,7 +150,7 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
                   </TableHeader>
                   <TableBody>
                     {data.onlyInB.map((pkg) => (
-                      <TableRow key={pkg.id}>
+                      <TableRow key={pkg.id} data-testid={`host-compare-only-in-b-row-${pkg.name}`}>
                         <TableCell className="font-mono text-sm">{pkg.name}</TableCell>
                         <TableCell className="font-mono text-sm text-muted-foreground">
                           {pkg.version}
@@ -167,7 +167,9 @@ export function CompareHostsClient({ orgId, hostIdA, hostIdB }: Props) {
             data.onlyInA.length === 0 &&
             data.onlyInB.length === 0 && (
               <div className="text-center py-12 text-sm text-muted-foreground">
+                <span data-testid="host-compare-identical-message">
                 These hosts have identical package sets.
+                </span>
               </div>
             )}
         </div>

--- a/apps/web/tests/e2e/hosts/compare.spec.ts
+++ b/apps/web/tests/e2e/hosts/compare.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('authenticated user can compare packages between two hosts', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      status
+    )
+    VALUES
+      (
+        'compare-host-a',
+        ${orgId},
+        'compare-host-a',
+        'Compare Host A',
+        'Ubuntu 24.04',
+        'x86_64',
+        'online'
+      ),
+      (
+        'compare-host-b',
+        ${orgId},
+        'compare-host-b',
+        'Compare Host B',
+        'Ubuntu 24.04',
+        'x86_64',
+        'online'
+      )
+  `
+
+  await sql`
+    INSERT INTO software_packages (
+      id,
+      organisation_id,
+      host_id,
+      name,
+      version,
+      architecture,
+      source,
+      first_seen_at,
+      last_seen_at
+    )
+    VALUES
+      (
+        'compare-pkg-openssl-a',
+        ${orgId},
+        'compare-host-a',
+        'openssl',
+        '3.0.2',
+        'x86_64',
+        'dpkg',
+        NOW() - INTERVAL '2 days',
+        NOW() - INTERVAL '1 hour'
+      ),
+      (
+        'compare-pkg-nginx-a',
+        ${orgId},
+        'compare-host-a',
+        'nginx',
+        '1.24.0',
+        'x86_64',
+        'dpkg',
+        NOW() - INTERVAL '2 days',
+        NOW() - INTERVAL '1 hour'
+      ),
+      (
+        'compare-pkg-openssl-b',
+        ${orgId},
+        'compare-host-b',
+        'openssl',
+        '3.0.3',
+        'x86_64',
+        'dpkg',
+        NOW() - INTERVAL '1 day',
+        NOW() - INTERVAL '30 minutes'
+      ),
+      (
+        'compare-pkg-curl-b',
+        ${orgId},
+        'compare-host-b',
+        'curl',
+        '8.7.1',
+        'x86_64',
+        'dpkg',
+        NOW() - INTERVAL '1 day',
+        NOW() - INTERVAL '30 minutes'
+      )
+  `
+
+  await page.goto('/hosts/compare-host-a/compare?with=compare-host-b')
+
+  await expect(page.getByTestId('host-compare-heading')).toBeVisible()
+  await expect(page.getByTestId('host-compare-different-versions')).toContainText('Different versions')
+  await expect(page.getByTestId('host-compare-different-row-openssl')).toContainText('3.0.2')
+  await expect(page.getByTestId('host-compare-different-row-openssl')).toContainText('3.0.3')
+
+  await expect(page.getByTestId('host-compare-only-in-a')).toContainText('Only in host A')
+  await expect(page.getByTestId('host-compare-only-in-a-row-nginx')).toContainText('1.24.0')
+
+  await expect(page.getByTestId('host-compare-only-in-b')).toContainText('Only in host B')
+  await expect(page.getByTestId('host-compare-only-in-b-row-curl')).toContainText('8.7.1')
+})
+
+test('authenticated user sees an empty-state message when no comparison host is supplied', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      status
+    )
+    VALUES (
+      'compare-host-empty',
+      ${orgId},
+      'compare-host-empty',
+      'Compare Host Empty',
+      'Ubuntu 24.04',
+      'x86_64',
+      'online'
+    )
+  `
+
+  await page.goto('/hosts/compare-host-empty/compare')
+
+  await expect(page.getByTestId('host-compare-empty-state')).toContainText(
+    'No host to compare with.',
+  )
+  await expect(page.getByRole('link', { name: 'Back to host' })).toHaveAttribute(
+    'href',
+    '/hosts/compare-host-empty',
+  )
+})

--- a/apps/web/tests/e2e/settings/security-overview.spec.ts
+++ b/apps/web/tests/e2e/settings/security-overview.spec.ts
@@ -6,8 +6,6 @@ import { join } from 'node:path'
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 
-const E2E_AGENT_CA_FORM_VALUE = 'placeholder'
-
 function createAgentCaFixture() {
   const fixtureDir = mkdtempSync(join(tmpdir(), 'ct-ops-security-ca-'))
   const keyPath = join(fixtureDir, 'agent-ca.key')
@@ -31,10 +29,12 @@ function createAgentCaFixture() {
     ], { stdio: 'ignore' })
 
     const certPem = readFileSync(certPath, 'utf8')
+    const keyPem = readFileSync(keyPath, 'utf8')
     const cert = new X509Certificate(certPem)
 
     return {
       certPem,
+      keyPem,
       subject: cert.subject,
       fingerprintSha256: cert.fingerprint256.replace(/:/g, '').toLowerCase(),
       notBefore: new Date(cert.validFrom).toISOString(),
@@ -46,8 +46,9 @@ function createAgentCaFixture() {
 }
 
 const E2E_AGENT_CA = createAgentCaFixture()
+const E2E_UPLOADED_AGENT_CA = createAgentCaFixture()
 
-test('admin can review the current agent CA and upload form readiness in security settings', async ({ authenticatedPage: page }) => {
+test('admin can review the current agent CA and upload a replacement CA from security settings', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
 
   await sql`
@@ -90,11 +91,60 @@ test('admin can review the current agent CA and upload form readiness in securit
   const uploadButton = page.getByTestId('security-upload-submit')
   await expect(uploadButton).toBeDisabled()
 
-  await page.getByTestId('security-upload-cert').fill(E2E_AGENT_CA.certPem)
+  await page.getByTestId('security-upload-cert').fill(E2E_UPLOADED_AGENT_CA.certPem)
   await expect(uploadButton).toBeDisabled()
 
-  await page.getByTestId('security-upload-key').fill(E2E_AGENT_CA_FORM_VALUE)
+  await page.getByTestId('security-upload-key').fill(E2E_UPLOADED_AGENT_CA.keyPem)
   await expect(uploadButton).toBeEnabled()
+
+  await uploadButton.click()
+
+  await expect(page.getByText('Upload successful')).toBeVisible()
+  await expect(page.getByText('Uploaded. Fingerprint:')).toBeVisible()
+  await expect(page.getByTestId('security-agent-ca-source')).toContainText('Customer-provided')
+  await expect(page.getByTestId('security-agent-ca-subject')).toContainText(E2E_UPLOADED_AGENT_CA.subject)
+  await expect(page.getByTestId('security-agent-ca-fingerprint')).toContainText(
+    E2E_UPLOADED_AGENT_CA.fingerprintSha256,
+  )
+
+  await expect(page.getByTestId('security-upload-cert')).toHaveValue('')
+  await expect(page.getByTestId('security-upload-key')).toHaveValue('')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        id: string
+        source: string
+        fingerprint_sha256: string
+        deleted_at: string | null
+      }>>`
+        SELECT id, source, fingerprint_sha256, deleted_at
+        FROM certificate_authorities
+        WHERE purpose = 'agent_ca'
+        ORDER BY created_at ASC
+      `
+
+      return rows.map((row) => ({
+        id: row.id,
+        source: row.source,
+        fingerprint_sha256: row.fingerprint_sha256,
+        is_deleted: row.deleted_at !== null,
+      }))
+    })
+    .toEqual([
+      {
+        id: 'e2e-agent-ca-current',
+        source: 'auto',
+        fingerprint_sha256: E2E_AGENT_CA.fingerprintSha256,
+        is_deleted: true,
+      },
+      {
+        id: expect.any(String),
+        source: 'byo',
+        fingerprint_sha256: E2E_UPLOADED_AGENT_CA.fingerprintSha256,
+        is_deleted: false,
+      },
+    ])
 
   await expect(page.getByRole('link', { name: 'Terminal access' })).toHaveAttribute(
     'href',


### PR DESCRIPTION
## Summary
- add E2E coverage for the host package comparison flow, including the empty-state path
- expand security settings coverage to exercise custom agent CA uploads and CA rotation persistence
- add stable compare-page test ids so the new E2E assertions do not depend on layout text

## Testing
- pnpm --filter web test:e2e -- tests/e2e/hosts/compare.spec.ts tests/e2e/settings/security-overview.spec.ts