### PR TITLE
test(web): cover automated host logs and team role fallback

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/logs-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/logs-tab.tsx
@@ -147,14 +147,17 @@ export function LogsTab({ orgId, hostId }: Props) {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-base font-semibold text-foreground">Automated Logs</h3>
+        <h3 className="text-base font-semibold text-foreground" data-testid="host-logs-heading">Automated Logs</h3>
         <p className="text-sm text-muted-foreground mt-0.5">
           Runs started automatically by the system — e.g. periodic software inventory scans.
         </p>
       </div>
 
       {selectedIds.size > 0 && (
-        <div className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2">
+        <div
+          className="flex items-center justify-between rounded-lg border bg-muted/50 px-3 py-2"
+          data-testid="host-logs-selection"
+        >
           <span className="text-sm text-muted-foreground">
             {selectedIds.size} selected
           </span>
@@ -163,6 +166,7 @@ export function LogsTab({ orgId, hostId }: Props) {
             size="sm"
             onClick={() => doDelete()}
             disabled={isDeleting}
+            data-testid="host-logs-delete-selected"
           >
             {isDeleting ? (
               <Loader2 className="size-3.5 mr-1.5 animate-spin" />
@@ -175,7 +179,7 @@ export function LogsTab({ orgId, hostId }: Props) {
       )}
 
       {runs.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-10 text-center">
+        <div className="rounded-lg border border-dashed p-10 text-center" data-testid="host-logs-empty">
           <FileText className="size-7 mx-auto text-muted-foreground mb-3" />
           <p className="text-sm font-medium text-foreground">No automated runs yet</p>
           <p className="text-xs text-muted-foreground mt-1">
@@ -203,7 +207,11 @@ export function LogsTab({ orgId, hostId }: Props) {
             </TableHeader>
             <TableBody>
               {runs.map((run) => (
-                <TableRow key={run.id} data-state={selectedIds.has(run.id) ? 'selected' : undefined}>
+                <TableRow
+                  key={run.id}
+                  data-state={selectedIds.has(run.id) ? 'selected' : undefined}
+                  data-testid={`host-log-row-${run.id}`}
+                >
                   <TableCell>
                     <Checkbox
                       checked={selectedIds.has(run.id)}

--- a/apps/web/tests/e2e/hosts/automated-logs.spec.ts
+++ b/apps/web/tests/e2e/hosts/automated-logs.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('authenticated user can bulk delete automated host logs from the host detail page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'host-logs-e2e',
+      ${orgId},
+      'host-logs-node-1',
+      'Automation Host',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.81.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`
+    INSERT INTO task_runs (
+      id,
+      organisation_id,
+      triggered_by,
+      target_type,
+      target_id,
+      task_type,
+      config,
+      max_parallel,
+      status,
+      started_at,
+      completed_at
+    )
+    VALUES
+      (
+        'host-log-run-1',
+        ${orgId},
+        NULL,
+        'host',
+        'host-logs-e2e',
+        'software_inventory',
+        '{}'::jsonb,
+        1,
+        'completed',
+        NOW() - INTERVAL '3 hours',
+        NOW() - INTERVAL '170 minutes'
+      ),
+      (
+        'host-log-run-2',
+        ${orgId},
+        NULL,
+        'host',
+        'host-logs-e2e',
+        'software_inventory',
+        '{}'::jsonb,
+        1,
+        'failed',
+        NOW() - INTERVAL '2 hours',
+        NOW() - INTERVAL '110 minutes'
+      )
+  `
+
+  await sql`
+    INSERT INTO task_run_hosts (
+      id,
+      organisation_id,
+      task_run_id,
+      host_id,
+      status,
+      result,
+      started_at,
+      completed_at
+    )
+    VALUES
+      (
+        'host-log-run-host-1',
+        ${orgId},
+        'host-log-run-1',
+        'host-logs-e2e',
+        'success',
+        '{"package_count":52,"source":"apt"}'::jsonb,
+        NOW() - INTERVAL '3 hours',
+        NOW() - INTERVAL '170 minutes'
+      ),
+      (
+        'host-log-run-host-2',
+        ${orgId},
+        'host-log-run-2',
+        'host-logs-e2e',
+        'failed',
+        '{"package_count":0,"source":"apt"}'::jsonb,
+        NOW() - INTERVAL '2 hours',
+        NOW() - INTERVAL '110 minutes'
+      )
+  `
+
+  await page.goto('/hosts/host-logs-e2e')
+
+  await expect(page.getByRole('heading', { name: 'Automation Host' })).toBeVisible()
+
+  await page.getByTestId('host-parent-tab-tools').click()
+  await page.getByTestId('host-tab-logs').click()
+
+  await expect(page.getByTestId('host-logs-heading')).toBeVisible()
+  await expect(page.getByTestId('host-log-row-host-log-run-1')).toContainText('Software inventory')
+  await expect(page.getByTestId('host-log-row-host-log-run-1')).toContainText('52 packages')
+  await expect(page.getByTestId('host-log-row-host-log-run-2')).toContainText('Failed')
+
+  await page.getByLabel('Select all').click()
+  await expect(page.getByTestId('host-logs-selection')).toContainText('2 selected')
+  await page.getByTestId('host-logs-delete-selected').click()
+
+  await expect(page.getByTestId('host-log-row-host-log-run-1')).toHaveCount(0)
+  await expect(page.getByTestId('host-log-row-host-log-run-2')).toHaveCount(0)
+  await expect(page.getByTestId('host-logs-empty')).toBeVisible()
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{
+        id: string
+        deleted_at: string | null
+        host_deleted_at: string | null
+      }>>`
+        SELECT
+          task_runs.id,
+          task_runs.deleted_at::text,
+          task_run_hosts.deleted_at::text AS host_deleted_at
+        FROM task_runs
+        JOIN task_run_hosts ON task_run_hosts.task_run_id = task_runs.id
+        WHERE task_runs.id IN ('host-log-run-1', 'host-log-run-2')
+        ORDER BY task_runs.id
+      `
+
+      return rows
+    })
+    .toEqual([
+      {
+        id: 'host-log-run-1',
+        deleted_at: expect.any(String),
+        host_deleted_at: expect.any(String),
+      },
+      {
+        id: 'host-log-run-2',
+        deleted_at: expect.any(String),
+        host_deleted_at: expect.any(String),
+      },
+    ])
+})

--- a/apps/web/tests/e2e/team/members.spec.ts
+++ b/apps/web/tests/e2e/team/members.spec.ts
@@ -74,6 +74,31 @@ test('admin can change a team member role and manage their lifecycle', async ({ 
       roles: ['engineer', 'read_only'],
     })
 
+  await page.getByTestId(`team-member-role-trigger-${memberId}`).click()
+  await page.getByTestId(`team-member-role-option-${memberId}-engineer`).click()
+  await expect(memberRow).toContainText('Read Only')
+  await expect(memberRow).not.toContainText('Engineer')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ role: string; roles: string[] }>>`
+        SELECT role, roles
+        FROM "user"
+        WHERE id = ${memberId}
+        LIMIT 1
+      `
+      return rows[0]
+        ? {
+            role: rows[0].role,
+            roles: rows[0].roles,
+          }
+        : null
+    })
+    .toEqual({
+      role: 'read_only',
+      roles: ['read_only'],
+    })
+
   await page.getByTestId(`team-member-deactivate-${memberId}`).click()
   await expect(page.getByTestId(`team-member-status-${memberId}`)).toContainText('Inactive')
 


### PR DESCRIPTION
## Summary
- add E2E coverage for bulk deleting automated host logs from the host detail page
- add stable test ids for the host logs tab interactions and assertions
- expand team member E2E coverage to verify multi-role fallback when removing the primary role

## Validation
- pnpm --filter web test:e2e -- tests/e2e/hosts/automated-logs.spec.ts tests/e2e/team/members.spec.ts