### PR TITLE
feat(web): add seat capacity licence payload

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 82 — Seat-capacity licence payload
+
+**Licence entitlement model** (`apps/web/lib/licence.ts`, `apps/web/lib/actions/licence-guard.ts`)
+- Added validated `maxUsers` support to signed CT-Ops licence payloads and the effective licence object used by trusted server-side guard paths.
+- Tightened capacity claim parsing so `maxUsers` and legacy `maxHosts` are accepted only when they are positive safe integers.
+- Kept `maxHosts` as a legacy optional host cap for compatibility while the migration moves commercial CT-Ops licensing toward user-seat capacity.
+
+**Validation**
+- Added licence validation coverage for `maxUsers`, invalid capacity claims, and expired paid licences.
+- Validation run: `node --experimental-strip-types --test lib/licence.test.mjs` from `apps/web`.
+
 ### Session 81 — RPM CVE comparison tightening
 
 **RPM match accuracy** (`apps/ingest/internal/vuln/`)

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -26,6 +26,7 @@ export class LicenceRequiredError extends Error {
 export type EffectiveLicence = {
   tier: LicenceTier
   features: Feature[]
+  maxUsers?: number
   maxHosts?: number
   licenceId?: string
   expiresAt?: Date
@@ -66,6 +67,7 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
   return {
     tier: result.payload.tier,
     features: result.payload.features,
+    maxUsers: result.payload.maxUsers,
     maxHosts: result.payload.maxHosts,
     licenceId: result.payload.jti,
     expiresAt: new Date(result.payload.exp * 1000),

--- a/apps/web/lib/licence.test.mjs
+++ b/apps/web/lib/licence.test.mjs
@@ -21,7 +21,7 @@ async function createKeyPair() {
   }
 }
 
-async function signJwt(privateKeyPem, audience, claims = {}) {
+async function signJwt(privateKeyPem, audience, claims = {}, options = {}) {
   const privateKey = await importPKCS8(privateKeyPem, 'RS256')
   return new SignJWT(claims)
     .setProtectedHeader({ alg: 'RS256', typ: 'JWT' })
@@ -29,22 +29,27 @@ async function signJwt(privateKeyPem, audience, claims = {}) {
     .setAudience(audience)
     .setIssuedAt()
     .setNotBefore(0)
-    .setExpirationTime('1 hour')
+    .setExpirationTime(options.expirationTime ?? '1 hour')
     .sign(privateKey)
 }
 
-async function signLicence(privateKeyPem, claims = {}) {
-  return signJwt(privateKeyPem, 'install.carrtech.dev', {
-    tier: 'enterprise',
-    features: ['whiteLabel'],
-    customer: {
-      name: 'Example Corp',
-      email: 'ops@example.com',
+async function signLicence(privateKeyPem, claims = {}, options = {}) {
+  return signJwt(
+    privateKeyPem,
+    'install.carrtech.dev',
+    {
+      tier: 'enterprise',
+      features: ['whiteLabel'],
+      customer: {
+        name: 'Example Corp',
+        email: 'ops@example.com',
+      },
+      sub: 'org_123',
+      jti: 'lic_123',
+      ...claims,
     },
-    sub: 'org_123',
-    jti: 'lic_123',
-    ...claims,
-  })
+    options,
+  )
 }
 
 async function signRevocationBundle(privateKeyPem, revoked = []) {
@@ -87,6 +92,55 @@ test('validateLicenceKey accepts a signed licence when the revocation list is un
   const result = await validateLicenceKey(key)
 
   assert.equal(result.valid, true)
+})
+
+test('validateLicenceKey preserves positive integer user seat capacity', async () => {
+  const keys = await createKeyPair()
+  process.env.NODE_ENV = 'production'
+  process.env.LICENCE_PUBLIC_KEY = keys.publicKeyPem
+  process.env.LICENCE_REVOCATION_URL = ''
+
+  const key = await signLicence(keys.privateKeyPem, {
+    maxUsers: 25,
+    maxHosts: 500,
+  })
+  const result = await validateLicenceKey(key)
+
+  assert.equal(result.valid, true)
+  assert.equal(result.payload.maxUsers, 25)
+  assert.equal(result.payload.maxHosts, 500)
+})
+
+test('validateLicenceKey ignores invalid capacity claims', async () => {
+  const keys = await createKeyPair()
+  process.env.NODE_ENV = 'production'
+  process.env.LICENCE_PUBLIC_KEY = keys.publicKeyPem
+  process.env.LICENCE_REVOCATION_URL = ''
+
+  const key = await signLicence(keys.privateKeyPem, {
+    maxUsers: 0,
+    maxHosts: 12.5,
+  })
+  const result = await validateLicenceKey(key)
+
+  assert.equal(result.valid, true)
+  assert.equal(result.payload.maxUsers, undefined)
+  assert.equal(result.payload.maxHosts, undefined)
+})
+
+test('validateLicenceKey rejects expired paid licences', async () => {
+  const keys = await createKeyPair()
+  process.env.NODE_ENV = 'production'
+  process.env.LICENCE_PUBLIC_KEY = keys.publicKeyPem
+  process.env.LICENCE_REVOCATION_URL = ''
+
+  const key = await signLicence(keys.privateKeyPem, {}, { expirationTime: '1 second ago' })
+  const result = await validateLicenceKey(key)
+
+  assert.deepEqual(result, {
+    valid: false,
+    error: 'Licence key has expired',
+  })
 })
 
 test('validateLicenceKey rejects a licence whose jti is present in the signed revocation bundle', async () => {

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -79,6 +79,7 @@ export type LicencePayload = {
   jti: string
   tier: PaidTier
   features: Feature[]
+  maxUsers?: number
   maxHosts?: number
   customer: LicenceCustomer
 }
@@ -114,6 +115,10 @@ function isCustomer(v: unknown): v is LicenceCustomer {
   if (!v || typeof v !== 'object') return false
   const c = v as Record<string, unknown>
   return typeof c.name === 'string' && typeof c.email === 'string'
+}
+
+function parsePositiveIntegerClaim(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isSafeInteger(v) && v > 0 ? v : undefined
 }
 
 function resolveRevocationUrl(env: NodeJS.ProcessEnv = process.env): string | null {
@@ -272,8 +277,8 @@ export async function validateLicenceKey(key: string): Promise<LicenceValidation
       return { valid: false, error: 'Licence key is missing customer details' }
     }
 
-    const rawMaxHosts = payload['maxHosts']
-    const maxHosts = typeof rawMaxHosts === 'number' && rawMaxHosts > 0 ? rawMaxHosts : undefined
+    const maxUsers = parsePositiveIntegerClaim(payload['maxUsers'])
+    const maxHosts = parsePositiveIntegerClaim(payload['maxHosts'])
 
     if (await isLicenceRevoked(payload.jti)) {
       return { valid: false, error: 'Licence key has been revoked' }
@@ -291,13 +296,14 @@ export async function validateLicenceKey(key: string): Promise<LicenceValidation
         jti: payload.jti,
         tier: payload['tier'],
         features,
+        maxUsers,
         maxHosts,
         customer: rawCustomer,
       },
     }
   } catch (err) {
     if (err instanceof Error) {
-      if (err.message.includes('expired')) {
+      if (err.name === 'JWTExpired' || err.message.includes('expired')) {
         return { valid: false, error: 'Licence key has expired' }
       }
       if (err.message.includes('signature')) {

--- a/apps/web/scripts/diagnose-licence.mjs
+++ b/apps/web/scripts/diagnose-licence.mjs
@@ -88,6 +88,8 @@ async function main() {
   console.log(`  nbf        : ${!payload.nbf || payload.nbf <= now ? 'OK' : 'NOT YET VALID'}`)
   console.log(`  tier       : ${payload.tier}`)
   console.log(`  features   : ${JSON.stringify(payload.features)}`)
+  console.log(`  maxUsers   : ${payload.maxUsers ?? '(unset)'}`)
+  console.log(`  maxHosts   : ${payload.maxHosts ?? '(unset)'}`)
 
   console.log('--- Signature verification ---')
   await verifyWith('DEV public key', DEV_PUBLIC_KEY_PEM, jwt)

--- a/apps/web/tests/e2e/fixtures/licence.ts
+++ b/apps/web/tests/e2e/fixtures/licence.ts
@@ -5,6 +5,7 @@ type TestLicenceOptions = {
   orgId: string
   tier?: 'pro' | 'enterprise'
   features?: string[]
+  maxUsers?: number
   maxHosts?: number
 }
 
@@ -15,6 +16,7 @@ export async function issueTestLicence({
   orgId,
   tier = 'pro',
   features = [],
+  maxUsers = 10,
   maxHosts = 100,
 }: TestLicenceOptions): Promise<string> {
   const privateKeyPem = process.env['E2E_LICENCE_PRIVATE_KEY']
@@ -26,6 +28,7 @@ export async function issueTestLicence({
   return new SignJWT({
     tier,
     features,
+    maxUsers,
     maxHosts,
     customer: {
       name: 'E2E Test Customer',

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -176,7 +176,7 @@ Update the status and notes in this table as work lands.
 | Phase | Status | Owner / PR | Notes |
 | --- | --- | --- | --- |
 | 1. Product decision record | Complete | #793 | Added `docs/ct-ops-licensing-and-ct-cve-product-decision.md` documenting new licensing and CT-CVE product boundary. |
-| 2. Capacity entitlement model | Not started | | Add seat-based licence semantics such as `maxUsers`; deprecate feature unlocks for Pro. |
+| 2. Capacity entitlement model | Complete | #794 | Added validated `maxUsers` licence capacity support; retained `maxHosts` as a legacy optional host cap until later compatibility cleanup. |
 | 3. Seat enforcement | Not started | | Enforce user seats on invites, restored users, invite acceptance, reactivation, LDAP auto-provisioning, and future SSO provisioning. |
 | 4. Remove Pro gates | Not started | | Remove Pro-only gates from core CT Ops features while preserving true Enterprise gates. |
 | 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around seats, expiry, and enterprise capabilities. |
@@ -396,3 +396,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
   standalone deployment, and the CT Ops/CT-CVE API boundary. Confirmed the
   private `carrtech-dev/ct-cve` repository is accessible and currently has no
   default branch.
+- Phase 2 completed by adding `maxUsers` support to licence validation,
+  effective licence loading, E2E test licence issuance, and licence diagnostics.
+  Capacity claims now accept only positive safe integers. `maxHosts` remains as
+  a legacy optional host cap for compatibility; Pro feature-gate removal remains
+  tracked in phase 4.


### PR DESCRIPTION
## Summary

- Add `maxUsers` support to signed CT-Ops licence payload validation and effective licence loading.
- Tighten capacity parsing so `maxUsers` and legacy `maxHosts` only accept positive safe integers.
- Update E2E licence issuance, licence diagnostics, `PROGRESS.md`, and the CT-CVE migration tracker for phase 2.

## Validation

- `node --experimental-strip-types --test lib/licence.test.mjs` from `apps/web`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web exec eslint lib/licence.ts lib/actions/licence-guard.ts lib/licence.test.mjs scripts/diagnose-licence.mjs tests/e2e/fixtures/licence.ts`
- `git diff --check`

## Notes

This is stacked on PR #793 (`docs/ct-cve-product-decision-record`) because phase 1 has not landed yet and this PR updates the same migration tracker. `maxHosts` is retained as a legacy optional host cap for compatibility; Pro gate removal remains tracked in phase 4.
