### PR TITLE
test(web): add bulk tag and certificate detail e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/certificates/[id]/certificate-detail-client.tsx
+++ b/apps/web/app/(dashboard)/certificates/[id]/certificate-detail-client.tsx
@@ -80,10 +80,10 @@ export function CertificateDetailClient({ orgId: _orgId, initialCertificate, ini
         </Link>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-semibold text-foreground truncate">{cert.commonName}</h1>
+            <h1 className="text-2xl font-semibold text-foreground truncate" data-testid="certificate-detail-heading">{cert.commonName}</h1>
             <CertificateStatusBadge status={cert.status as CertificateStatus} />
           </div>
-          <p className="text-muted-foreground mt-1 text-sm">
+          <p className="text-muted-foreground mt-1 text-sm" data-testid="certificate-detail-host-port">
             {cert.host}:{cert.port}
             {cert.serverName !== cert.host ? ` (SNI: ${cert.serverName})` : ''}
           </p>
@@ -126,7 +126,7 @@ export function CertificateDetailClient({ orgId: _orgId, initialCertificate, ini
         </CardHeader>
         <CardContent>
           <div className="flex items-center gap-1">
-            <code className="text-sm font-mono break-all text-foreground">{cert.fingerprintSha256}</code>
+            <code className="text-sm font-mono break-all text-foreground" data-testid="certificate-detail-fingerprint">{cert.fingerprintSha256}</code>
             <CopyButton value={cert.fingerprintSha256} />
           </div>
         </CardContent>
@@ -141,7 +141,7 @@ export function CertificateDetailClient({ orgId: _orgId, initialCertificate, ini
           <CardContent>
             <div className="flex flex-wrap gap-2">
               {sans.map((san) => (
-                <Badge key={san} variant="secondary" className="font-mono text-xs">
+                <Badge key={san} variant="secondary" className="font-mono text-xs" data-testid={`certificate-detail-san-${san}`}>
                   {san}
                 </Badge>
               ))}
@@ -159,7 +159,7 @@ export function CertificateDetailClient({ orgId: _orgId, initialCertificate, ini
           <CardContent className="space-y-2 text-sm">
             <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5">
               <span className="text-muted-foreground font-medium">Subject</span>
-              <span className="font-mono break-all">{details.subject}</span>
+              <span className="font-mono break-all" data-testid="certificate-detail-subject">{details.subject}</span>
               <span className="text-muted-foreground font-medium">Serial Number</span>
               <span className="font-mono break-all">{details.serialNumber}</span>
               <span className="text-muted-foreground font-medium">Signature Algorithm</span>
@@ -219,7 +219,7 @@ export function CertificateDetailClient({ orgId: _orgId, initialCertificate, ini
           ) : (
             <div className="space-y-3">
               {events.map((ev) => (
-                <div key={ev.id} className="flex items-start gap-3">
+                <div key={ev.id} className="flex items-start gap-3" data-testid={`certificate-detail-event-${ev.id}`}>
                   <Clock className="size-4 text-muted-foreground mt-0.5 shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">

--- a/apps/web/app/(dashboard)/hosts/bulk-tag/bulk-tag-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/bulk-tag/bulk-tag-client.tsx
@@ -119,7 +119,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
   return (
     <div className="space-y-6 p-6">
       <div>
-        <h1 className="text-2xl font-semibold">Bulk Tag Hosts</h1>
+        <h1 className="text-2xl font-semibold" data-testid="bulk-tag-heading">Bulk Tag Hosts</h1>
         <p className="text-muted-foreground text-sm">
           Select hosts by filter, preview matches, and apply tags. Optionally save the filter as a
           rule that auto-applies to future matching hosts at approval time.
@@ -133,6 +133,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               ? 'border-destructive/50 bg-destructive/10 text-destructive'
               : 'border-secondary bg-secondary text-secondary-foreground'
           }`}
+          data-testid="bulk-tag-message"
         >
           {message.text}
         </div>
@@ -151,6 +152,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               placeholder="web-*.prod"
               value={hostnameGlob}
               onChange={(e) => setHostnameGlob(e.target.value)}
+              data-testid="bulk-tag-filter-hostname-glob"
             />
           </div>
           <div className="space-y-1">
@@ -160,6 +162,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               placeholder="db"
               value={hostnameContains}
               onChange={(e) => setHostnameContains(e.target.value)}
+              data-testid="bulk-tag-filter-hostname-contains"
             />
           </div>
           <div className="space-y-1">
@@ -169,6 +172,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               placeholder="10.0.0.0/8 192.168.1.0/24"
               value={ipCidrs}
               onChange={(e) => setIpCidrs(e.target.value)}
+              data-testid="bulk-tag-filter-ip-cidrs"
             />
           </div>
           <div className="space-y-1">
@@ -178,6 +182,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               placeholder="linux, windows"
               value={osList}
               onChange={(e) => setOsList(e.target.value)}
+              data-testid="bulk-tag-filter-os"
             />
           </div>
           <div className="space-y-1">
@@ -187,6 +192,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               placeholder="amd64, arm64"
               value={archList}
               onChange={(e) => setArchList(e.target.value)}
+              data-testid="bulk-tag-filter-arch"
             />
           </div>
           <div className="space-y-1">
@@ -196,6 +202,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               placeholder="online"
               value={statusList}
               onChange={(e) => setStatusList(e.target.value)}
+              data-testid="bulk-tag-filter-status"
             />
           </div>
         </CardContent>
@@ -219,12 +226,14 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
           variant="outline"
           onClick={() => previewMutation.mutate()}
           disabled={previewMutation.isPending}
+          data-testid="bulk-tag-preview"
         >
           Preview matches
         </Button>
         <Button
           onClick={() => applyMutation.mutate()}
           disabled={!canApply || applyMutation.isPending}
+          data-testid="bulk-tag-apply"
         >
           Apply tags
         </Button>
@@ -232,6 +241,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
           variant="secondary"
           onClick={() => setSaveOpen(true)}
           disabled={tags.length === 0}
+          data-testid="bulk-tag-save-open"
         >
           Save as rule
         </Button>
@@ -240,11 +250,11 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
       {preview && (
         <Card>
           <CardHeader>
-            <CardTitle>Matching hosts ({preview.length})</CardTitle>
+            <CardTitle data-testid="bulk-tag-preview-heading">Matching hosts ({preview.length})</CardTitle>
           </CardHeader>
           <CardContent>
             {preview.length === 0 ? (
-              <p className="text-muted-foreground text-sm">No hosts match the current filter.</p>
+              <p className="text-muted-foreground text-sm" data-testid="bulk-tag-preview-empty">No hosts match the current filter.</p>
             ) : (
               <Table>
                 <TableHeader>
@@ -257,7 +267,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
                 </TableHeader>
                 <TableBody>
                   {preview.map((h) => (
-                    <TableRow key={h.id}>
+                    <TableRow key={h.id} data-testid={`bulk-tag-preview-row-${h.id}`}>
                       <TableCell>{h.displayName ?? h.hostname}</TableCell>
                       <TableCell>{h.os ?? '—'}</TableCell>
                       <TableCell>{h.status}</TableCell>
@@ -289,6 +299,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
               value={ruleName}
               onChange={(e) => setRuleName(e.target.value)}
               placeholder="EU prod zone"
+              data-testid="bulk-tag-rule-name"
             />
           </div>
           <DialogFooter>
@@ -298,6 +309,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
             <Button
               onClick={() => saveRuleMutation.mutate()}
               disabled={!ruleName.trim() || saveRuleMutation.isPending}
+              data-testid="bulk-tag-rule-save"
             >
               Save rule
             </Button>

--- a/apps/web/components/shared/tag-editor.tsx
+++ b/apps/web/components/shared/tag-editor.tsx
@@ -171,6 +171,7 @@ export function TagEditor({
                 <Input
                   id="tag-editor-key"
                   ref={keyRef}
+                  data-testid="tag-editor-key"
                   value={keyInput}
                   onChange={(e) => {
                     setKeyInput(e.target.value)
@@ -219,6 +220,7 @@ export function TagEditor({
                 <Input
                   id="tag-editor-value"
                   ref={valueRef}
+                  data-testid="tag-editor-value"
                   value={valueInput}
                   onChange={(e) => {
                     setValueInput(e.target.value)
@@ -261,6 +263,7 @@ export function TagEditor({
             size="sm"
             onClick={commitFromInputs}
             disabled={!keyInput.trim() || !valueInput.trim()}
+            data-testid="tag-editor-add"
           >
             Add
           </Button>

--- a/apps/web/tests/e2e/certificates/inventory.spec.ts
+++ b/apps/web/tests/e2e/certificates/inventory.spec.ts
@@ -101,12 +101,64 @@ test('admin can review, filter, and delete tracked certificates', async ({ authe
       )
   `
 
+  await sql`
+    INSERT INTO certificate_events (
+      id,
+      organisation_id,
+      certificate_id,
+      event_type,
+      previous_status,
+      new_status,
+      message,
+      occurred_at
+    )
+    VALUES
+      (
+        'cert-event-discovered',
+        ${orgId},
+        'cert-e2e-valid',
+        'discovered',
+        NULL,
+        'valid',
+        'Discovered certificate from TLS handshake.',
+        NOW() - INTERVAL '10 days'
+      ),
+      (
+        'cert-event-renewed',
+        ${orgId},
+        'cert-e2e-valid',
+        'renewed',
+        'expiring_soon',
+        'valid',
+        'Certificate was renewed and validity extended.',
+        NOW() - INTERVAL '2 days'
+      )
+  `
+
   await page.goto('/certificates')
 
   await expect(page.getByTestId('certificates-heading')).toBeVisible()
   await expect(page.getByTestId('certificate-row-cert-e2e-valid')).toContainText('api.example.com')
   await expect(page.getByTestId('certificate-row-cert-e2e-expiring')).toContainText('edge.example.com')
   await expect(page.getByTestId('certificate-row-cert-e2e-expired')).toContainText('legacy.example.com')
+
+  await page.getByTestId('certificate-row-cert-e2e-valid').click()
+
+  await expect(page.getByTestId('certificate-detail-heading')).toContainText('api.example.com')
+  await expect(page.getByTestId('certificate-detail-host-port')).toContainText('api.example.com:443')
+  await expect(page.getByTestId('certificate-detail-fingerprint')).toContainText('sha256-valid')
+  await expect(page.getByTestId('certificate-detail-san-api.example.com')).toBeVisible()
+  await expect(page.getByTestId('certificate-detail-subject')).toContainText('CN=api.example.com')
+  await expect(page.getByTestId('certificate-detail-event-cert-event-discovered')).toContainText('Discovered')
+  await expect(page.getByTestId('certificate-detail-event-cert-event-discovered')).toContainText(
+    'Discovered certificate from TLS handshake.',
+  )
+  await expect(page.getByTestId('certificate-detail-event-cert-event-renewed')).toContainText('Renewed')
+  await expect(page.getByTestId('certificate-detail-event-cert-event-renewed')).toContainText(
+    'Certificate was renewed and validity extended.',
+  )
+
+  await page.goto('/certificates')
 
   await page.getByTestId('certificates-filter-host').fill('edge')
   await expect(page.getByTestId('certificate-row-cert-e2e-expiring')).toBeVisible()

--- a/apps/web/tests/e2e/hosts/bulk-tag.spec.ts
+++ b/apps/web/tests/e2e/hosts/bulk-tag.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can preview, apply, and save bulk host tags', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES
+      (
+        'bulk-tag-host-match',
+        ${orgId},
+        'web-01',
+        'Web 01',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.30.0.10"]'::jsonb,
+        'online',
+        NOW()
+      ),
+      (
+        'bulk-tag-host-ignore',
+        ${orgId},
+        'db-01',
+        'DB 01',
+        'Ubuntu 24.04',
+        'x86_64',
+        '["10.30.0.20"]'::jsonb,
+        'offline',
+        NOW()
+      )
+  `
+
+  await page.goto('/hosts/bulk-tag')
+
+  await expect(page.getByTestId('bulk-tag-heading')).toBeVisible()
+
+  await page.getByTestId('bulk-tag-filter-hostname-contains').fill('web')
+  await page.getByTestId('bulk-tag-filter-status').fill('online')
+  await page.getByTestId('tag-editor-key').fill('env')
+  await page.getByTestId('tag-editor-value').fill('prod')
+  await page.getByTestId('tag-editor-add').click()
+
+  await page.getByTestId('bulk-tag-preview').click()
+
+  await expect(page.getByTestId('bulk-tag-preview-heading')).toContainText('Matching hosts (1)')
+  await expect(page.getByTestId('bulk-tag-preview-row-bulk-tag-host-match')).toContainText('Web 01')
+  await expect(page.getByTestId('bulk-tag-preview-row-bulk-tag-host-ignore')).toHaveCount(0)
+
+  await page.getByTestId('bulk-tag-apply').click()
+  await expect(page.getByTestId('bulk-tag-message')).toContainText('Applied tags to 1 host(s).')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ key: string; value: string }>>`
+        SELECT tags.key, tags.value
+        FROM resource_tags
+        JOIN tags ON tags.id = resource_tags.tag_id
+        WHERE resource_tags.resource_type = 'host'
+          AND resource_tags.resource_id = 'bulk-tag-host-match'
+        ORDER BY tags.key ASC, tags.value ASC
+      `
+      return rows
+    })
+    .toEqual([{ key: 'env', value: 'prod' }])
+
+  const ignoredRows = await sql<Array<{ count: string }>>`
+    SELECT COUNT(*)::text AS count
+    FROM resource_tags
+    WHERE resource_type = 'host'
+      AND resource_id = 'bulk-tag-host-ignore'
+  `
+  expect(ignoredRows[0]?.count).toBe('0')
+
+  await page.getByTestId('bulk-tag-save-open').click()
+  await page.getByTestId('bulk-tag-rule-name').fill('Production web hosts')
+  await page.getByTestId('bulk-tag-rule-save').click()
+
+  await expect(page.getByTestId('bulk-tag-message')).toContainText(
+    'Rule saved — it will auto-apply to matching hosts on approval.',
+  )
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        name: string
+        filter: { hostnameContains?: string; status?: string[] } | null
+        tags: Array<{ key: string; value: string }> | null
+      }>>`
+        SELECT name, filter, tags
+        FROM tag_rules
+        WHERE organisation_id = ${orgId}
+          AND deleted_at IS NULL
+          AND name = 'Production web hosts'
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toMatchObject({
+      name: 'Production web hosts',
+      filter: {
+        hostnameContains: 'web',
+        status: ['online'],
+      },
+      tags: [{ key: 'env', value: 'prod' }],
+    })
+})


### PR DESCRIPTION
## Summary
- add first E2E coverage for the bulk host tagging workflow
- expand certificate inventory coverage to exercise the certificate detail page and event timeline
- add stable selectors needed by those flows without changing product behavior

## Validation
- pnpm --filter web test:e2e -- tests/e2e/hosts/bulk-tag.spec.ts tests/e2e/certificates/inventory.spec.ts
