### PR TITLE
docs: record CT Ops licensing and CT-CVE boundary

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -175,7 +175,7 @@ Update the status and notes in this table as work lands.
 
 | Phase | Status | Owner / PR | Notes |
 | --- | --- | --- | --- |
-| 1. Product decision record | Not started | | Document new licensing and CT-CVE product boundary. |
+| 1. Product decision record | Complete | #793 | Added `docs/ct-ops-licensing-and-ct-cve-product-decision.md` documenting new licensing and CT-CVE product boundary. |
 | 2. Capacity entitlement model | Not started | | Add seat-based licence semantics such as `maxUsers`; deprecate feature unlocks for Pro. |
 | 3. Seat enforcement | Not started | | Enforce user seats on invites, restored users, invite acceptance, reactivation, LDAP auto-provisioning, and future SSO provisioning. |
 | 4. Remove Pro gates | Not started | | Remove Pro-only gates from core CT Ops features while preserving true Enterprise gates. |
@@ -391,3 +391,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
 - Initial migration plan created.
 - Added standalone session instructions so future agents choose one manageable
   migration section, update this file, then commit, push, and open a PR.
+- Phase 1 completed by adding a product decision record for CT Ops seat-based
+  licensing, Enterprise capability boundaries, CT-CVE product ownership,
+  standalone deployment, and the CT Ops/CT-CVE API boundary. Confirmed the
+  private `carrtech-dev/ct-cve` repository is accessible and currently has no
+  default branch.

--- a/docs/ct-ops-licensing-and-ct-cve-product-decision.md
+++ b/docs/ct-ops-licensing-and-ct-cve-product-decision.md
@@ -1,0 +1,181 @@
+# CT Ops Licensing and CT-CVE Product Decision Record
+
+Status: Accepted
+
+Date: 2026-04-29
+
+## Context
+
+CT Ops currently uses a feature-unlock licensing model where Pro licences
+enable selected product areas. Vulnerability monitoring is also implemented
+inside CT Ops, spanning the ingest service, web database schema, server actions,
+reports, settings UI, and tests.
+
+The product direction is changing in two related ways:
+
+- CT Ops core functionality should be available in the open-source product
+  without Pro feature gates.
+- Vulnerability intelligence should become a standalone product, CT-CVE, with
+  its own subscription, service boundary, data ownership, and release cadence.
+
+## Decision
+
+CT Ops will move from feature-gated Pro licensing to seat-based licensing for
+the core operations product. CT-CVE will be extracted into an independent
+product and service.
+
+## CT Ops Product Model
+
+CT Ops remains the fleet, asset, agent, operations, alerting, reporting, and
+workflow system.
+
+Core CT Ops functionality is available in the Community tier. Commercial CT Ops
+tiers are capacity and support tiers, not feature-unlock tiers for core
+operations workflows.
+
+Target tiers:
+
+- Community: open-source CT Ops with all core operations features available,
+  limited by included user seats.
+- Pro: paid CT Ops tier based on user seats.
+- Enterprise: paid CT Ops tier based on user seats plus enterprise-only
+  capabilities.
+
+Enterprise capabilities are limited to areas that are genuinely enterprise
+specific, such as SAML, advanced or custom RBAC, compliance packs, white
+labelling, high-availability migration tooling, enterprise air-gap bundlers,
+and enhanced support commitments. Enterprise restrictions must remain enforced
+by trusted backend paths, not only by UI controls.
+
+The old Pro feature-unlock model is deprecated. Existing licence verification,
+offline validation, expiry handling, and revocation mechanics should be kept,
+but the entitlement payload should move toward capacity fields such as
+`maxUsers`.
+
+## Seat-Based Licensing
+
+CT Ops paid licences should express user capacity rather than feature unlocks.
+
+The target user-seat rule is:
+
+- Active, non-deleted users consume seats.
+- Pending, unexpired invitations consume seats.
+- Deactivated users do not consume seats.
+- Removed or deleted users do not consume seats.
+
+Seat enforcement must happen server-side on every path that can create or
+restore access, including invites, invite acceptance, user reactivation, LDAP
+auto-provisioning, and future SSO auto-provisioning.
+
+`maxHosts` should not remain the primary commercial capacity control for CT Ops
+core licensing. A later compatibility phase must decide whether to keep it as a
+separate optional host cap, ignore it for newly issued licences, or remove it
+after existing licence payloads are migrated.
+
+Expired or invalid paid licences should degrade to the Community tier without
+shutting down the installation. The installation should continue operating
+within Community seat rules, with Enterprise-only capabilities disabled when no
+valid Enterprise entitlement exists.
+
+## CT-CVE Product Model
+
+CT-CVE is a separate subscription product. The repository target is:
+
+```text
+git@github.com:carrtech-dev/ct-cve.git
+```
+
+CT-CVE owns:
+
+- Vulnerability feed sync.
+- CVE and advisory catalog management.
+- Vendor package advisory parsing.
+- Package version matching.
+- Vulnerability enrichment and confidence classification.
+- CT-CVE GUI and API surfaces.
+- CT-CVE subscription and licence placeholders.
+
+CT Ops must not retain internal ownership of these responsibilities after the
+migration is complete. CT Ops may keep imported finding display and operational
+reporting surfaces when they are backed by the CT Ops/CT-CVE integration
+contract rather than by CT Ops-owned feed and matching internals.
+
+CT-CVE must be useful without CT Ops. Customers can subscribe to and run CT-CVE
+independently. When customers run both products, CT Ops can provide inventory
+to CT-CVE and receive findings back.
+
+## Deployment Model
+
+CT-CVE runs as its own container rather than as hidden functionality inside
+`ct-ops-ingest`.
+
+The initial bundled deployment model is:
+
+```text
+ct-ops-web
+ct-ops-ingest
+ct-ops-db
+ct-cve
+ct-cve-db or a separate CT-CVE schema/database on the same Postgres server
+```
+
+For the first CT-CVE release, one `ct-cve` container may host both API and
+background worker responsibilities. Splitting that into `ct-cve-api` and
+`ct-cve-worker` remains a later scaling and operations decision.
+
+CT-CVE has its own configuration, migrations, Dockerfile, CI, README, and
+release cadence.
+
+## Integration Boundary
+
+CT Ops and CT-CVE integrate through stable APIs. They must not share private
+database tables, Go packages, TypeScript modules, or internal service calls.
+
+The target integration flow is:
+
+```text
+CT Ops inventory -> CT-CVE
+CT-CVE findings -> CT Ops
+```
+
+The first integration contract should prefer CT Ops pushing scoped inventory
+snapshots to CT-CVE and accepting idempotent finding deliveries from CT-CVE.
+CT-CVE can expose pull APIs later if a deployment profile needs them, but the
+initial contract should avoid CT-CVE reaching directly into CT Ops internals.
+
+The phase 6 API contract must define:
+
+- Organisation scoping.
+- Host and package identity.
+- Inventory payloads.
+- Finding payloads.
+- Idempotency keys.
+- Authentication and authorization.
+- Signed service token format.
+- Replay protection.
+- Rate limits.
+- Retry and error semantics.
+- CT Ops connection status reporting.
+
+Imported CT-CVE findings in CT Ops must be treated as integration data. CT-CVE
+remains the source of truth for vulnerability intelligence, feed state,
+matching rules, enrichment, and vulnerability catalog management.
+
+## Consequences
+
+This decision drives the remaining migration phases:
+
+- Add `maxUsers` and capacity entitlement semantics before removing feature
+  gates.
+- Enforce seats on trusted backend paths before relying on UI seat displays.
+- Remove Pro-only gates from core CT Ops features while preserving
+  Enterprise-only backend checks.
+- Rewrite licensing UI and docs around seats, expiry, and Enterprise
+  capabilities.
+- Define the CT Ops/CT-CVE API contract before extracting CVE implementation.
+- Bootstrap CT-CVE in the private `carrtech-dev/ct-cve` repository.
+- Remove CT Ops-owned vulnerability feed, catalog, matching, configuration, UI,
+  and test residue after the connector replaces those responsibilities.
+
+This document does not change runtime behavior. It records the target product
+boundary so later implementation PRs can be small, ordered, and reviewable.


### PR DESCRIPTION
## Summary

- Add a product decision record for CT Ops seat-based licensing and tier semantics.
- Document CT-CVE as a standalone subscription product with separate deployment and repository ownership.
- Mark migration phase 1 complete in the CT-CVE migration plan and record the private CT-CVE repo access note.

## Validation

- `git diff --check`
- Long-line scan limited to existing migration table/sample command formatting.

## Notes

This is documentation-only and does not change runtime behavior. `PROGRESS.md` was not updated because this does not satisfy an existing product implementation requirement.
