### PR TITLE
feat(web): enforce user seat limits

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 83 — User-seat enforcement
+
+**Seat enforcement** (`apps/web/lib/actions/seat-enforcement.ts`, `apps/web/lib/licence-seats.ts`)
+- Added shared seat usage calculation for active non-deleted users plus pending unexpired invitations.
+- Enforced `maxUsers` on admin invites, removed-user restoration, invite acceptance, user reactivation, and LDAP auto-provisioning.
+- Preserved compatibility for licences without `maxUsers` by treating them as unlimited until Community seat rules are finalized.
+
+**Validation**
+- Added unit coverage for seat usage calculations and E2E coverage for invite creation and invite acceptance at the seat limit.
+- Validation run: `npm run type-check`, `npm run test:unit`, and `npm run test:e2e -- tests/e2e/team/invitations.spec.ts tests/e2e/auth/invite-acceptance.spec.ts` from `apps/web`.
+
 ### Session 82 — Seat-capacity licence payload
 
 **Licence entitlement model** (`apps/web/lib/licence.ts`, `apps/web/lib/actions/licence-guard.ts`)

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -10,6 +10,7 @@ import { createRateLimiter } from '@/lib/rate-limit'
 import { getBetterAuthSecret } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
 import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
+import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
 
 // 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
 const ldapRateLimit = createRateLimiter({
@@ -129,6 +130,7 @@ export async function POST(request: NextRequest) {
           userId = existingUser.id
         } else {
           // Create new user
+          await assertCanReserveUserSeat(config.organisationId)
           userId = createId()
           const email = ldapUser.email || `${ldapUser.username}@ldap.local`
 
@@ -206,6 +208,13 @@ export async function POST(request: NextRequest) {
       NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
     )
   } catch (err) {
+    const seatLimitMessage = toSeatLimitErrorMessage(err)
+    if (seatLimitMessage) {
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: seatLimitMessage }, { status: 403 }),
+      )
+    }
     logError('[LDAP] Unexpected error during login:', err)
     return withAuthDelay(
       requestStart,

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -8,6 +8,7 @@ import { eq, and, isNull, gt } from 'drizzle-orm'
 import type { Invitation } from '@/lib/db/schema'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getPrimaryRole, normalizeAssignedRoles } from '@/lib/auth/roles'
+import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
 
 // 10 invite-token lookups per IP per 60 s — prevents token enumeration
 const inviteRateLimit = createRateLimiter({
@@ -86,6 +87,8 @@ export async function acceptInvite(
     const inviteRoles = normalizeAssignedRoles(invite.roles, invite.role)
     const inviteRole = getPrimaryRole(inviteRoles, invite.role)
 
+    await assertCanReserveUserSeat(invite.organisationId, { excludeInviteId: invite.id })
+
     await db
       .update(users)
       .set({
@@ -103,6 +106,10 @@ export async function acceptInvite(
 
     return { success: true }
   } catch (err) {
+    const seatLimitMessage = toSeatLimitErrorMessage(err)
+    if (seatLimitMessage) {
+      return { error: seatLimitMessage }
+    }
     logError('Failed to accept invite:', err)
     return { error: 'An unexpected error occurred' }
   }

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -79,6 +79,10 @@ export async function getEffectiveLicence(orgId: string): Promise<EffectiveLicen
   return loadEffectiveLicence(orgId)
 }
 
+export async function getTrustedEffectiveLicence(orgId: string): Promise<EffectiveLicence> {
+  return loadEffectiveLicence(orgId)
+}
+
 export async function hasLicenceFeature(orgId: string, feature: Feature): Promise<boolean> {
   await requireOrgAccess(orgId)
   const licence = await loadEffectiveLicence(orgId)

--- a/apps/web/lib/actions/seat-enforcement.ts
+++ b/apps/web/lib/actions/seat-enforcement.ts
@@ -1,0 +1,68 @@
+import 'server-only'
+
+import { and, count, eq, gt, isNull, ne } from 'drizzle-orm'
+
+import { db } from '@/lib/db'
+import { invitations, users } from '@/lib/db/schema'
+import { calculateSeatUsage, canReserveSeats, formatSeatLimitError, type SeatUsage } from '@/lib/licence-seats'
+import { getTrustedEffectiveLicence } from '@/lib/actions/licence-guard'
+
+type SeatUsageOptions = {
+  excludeInviteId?: string
+}
+
+export class SeatLimitError extends Error {
+  constructor(public usage: SeatUsage) {
+    super(formatSeatLimitError(usage))
+    this.name = 'SeatLimitError'
+  }
+}
+
+export async function getOrgSeatUsage(orgId: string, options: SeatUsageOptions = {}): Promise<SeatUsage> {
+  const licence = await getTrustedEffectiveLicence(orgId)
+  const now = new Date()
+
+  const pendingInviteWhere = options.excludeInviteId
+    ? and(
+        eq(invitations.organisationId, orgId),
+        isNull(invitations.deletedAt),
+        isNull(invitations.acceptedAt),
+        gt(invitations.expiresAt, now),
+        ne(invitations.id, options.excludeInviteId),
+      )
+    : and(
+        eq(invitations.organisationId, orgId),
+        isNull(invitations.deletedAt),
+        isNull(invitations.acceptedAt),
+        gt(invitations.expiresAt, now),
+      )
+
+  const [activeUsersRow, pendingInvitesRow] = await Promise.all([
+    db
+      .select({ total: count() })
+      .from(users)
+      .where(and(eq(users.organisationId, orgId), eq(users.isActive, true), isNull(users.deletedAt))),
+    db.select({ total: count() }).from(invitations).where(pendingInviteWhere),
+  ])
+
+  return calculateSeatUsage({
+    activeUsers: activeUsersRow[0]?.total ?? 0,
+    pendingInvites: pendingInvitesRow[0]?.total ?? 0,
+    maxUsers: licence.maxUsers,
+  })
+}
+
+export async function assertCanReserveUserSeat(
+  orgId: string,
+  options: SeatUsageOptions = {},
+): Promise<SeatUsage> {
+  const usage = await getOrgSeatUsage(orgId, options)
+  if (!canReserveSeats(usage, 1)) {
+    throw new SeatLimitError(usage)
+  }
+  return usage
+}
+
+export function toSeatLimitErrorMessage(err: unknown): string | null {
+  return err instanceof SeatLimitError ? err.message : null
+}

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -11,6 +11,7 @@ import type { User, Invitation } from '@/lib/db/schema'
 import { getBetterAuthOrigin } from '@/lib/auth/env'
 import { writeAuditEvent } from '@/lib/audit/events'
 import { ASSIGNED_ROLES, INVITABLE_ROLES, getPrimaryRole, normalizeAssignedRoles } from '@/lib/auth/roles'
+import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
 
 const inviteSchema = z.object({
   email: z.string().email('Enter a valid email address'),
@@ -76,6 +77,7 @@ export async function inviteUser(
       ),
     })
     if (removedUser) {
+      await assertCanReserveUserSeat(orgId)
       await db
         .update(users)
         .set({ deletedAt: null, isActive: true, role: nextRole, roles: nextRoles, updatedAt: new Date() })
@@ -107,6 +109,8 @@ export async function inviteUser(
       return { error: 'An invitation has already been sent to this email address' }
     }
 
+    await assertCanReserveUserSeat(orgId)
+
     const expiresAt = new Date()
     expiresAt.setDate(expiresAt.getDate() + 7)
 
@@ -127,6 +131,10 @@ export async function inviteUser(
     const baseUrl = getBetterAuthOrigin()
     return { inviteLink: `${baseUrl}/register?invite=${invite.token}` }
   } catch (err) {
+    const seatLimitMessage = toSeatLimitErrorMessage(err)
+    if (seatLimitMessage) {
+      return { error: seatLimitMessage }
+    }
     logError('Failed to invite user:', err)
     return { error: 'An unexpected error occurred' }
   }
@@ -246,6 +254,18 @@ export async function reactivateUser(
   try {
     await requireOrgAdminAccess(orgId)
 
+    const targetUser = await db.query.users.findFirst({
+      where: and(eq(users.id, targetUserId), eq(users.organisationId, orgId), isNull(users.deletedAt)),
+      columns: { id: true, isActive: true },
+    })
+    if (!targetUser) {
+      return { error: 'User not found' }
+    }
+
+    if (!targetUser.isActive) {
+      await assertCanReserveUserSeat(orgId)
+    }
+
     await db
       .update(users)
       .set({ isActive: true, updatedAt: new Date() })
@@ -253,6 +273,10 @@ export async function reactivateUser(
 
     return { success: true }
   } catch (err) {
+    const seatLimitMessage = toSeatLimitErrorMessage(err)
+    if (seatLimitMessage) {
+      return { error: seatLimitMessage }
+    }
     logError('Failed to reactivate user:', err)
     return { error: 'An unexpected error occurred' }
   }

--- a/apps/web/lib/licence-seats.test.mjs
+++ b/apps/web/lib/licence-seats.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  calculateSeatUsage,
+  canReserveSeats,
+  formatSeatLimitError,
+} from './licence-seats.ts'
+
+test('calculateSeatUsage counts active users and pending invites only', () => {
+  const usage = calculateSeatUsage({
+    activeUsers: 2,
+    pendingInvites: 1,
+    maxUsers: 4,
+  })
+
+  assert.deepEqual(usage, {
+    activeUsers: 2,
+    pendingInvites: 1,
+    usedSeats: 3,
+    maxUsers: 4,
+    remainingSeats: 1,
+  })
+})
+
+test('canReserveSeats allows usage below the max user capacity', () => {
+  const usage = calculateSeatUsage({
+    activeUsers: 1,
+    pendingInvites: 1,
+    maxUsers: 3,
+  })
+
+  assert.equal(canReserveSeats(usage, 1), true)
+})
+
+test('canReserveSeats blocks reservations that would exceed maxUsers', () => {
+  const usage = calculateSeatUsage({
+    activeUsers: 2,
+    pendingInvites: 1,
+    maxUsers: 3,
+  })
+
+  assert.equal(canReserveSeats(usage, 1), false)
+  assert.equal(formatSeatLimitError(usage), 'User seat limit reached. This licence allows 3 users.')
+})
+
+test('canReserveSeats treats a missing maxUsers claim as unlimited for this compatibility phase', () => {
+  const usage = calculateSeatUsage({
+    activeUsers: 200,
+    pendingInvites: 40,
+  })
+
+  assert.equal(canReserveSeats(usage, 1), true)
+  assert.equal(usage.remainingSeats, undefined)
+})

--- a/apps/web/lib/licence-seats.ts
+++ b/apps/web/lib/licence-seats.ts
@@ -1,0 +1,29 @@
+export type SeatUsageInput = {
+  activeUsers: number
+  pendingInvites: number
+  maxUsers?: number
+}
+
+export type SeatUsage = SeatUsageInput & {
+  usedSeats: number
+  remainingSeats?: number
+}
+
+export function calculateSeatUsage(input: SeatUsageInput): SeatUsage {
+  const usedSeats = input.activeUsers + input.pendingInvites
+  return {
+    ...input,
+    usedSeats,
+    remainingSeats: input.maxUsers === undefined ? undefined : Math.max(input.maxUsers - usedSeats, 0),
+  }
+}
+
+export function canReserveSeats(usage: SeatUsage, seats = 1): boolean {
+  if (usage.maxUsers === undefined) return true
+  return usage.usedSeats + seats <= usage.maxUsers
+}
+
+export function formatSeatLimitError(usage: Pick<SeatUsage, 'maxUsers'>): string {
+  const seats = usage.maxUsers ?? 0
+  return `User seat limit reached. This licence allows ${seats} ${seats === 1 ? 'user' : 'users'}.`
+}

--- a/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
+++ b/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_USER, TEST_ORG } from '../fixtures/seed'
+import { issueTestLicence } from '../fixtures/licence'
 
 test('invite acceptance rejects logged-in users whose email does not match the invitation', async ({
   page,
@@ -162,4 +163,104 @@ test('invite acceptance attaches the matching user to the organisation', async (
     LIMIT 1
   `
   expect(invite?.accepted_at).not.toBeNull()
+})
+
+test('invite acceptance rejects when no user seat is available', async ({ page }) => {
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const invitedEmail = `seat-limited-invitee-${suffix}@example.com`
+  const invitedPassword = 'TestPassword123!'
+  const inviteToken = `seat-limited-invite-token-${suffix}`
+
+  const [org] = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM organisations
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(org?.id).toBeTruthy()
+
+  try {
+    const licenceKey = await issueTestLicence({ orgId: org!.id, tier: 'pro', maxUsers: 1 })
+    await sql`
+      UPDATE organisations
+      SET licence_key = ${licenceKey},
+          licence_tier = 'pro'
+      WHERE id = ${org!.id}
+    `
+
+    const signUpResponse = await page.request.post('/api/auth/sign-up/email', {
+      data: {
+        email: invitedEmail,
+        password: invitedPassword,
+        name: 'Seat Limited Invitee',
+      },
+    })
+    expect(signUpResponse.ok()).toBeTruthy()
+
+    await sql`
+      UPDATE "user"
+      SET email_verified = true,
+          is_active = true
+      WHERE email = ${invitedEmail}
+    `
+
+    await sql`
+      INSERT INTO invitations (
+        id,
+        email,
+        role,
+        token,
+        organisation_id,
+        invited_by_id,
+        expires_at,
+        created_at,
+        updated_at
+      )
+      VALUES (
+        ${`seat-limited-invite-${suffix}`},
+        ${invitedEmail},
+        'engineer',
+        ${inviteToken},
+        ${org!.id},
+        (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+        NOW() + INTERVAL '1 day',
+        NOW(),
+        NOW()
+      )
+    `
+
+    const signInResponse = await page.request.post('/api/auth/sign-in/email', {
+      data: {
+        email: invitedEmail,
+        password: invitedPassword,
+      },
+    })
+    expect(signInResponse.ok()).toBeTruthy()
+
+    await page.goto(`/accept-invite?token=${inviteToken}`)
+
+    const [invitee] = await sql<Array<{ organisation_id: string | null }>>`
+      SELECT organisation_id
+      FROM "user"
+      WHERE email = ${invitedEmail}
+      LIMIT 1
+    `
+    expect(invitee?.organisation_id).toBeNull()
+
+    const [invite] = await sql<Array<{ accepted_at: Date | null }>>`
+      SELECT accepted_at
+      FROM invitations
+      WHERE token = ${inviteToken}
+      LIMIT 1
+    `
+    expect(invite?.accepted_at).toBeNull()
+  } finally {
+    await sql`
+      UPDATE organisations
+      SET licence_key = NULL,
+          licence_tier = 'community'
+      WHERE id = ${org!.id}
+    `
+  }
 })

--- a/apps/web/tests/e2e/team/invitations.spec.ts
+++ b/apps/web/tests/e2e/team/invitations.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_ORG } from '../fixtures/seed'
+import { issueTestLicence } from '../fixtures/licence'
 
 async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
   const rows = await sql<Array<{ id: string }>>`
@@ -11,6 +12,25 @@ async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
   `
   expect(rows).toHaveLength(1)
   return rows[0]!.id
+}
+
+async function setOrgSeatLimit(sql: ReturnType<typeof getTestDb>, orgId: string, maxUsers: number): Promise<void> {
+  const licenceKey = await issueTestLicence({ orgId, tier: 'pro', maxUsers })
+  await sql`
+    UPDATE organisations
+    SET licence_key = ${licenceKey},
+        licence_tier = 'pro'
+    WHERE id = ${orgId}
+  `
+}
+
+async function clearOrgLicence(sql: ReturnType<typeof getTestDb>, orgId: string): Promise<void> {
+  await sql`
+    UPDATE organisations
+    SET licence_key = NULL,
+        licence_tier = 'community'
+    WHERE id = ${orgId}
+  `
 }
 
 test('admin can create and cancel a team invitation', async ({ authenticatedPage: page }) => {
@@ -100,6 +120,36 @@ test('admin cannot create a duplicate pending invitation for the same email addr
   expect(inviteRows[0]?.role).toBe('engineer')
   expect(inviteRows[0]?.roles).toEqual(['engineer'])
   expect(inviteRows[0]?.deleted_at).toBeNull()
+})
+
+test('admin cannot create an invitation when user seats are exhausted', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  try {
+    await setOrgSeatLimit(sql, orgId, 1)
+
+    await page.goto('/team')
+
+    await expect(page.getByTestId('team-heading')).toBeVisible()
+    await page.getByTestId('team-invite-open').click()
+    await page.getByTestId('team-invite-email').fill('seat-limited-teammate@example.com')
+    await page.getByTestId('team-invite-role-engineer').click()
+    await page.getByTestId('team-invite-submit').click()
+
+    await expect(page.getByText('User seat limit reached. This licence allows 1 user.')).toBeVisible()
+    await expect(page.getByTestId('team-invite-link')).toHaveCount(0)
+
+    const inviteRows = await sql<Array<{ id: string }>>`
+      SELECT id
+      FROM invitations
+      WHERE organisation_id = ${orgId}
+        AND email = 'seat-limited-teammate@example.com'
+    `
+    expect(inviteRows).toHaveLength(0)
+  } finally {
+    await clearOrgLicence(sql, orgId)
+  }
 })
 
 test('admin re-inviting a removed user restores their membership instead of creating a pending invite', async ({ authenticatedPage: page }) => {

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -177,7 +177,7 @@ Update the status and notes in this table as work lands.
 | --- | --- | --- | --- |
 | 1. Product decision record | Complete | #793 | Added `docs/ct-ops-licensing-and-ct-cve-product-decision.md` documenting new licensing and CT-CVE product boundary. |
 | 2. Capacity entitlement model | Complete | #796 | Added validated `maxUsers` licence capacity support; retained `maxHosts` as a legacy optional host cap until later compatibility cleanup. |
-| 3. Seat enforcement | Not started | | Enforce user seats on invites, restored users, invite acceptance, reactivation, LDAP auto-provisioning, and future SSO provisioning. |
+| 3. Seat enforcement | Complete | feat/seat-enforcement | Enforced `maxUsers` seats on invites, restored users, invite acceptance, reactivation, and LDAP auto-provisioning. Future SSO provisioning must use the same helper when added. |
 | 4. Remove Pro gates | Not started | | Remove Pro-only gates from core CT Ops features while preserving true Enterprise gates. |
 | 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around seats, expiry, and enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Not started | | Define inventory export and finding ingestion boundary before moving code. |
@@ -402,3 +402,11 @@ Append dated notes here as phases progress. Keep notes short and factual.
   a legacy optional host cap for compatibility; Pro feature-gate removal remains
   tracked in phase 4. Re-homed the change onto `main` via PR #796 after PR #794
   was merged into the Phase 1 branch.
+- Phase 3 completed for current user-provisioning paths by adding shared seat
+  usage calculation and backend `maxUsers` checks for admin invitations, removed
+  user restoration, invite acceptance, user reactivation, and LDAP
+  auto-provisioning. Pending valid invites and active non-deleted users consume
+  seats; deactivated and deleted users do not. Licences without `maxUsers`
+  remain unlimited for this compatibility phase. Validation: `npm run
+  type-check`, `npm run test:unit`, and targeted E2E coverage for team
+  invitations and invite acceptance.


### PR DESCRIPTION
## Summary
- add shared user-seat usage calculation for active users plus pending valid invites
- enforce maxUsers on invites, removed-user restoration, invite acceptance, reactivation, and LDAP auto-provisioning
- update the CT-CVE migration plan and PROGRESS.md for Phase 3

## Validation
- npm run type-check
- npm run test:unit
- npm run test:e2e -- tests/e2e/team/invitations.spec.ts tests/e2e/auth/invite-acceptance.spec.ts