### PR TITLE
docs: add CT-CVE migration plan

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -1,0 +1,352 @@
+# CT Ops Licensing and CT-CVE Migration Plan
+
+This document is the working plan for changing CT Ops from feature-gated Pro
+licensing to seat-based open-source licensing, and for extracting CVE monitoring
+into a standalone product named CT-CVE.
+
+Every agent session that works on this migration must update this file in the
+same pull request as its code or documentation changes.
+
+## Required Agent Workflow
+
+Before changing files, read and follow [AGENTS.md](../AGENTS.md). In particular:
+
+- Create a dedicated Git worktree before editing files.
+- Make edits only inside that worktree.
+- Use test-driven development for behavior changes where practical.
+- Run relevant validation before committing.
+- Commit with a Conventional Commit message.
+- Push the branch and open a pull request with a Conventional Commit title.
+- Update `PROGRESS.md` when a change satisfies part or all of an existing
+  product requirement.
+
+If a migration task changes behavior but cannot practically be tested first,
+document why in the pull request and describe the validation that was performed.
+
+## Product Direction
+
+CT Ops is moving to an open-source model where core functionality is available
+without Pro feature gates. Commercial CT Ops tiers are based on user seats.
+
+Target CT Ops tiers:
+
+- **Community**: open-source, all core CT Ops features available, limited by
+  included user seats.
+- **Pro**: seat-based paid tier.
+- **Enterprise**: seat-based paid tier plus enterprise-only capabilities.
+
+CT-CVE becomes a separate product:
+
+- CT-CVE owns vulnerability feed sync, CVE/advisory catalog management, package
+  matching, vulnerability enrichment, and its own GUI/API.
+- CT Ops remains the fleet, asset, agent, operations, and reporting system.
+- CT-CVE can be subscribed to and run independently.
+- CT Ops can ingest CT-CVE findings when customers use both products.
+
+## Deployment Model
+
+CT-CVE should run in its own container rather than being hidden inside
+`ct-ops-ingest`.
+
+Initial bundled deployment should look roughly like:
+
+```text
+ct-ops-web
+ct-ops-ingest
+ct-ops-db
+ct-cve
+ct-cve-db or a separate schema/database on the same Postgres server
+```
+
+For the first CT-CVE release, one `ct-cve` container may host both API and
+background worker responsibilities. Splitting into `ct-cve-api` and
+`ct-cve-worker` can come later if scale or operational reliability requires it.
+
+CT-CVE must integrate with CT Ops through a deliberate API boundary, not by
+reaching into CT Ops internals as another module.
+
+Expected data flow:
+
+```text
+CT Ops inventory -> CT-CVE
+CT-CVE findings -> CT Ops
+```
+
+## Non-Negotiable Cleanup Rule
+
+When this migration is complete, CT Ops must not contain residue from features
+that moved to CT-CVE.
+
+This includes:
+
+- Dead Go packages.
+- Dead TypeScript modules.
+- Unused React pages/components.
+- Unused server actions.
+- Obsolete database migrations or schema objects where a safe removal path
+  exists.
+- Obsolete config keys and environment variables.
+- Obsolete docs.
+- Obsolete test fixtures.
+- Obsolete unit, integration, and e2e tests that only cover removed CT-CVE
+  internals.
+- Stale changelog or progress references that imply CT Ops still owns CT-CVE
+  internals.
+
+If a compatibility shim must remain temporarily, the PR that adds or keeps it
+must include:
+
+- Why it is still required.
+- Which release or migration step removes it.
+- A test proving the shim behavior.
+- A checklist item in this document tracking its removal.
+
+## Current CT Ops Code Areas
+
+Known Pro/Enterprise gating areas:
+
+- `apps/web/lib/features.ts`
+- `apps/web/lib/actions/licence-guard.ts`
+- `apps/web/components/shared/locked-feature.tsx`
+- `apps/web/components/shared/feature-gate.tsx`
+- `apps/web/components/shared/sidebar.tsx`
+- Page-level locks under `apps/web/app/(dashboard)`
+- Server actions using `requireFeature()`
+- Licensing docs and e2e fixtures that issue Pro licences only to unlock pages
+
+Known CVE ownership areas to extract or replace:
+
+- `apps/ingest/internal/vuln/`
+- `apps/ingest/cmd/ingest/main.go` vulnerability matcher/syncer wiring
+- `apps/web/lib/db/schema/vulnerabilities.ts`
+- `apps/web/lib/db/migrations/0049_linux_cve_checking.sql`
+- `apps/web/lib/db/migrations/0052_vulnerability_finding_confidence.sql`
+- `apps/web/lib/actions/vulnerabilities.ts`
+- `apps/web/lib/vulnerabilities/`
+- `apps/web/app/(dashboard)/reports/vulnerabilities/`
+- `apps/web/app/(dashboard)/settings/vulnerabilities/`
+- Vulnerability e2e tests under `apps/web/tests/e2e`
+- Vulnerability feed configuration docs and env vars
+
+Agents should refresh this list as they discover additional code paths.
+
+## Migration Phases
+
+Update the status and notes in this table as work lands.
+
+| Phase | Status | Owner / PR | Notes |
+| --- | --- | --- | --- |
+| 1. Product decision record | Not started | | Document new licensing and CT-CVE product boundary. |
+| 2. Capacity entitlement model | Not started | | Add seat-based licence semantics such as `maxUsers`; deprecate feature unlocks for Pro. |
+| 3. Seat enforcement | Not started | | Enforce user seats on invites, restored users, invite acceptance, reactivation, LDAP auto-provisioning, and future SSO provisioning. |
+| 4. Remove Pro gates | Not started | | Remove Pro-only gates from core CT Ops features while preserving true Enterprise gates. |
+| 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around seats, expiry, and enterprise capabilities. |
+| 6. CT Ops/CT-CVE API contract | Not started | | Define inventory export and finding ingestion boundary before moving code. |
+| 7. CT-CVE repo bootstrap | Not started | | Create standalone repo/service with extracted sync, parser, matching, and test logic. |
+| 8. CT-CVE GUI | Not started | | Move or rebuild CVE catalog, source status, NVD key settings, finding views, and filters. |
+| 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
+| 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
+| 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
+
+Allowed status values:
+
+- `Not started`
+- `In progress`
+- `Blocked`
+- `Complete`
+
+## Phase Details
+
+### 1. Product Decision Record
+
+Create an architecture decision record or product direction document covering:
+
+- CT Ops open-source direction.
+- Community, Pro, and Enterprise tier semantics.
+- Seat-based CT Ops licensing.
+- CT-CVE as a separate subscription product.
+- CT-CVE container/deployment model.
+- CT Ops and CT-CVE integration boundary.
+
+This phase should avoid behavior changes.
+
+### 2. Capacity Entitlement Model
+
+Replace the feature-unlock mental model with a capacity model.
+
+Expected work:
+
+- Add licence payload support for user seats, for example `maxUsers`.
+- Keep existing offline licence verification and revocation mechanics.
+- Decide whether `maxHosts` is deprecated, retained for a separate host cap, or
+  removed in a later compatibility phase.
+- Ensure invalid or expired paid licences degrade safely.
+- Add/update unit tests for licence validation.
+
+### 3. Seat Enforcement
+
+Seats must be enforced by trusted backend paths, never only by UI controls.
+
+At minimum, enforce limits in:
+
+- `inviteUser`
+- restoring previously removed users
+- `acceptInvite`
+- `reactivateUser`
+- LDAP auto-provisioning
+- SAML/OIDC auto-provisioning when implemented
+
+Seat count should include active non-deleted users and pending valid invites.
+Deactivated or removed users should free seats according to the final product
+rule chosen for billing.
+
+Tests should cover invite creation, invite acceptance, reactivation, deleted
+users, pending invites, and LDAP provisioning if that path remains active.
+
+### 4. Remove Pro Gates
+
+Remove Pro gates from core CT Ops functionality.
+
+Expected removals:
+
+- Pro-only page locks.
+- Pro-only sidebar lock badges.
+- Pro-only `requireFeature()` checks.
+- Pro-only settings clamps such as metric retention where the new product model
+  makes them inappropriate.
+- E2E test setup that issues Pro licences only to access now-open pages.
+
+Retain only true Enterprise gates after the product decision record defines
+them. Enterprise checks must remain backend-enforced.
+
+### 5. Licensing UI and Docs
+
+Rewrite licensing surfaces around seats.
+
+Expected UI:
+
+- Current tier.
+- Active users.
+- Pending invites.
+- Seat limit.
+- Seats remaining.
+- Licence expiry.
+- Enterprise capability status where applicable.
+
+Expected docs updates:
+
+- `apps/docs/docs/licensing.md`
+- deployment and configuration docs
+- `.env.example` comments
+- any installer or air-gap documentation that mentions Pro feature unlocks
+
+### 6. CT Ops/CT-CVE API Contract
+
+Define the integration before extracting implementation.
+
+Required decisions:
+
+- Whether CT-CVE pulls inventory from CT Ops, CT Ops pushes inventory to CT-CVE,
+  or both are supported.
+- Finding ingestion payload shape.
+- Organisation scoping.
+- Host/package identity model.
+- Idempotency keys.
+- Authentication and authorization, preferably signed service tokens.
+- Rate limits and replay protection.
+- Error handling and retry semantics.
+- How CT Ops shows CT-CVE connection status.
+
+CT Ops should expose or consume stable APIs instead of sharing private database
+tables with CT-CVE.
+
+### 7. CT-CVE Repo Bootstrap
+
+Create the standalone CT-CVE repository/service.
+
+Expected work:
+
+- Extract or port vulnerability feed sync.
+- Extract or port parser tests.
+- Extract or port package version matching.
+- Add CT-CVE database migrations.
+- Add service config.
+- Add Dockerfile and local compose example.
+- Add CI.
+- Add README.
+
+CT-CVE should have its own release cadence and should not require CT Ops to run
+unless the customer enables CT Ops integration.
+
+### 8. CT-CVE GUI
+
+Build the standalone CT-CVE UI/API surface.
+
+Expected capabilities:
+
+- CVE catalog.
+- Vulnerability source status.
+- NVD API key management.
+- Finding views.
+- Host/package filters.
+- Subscription/licence placeholders for standalone CT-CVE.
+
+If UI code is moved from CT Ops, remove the original CT Ops copies once the CT
+Ops connector replaces them.
+
+### 9. CT Ops Connector
+
+Wire CT Ops to CT-CVE using the phase 6 contract.
+
+Expected work:
+
+- CT Ops inventory export or push path.
+- CT-CVE finding ingestion into CT Ops.
+- CT Ops connection status.
+- Secure service-token setup.
+- Idempotent imports.
+- Backend rate limits.
+- Tests for auth, scoping, duplicate delivery, and stale/deleted hosts.
+
+### 10. Remove Internal CT Ops CVE Ownership
+
+Once the connector works, remove CT Ops internals that CT-CVE now owns.
+
+Expected removals:
+
+- Ingest vulnerability syncer startup.
+- Ingest vulnerability matcher startup.
+- `apps/ingest/internal/vuln/`, unless a deliberately named compatibility
+  adapter remains temporarily.
+- CT Ops NVD key storage.
+- CT Ops vulnerability source management.
+- CT Ops vulnerability feed config.
+- CT Ops pages that manage external vulnerability APIs.
+- Tests covering removed internals.
+
+CT Ops may keep tables and views that store/display imported findings if that is
+the chosen integration model.
+
+### 11. Final Residue Audit
+
+Before declaring the migration complete, run and record searches proving CT Ops
+does not retain moved CT-CVE internals.
+
+Suggested checks:
+
+```sh
+rg -n "vuln|vulnerability|CVE|NVD|CISA|KEV|OSV|Red Hat|Ubuntu OSV|Alpine SecDB" .
+rg -n "requireFeature|FeatureGate|LockedFeature|reportsExport|certExpiryTracker|serviceAccountTracker" apps/web
+rg -n "maxHosts|maxUsers|seat|licence|license" apps docs
+```
+
+The final audit PR must explain which remaining matches are legitimate CT Ops
+integration/display code and which moved CT-CVE internals were removed.
+
+## Running Notes
+
+Append dated notes here as phases progress. Keep notes short and factual.
+
+### 2026-04-29
+
+- Initial migration plan created.

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -4,8 +4,47 @@ This document is the working plan for changing CT Ops from feature-gated Pro
 licensing to seat-based open-source licensing, and for extracting CVE monitoring
 into a standalone product named CT-CVE.
 
+This file is intentionally standalone. If an agent is given only this file as
+its task, it has enough instruction to choose the next piece of work, execute
+that piece, update this file, and open a pull request.
+
 Every agent session that works on this migration must update this file in the
 same pull request as its code or documentation changes.
+
+## How To Use This File In An Agent Session
+
+Do not attempt the full migration in one session.
+
+Each agent session must:
+
+1. Read this entire file and [AGENTS.md](../AGENTS.md).
+2. Inspect the current codebase enough to understand the next safe migration
+   step.
+3. Pick one logical, manageable section of work that can be completed,
+   validated, committed, pushed, and opened as a PR in the current session.
+4. Prefer the earliest `Not started` or `In progress` migration phase that is
+   not blocked. If that phase is too large, choose one coherent subtask from
+   that phase and document the narrower scope in this file.
+5. Mark the selected phase `In progress` before or during implementation.
+6. Make only the changes needed for the selected section. Do not start later
+   phases unless they are strictly required to complete the selected section.
+7. Run validation appropriate to the files and behavior changed.
+8. Update this file before committing:
+   - Set the phase status to `Complete` if the phase is fully done.
+   - Leave the phase as `In progress` if only part of it is complete.
+   - Set the phase to `Blocked` if work cannot continue, and explain why.
+   - Fill in the `Owner / PR` cell with the branch or PR number when known.
+   - Add a dated running note summarizing what changed and what remains.
+9. Update `PROGRESS.md` if the change satisfies part or all of an existing
+   product requirement.
+10. Commit with a Conventional Commit message, push the branch, and open a pull
+    request with a Conventional Commit title.
+
+The expected output of a session is a small, reviewable PR. A good session might
+complete one document, one API contract, one entitlement helper, one enforcement
+path, one UI removal slice, or one cleanup audit. It should not combine
+licensing rewrites, CT-CVE extraction, connector work, and cleanup in the same
+PR.
 
 ## Required Agent Workflow
 
@@ -350,3 +389,5 @@ Append dated notes here as phases progress. Keep notes short and factual.
 ### 2026-04-29
 
 - Initial migration plan created.
+- Added standalone session instructions so future agents choose one manageable
+  migration section, update this file, then commit, push, and open a PR.


### PR DESCRIPTION
## Summary
- Add a canonical CT Ops licensing and CT-CVE migration plan
- Include required agent update instructions and reference AGENTS.md workflow
- Document the standalone CT-CVE container model and final no-residue cleanup rule

## Validation
- git diff --check
- git diff --cached --check