### PR TITLE
test(web): cover monitoring alert defaults and webhooks

### DIFF
--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -181,12 +181,23 @@ function AddWebhookDialog({
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="webhook-name">Name</Label>
-            <Input id="webhook-name" placeholder="e.g. PagerDuty" {...register('name')} />
+            <Input
+              id="webhook-name"
+              placeholder="e.g. PagerDuty"
+              data-testid="alert-webhook-name"
+              {...register('name')}
+            />
             {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="webhook-url">URL</Label>
-            <Input id="webhook-url" placeholder="https://..." type="url" {...register('url')} />
+            <Input
+              id="webhook-url"
+              placeholder="https://..."
+              type="url"
+              data-testid="alert-webhook-url"
+              {...register('url')}
+            />
             {errors.url && <p className="text-sm text-red-600">{errors.url.message}</p>}
           </div>
           <div className="space-y-1.5">
@@ -197,6 +208,7 @@ function AddWebhookDialog({
               id="webhook-secret"
               placeholder="Used for HMAC-SHA256 signature"
               type="password"
+              data-testid="alert-webhook-secret"
               {...register('secret')}
             />
           </div>
@@ -204,7 +216,7 @@ function AddWebhookDialog({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} data-testid="alert-webhook-submit">
               Add Channel
             </Button>
           </DialogFooter>
@@ -1461,6 +1473,7 @@ export function AlertsClient({
               size="sm"
               variant="outline"
               onClick={() => setAddWebhookOpen(true)}
+              data-testid="alerts-add-webhook"
             >
               <Plus className="size-3.5 mr-1" />
               Add Webhook

--- a/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
@@ -129,7 +129,12 @@ function AddDefaultDialog({
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 py-2">
           <div className="space-y-1">
             <Label htmlFor="name">Rule Name</Label>
-            <Input id="name" placeholder="e.g. High CPU Usage" {...register('name')} />
+            <Input
+              id="name"
+              placeholder="e.g. High CPU Usage"
+              data-testid="settings-alert-default-name"
+              {...register('name')}
+            />
             {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
           </div>
 
@@ -141,7 +146,7 @@ function AddDefaultDialog({
                 name="metric"
                 render={({ field }) => (
                   <Select onValueChange={field.onChange} value={field.value}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger data-testid="settings-alert-default-metric"><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="cpu">CPU</SelectItem>
                       <SelectItem value="memory">Memory</SelectItem>
@@ -158,7 +163,7 @@ function AddDefaultDialog({
                 name="operator"
                 render={({ field }) => (
                   <Select onValueChange={field.onChange} value={field.value}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger data-testid="settings-alert-default-operator"><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="gt">Above (&gt;)</SelectItem>
                       <SelectItem value="lt">Below (&lt;)</SelectItem>
@@ -174,6 +179,7 @@ function AddDefaultDialog({
                 type="number"
                 min={0}
                 max={100}
+                data-testid="settings-alert-default-threshold"
                 {...register('threshold', { valueAsNumber: true })}
               />
               {errors.threshold && <p className="text-xs text-destructive">{errors.threshold.message}</p>}
@@ -182,15 +188,15 @@ function AddDefaultDialog({
 
           <div className="space-y-1">
             <Label>Severity</Label>
-            <Controller
-              control={control}
-              name="severity"
-              render={({ field }) => (
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="info">Info</SelectItem>
-                    <SelectItem value="warning">Warning</SelectItem>
+              <Controller
+                control={control}
+                name="severity"
+                render={({ field }) => (
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <SelectTrigger data-testid="settings-alert-default-severity"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="info">Info</SelectItem>
+                      <SelectItem value="warning">Warning</SelectItem>
                     <SelectItem value="critical">Critical</SelectItem>
                   </SelectContent>
                 </Select>
@@ -202,7 +208,7 @@ function AddDefaultDialog({
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} data-testid="settings-alert-default-submit">
               {isSubmitting ? 'Adding…' : 'Add Default'}
             </Button>
           </DialogFooter>
@@ -237,7 +243,7 @@ export function GlobalAlertsClient({ orgId, initialDefaults }: GlobalAlertsClien
   return (
     <div className="space-y-6 p-6 max-w-4xl">
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Global Alert Defaults</h1>
+        <h1 className="text-2xl font-semibold tracking-tight" data-testid="settings-alert-defaults-heading">Global Alert Defaults</h1>
         <p className="text-sm text-muted-foreground mt-1">
           These metric alert rules are automatically applied to every new host when an agent is approved.
           After a host is added you can remove individual rules from the host&apos;s Alerts tab.
@@ -256,14 +262,14 @@ export function GlobalAlertsClient({ orgId, initialDefaults }: GlobalAlertsClien
               Check-based rules must be configured per host since they reference host-specific checks.
             </CardDescription>
           </div>
-          <Button size="sm" onClick={() => setDialogOpen(true)}>
+          <Button size="sm" onClick={() => setDialogOpen(true)} data-testid="settings-alert-defaults-add">
             <Plus className="size-4 mr-1" />
             Add Default
           </Button>
         </CardHeader>
         <CardContent>
           {defaults.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+            <div className="flex flex-col items-center justify-center gap-2 py-10 text-center" data-testid="settings-alert-defaults-empty">
               <Bell className="size-8 text-muted-foreground/40" />
               <p className="text-sm text-muted-foreground">No global alert defaults configured.</p>
               <p className="text-xs text-muted-foreground">
@@ -282,7 +288,7 @@ export function GlobalAlertsClient({ orgId, initialDefaults }: GlobalAlertsClien
               </TableHeader>
               <TableBody>
                 {defaults.map((rule) => (
-                  <TableRow key={rule.id}>
+                  <TableRow key={rule.id} data-testid={`settings-alert-default-row-${rule.id}`}>
                     <TableCell className="font-medium">{rule.name}</TableCell>
                     <TableCell className="font-mono text-sm">{ruleSummary(rule)}</TableCell>
                     <TableCell>
@@ -295,6 +301,7 @@ export function GlobalAlertsClient({ orgId, initialDefaults }: GlobalAlertsClien
                         className="size-8 text-muted-foreground hover:text-destructive"
                         onClick={() => deleteMutation.mutate(rule.id)}
                         disabled={deleteMutation.isPending}
+                        data-testid={`settings-alert-default-delete-${rule.id}`}
                       >
                         <Trash2 className="size-4" />
                       </Button>

--- a/apps/web/tests/e2e/alerts/alerts.spec.ts
+++ b/apps/web/tests/e2e/alerts/alerts.spec.ts
@@ -229,7 +229,7 @@ test('admin can review, filter, acknowledge, and clean up alert settings', async
   ])
 })
 
-test('admin can create a silence and an email notification channel from the alerts page', async ({ authenticatedPage: page }) => {
+test('admin can create a silence, email channel, and webhook channel from the alerts page', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const { orgId, userId } = await getOrgAndUserIds(sql)
 
@@ -279,6 +279,15 @@ test('admin can create a silence and an email notification channel from the aler
   await expect(channelRow).toContainText('alerts2@example.com')
   await expect(channelRow).toContainText('team@example.com')
 
+  await page.getByTestId('alerts-add-webhook').click()
+  await page.getByTestId('alert-webhook-name').fill('PagerDuty Webhook')
+  await page.getByTestId('alert-webhook-url').fill('https://alerts.example.com/hooks/pagerduty')
+  await page.getByTestId('alert-webhook-secret').fill('super-secret-token')
+  await page.getByTestId('alert-webhook-submit').click()
+
+  const webhookRow = page.getByRole('row').filter({ hasText: 'PagerDuty Webhook' })
+  await expect(webhookRow).toContainText('https://alerts.example.com/hooks/pagerduty')
+
   const createdRows = await sql<Array<{
     silence_reason: string | null
     silence_host_id: string | null
@@ -286,6 +295,10 @@ test('admin can create a silence and an email notification channel from the aler
     channel_name: string | null
     channel_type: string | null
     recipients: string[] | null
+    webhook_name: string | null
+    webhook_type: string | null
+    webhook_url: string | null
+    webhook_secret: string | null
   }>>`
     SELECT
       (SELECT reason FROM alert_silences WHERE organisation_id = ${orgId} AND reason = 'E2E maintenance window' AND deleted_at IS NULL LIMIT 1) AS silence_reason,
@@ -293,7 +306,11 @@ test('admin can create a silence and an email notification channel from the aler
       (SELECT created_by FROM alert_silences WHERE organisation_id = ${orgId} AND reason = 'E2E maintenance window' AND deleted_at IS NULL LIMIT 1) AS silence_created_by,
       (SELECT name FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS channel_name,
       (SELECT type FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS channel_type,
-      (SELECT ARRAY(SELECT jsonb_array_elements_text(config->'toAddresses')) FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS recipients
+      (SELECT ARRAY(SELECT jsonb_array_elements_text(config->'toAddresses')) FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'Escalation Email' AND deleted_at IS NULL LIMIT 1) AS recipients,
+      (SELECT name FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'PagerDuty Webhook' AND deleted_at IS NULL LIMIT 1) AS webhook_name,
+      (SELECT type FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'PagerDuty Webhook' AND deleted_at IS NULL LIMIT 1) AS webhook_type,
+      (SELECT config->>'url' FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'PagerDuty Webhook' AND deleted_at IS NULL LIMIT 1) AS webhook_url,
+      (SELECT config->>'secret' FROM notification_channels WHERE organisation_id = ${orgId} AND name = 'PagerDuty Webhook' AND deleted_at IS NULL LIMIT 1) AS webhook_secret
   `
 
   expect(createdRows).toEqual([
@@ -304,6 +321,10 @@ test('admin can create a silence and an email notification channel from the aler
       channel_name: 'Escalation Email',
       channel_type: 'smtp',
       recipients: ['alerts2@example.com', 'team@example.com'],
+      webhook_name: 'PagerDuty Webhook',
+      webhook_type: 'webhook',
+      webhook_url: 'https://alerts.example.com/hooks/pagerduty',
+      webhook_secret: 'super-secret-token',
     },
   ])
 })

--- a/apps/web/tests/e2e/settings/alert-defaults.spec.ts
+++ b/apps/web/tests/e2e/settings/alert-defaults.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+test('admin can create and delete global alert defaults from monitoring settings', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+
+  await page.goto('/settings/monitoring')
+  await expect(page.getByTestId('settings-alert-defaults-heading')).toBeVisible()
+  await expect(page.getByTestId('settings-alert-defaults-empty')).toBeVisible()
+
+  await page.getByTestId('settings-alert-defaults-add').click()
+  await page.getByTestId('settings-alert-default-name').fill('Memory saturation')
+  await page.getByTestId('settings-alert-default-metric').click()
+  await page.getByRole('option', { name: 'Memory' }).click()
+  await page.getByTestId('settings-alert-default-threshold').fill('85')
+  await page.getByTestId('settings-alert-default-severity').click()
+  await page.getByRole('option', { name: 'Critical' }).click()
+  await page.getByTestId('settings-alert-default-submit').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        id: string
+        name: string
+        severity: string
+        condition_type: string
+        config: { metric?: string; operator?: string; threshold?: number } | null
+      }>>`
+        SELECT id, name, severity, condition_type, config
+        FROM alert_rules
+        WHERE organisation_id = (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug})
+          AND host_id IS NULL
+          AND is_global_default = true
+          AND deleted_at IS NULL
+          AND name = 'Memory saturation'
+        LIMIT 1
+      `
+
+      return rows[0] ?? null
+    })
+    .toMatchObject({
+      id: expect.any(String),
+      name: 'Memory saturation',
+      severity: 'critical',
+      condition_type: 'metric_threshold',
+      config: {
+        metric: 'memory',
+        operator: 'gt',
+        threshold: 85,
+      },
+    })
+
+  const createdRows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM alert_rules
+    WHERE organisation_id = (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug})
+      AND host_id IS NULL
+      AND is_global_default = true
+      AND deleted_at IS NULL
+      AND name = 'Memory saturation'
+    LIMIT 1
+  `
+  const createdRuleId = createdRows[0]!.id
+
+  const row = page.getByTestId(`settings-alert-default-row-${createdRuleId}`)
+  await expect(row).toContainText('Memory saturation')
+  await expect(row).toContainText('MEMORY > 85%')
+  await expect(row).toContainText('Critical')
+
+  await page.getByTestId(`settings-alert-default-delete-${createdRuleId}`).click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM alert_rules
+        WHERE id = ${createdRuleId}
+        LIMIT 1
+      `
+
+      return rows[0]?.deleted_at ?? null
+    })
+    .toEqual(expect.any(Date))
+
+  await expect(page.getByTestId(`settings-alert-default-row-${createdRuleId}`)).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary
- add E2E coverage for global alert defaults on monitoring settings
- expand alerts-page coverage to include webhook notification channels
- add stable selectors for the new monitoring and webhook flows

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/settings/alert-defaults.spec.ts tests/e2e/alerts/alerts.spec.ts`
