### PR TITLE
feat(vuln): ingest red hat csaf package fixes

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,20 @@
 
 ## What Has Been Built
 
+### Session 80 — Red Hat CSAF package advisory ingestion
+
+**Confirmed RPM advisory data** (`apps/ingest/internal/vuln/`)
+- Added Red Hat CSAF advisory summary ingestion so `released_packages` are normalised into `vulnerability_affected_packages` fixed-version rows under `redhat-security-data`.
+- Derived RHEL major versions from RPM EVR release strings such as `1:3.5.1-7.el9_7`, allowing Alma/Rocky/RHEL-compatible hosts to match advisory rows for RHEL 9.
+- Preserved CVE/advisory metadata on generated fixed rows so confirmed findings carry advisory context.
+
+**RPM inventory accuracy** (`agent/internal/tasks/`)
+- Updated RPM software inventory to retain full installed EVR in `source_version` when the source RPM does not provide an epoch, preventing source-package comparisons from falling back to upstream-only versions.
+
+**Validation**
+- Added unit coverage for Red Hat CSAF released-package parsing, CSAF sync URL windowing, and RPM source-version EVR preservation.
+- Validation run: `go test ./internal/vuln`, `go test ./...` from `apps/ingest`, `go test ./internal/tasks`, and `go test ./...` from `agent`.
+
 ### Session 79 — Multi-role team membership
 
 **Additive role model** (`apps/web/lib/auth/`, `apps/web/lib/actions/`, `apps/web/lib/db/schema/`, `apps/web/lib/db/migrations/0053_bright_black_cat.sql`)

--- a/agent/internal/tasks/software_inventory_metadata_test.go
+++ b/agent/internal/tasks/software_inventory_metadata_test.go
@@ -54,3 +54,12 @@ func TestParseRpmSourcePackage(t *testing.T) {
 		t.Fatalf("parseSourceRPM = (%q, %q, %q), want openssl 3.2.2 9.el9_5", name, version, release)
 	}
 }
+
+func TestRPMSourceVersionForMatchKeepsInstalledEVR(t *testing.T) {
+	t.Parallel()
+
+	sourceVersion := rpmSourceVersionForMatch("1:3.5.1-5.el9_7", "3.5.1", "5.el9_7")
+	if sourceVersion != "1:3.5.1-5.el9_7" {
+		t.Fatalf("rpmSourceVersionForMatch = %q, want full installed EVR", sourceVersion)
+	}
+}

--- a/agent/internal/tasks/software_inventory_unix.go
+++ b/agent/internal/tasks/software_inventory_unix.go
@@ -213,10 +213,7 @@ func collectRpm(ctx context.Context, info osReleaseInfo) ([]collectedPackage, er
 			p.SourceName = p.Name
 		}
 		if p.SourceVersion == "" {
-			p.SourceVersion = version
-			if sourceRelease != "" {
-				p.SourceVersion += "-" + sourceRelease
-			}
+			p.SourceVersion = rpmSourceVersionForMatch(fullVersion, version, sourceRelease)
 		}
 		if ts := trimField(fields, 7); ts != "" {
 			if unix, err := strconv.ParseInt(ts, 10, 64); err == nil {
@@ -229,6 +226,19 @@ func collectRpm(ctx context.Context, info osReleaseInfo) ([]collectedPackage, er
 		}
 	}
 	return pkgs, nil
+}
+
+func rpmSourceVersionForMatch(fullVersion, sourceVersion, sourceRelease string) string {
+	if fullVersion != "" {
+		return fullVersion
+	}
+	if sourceVersion == "" {
+		return ""
+	}
+	if sourceRelease != "" {
+		return sourceVersion + "-" + sourceRelease
+	}
+	return sourceVersion
 }
 
 func parseSourceRPM(source string) (name, version, release string) {

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -183,6 +183,7 @@ func main() {
 		AlpineBaseURL:  cfg.Vulnerability.AlpineBaseURL,
 		AlpineReleases: cfg.Vulnerability.AlpineReleases,
 		RedHatURL:      cfg.Vulnerability.RedHatURL,
+		RedHatCSAFURL:  cfg.Vulnerability.RedHatCSAFURL,
 	}, vulnerabilityMatcher)
 
 	// Start cert URL refresh sweeper goroutine

--- a/apps/ingest/internal/config/config.go
+++ b/apps/ingest/internal/config/config.go
@@ -92,6 +92,7 @@ type VulnerabilityConfig struct {
 	AlpineBaseURL  string        `yaml:"alpine_base_url"`
 	AlpineReleases []string      `yaml:"alpine_releases"`
 	RedHatURL      string        `yaml:"redhat_url"`
+	RedHatCSAFURL  string        `yaml:"redhat_csaf_url"`
 }
 
 // Load reads a YAML config file and applies INGEST_ environment overrides.
@@ -266,6 +267,7 @@ func defaults() *Config {
 			AlpineBaseURL:  "https://secdb.alpinelinux.org",
 			AlpineReleases: []string{"v3.18", "v3.19", "v3.20", "v3.21", "v3.22", "v3.23"},
 			RedHatURL:      "https://access.redhat.com/hydra/rest/securitydata/cve.json",
+			RedHatCSAFURL:  "https://access.redhat.com/hydra/rest/securitydata/csaf.json",
 		},
 	}
 }
@@ -352,6 +354,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("INGEST_VULNERABILITY_REDHAT_URL"); v != "" {
 		cfg.Vulnerability.RedHatURL = v
+	}
+	if v := os.Getenv("INGEST_VULNERABILITY_REDHAT_CSAF_URL"); v != "" {
+		cfg.Vulnerability.RedHatCSAFURL = v
 	}
 }
 

--- a/apps/ingest/internal/vuln/parsers.go
+++ b/apps/ingest/internal/vuln/parsers.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
+
+var rpmELVersionPattern = regexp.MustCompile(`(?:^|[._-])el([0-9]+)(?:[._-]|$)`)
 
 func ParseCISAKEV(r io.Reader) ([]KEVEntry, error) {
 	var doc struct {
@@ -473,6 +476,98 @@ func parseRedHatCVEList(r io.Reader) ([]CVERecord, []AffectedPackage, error) {
 	return cves, affected, nil
 }
 
+func ParseRedHatCSAFList(r io.Reader) ([]CVERecord, []AffectedPackage, error) {
+	var rows []struct {
+		RHSA             string   `json:"RHSA"`
+		Severity         string   `json:"severity"`
+		ReleasedOn       string   `json:"released_on"`
+		CVEs             []string `json:"CVEs"`
+		ReleasedPackages []string `json:"released_packages"`
+		ResourceURL      string   `json:"resource_url"`
+	}
+	if err := json.NewDecoder(r).Decode(&rows); err != nil {
+		return nil, nil, err
+	}
+
+	recordsByCVE := make(map[string]CVERecord)
+	var affected []AffectedPackage
+	for _, row := range rows {
+		severity := normalizeSeverity(row.Severity)
+		var releasedAt *time.Time
+		if t := parseRFC3339(row.ReleasedOn); t != nil {
+			releasedAt = t
+		}
+		cveIDs := uniqueNonEmptyStrings(row.CVEs)
+		if len(cveIDs) == 0 {
+			continue
+		}
+		for _, cveID := range cveIDs {
+			if _, ok := recordsByCVE[cveID]; !ok {
+				recordsByCVE[cveID] = CVERecord{
+					CVEID:       cveID,
+					Severity:    severity,
+					PublishedAt: releasedAt,
+					ModifiedAt:  releasedAt,
+					Source:      "redhat-security-data",
+				}
+			}
+		}
+
+		for _, pkg := range row.ReleasedPackages {
+			name, fixed := splitRedHatFixedPackage(pkg)
+			if name == "" || fixed == "" {
+				continue
+			}
+			distroVersion := redHatVersionFromFixedEVR(fixed)
+			if distroVersion == "" {
+				continue
+			}
+			for _, cveID := range cveIDs {
+				affected = append(affected, AffectedPackage{
+					CVEID:           cveID,
+					Source:          "redhat-security-data",
+					DistroID:        "rhel",
+					DistroVersionID: distroVersion,
+					PackageName:     name,
+					FixedVersion:    fixed,
+					Severity:        severity,
+					PackageState:    "fixed",
+					MetadataJSON: encodeMetadata(map[string]string{
+						"advisory":     row.RHSA,
+						"released_on":  row.ReleasedOn,
+						"package":      pkg,
+						"resource_url": row.ResourceURL,
+						"source":       "csaf",
+					}),
+				})
+			}
+		}
+	}
+
+	cves := make([]CVERecord, 0, len(recordsByCVE))
+	for _, record := range recordsByCVE {
+		cves = append(cves, record)
+	}
+	return cves, affected, nil
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
 func parseFloat(value string) (float64, error) {
 	var out float64
 	_, err := fmt.Sscanf(value, "%f", &out)
@@ -538,6 +633,14 @@ func stripRPMArchitecture(value string) string {
 	default:
 		return value
 	}
+}
+
+func redHatVersionFromFixedEVR(fixed string) string {
+	match := rpmELVersionPattern.FindStringSubmatch(fixed)
+	if len(match) != 2 {
+		return ""
+	}
+	return match[1]
 }
 
 func redHatProductVersion(productName string) string {

--- a/apps/ingest/internal/vuln/parsers_test.go
+++ b/apps/ingest/internal/vuln/parsers_test.go
@@ -126,3 +126,54 @@ func TestParseRedHatFreeTextAffectedPackageIsProbable(t *testing.T) {
 		t.Fatalf("unexpected affected row: %#v", affected[0])
 	}
 }
+
+func TestParseRedHatCSAFListReleasedPackages(t *testing.T) {
+	t.Parallel()
+
+	doc := `[{
+	  "RHSA": "RHSA-2026:1473",
+	  "severity": "important",
+	  "released_on": "2026-01-28T10:08:56Z",
+	  "CVEs": ["CVE-2025-66199", "CVE-2025-15467"],
+	  "released_packages": [
+	    "openssl-1:3.5.1-7.el9_7.x86_64",
+	    "openssl-libs-1:3.5.1-7.el9_7.x86_64",
+	    "openssl-1:3.5.1-7.el9_7.src",
+	    "openssl-main@x86_64"
+	  ],
+	  "resource_url": "https://access.redhat.com/hydra/rest/securitydata/csaf/RHSA-2026:1473.json"
+	}]`
+
+	records, affected, err := ParseRedHatCSAFList(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("ParseRedHatCSAFList: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("len(records) = %d, want 2: %#v", len(records), records)
+	}
+	if len(affected) != 6 {
+		t.Fatalf("len(affected) = %d, want 6: %#v", len(affected), affected)
+	}
+	var row AffectedPackage
+	for _, candidate := range affected {
+		if candidate.CVEID == "CVE-2025-15467" && candidate.PackageName == "openssl-libs" {
+			row = candidate
+			break
+		}
+	}
+	if row.CVEID != "CVE-2025-15467" || row.PackageName != "openssl-libs" {
+		t.Fatalf("unexpected affected row identity: %#v", row)
+	}
+	if row.DistroID != "rhel" || row.DistroVersionID != "9" {
+		t.Fatalf("distro = %q %q, want rhel 9", row.DistroID, row.DistroVersionID)
+	}
+	if row.FixedVersion != "1:3.5.1-7.el9_7" {
+		t.Fatalf("FixedVersion = %q, want full RPM EVR", row.FixedVersion)
+	}
+	if row.PackageState != "fixed" || row.Severity != SeverityHigh {
+		t.Fatalf("state/severity = %q/%q, want fixed/high", row.PackageState, row.Severity)
+	}
+	if !strings.Contains(string(row.MetadataJSON), "RHSA-2026:1473") {
+		t.Fatalf("metadata did not include advisory: %s", string(row.MetadataJSON))
+	}
+}

--- a/apps/ingest/internal/vuln/sync.go
+++ b/apps/ingest/internal/vuln/sync.go
@@ -31,6 +31,7 @@ type SyncConfig struct {
 	AlpineBaseURL  string
 	AlpineReleases []string
 	RedHatURL      string
+	RedHatCSAFURL  string
 }
 
 func DefaultSyncConfig() SyncConfig {
@@ -46,6 +47,7 @@ func DefaultSyncConfig() SyncConfig {
 		AlpineBaseURL:  "https://secdb.alpinelinux.org",
 		AlpineReleases: []string{"v3.18", "v3.19", "v3.20", "v3.21", "v3.22", "v3.23"},
 		RedHatURL:      "https://access.redhat.com/hydra/rest/securitydata/cve.json",
+		RedHatCSAFURL:  "https://access.redhat.com/hydra/rest/securitydata/csaf.json",
 	}
 }
 
@@ -101,6 +103,7 @@ func SyncOnce(ctx context.Context, pool *pgxpool.Pool, cfg SyncConfig) error {
 		syncAlpine,
 		syncNVD,
 		syncRedHat,
+		syncRedHatCSAF,
 	}
 	for _, source := range sources {
 		if err := source(ctx, pool, client, cfg); err != nil {
@@ -330,6 +333,39 @@ func syncRedHat(ctx context.Context, pool *pgxpool.Pool, client *http.Client, cf
 		return markSourceResult(ctx, pool, sourceID, meta, len(cves)+len(affected), err)
 	}
 	return markSourceResult(ctx, pool, sourceID, meta, len(cves)+len(affected), nil)
+}
+
+func syncRedHatCSAF(ctx context.Context, pool *pgxpool.Pool, client *http.Client, cfg SyncConfig) error {
+	if cfg.RedHatCSAFURL == "" {
+		return nil
+	}
+	sourceID := "redhat-security-data-csaf"
+	sourceURL := redHatCSAFURLWithAfter(cfg.RedHatCSAFURL)
+	body, meta, err := fetchSource(ctx, pool, client, sourceID, sourceURL)
+	if err != nil || body == nil {
+		return markSourceResult(ctx, pool, sourceID, meta, 0, err)
+	}
+	cves, affected, err := ParseRedHatCSAFList(bytes.NewReader(body))
+	if err != nil {
+		return markSourceResult(ctx, pool, sourceID, meta, 0, err)
+	}
+	if err := persistRecords(ctx, pool, cves, affected); err != nil {
+		return markSourceResult(ctx, pool, sourceID, meta, len(cves)+len(affected), err)
+	}
+	return markSourceResult(ctx, pool, sourceID, meta, len(cves)+len(affected), nil)
+}
+
+func redHatCSAFURLWithAfter(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	if q.Get("after") == "" {
+		q.Set("after", time.Now().AddDate(-1, 0, 0).Format("2006-01-02"))
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 func persistRecords(ctx context.Context, pool *pgxpool.Pool, cves []CVERecord, affected []AffectedPackage) error {

--- a/apps/ingest/internal/vuln/sync_test.go
+++ b/apps/ingest/internal/vuln/sync_test.go
@@ -1,0 +1,37 @@
+package vuln
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestRedHatCSAFURLWithAfterAddsDefaultWindow(t *testing.T) {
+	t.Parallel()
+
+	got := redHatCSAFURLWithAfter("https://access.redhat.com/hydra/rest/securitydata/csaf.json")
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	after := parsed.Query().Get("after")
+	if after == "" {
+		t.Fatalf("after query parameter missing from %q", got)
+	}
+	if _, err := time.Parse("2006-01-02", after); err != nil {
+		t.Fatalf("after = %q is not a date: %v", after, err)
+	}
+}
+
+func TestRedHatCSAFURLWithAfterPreservesConfiguredWindow(t *testing.T) {
+	t.Parallel()
+
+	got := redHatCSAFURLWithAfter("https://access.redhat.com/hydra/rest/securitydata/csaf.json?after=2026-01-01")
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	if after := parsed.Query().Get("after"); after != "2026-01-01" {
+		t.Fatalf("after = %q, want configured date", after)
+	}
+}


### PR DESCRIPTION
## Summary
- ingest Red Hat CSAF advisory summaries and normalize `released_packages` into confirmed `vulnerability_affected_packages` fixed-version rows
- derive RHEL major versions from RPM EVR release strings such as `1:3.5.1-7.el9_7`
- keep Red Hat CSAF source-state separate from the CVE summary cache while storing package rows under `redhat-security-data`
- preserve full installed RPM EVR in agent `source_version` fallback for source-package comparisons

## Why
The Red Hat CVE summary sync was recording CVE metadata but produced zero package-level affected rows, so Alma/RHEL-compatible hosts had nothing actionable to match against. The CSAF advisory summary endpoint exposes released RPM package EVRs, which are the fixed-version records the confirmed matcher needs.

## Validation
- `go test ./internal/vuln`
- `go test ./...` from `apps/ingest`
- `go test ./internal/tasks`
- `go test ./...` from `agent`
