### PR TITLE
test(web): add certificate upload and bundle e2e coverage

### DIFF
--- a/apps/web/tests/e2e/certificate-checker/url-check.spec.ts
+++ b/apps/web/tests/e2e/certificate-checker/url-check.spec.ts
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_ORG } from '../fixtures/seed'
@@ -140,6 +142,108 @@ test('authenticated user can analyse a pasted certificate and clear the result',
   await page.getByTestId('certificate-checker-clear').click()
   await expect(page.getByTestId('certificate-checker-result')).toHaveCount(0)
   await expect(page.getByTestId('certificate-checker-empty-state')).toBeVisible()
+})
+
+test('authenticated user can analyse an uploaded certificate file with a matching key', async ({ authenticatedPage: page }) => {
+  let capturedBody: Record<string, unknown> | null = null
+
+  await page.route('**/api/tools/certificate-checker', async (route) => {
+    capturedBody = route.request().postDataJSON() as Record<string, unknown>
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        keyMatch: true,
+        certificate: {
+          pem: TRACKING_TEST_CERT_PEM,
+          subject: 'CN=upload.example.com, O=Example Corp, C=GB',
+          issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+          commonName: 'upload.example.com',
+          organization: 'Example Corp',
+          organizationalUnit: 'Platform',
+          country: 'GB',
+          state: 'London',
+          locality: 'London',
+          issuerCommonName: 'Example Issuing CA',
+          issuerOrganization: 'Example PKI',
+          notBefore: '2026-01-01T00:00:00.000Z',
+          notAfter: '2027-01-01T00:00:00.000Z',
+          daysRemaining: 200,
+          isExpired: false,
+          isExpiringSoon: false,
+          isSelfSigned: false,
+          isCA: false,
+          pathLength: null,
+          serialNumber: 'UPLOAD12345',
+          fingerprintSha256: 'UPLOAD:AA:BB:CC:DD',
+          fingerprintSha512: 'UPLOAD:11:22:33:44',
+          keyAlgorithm: 'RSA',
+          keySize: 2048,
+          curve: null,
+          signatureAlgorithm: 'sha256WithRSAEncryption',
+          subjectKeyId: 'upload-subject-key-id',
+          authorityKeyId: 'upload-authority-key-id',
+          keyUsage: ['Digital Signature', 'Key Encipherment'],
+          extendedKeyUsage: ['TLS Web Server Authentication'],
+          certificatePolicies: ['2.23.140.1.2.1'],
+          sans: [
+            { type: 'DNS', value: 'upload.example.com' },
+          ],
+          ocspUrls: [],
+          caIssuers: [],
+          crlUrls: [],
+          chain: [
+            {
+              subject: 'CN=upload.example.com, O=Example Corp, C=GB',
+              issuer: 'CN=Example Issuing CA, O=Example PKI, C=GB',
+              notBefore: '2026-01-01T00:00:00.000Z',
+              notAfter: '2027-01-01T00:00:00.000Z',
+              isCA: false,
+              fingerprintSha256: 'UPLOAD:AA:BB:CC:DD',
+            },
+          ],
+        },
+      }),
+    })
+  })
+
+  const tmpDir = path.join(process.cwd(), 'tests', 'e2e', '.tmp')
+  const certPath = path.join(tmpDir, 'certificate-checker-upload.der')
+  const keyPath = path.join(tmpDir, 'certificate-checker-upload.key')
+  const certBytes = Buffer.from([0x30, 0x82, 0x01, 0x0a, 0x02, 0x82, 0x01, 0x01, 0x00, 0xd9, 0xaa, 0x55])
+  const keyPem = [
+    '-----BEGIN PRIVATE KEY-----',
+    'uploaded-test-key',
+    '-----END PRIVATE KEY-----',
+  ].join('\n')
+
+  await mkdir(tmpDir, { recursive: true })
+  await writeFile(certPath, certBytes)
+  await writeFile(keyPath, keyPem)
+
+  await page.goto('/certificate-checker')
+
+  await expect(page.getByTestId('certificate-checker-heading')).toBeVisible()
+  await page.locator('input[type="file"]').nth(0).setInputFiles(certPath)
+  await page.locator('input[type="file"]').nth(1).setInputFiles(keyPath)
+  await page.getByRole('button', { name: 'Analyse Certificate' }).click()
+
+  await expect
+    .poll(() => capturedBody)
+    .toMatchObject({
+      action: 'parse',
+      data: certBytes.toString('base64'),
+      keyPem,
+    })
+
+  await expect(page.getByTestId('certificate-checker-result')).toBeVisible()
+  await expect(page.getByTestId('certificate-checker-result-title')).toContainText('upload.example.com')
+  await expect(page.getByTestId('certificate-checker-status')).toContainText('Valid')
+  await expect(page.getByTestId('certificate-checker-key-match')).toContainText(
+    'Private key matches this certificate',
+  )
 })
 
 test('authenticated user can track an uploaded certificate after analysis', async ({ authenticatedPage: page }) => {

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -134,3 +134,79 @@ test('admin can create an auto-approved token that skips TLS verification', asyn
 
   expect(rows).toHaveLength(0)
 })
+
+test('admin can generate an install bundle with an existing token and bundle tags', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+  let capturedBody: Record<string, unknown> | null = null
+
+  await sql`
+    INSERT INTO agent_enrolment_tokens (
+      id,
+      organisation_id,
+      label,
+      token,
+      created_by_id,
+      auto_approve,
+      skip_verify,
+      max_uses,
+      usage_count,
+      expires_at,
+      metadata
+    )
+    VALUES (
+      'bundle-existing-token-id',
+      ${orgId},
+      'Bundle Existing Token',
+      'bundle-existing-token-value',
+      ${userId},
+      false,
+      false,
+      5,
+      0,
+      NOW() + INTERVAL '14 days',
+      '{}'::jsonb
+    )
+  `
+
+  await page.route('**/api/agent/bundle', async (route) => {
+    capturedBody = route.request().postDataJSON() as Record<string, unknown>
+
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'application/zip',
+        'content-disposition': 'attachment; filename=\"ct-ops-agent-linux-amd64.zip\"',
+      },
+      body: 'bundle-zip-placeholder',
+    })
+  })
+
+  await page.goto('/settings/agents')
+
+  await expect(page.getByTestId('agent-enrolment-heading')).toBeVisible()
+  await page.getByRole('button', { name: 'Download Install Bundle' }).click()
+
+  await page.getByLabel('Ingest address (optional)').fill('ingest.example.internal:7443')
+  await page.getByLabel('Embed an existing token').click()
+  await page.getByLabel('Active token').click()
+  await page.getByRole('option', { name: 'Bundle Existing Token' }).click()
+  await page.getByTestId('tag-editor-key').fill('env')
+  await page.getByTestId('tag-editor-value').fill('prod')
+  await page.getByTestId('tag-editor-add').click()
+  const downloadButton = page.getByRole('dialog').getByRole('button', { name: 'Download' })
+  await downloadButton.scrollIntoViewIfNeeded()
+  await downloadButton.evaluate((button: HTMLButtonElement) => button.click())
+
+  await expect
+    .poll(() => capturedBody)
+    .toMatchObject({
+      os: 'linux',
+      arch: 'amd64',
+      ingestAddress: 'ingest.example.internal:7443',
+      tokenId: 'bundle-existing-token-id',
+      tags: [{ key: 'env', value: 'prod' }],
+    })
+
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary
- add certificate-checker E2E coverage for uploaded certificate file parsing with a matching key
- expand agent enrolment E2E coverage to include install-bundle generation with an existing token and bundle tags

## Validation
- pnpm --filter web test:e2e -- tests/e2e/certificate-checker/url-check.spec.ts tests/e2e/settings/agent-enrolment.spec.ts
