### PR TITLE
docs: require migration branch cleanup

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -39,6 +39,11 @@ Each agent session must:
    product requirement.
 10. Commit with a Conventional Commit message, push the branch, and open a pull
     request with a Conventional Commit title.
+11. After the PR is merged, remove the task worktree and delete the merged
+    local and remote branches. Before deleting anything, confirm the worktree is
+    clean and the branch's PR is merged. If a squash merge makes `git log`
+    appear to show unmerged commits, verify the GitHub PR state and the merged
+    squash commit before treating the branch as stale.
 
 The expected output of a session is a small, reviewable PR. A good session might
 complete one document, one API contract, one entitlement helper, one enforcement
@@ -58,6 +63,11 @@ Before changing files, read and follow [AGENTS.md](../AGENTS.md). In particular:
 - Push the branch and open a pull request with a Conventional Commit title.
 - Update `PROGRESS.md` when a change satisfies part or all of an existing
   product requirement.
+- Do not leave stale migration branches or worktrees behind. Once a migration
+  PR has merged, verify the relevant worktree has no uncommitted work, then
+  delete the merged local branch, the remote branch, and the task worktree.
+  Never delete an unmerged branch, an open-PR branch, or a worktree with
+  uncommitted user work.
 
 If a migration task changes behavior but cannot practically be tested first,
 document why in the pull request and describe the validation that was performed.
@@ -410,3 +420,6 @@ Append dated notes here as phases progress. Keep notes short and factual.
   remain unlimited for this compatibility phase. Validation: `npm run
   type-check`, `npm run test:unit`, and targeted E2E coverage for team
   invitations and invite acceptance.
+- Added explicit migration-session cleanup instructions requiring agents to
+  remove merged task worktrees and delete merged local and remote branches after
+  confirming the PR is merged and the worktree is clean.


### PR DESCRIPTION
## Summary
- add explicit migration-session cleanup instructions to remove merged task worktrees
- require deleting merged local and remote branches only after confirming the PR is merged and the worktree is clean
- note squash-merge verification so agents do not misread stale branch state

## Validation
- git diff --check