### PR TITLE
docs: update CT Ops Free and Enterprise licensing plan

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -1,8 +1,8 @@
 # CT Ops Licensing and CT-CVE Migration Plan
 
-This document is the working plan for changing CT Ops from feature-gated Pro
-licensing to seat-based open-source licensing, and for extracting CVE monitoring
-into a standalone product named CT-CVE.
+This document is the working plan for changing CT Ops from feature-gated
+licensing to seat-based open-source licensing with Free and Enterprise tiers,
+and for extracting CVE monitoring into a standalone product named CT-CVE.
 
 This file is intentionally standalone. If an agent is given only this file as
 its task, it has enough instruction to choose the next piece of work, execute
@@ -65,14 +65,29 @@ document why in the pull request and describe the validation that was performed.
 ## Product Direction
 
 CT Ops is moving to an open-source model where core functionality is available
-without Pro feature gates. Commercial CT Ops tiers are based on user seats.
+without paid feature gates. Commercial CT Ops licensing is based on user seats
+and Enterprise-only capabilities.
 
 Target CT Ops tiers:
 
-- **Community**: open-source, all core CT Ops features available, limited by
+- **Free**: open-source CT Ops with all core CT Ops features available and 5
   included user seats.
-- **Pro**: seat-based paid tier.
-- **Enterprise**: seat-based paid tier plus enterprise-only capabilities.
+- **Free + extra seats**: same CT Ops feature set as Free, with additional user
+  seats purchased through a signed seat-pack licence.
+- **Enterprise**: signed seat-based licence that includes purchased user seats,
+  Enterprise-only capabilities, and enhanced support.
+
+Enterprise-only capabilities should remain narrow and genuinely enterprise
+specific, such as SAML, advanced or custom RBAC, compliance packs, white
+labelling, high-availability migration tooling, enterprise air-gap bundlers,
+official-build support eligibility, and enhanced support commitments.
+
+Because CT Ops is open source and self-hosted, seat enforcement cannot be made
+tamper-proof against users who are willing to maintain a patched fork. The goal
+is to make honest use easy, casual bypass inconvenient, and commercial bypass
+unsupported. Seat enforcement must be complete in trusted backend paths, and
+official support may depend on signed licences, auditability, support status,
+official build provenance, and licence/build verification in support bundles.
 
 CT-CVE becomes a separate product:
 
@@ -142,7 +157,7 @@ must include:
 
 ## Current CT Ops Code Areas
 
-Known Pro/Enterprise gating areas:
+Known paid/Enterprise gating areas:
 
 - `apps/web/lib/features.ts`
 - `apps/web/lib/actions/licence-guard.ts`
@@ -151,7 +166,7 @@ Known Pro/Enterprise gating areas:
 - `apps/web/components/shared/sidebar.tsx`
 - Page-level locks under `apps/web/app/(dashboard)`
 - Server actions using `requireFeature()`
-- Licensing docs and e2e fixtures that issue Pro licences only to unlock pages
+- Licensing docs and e2e fixtures that issue paid licences only to unlock pages
 
 Known CVE ownership areas to extract or replace:
 
@@ -177,9 +192,9 @@ Update the status and notes in this table as work lands.
 | --- | --- | --- | --- |
 | 1. Product decision record | Complete | #793 | Added `docs/ct-ops-licensing-and-ct-cve-product-decision.md` documenting new licensing and CT-CVE product boundary. |
 | 2. Capacity entitlement model | Complete | #794 | Added validated `maxUsers` licence capacity support; retained `maxHosts` as a legacy optional host cap until later compatibility cleanup. |
-| 3. Seat enforcement | Not started | | Enforce user seats on invites, restored users, invite acceptance, reactivation, LDAP auto-provisioning, and future SSO provisioning. |
-| 4. Remove Pro gates | Not started | | Remove Pro-only gates from core CT Ops features while preserving true Enterprise gates. |
-| 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around seats, expiry, and enterprise capabilities. |
+| 3. Seat enforcement | Not started | | Enforce Free 5-seat limits and signed licence `maxUsers` on invites, restored users, invite acceptance, reactivation, LDAP auto-provisioning, and future SSO provisioning. |
+| 4. Remove paid feature gates | Not started | | Remove paid gates from core CT Ops features while preserving true Enterprise gates. |
+| 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around Free seats, purchased seats, expiry, Enterprise capabilities, and support/build verification. |
 | 6. CT Ops/CT-CVE API contract | Not started | | Define inventory export and finding ingestion boundary before moving code. |
 | 7. CT-CVE repo bootstrap | Not started | | Create standalone repo/service with extracted sync, parser, matching, and test logic. |
 | 8. CT-CVE GUI | Not started | | Move or rebuild CVE catalog, source status, NVD key settings, finding views, and filters. |
@@ -201,7 +216,7 @@ Allowed status values:
 Create an architecture decision record or product direction document covering:
 
 - CT Ops open-source direction.
-- Community, Pro, and Enterprise tier semantics.
+- Free, Free + extra seats, and Enterprise tier semantics.
 - Seat-based CT Ops licensing.
 - CT-CVE as a separate subscription product.
 - CT-CVE container/deployment model.
@@ -216,6 +231,11 @@ Replace the feature-unlock mental model with a capacity model.
 Expected work:
 
 - Add licence payload support for user seats, for example `maxUsers`.
+- Treat unlicensed Free installs as having 5 included seats.
+- Support signed seat-pack licences that increase Free seat capacity without
+  enabling Enterprise-only capabilities.
+- Support signed Enterprise licences that carry `maxUsers` and Enterprise-only
+  capability claims.
 - Keep existing offline licence verification and revocation mechanics.
 - Decide whether `maxHosts` is deprecated, retained for a separate host cap, or
   removed in a later compatibility phase.
@@ -225,6 +245,16 @@ Expected work:
 ### 3. Seat Enforcement
 
 Seats must be enforced by trusted backend paths, never only by UI controls.
+The default Free limit is 5 seats unless a valid signed seat-pack or Enterprise
+licence raises `maxUsers`.
+
+The effective seat limit should be:
+
+```text
+valid Enterprise licence -> licence maxUsers
+valid Free seat-pack licence -> 5 included seats + purchased extra seats
+no valid licence -> 5 included seats
+```
 
 At minimum, enforce limits in:
 
@@ -242,18 +272,18 @@ rule chosen for billing.
 Tests should cover invite creation, invite acceptance, reactivation, deleted
 users, pending invites, and LDAP provisioning if that path remains active.
 
-### 4. Remove Pro Gates
+### 4. Remove Paid Feature Gates
 
-Remove Pro gates from core CT Ops functionality.
+Remove paid gates from core CT Ops functionality.
 
 Expected removals:
 
-- Pro-only page locks.
-- Pro-only sidebar lock badges.
-- Pro-only `requireFeature()` checks.
-- Pro-only settings clamps such as metric retention where the new product model
+- Paid page locks.
+- Paid sidebar lock badges.
+- Paid `requireFeature()` checks.
+- Paid settings clamps such as metric retention where the new product model
   makes them inappropriate.
-- E2E test setup that issues Pro licences only to access now-open pages.
+- E2E test setup that issues paid licences only to access now-open pages.
 
 Retain only true Enterprise gates after the product decision record defines
 them. Enterprise checks must remain backend-enforced.
@@ -267,17 +297,22 @@ Expected UI:
 - Current tier.
 - Active users.
 - Pending invites.
+- Free included seats.
+- Purchased extra seats.
 - Seat limit.
 - Seats remaining.
 - Licence expiry.
 - Enterprise capability status where applicable.
+- Official build / support verification status.
+- Unsupported-build status if licence enforcement or build provenance cannot be
+  verified.
 
 Expected docs updates:
 
 - `apps/docs/docs/licensing.md`
 - deployment and configuration docs
 - `.env.example` comments
-- any installer or air-gap documentation that mentions Pro feature unlocks
+- any installer or air-gap documentation that mentions paid feature unlocks
 
 ### 6. CT Ops/CT-CVE API Contract
 
@@ -399,5 +434,12 @@ Append dated notes here as phases progress. Keep notes short and factual.
 - Phase 2 completed by adding `maxUsers` support to licence validation,
   effective licence loading, E2E test licence issuance, and licence diagnostics.
   Capacity claims now accept only positive safe integers. `maxHosts` remains as
-  a legacy optional host cap for compatibility; Pro feature-gate removal remains
-  tracked in phase 4.
+  a legacy optional host cap for compatibility; paid feature-gate removal
+  remains tracked in phase 4.
+- PR #795 updated the target CT Ops licensing model to Free and Enterprise. Free
+  includes 5 seats and can be expanded with signed seat-pack licences;
+  Enterprise adds signed seat capacity, Enterprise-only capabilities, and
+  enhanced support. Documented that open-source seat enforcement is not
+  tamper-proof and should be backed by complete backend checks, signed
+  licences, official build provenance, support status, auditability, and
+  support-bundle verification.


### PR DESCRIPTION
## Summary

- Update the CT-CVE migration plan to use the revised CT Ops licensing model: Free, Free + extra seats, and Enterprise.
- Document the Free 5-seat baseline, signed seat-pack licences, and Enterprise-only capability boundary.
- Add the open-source enforcement posture: backend checks, signed licences, build provenance, support status, auditability, and support-bundle verification.
- Rename phase 4 from removing Pro gates to removing paid feature gates and update phase 5 UI/docs expectations.

## Validation

- `git diff --check`
- Long-line scan only flagged the existing migration table/sample command formatting.

## Notes

Documentation-only change. This PR is stacked on PR #794 because it updates the same migration tracker state before phase 3 implementation.
