### PR TITLE
fix(web): isolate host network e2e state

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -228,10 +228,21 @@ function VulnerabilityStatusBadge({ status }: { status: HostVulnerabilityAssessm
   )
 }
 
-function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+function TabButton({
+  active,
+  onClick,
+  children,
+  testId,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+  testId?: string
+}) {
   return (
     <button
       onClick={onClick}
+      data-testid={testId}
       className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
         active
           ? 'border-primary text-foreground'
@@ -528,6 +539,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
               setActiveParentTab(parent.id)
               setActiveTab(parent.defaultTab)
             }}
+            testId={`host-parent-tab-${parent.id}`}
           >
             {parent.label}
             {parent.id === 'monitoring' && activeAlertCount > 0 && (
@@ -549,6 +561,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
                 key={childTab}
                 active={activeTab === childTab}
                 onClick={() => setActiveTab(childTab)}
+                testId={`host-tab-${childTab}`}
               >
                 {TAB_LABELS[childTab]}
                 {childTab === 'storage' && disks.length > 0 && (
@@ -945,12 +958,17 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
 
       {/* Groups Tab */}
       {activeTab === 'groups' && (
-        <div className="space-y-4">
+        <div className="space-y-4" data-testid="host-groups-tab">
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               Groups this host belongs to.
             </p>
-            <Button size="sm" onClick={() => setAddGroupOpen(true)} disabled={allGroups.length === hostGroupsList.length}>
+            <Button
+              size="sm"
+              onClick={() => setAddGroupOpen(true)}
+              disabled={allGroups.length === hostGroupsList.length}
+              data-testid="host-groups-add-trigger"
+            >
               <Layers className="size-4 mr-1" />
               Add to Group
             </Button>
@@ -970,7 +988,11 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
           ) : (
             <div className="rounded-lg border divide-y">
               {hostGroupsList.map((group) => (
-                <div key={group.id} className="flex items-center gap-3 px-4 py-3">
+                <div
+                  key={group.id}
+                  className="flex items-center gap-3 px-4 py-3"
+                  data-testid={`host-group-row-${group.id}`}
+                >
                   <Layers className="size-4 text-muted-foreground shrink-0" />
                   <div className="flex-1 min-w-0">
                     <Link
@@ -989,6 +1011,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
                     className="size-8 text-destructive hover:text-destructive shrink-0"
                     disabled={isRemovingFromGroup}
                     onClick={() => doRemoveFromGroup(group.id)}
+                    data-testid={`host-groups-remove-${group.id}`}
                   >
                     <Trash2 className="size-3.5" />
                   </Button>
@@ -1027,6 +1050,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
                           variant="outline"
                           disabled={isAddingToGroup}
                           onClick={() => doAddToGroup(group.id)}
+                          data-testid={`host-groups-add-${group.id}`}
                         >
                           {isAddingToGroup ? <Loader2 className="size-3.5 animate-spin" /> : 'Add'}
                         </Button>

--- a/apps/web/app/(dashboard)/service-accounts/service-accounts-client.tsx
+++ b/apps/web/app/(dashboard)/service-accounts/service-accounts-client.tsx
@@ -79,6 +79,7 @@ function SummaryCard({
   colorClass,
   onClick,
   active,
+  testId,
 }: {
   title: string
   count: number
@@ -86,11 +87,13 @@ function SummaryCard({
   colorClass: string
   onClick: () => void
   active: boolean
+  testId: string
 }) {
   return (
     <Card
       className={`cursor-pointer transition-colors ${active ? 'ring-2 ring-primary' : 'hover:bg-muted/50'}`}
       onClick={onClick}
+      data-testid={testId}
     >
       <CardHeader className="pb-2">
         <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
@@ -297,6 +300,7 @@ export function ServiceAccountsClient({
           colorClass="text-foreground"
           onClick={() => setStatusFilter('all')}
           active={statusFilter === 'all'}
+          testId="service-accounts-summary-total"
         />
         <SummaryCard
           title="Active"
@@ -305,6 +309,7 @@ export function ServiceAccountsClient({
           colorClass="text-green-600"
           onClick={() => setStatusFilter(statusFilter === 'active' ? 'all' : 'active')}
           active={statusFilter === 'active'}
+          testId="service-accounts-summary-active"
         />
         <SummaryCard
           title="Disabled"
@@ -313,6 +318,7 @@ export function ServiceAccountsClient({
           colorClass="text-gray-500"
           onClick={() => setStatusFilter(statusFilter === 'disabled' ? 'all' : 'disabled')}
           active={statusFilter === 'disabled'}
+          testId="service-accounts-summary-disabled"
         />
         <SummaryCard
           title="Locked"
@@ -321,6 +327,7 @@ export function ServiceAccountsClient({
           colorClass="text-red-600"
           onClick={() => setStatusFilter(statusFilter === 'locked' ? 'all' : 'locked')}
           active={statusFilter === 'locked'}
+          testId="service-accounts-summary-locked"
         />
         <SummaryCard
           title="Expired"
@@ -329,6 +336,7 @@ export function ServiceAccountsClient({
           colorClass="text-amber-600"
           onClick={() => setStatusFilter(statusFilter === 'expired' ? 'all' : 'expired')}
           active={statusFilter === 'expired'}
+          testId="service-accounts-summary-expired"
         />
       </div>
 

--- a/apps/web/tests/e2e/fixtures/db.ts
+++ b/apps/web/tests/e2e/fixtures/db.ts
@@ -36,6 +36,7 @@ const APP_TABLES = [
   'host_group_members',
   'host_groups',
   'host_metrics',
+  'host_network_memberships',
   'host_package_updates',
   'host_patch_statuses',
   'host_vulnerability_findings',

--- a/apps/web/tests/e2e/hosts/host-detail-memberships.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-detail-memberships.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('authenticated user can manage group and network memberships from the host detail page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'membership-host-1',
+      ${orgId},
+      'ops-node-01',
+      'Ops Node 01',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.70.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`
+    INSERT INTO host_groups (
+      id,
+      organisation_id,
+      name,
+      description
+    )
+    VALUES (
+      'membership-group-1',
+      ${orgId},
+      'Canary Fleet',
+      'Hosts staged for rollout validation'
+    )
+  `
+
+  await sql`
+    INSERT INTO networks (
+      id,
+      organisation_id,
+      name,
+      cidr,
+      description
+    )
+    VALUES (
+      'membership-network-1',
+      ${orgId},
+      'Ops LAN',
+      '10.70.0.0/24',
+      'Operations network'
+    )
+  `
+
+  await page.goto('/hosts/membership-host-1')
+
+  await expect(page.getByText('Ops Node 01')).toBeVisible()
+
+  await page.getByTestId('host-parent-tab-management').click()
+  await expect(page.getByTestId('host-groups-tab')).toBeVisible()
+  await expect(page.getByText('Not in any groups')).toBeVisible()
+
+  await page.getByTestId('host-groups-add-trigger').click()
+  await page.getByTestId('host-groups-add-membership-group-1').click()
+
+  const groupRow = page.getByTestId('host-group-row-membership-group-1')
+  await expect(groupRow).toContainText('Canary Fleet')
+  await expect(page.getByText('Not in any groups')).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at
+        FROM host_group_members
+        WHERE organisation_id = ${orgId}
+          AND group_id = 'membership-group-1'
+          AND host_id = 'membership-host-1'
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({ deleted_at: null })
+
+  await page.getByTestId('host-groups-remove-membership-group-1').click()
+  await expect(groupRow).toHaveCount(0)
+  await expect(page.getByText('Not in any groups')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at
+        FROM host_group_members
+        WHERE organisation_id = ${orgId}
+          AND group_id = 'membership-group-1'
+          AND host_id = 'membership-host-1'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .not.toBeNull()
+
+  await page.getByTestId('host-parent-tab-infrastructure').click()
+  await page.getByTestId('host-tab-host-networks').click()
+  await expect(page.getByTestId('host-networks-tab')).toBeVisible()
+  await expect(page.getByText('Not in any networks')).toBeVisible()
+
+  await page.getByTestId('host-networks-add-trigger').click()
+  await page.getByTestId('host-networks-add-membership-network-1').click()
+
+  const networkRow = page.getByTestId('host-network-row-membership-network-1')
+  await expect(networkRow).toContainText('Ops LAN')
+  await expect(page.getByTestId('host-network-membership-membership-network-1')).toContainText('Manual')
+  await expect(page.getByText('Not in any networks')).toHaveCount(0)
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: string | null; auto_assigned: boolean }>>`
+        SELECT deleted_at, auto_assigned
+        FROM host_network_memberships
+        WHERE organisation_id = ${orgId}
+          AND network_id = 'membership-network-1'
+          AND host_id = 'membership-host-1'
+        LIMIT 1
+      `
+      return rows[0] ?? null
+    })
+    .toEqual({ deleted_at: null, auto_assigned: false })
+
+  await page.getByTestId('host-networks-remove-membership-network-1').click()
+  await expect(networkRow).toHaveCount(0)
+  await expect(page.getByText('Not in any networks')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at
+        FROM host_network_memberships
+        WHERE organisation_id = ${orgId}
+          AND network_id = 'membership-network-1'
+          AND host_id = 'membership-host-1'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .not.toBeNull()
+})

--- a/apps/web/tests/e2e/service-accounts/service-accounts.spec.ts
+++ b/apps/web/tests/e2e/service-accounts/service-accounts.spec.ts
@@ -54,6 +54,22 @@ test('admin can review, filter, and add service accounts', async ({ authenticate
         'Legacy Service',
         'svc-disabled@example.com',
         'disabled'
+      ),
+      (
+        'svc-account-locked',
+        ${orgId},
+        'svc-locked',
+        'Locked Service',
+        'svc-locked@example.com',
+        'locked'
+      ),
+      (
+        'svc-account-expired',
+        ${orgId},
+        'svc-expired',
+        'Expired Service',
+        'svc-expired@example.com',
+        'expired'
       )
   `
 
@@ -62,6 +78,27 @@ test('admin can review, filter, and add service accounts', async ({ authenticate
   await expect(page.getByTestId('service-accounts-heading')).toBeVisible()
   await expect(page.getByTestId('service-account-row-svc-account-active')).toContainText('svc-active')
   await expect(page.getByTestId('service-account-row-svc-account-disabled')).toContainText('svc-disabled')
+  await expect(page.getByTestId('service-account-row-svc-account-locked')).toContainText('svc-locked')
+  await expect(page.getByTestId('service-account-row-svc-account-expired')).toContainText('svc-expired')
+  await expect(page.getByText('4 service accounts tracked')).toBeVisible()
+
+  await page.getByTestId('service-accounts-summary-locked').click()
+  await expect(page.getByTestId('service-account-row-svc-account-locked')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-active')).toHaveCount(0)
+  await expect(page.getByTestId('service-account-row-svc-account-disabled')).toHaveCount(0)
+  await expect(page.getByTestId('service-account-row-svc-account-expired')).toHaveCount(0)
+
+  await page.getByTestId('service-accounts-summary-expired').click()
+  await expect(page.getByTestId('service-account-row-svc-account-expired')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-active')).toHaveCount(0)
+  await expect(page.getByTestId('service-account-row-svc-account-disabled')).toHaveCount(0)
+  await expect(page.getByTestId('service-account-row-svc-account-locked')).toHaveCount(0)
+
+  await page.getByTestId('service-accounts-summary-total').click()
+  await expect(page.getByTestId('service-account-row-svc-account-active')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-disabled')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-locked')).toBeVisible()
+  await expect(page.getByTestId('service-account-row-svc-account-expired')).toBeVisible()
 
   await page.getByTestId('service-accounts-search-input').fill('Legacy Service')
   await expect(page.getByTestId('service-account-row-svc-account-disabled')).toBeVisible()
@@ -84,7 +121,7 @@ test('admin can review, filter, and add service accounts', async ({ authenticate
 
   const newRow = page.getByRole('row').filter({ hasText: 'svc-reporting' })
   await expect(newRow).toContainText('Reporting Service')
-  await expect(page.getByText('3 service accounts tracked')).toBeVisible()
+  await expect(page.getByText('5 service accounts tracked')).toBeVisible()
 
   const rows = await sql<Array<{ username: string; status: string; email: string | null }>>`
     SELECT username, status, email


### PR DESCRIPTION
## Summary
- add host detail e2e coverage for managing group and network memberships
- extend service account e2e coverage for locked and expired summary filters
- truncate host network memberships in the shared e2e database harness to prevent leaked state

## Testing
- pnpm --filter web test:e2e -- tests/e2e/hosts/host-detail-memberships.spec.ts tests/e2e/service-accounts/service-accounts.spec.ts