### PR TITLE
docs(cve): require fresh migration base

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -11,35 +11,70 @@ that piece, update this file, and open a pull request.
 Every agent session that works on this migration must update this file in the
 same pull request as its code or documentation changes.
 
+## Mandatory Fresh-Base And Collision Check
+
+Before choosing work or creating a task worktree, every agent session must
+refresh remote state and use `origin/main` as the source of truth.
+
+Required preflight:
+
+```sh
+git fetch origin main
+git worktree add -b <task-branch> ../<task-worktree> origin/main
+cd ../<task-worktree>
+gh pr list --state open --search "ct-cve OR licensing OR licence OR license OR migration OR Pro gates OR seats"
+gh pr list --state merged --limit 20
+```
+
+Do not create a migration worktree from local `main` unless local `main` has
+first been fast-forwarded to `origin/main` and verified with:
+
+```sh
+git rev-parse main
+git rev-parse origin/main
+```
+
+The two commit hashes must match. If they do not match, local `main` is stale
+and must not be used for migration planning.
+
+After creating the worktree, reread this file from inside that fresh worktree.
+If the earliest `Not started` phase in the fresh worktree differs from what was
+seen before the fetch, trust the fresh worktree. If an open PR already owns the
+same phase or overlapping files, do not duplicate that work. Either review that
+PR, choose a non-overlapping later subtask only if it is unblocked, or stop and
+ask for direction.
+
 ## How To Use This File In An Agent Session
 
 Do not attempt the full migration in one session.
 
 Each agent session must:
 
-1. Read this entire file and [AGENTS.md](../AGENTS.md).
-2. Inspect the current codebase enough to understand the next safe migration
+1. Run the mandatory fresh-base and collision check above.
+2. Read this entire file and [AGENTS.md](../AGENTS.md) from inside the fresh
+   worktree created from `origin/main`.
+3. Inspect the current codebase enough to understand the next safe migration
    step.
-3. Pick one logical, manageable section of work that can be completed,
+4. Pick one logical, manageable section of work that can be completed,
    validated, committed, pushed, and opened as a PR in the current session.
-4. Prefer the earliest `Not started` or `In progress` migration phase that is
+5. Prefer the earliest `Not started` or `In progress` migration phase that is
    not blocked. If that phase is too large, choose one coherent subtask from
    that phase and document the narrower scope in this file.
-5. Mark the selected phase `In progress` before or during implementation.
-6. Make only the changes needed for the selected section. Do not start later
+6. Mark the selected phase `In progress` before or during implementation.
+7. Make only the changes needed for the selected section. Do not start later
    phases unless they are strictly required to complete the selected section.
-7. Run validation appropriate to the files and behavior changed.
-8. Update this file before committing:
+8. Run validation appropriate to the files and behavior changed.
+9. Update this file before committing:
    - Set the phase status to `Complete` if the phase is fully done.
    - Leave the phase as `In progress` if only part of it is complete.
    - Set the phase to `Blocked` if work cannot continue, and explain why.
    - Fill in the `Owner / PR` cell with the branch or PR number when known.
    - Add a dated running note summarizing what changed and what remains.
-9. Update `PROGRESS.md` if the change satisfies part or all of an existing
+10. Update `PROGRESS.md` if the change satisfies part or all of an existing
    product requirement.
-10. Commit with a Conventional Commit message, push the branch, and open a pull
+11. Commit with a Conventional Commit message, push the branch, and open a pull
     request with a Conventional Commit title.
-11. After the PR is merged, remove the task worktree and delete the merged
+12. After the PR is merged, remove the task worktree and delete the merged
     local and remote branches. Before deleting anything, confirm the worktree is
     clean and the branch's PR is merged. If a squash merge makes `git log`
     appear to show unmerged commits, verify the GitHub PR state and the merged
@@ -55,8 +90,11 @@ PR.
 
 Before changing files, read and follow [AGENTS.md](../AGENTS.md). In particular:
 
-- Create a dedicated Git worktree before editing files.
+- Fetch `origin/main` and create a dedicated Git worktree from `origin/main`
+  before editing files.
 - Make edits only inside that worktree.
+- Check open and recently merged PRs for overlapping migration work before
+  selecting a phase.
 - Use test-driven development for behavior changes where practical.
 - Run relevant validation before committing.
 - Commit with a Conventional Commit message.
@@ -438,3 +476,11 @@ Append dated notes here as phases progress. Keep notes short and factual.
   pages. Enterprise-only feature checks remain in the licence feature model.
   Validation: web type-check, unit suite, targeted E2E coverage for reports,
   certificates, service accounts, local users, and certificate tracking.
+
+### 2026-04-30
+
+- Added a mandatory fresh-base and collision-check preflight after duplicate
+  Phase 4 work was attempted from stale local `main` despite the phase already
+  being complete on `origin/main`. Future migration sessions must fetch
+  `origin/main`, create worktrees from `origin/main`, verify local `main` is not
+  used when stale, and inspect open/recently merged PRs before selecting work.


### PR DESCRIPTION
## Summary
- Require migration agents to fetch `origin/main` before choosing work
- Require task worktrees to be created from `origin/main`, with an explicit stale-local-main check
- Add open/recently merged PR collision checks before selecting a migration phase
- Record the stale-main duplicate Phase 4 incident in the running notes

## Validation
- `git diff --check`