### PR TITLE
feat(web): open core report pages

### DIFF
--- a/apps/web/app/(dashboard)/reports/patch-status/page.tsx
+++ b/apps/web/app/(dashboard)/reports/patch-status/page.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
-import { getEffectiveLicence } from '@/lib/actions/licence-guard'
-import { hasFeature } from '@/lib/features'
-import { LockedFeature } from '@/components/shared/locked-feature'
 import { getPatchManagementReport } from '@/lib/actions/patch-status'
 import { PatchStatusReportClient } from './patch-status-report-client'
 
@@ -13,11 +10,6 @@ export const metadata: Metadata = {
 export default async function PatchStatusReportPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
-
-  const licence = await getEffectiveLicence(orgId)
-  if (!hasFeature(licence.tier, 'reportsExport')) {
-    return <LockedFeature feature="reportsExport" tier={licence.tier} />
-  }
 
   const report = await getPatchManagementReport(orgId)
   return <PatchStatusReportClient report={report} />

--- a/apps/web/app/(dashboard)/reports/software/page.tsx
+++ b/apps/web/app/(dashboard)/reports/software/page.tsx
@@ -5,9 +5,6 @@ import { organisations, hostGroups } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { SoftwareReportClient } from './software-report-client'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
-import { getEffectiveLicence } from '@/lib/actions/licence-guard'
-import { hasFeature } from '@/lib/features'
-import { LockedFeature } from '@/components/shared/locked-feature'
 
 export const metadata: Metadata = {
   title: 'Installed Software Report',
@@ -16,11 +13,6 @@ export const metadata: Metadata = {
 export default async function SoftwareReportPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
-
-  const licence = await getEffectiveLicence(orgId)
-  if (!hasFeature(licence.tier, 'reportsExport')) {
-    return <LockedFeature feature="reportsExport" tier={licence.tier} />
-  }
 
   const [org, groups] = await Promise.all([
     db.query.organisations.findFirst({

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -88,10 +88,9 @@ const reportingNav: NavItem[] = [
     title: 'Reports',
     href: '/reports',
     icon: FileBarChart,
-    feature: 'reportsExport',
     children: [
-      { title: 'Installed Software', href: '/reports/software', icon: Package, feature: 'reportsExport' },
-      { title: 'Patch Status', href: '/reports/patch-status', icon: ShieldCheck, feature: 'reportsExport' },
+      { title: 'Installed Software', href: '/reports/software', icon: Package },
+      { title: 'Patch Status', href: '/reports/patch-status', icon: ShieldCheck },
       { title: 'Vulnerabilities', href: '/reports/vulnerabilities', icon: ShieldAlert, feature: 'reportsExport' },
     ],
   },

--- a/apps/web/lib/actions/patch-status.ts
+++ b/apps/web/lib/actions/patch-status.ts
@@ -3,7 +3,6 @@
 import { sql } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
-import { requireFeature } from '@/lib/actions/licence-guard'
 
 export interface PatchPackageUpdate {
   id: string
@@ -174,7 +173,6 @@ export async function getCurrentUpdatesForHost(
 
 export async function getPatchManagementReport(orgId: string): Promise<PatchManagementReport> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
 
   const rows = (await db.execute(sql`
     SELECT

--- a/apps/web/lib/actions/software-inventory.ts
+++ b/apps/web/lib/actions/software-inventory.ts
@@ -23,7 +23,6 @@ import type {
   SavedSoftwareReport,
   SoftwareInventorySettings,
 } from '@/lib/db/schema'
-import { requireFeature } from '@/lib/actions/licence-guard'
 import { escapeLikePattern } from '@/lib/utils'
 import { compareVersions } from '@/lib/version-compare'
 import { createRateLimiter } from '@/lib/rate-limit'
@@ -257,7 +256,6 @@ export async function searchPackageNames(
   q: string,
 ): Promise<PackageNameSuggestion[]> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   if (!q || q.length < 2 || q.length > 100) return []
 
   const escaped = `%${escapeLikePattern(q)}%`
@@ -321,7 +319,6 @@ export async function getSoftwareReport(
   filters: SoftwareReportFilters = {},
 ): Promise<SoftwareReportResult> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   if (!await softwareReportLimiter.check(orgId)) {
     throw new Error('Too many requests — please wait before generating another report.')
   }
@@ -457,7 +454,6 @@ export async function getNewPackages(
   windowDays: 7 | 30 = 7,
 ): Promise<NewPackageRow[]> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - windowDays)
 
@@ -508,7 +504,6 @@ export interface DriftRow {
 
 export async function getPackageDrift(orgId: string): Promise<DriftRow[]> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   const rows = await db
     .select({
       groupId: hostGroupMembers.groupId,
@@ -599,7 +594,6 @@ export async function getPackageDetails(
   osFamily?: string,
 ): Promise<PackageDetailsResult> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   const packages = await db
     .select({
       hostId: softwarePackages.hostId,
@@ -673,7 +667,6 @@ export async function getPackageVersions(
   packageName: string,
 ): Promise<string[]> {
   await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   const rows = await db.query.softwarePackages.findMany({
     columns: { version: true },
     where: and(
@@ -764,7 +757,6 @@ const saveReportSchema = z.object({
 
 export async function listSavedReports(orgId: string): Promise<SavedSoftwareReport[]> {
   const session = await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   return db.query.savedSoftwareReports.findMany({
     where: and(
       eq(savedSoftwareReports.organisationId, orgId),
@@ -781,7 +773,6 @@ export async function saveSoftwareReport(
   filters: SoftwareReportFilters,
 ): Promise<{ success: true; id: string } | { error: string }> {
   const session = await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   const parsed = saveReportSchema.safeParse({ name, filters })
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid data' }
@@ -809,7 +800,6 @@ export async function deleteSavedReport(
   reportId: string,
 ): Promise<{ success: true } | { error: string }> {
   const session = await requireOrgAccess(orgId)
-  await requireFeature(orgId, 'reportsExport')
   try {
     await db
       .update(savedSoftwareReports)

--- a/apps/web/tests/e2e/reports/patch-status.spec.ts
+++ b/apps/web/tests/e2e/reports/patch-status.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_ORG } from '../fixtures/seed'
-import { issueTestLicence } from '../fixtures/licence'
 
 async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
   const rows = await sql<Array<{ id: string }>>`
@@ -14,14 +13,6 @@ async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
 test('patch status report shows organisation compliance by network and host', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const orgId = await getOrgId(sql)
-  const licenceKey = await issueTestLicence({ orgId, tier: 'pro' })
-
-  await sql`
-    UPDATE organisations
-    SET licence_key = ${licenceKey},
-        licence_tier = 'pro'
-    WHERE id = ${orgId}
-  `
 
   await sql`
     INSERT INTO hosts (

--- a/apps/web/tests/e2e/reports/software.spec.ts
+++ b/apps/web/tests/e2e/reports/software.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
 import { TEST_ORG } from '../fixtures/seed'
-import { issueTestLicence } from '../fixtures/licence'
 
 async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
   const rows = await sql<Array<{ id: string }>>`
@@ -17,14 +16,6 @@ async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
 test('software report supports search, saved filters, new packages, and drift views', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const orgId = await getOrgId(sql)
-  const licenceKey = await issueTestLicence({ orgId, tier: 'pro' })
-
-  await sql`
-    UPDATE organisations
-    SET licence_key = ${licenceKey},
-        licence_tier = 'pro'
-    WHERE id = ${orgId}
-  `
 
   await sql`
     INSERT INTO hosts (

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -313,6 +313,9 @@ tables with CT-CVE.
 
 Create the standalone CT-CVE repository/service.
 
+The target repository already exists and is ready for migration work:
+`git@github.com:carrtech-dev/ct-cve.git`.
+
 Expected work:
 
 - Extract or port vulnerability feed sync.
@@ -404,8 +407,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
 - Phase 1 completed by adding a product decision record for CT Ops seat-based
   licensing, Enterprise capability boundaries, CT-CVE product ownership,
   standalone deployment, and the CT Ops/CT-CVE API boundary. Confirmed the
-  private `carrtech-dev/ct-cve` repository is accessible and currently has no
-  default branch.
+  private `carrtech-dev/ct-cve` repository exists at
+  `git@github.com:carrtech-dev/ct-cve.git` and is ready for migration work.
 - Phase 4 started on branch `feat/seat-capacity-model` by opening Installed
   Software and Patch Status reports to Community installs. Removed their
   page-level locks, backend `reportsExport` checks, sidebar Pro badges, and

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -188,7 +188,7 @@ Update the status and notes in this table as work lands.
 | 1. Product decision record | Complete | #793 | Added `docs/ct-ops-licensing-and-ct-cve-product-decision.md` documenting new licensing and CT-CVE product boundary. |
 | 2. Capacity entitlement model | Complete | #796 | Added validated `maxUsers` licence capacity support; retained `maxHosts` as a legacy optional host cap until later compatibility cleanup. |
 | 3. Seat enforcement | Complete | feat/seat-enforcement | Enforced `maxUsers` seats on invites, restored users, invite acceptance, reactivation, and LDAP auto-provisioning. Future SSO provisioning must use the same helper when added. |
-| 4. Remove Pro gates | Not started | | Remove Pro-only gates from core CT Ops features while preserving true Enterprise gates. |
+| 4. Remove Pro gates | In progress | feat/seat-capacity-model | Removed the Installed Software and Patch Status report Pro gates; remaining work includes other Pro-only page locks, sidebar badges, server action checks, and licence-only e2e setup. |
 | 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around seats, expiry, and enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Not started | | Define inventory export and finding ingestion boundary before moving code. |
 | 7. CT-CVE repo bootstrap | Not started | | Create standalone repo/service with extracted sync, parser, matching, and test logic. |
@@ -406,6 +406,11 @@ Append dated notes here as phases progress. Keep notes short and factual.
   standalone deployment, and the CT Ops/CT-CVE API boundary. Confirmed the
   private `carrtech-dev/ct-cve` repository is accessible and currently has no
   default branch.
+- Phase 4 started on branch `feat/seat-capacity-model` by opening Installed
+  Software and Patch Status reports to Community installs. Removed their
+  page-level locks, backend `reportsExport` checks, sidebar Pro badges, and
+  e2e-only Pro licence setup. Vulnerability reports remain gated pending the
+  CT-CVE API boundary and ownership split.
 - Phase 2 completed by adding `maxUsers` support to licence validation,
   effective licence loading, E2E test licence issuance, and licence diagnostics.
   Capacity claims now accept only positive safe integers. `maxHosts` remains as


### PR DESCRIPTION
## Summary
- open Installed Software and Patch Status reports to Community installs
- remove their page-level locks, backend reportsExport checks, and sidebar Pro badges
- update report E2E specs to run without issuing Pro licences and mark Phase 4 in progress

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint -- 'app/(dashboard)/reports/software/page.tsx' 'app/(dashboard)/reports/patch-status/page.tsx' components/shared/sidebar.tsx lib/actions/software-inventory.ts lib/actions/patch-status.ts tests/e2e/reports/software.spec.ts tests/e2e/reports/patch-status.spec.ts
- pnpm --filter web test:e2e tests/e2e/reports/software.spec.ts tests/e2e/reports/patch-status.spec.ts