### PR TITLE
test(web): expand notification e2e coverage

### DIFF
--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -532,7 +532,7 @@ export function NotificationsClient({
               </CardHeader>
 
               {expandedId === n.id && (
-                <CardContent className="pt-0 pb-3 px-4 border-t">
+                <CardContent className="pt-0 pb-3 px-4 border-t" data-testid={`notification-detail-${n.id}`}>
                   <div className="pt-3 space-y-3">
                     <p className="text-sm text-foreground">{n.body}</p>
                     <div className="flex items-center gap-2">
@@ -540,6 +540,7 @@ export function NotificationsClient({
                         size="sm"
                         variant="outline"
                         onClick={() => router.push(getResourceUrl(n.resourceType, n.resourceId))}
+                        data-testid={`notification-view-resource-${n.id}`}
                       >
                         <ExternalLink className="size-3.5 mr-1.5" />
                         View {n.resourceType}
@@ -550,6 +551,7 @@ export function NotificationsClient({
                           variant="ghost"
                           onClick={() => markReadMutation.mutate(n.id)}
                           disabled={markReadMutation.isPending}
+                          data-testid={`notification-mark-read-${n.id}`}
                         >
                           <CheckCircle2 className="size-3.5 mr-1.5" />
                           Mark as read
@@ -563,6 +565,7 @@ export function NotificationsClient({
                             qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
                             qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
                           })}
+                          data-testid={`notification-mark-unread-${n.id}`}
                         >
                           Mark as unread
                         </Button>
@@ -576,6 +579,7 @@ export function NotificationsClient({
                           deleteMutation.mutate(n.id)
                         }}
                         disabled={deleteMutation.isPending}
+                        data-testid={`notification-delete-${n.id}`}
                       >
                         <Trash2 className="size-3.5" />
                       </Button>

--- a/apps/web/components/shared/notification-bell.tsx
+++ b/apps/web/components/shared/notification-bell.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
 import { Bell } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { Button } from '@/components/ui/button'
@@ -39,7 +38,6 @@ function severityDot(severity: string) {
 }
 
 export function NotificationBell({ orgId, userId }: NotificationBellProps) {
-  const router = useRouter()
   const qc = useQueryClient()
 
   const { data: unreadCount = 0 } = useQuery({
@@ -72,18 +70,20 @@ export function NotificationBell({ orgId, userId }: NotificationBellProps) {
     },
   })
 
-  function handleNotificationClick(n: Notification) {
-    markReadMutation.mutate(n.id)
-    router.push(getResourceUrl(n.resourceType, n.resourceId))
+  function navigateTo(path: string) {
+    window.location.assign(path)
   }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative">
+        <Button variant="ghost" size="icon" className="relative" data-testid="notification-bell-trigger">
           <Bell className="size-4" />
           {unreadCount > 0 && (
-            <span className="absolute -top-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white leading-none">
+            <span
+              className="absolute -top-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white leading-none"
+              data-testid="notification-bell-unread-count"
+            >
               {unreadCount > 99 ? '99+' : unreadCount}
             </span>
           )}
@@ -98,6 +98,7 @@ export function NotificationBell({ orgId, userId }: NotificationBellProps) {
               variant="ghost"
               size="sm"
               className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
+              data-testid="notification-bell-mark-all-read"
               onClick={(e) => {
                 e.preventDefault()
                 markAllMutation.mutate()
@@ -118,20 +119,25 @@ export function NotificationBell({ orgId, userId }: NotificationBellProps) {
               <DropdownMenuItem
                 key={n.id}
                 className="flex items-start gap-2.5 p-3 cursor-pointer"
-                onClick={() => handleNotificationClick(n)}
+                data-testid={`notification-bell-item-${n.id}`}
+                onSelect={(event) => {
+                  event.preventDefault()
+                  markReadMutation.mutate(n.id)
+                  navigateTo(getResourceUrl(n.resourceType, n.resourceId))
+                }}
               >
-                {severityDot(n.severity)}
-                <div className="flex-1 min-w-0">
-                  <p className={`text-sm leading-snug truncate ${n.read ? 'text-muted-foreground' : 'font-medium text-foreground'}`}>
-                    {n.subject}
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
-                  </p>
-                </div>
-                {!n.read && (
-                  <span className="size-1.5 rounded-full bg-blue-500 shrink-0 mt-1.5" />
-                )}
+                  {severityDot(n.severity)}
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-sm leading-snug truncate ${n.read ? 'text-muted-foreground' : 'font-medium text-foreground'}`}>
+                      {n.subject}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                    </p>
+                  </div>
+                  {!n.read && (
+                    <span className="size-1.5 rounded-full bg-blue-500 shrink-0 mt-1.5" />
+                  )}
               </DropdownMenuItem>
             ))}
           </div>
@@ -139,7 +145,11 @@ export function NotificationBell({ orgId, userId }: NotificationBellProps) {
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="justify-center text-sm text-muted-foreground hover:text-foreground cursor-pointer py-2"
-          onClick={() => router.push('/notifications')}
+          data-testid="notification-bell-view-all"
+          onSelect={(event) => {
+            event.preventDefault()
+            navigateTo('/notifications')
+          }}
         >
           View all notifications
         </DropdownMenuItem>

--- a/apps/web/tests/e2e/notifications/bell.spec.ts
+++ b/apps/web/tests/e2e/notifications/bell.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('authenticated user can review topbar notifications and open the linked resource', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'notification-bell-host-1',
+      ${orgId},
+      'notification-bell-host-1',
+      'Notification Bell Host',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.70.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`
+    INSERT INTO notifications (
+      id,
+      organisation_id,
+      user_id,
+      subject,
+      body,
+      severity,
+      resource_type,
+      resource_id,
+      read,
+      created_at
+    )
+    VALUES
+      (
+        'notification-bell-unread-host',
+        ${orgId},
+        ${userId},
+        'Host needs attention',
+        'Notification Bell Host missed a recent heartbeat.',
+        'warning',
+        'host',
+        'notification-bell-host-1',
+        false,
+        NOW() - INTERVAL '3 minutes'
+      ),
+      (
+        'notification-bell-unread-certificate',
+        ${orgId},
+        ${userId},
+        'Certificate expires soon',
+        'edge.example.com expires in five days.',
+        'critical',
+        'certificate',
+        'certificate-bell-1',
+        false,
+        NOW() - INTERVAL '2 minutes'
+      )
+  `
+
+  await page.goto('/dashboard')
+
+  await expect(page.getByTestId('notification-bell-trigger')).toBeVisible()
+  await expect(page.getByTestId('notification-bell-unread-count')).toHaveText('2')
+
+  await page.getByTestId('notification-bell-trigger').click()
+  await expect(page.getByTestId('notification-bell-item-notification-bell-unread-host')).toContainText('Host needs attention')
+  await expect(page.getByTestId('notification-bell-item-notification-bell-unread-certificate')).toContainText('Certificate expires soon')
+
+  await page.getByTestId('notification-bell-item-notification-bell-unread-host').click()
+
+  await expect(page).toHaveURL(/\/hosts\/notification-bell-host-1$/)
+  await expect(page.getByRole('heading', { name: 'Notification Bell Host' })).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ read: boolean }>>`
+        SELECT read
+        FROM notifications
+        WHERE id = 'notification-bell-unread-host'
+        LIMIT 1
+      `
+      return rows[0]?.read ?? null
+    })
+    .toBe(true)
+})

--- a/apps/web/tests/e2e/notifications/inbox.spec.ts
+++ b/apps/web/tests/e2e/notifications/inbox.spec.ts
@@ -318,3 +318,91 @@ test('authenticated user can mark selected read notifications as unread', async 
       { id: 'notification-mark-unread-3', read: false },
     ])
 })
+
+test('authenticated user can expand a notification, change its read state, and delete it', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO notifications (
+      id,
+      organisation_id,
+      user_id,
+      subject,
+      body,
+      severity,
+      resource_type,
+      resource_id,
+      read,
+      created_at
+    )
+    VALUES (
+      'notification-row-actions-1',
+      ${orgId},
+      ${userId},
+      'Review the host details',
+      'The host detail page has new inventory data ready to review.',
+      'info',
+      'host',
+      'host-row-actions-1',
+      true,
+      NOW() - INTERVAL '4 minutes'
+    )
+  `
+
+  await page.goto('/notifications')
+
+  const notificationCard = page.getByTestId('notification-card-notification-row-actions-1')
+  await expect(notificationCard).toBeVisible()
+
+  await notificationCard.getByText('Review the host details').click()
+  await expect(page.getByTestId('notification-detail-notification-row-actions-1')).toContainText(
+    'The host detail page has new inventory data ready to review.',
+  )
+
+  await page.getByTestId('notification-mark-unread-notification-row-actions-1').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ read: boolean }>>`
+        SELECT read
+        FROM notifications
+        WHERE id = 'notification-row-actions-1'
+        LIMIT 1
+      `
+      return rows[0]?.read ?? null
+    })
+    .toBe(false)
+
+  await expect(page.getByTestId('notifications-tab-unread')).toContainText('1')
+
+  await page.getByTestId('notification-mark-read-notification-row-actions-1').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ read: boolean }>>`
+        SELECT read
+        FROM notifications
+        WHERE id = 'notification-row-actions-1'
+        LIMIT 1
+      `
+      return rows[0]?.read ?? null
+    })
+    .toBe(true)
+
+  await page.getByTestId('notification-delete-notification-row-actions-1').click()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ deleted_at: Date | null }>>`
+        SELECT deleted_at
+        FROM notifications
+        WHERE id = 'notification-row-actions-1'
+        LIMIT 1
+      `
+      return rows[0]?.deleted_at ?? null
+    })
+    .toEqual(expect.any(Date))
+
+  await expect(page.getByTestId('notification-card-notification-row-actions-1')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary
- add a new Playwright E2E spec for the topbar notification bell dropdown
- expand the notifications inbox spec to cover row-level read/unread/delete actions
- fix the bell dropdown so selecting a notification or "View all notifications" performs deterministic navigation

## Why
- the notification bell had no E2E coverage
- the inbox suite only covered bulk actions and missed the per-notification controls
- the new bell spec exposed a real navigation bug in the dropdown interaction

## Validation
- `pnpm --filter web test:e2e -- tests/e2e/notifications/bell.spec.ts tests/e2e/notifications/inbox.spec.ts`
