### PR TITLE
fix(vuln): prefer full rpm evr for matching

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 81 — RPM CVE comparison tightening
+
+**RPM match accuracy** (`apps/ingest/internal/vuln/`)
+- Tightened RPM source-package matching so upstream-only `source_version` values from older inventory scans no longer cause false positives against full vendor fixed EVRs.
+- The matcher now prefers the installed package EVR when it contains release/epoch detail missing from the source version, while preserving source-version matching for non-RPM package managers.
+- Added coverage for implicit zero epochs, fixed packages with equal EVR, newer Alma downstream releases, and source-package matches where `source_version` is upstream-only.
+
+**Validation**
+- Validation run: `go test ./internal/vuln` and `go test ./...` from `apps/ingest`.
+
 ### Session 80 — Red Hat CSAF package advisory ingestion
 
 **Confirmed RPM advisory data** (`apps/ingest/internal/vuln/`)

--- a/apps/ingest/internal/vuln/matcher_test.go
+++ b/apps/ingest/internal/vuln/matcher_test.go
@@ -125,6 +125,66 @@ func TestRPMBackportReleaseDoesNotMatchFixedPackage(t *testing.T) {
 	}
 }
 
+func TestRPMSourcePackageMatchUsesInstalledEVRWhenSourceVersionIsUpstreamOnly(t *testing.T) {
+	t.Parallel()
+
+	pkg := InventoryPackage{
+		Name:            "libarchive",
+		Version:         "3.5.3-9.el9_7",
+		Source:          "rpm",
+		DistroID:        "almalinux",
+		DistroIDLike:    []string{"rhel", "centos", "fedora"},
+		DistroVersionID: "9.7",
+		SourceName:      "libarchive",
+		SourceVersion:   "3.5.3",
+	}
+	affected := AffectedPackage{
+		Source:          "redhat-security-data",
+		DistroID:        "rhel",
+		DistroVersionID: "9",
+		PackageName:     "libarchive",
+		FixedVersion:    "0:3.5.3-9.el9_7",
+	}
+
+	match, reason := MatchPackage(pkg, affected)
+	if match {
+		t.Fatalf("expected installed RPM package not to match, reason=%q", reason)
+	}
+	if reason != "installed version is fixed" {
+		t.Fatalf("reason = %q, want fixed package reason", reason)
+	}
+}
+
+func TestRPMDownstreamReleaseDoesNotMatchOlderRHELFixedEVR(t *testing.T) {
+	t.Parallel()
+
+	pkg := InventoryPackage{
+		Name:            "openssh",
+		Version:         "8.7p1-48.el9_7.alma.1",
+		Source:          "rpm",
+		DistroID:        "almalinux",
+		DistroIDLike:    []string{"rhel", "centos", "fedora"},
+		DistroVersionID: "9.7",
+		SourceName:      "openssh",
+		SourceVersion:   "8.7p1",
+	}
+	affected := AffectedPackage{
+		Source:          "redhat-security-data",
+		DistroID:        "rhel",
+		DistroVersionID: "9",
+		PackageName:     "openssh",
+		FixedVersion:    "0:8.7p1-48.el9_7",
+	}
+
+	match, reason := MatchPackage(pkg, affected)
+	if match {
+		t.Fatalf("expected downstream RPM release not to match older fixed EVR, reason=%q", reason)
+	}
+	if reason != "installed version is fixed" {
+		t.Fatalf("reason = %q, want fixed package reason", reason)
+	}
+}
+
 func TestRPMRHELCompatibleDistroMatchesRedHatAdvisory(t *testing.T) {
 	t.Parallel()
 

--- a/apps/ingest/internal/vuln/parsers_test.go
+++ b/apps/ingest/internal/vuln/parsers_test.go
@@ -42,8 +42,18 @@ func TestParseDebianTracker(t *testing.T) {
 	if len(affected) != 2 {
 		t.Fatalf("len(affected) = %d, want 2", len(affected))
 	}
-	if affected[0].PackageName != "openssl" || affected[0].DistroCodename != "bookworm" || affected[0].FixedVersion != "3.0.11-1~deb12u2" {
-		t.Fatalf("unexpected affected row: %#v", affected[0])
+	var bookworm *AffectedPackage
+	for i := range affected {
+		if affected[i].DistroCodename == "bookworm" {
+			bookworm = &affected[i]
+			break
+		}
+	}
+	if bookworm == nil {
+		t.Fatalf("bookworm affected row missing: %#v", affected)
+	}
+	if bookworm.PackageName != "openssl" || bookworm.FixedVersion != "3.0.11-1~deb12u2" {
+		t.Fatalf("unexpected bookworm affected row: %#v", *bookworm)
 	}
 }
 

--- a/apps/ingest/internal/vuln/types.go
+++ b/apps/ingest/internal/vuln/types.go
@@ -1,6 +1,9 @@
 package vuln
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Severity string
 
@@ -100,7 +103,27 @@ func normalizeSeverity(value string) Severity {
 
 func sourceVersionForMatch(pkg InventoryPackage, affected AffectedPackage) string {
 	if pkg.SourceName != "" && pkg.SourceName == affected.PackageName && pkg.SourceVersion != "" {
+		if pkg.Source == "rpm" {
+			return bestRPMVersionForMatch(pkg.Version, pkg.SourceVersion)
+		}
 		return pkg.SourceVersion
 	}
 	return pkg.Version
+}
+
+func bestRPMVersionForMatch(installedVersion, sourceVersion string) string {
+	if sourceVersion == "" {
+		return installedVersion
+	}
+	if installedVersion == "" {
+		return sourceVersion
+	}
+	sourceHasEpoch := strings.Contains(sourceVersion, ":")
+	installedHasEpoch := strings.Contains(installedVersion, ":")
+	sourceHasRelease := strings.Contains(sourceVersion, "-")
+	installedHasRelease := strings.Contains(installedVersion, "-")
+	if (!sourceHasRelease && installedHasRelease) || (!sourceHasEpoch && installedHasEpoch) {
+		return installedVersion
+	}
+	return sourceVersion
 }

--- a/apps/ingest/internal/vuln/version_test.go
+++ b/apps/ingest/internal/vuln/version_test.go
@@ -30,6 +30,15 @@ func TestCompareRPMVersions(t *testing.T) {
 	if got := CompareDistroVersion("rpm", "2:1.0-1", "1:9.9-9"); got != 1 {
 		t.Fatalf("rpm epoch compare = %d, want 1", got)
 	}
+	if got := CompareDistroVersion("rpm", "3.5.3-9.el9_7", "0:3.5.3-9.el9_7"); got != 0 {
+		t.Fatalf("rpm implicit zero epoch compare = %d, want 0", got)
+	}
+	if got := CompareDistroVersion("rpm", "3.5.3-9.el9_7", "0:3.5.3-7.el9_7"); got != 1 {
+		t.Fatalf("rpm newer release compare = %d, want 1", got)
+	}
+	if got := CompareDistroVersion("rpm", "8.7p1-48.el9_7.alma.1", "0:8.7p1-48.el9_7"); got != 1 {
+		t.Fatalf("rpm downstream release compare = %d, want 1", got)
+	}
 }
 
 func TestCompareAlpineVersions(t *testing.T) {


### PR DESCRIPTION
## Summary
- prefer full installed RPM EVR when source-package inventory only has upstream `source_version`
- keep non-RPM source-version matching unchanged
- add coverage for implicit `0:` epoch equality, newer RPM releases, Alma downstream releases, and source-package matches using upstream-only source versions

## Why
Older RPM inventory can store `source_version` as only the upstream version, e.g. `3.5.3`, while Red Hat CSAF fixed rows contain full EVR such as `0:3.5.3-9.el9_7`. The matcher preferred that upstream-only source version when `source_name` matched the advisory package, causing false positives even when the installed binary EVR was equal to or newer than the fixed EVR.

## Validation
- `go test ./internal/vuln`
- `go test ./...` from `apps/ingest`
