### PR TITLE
docs(licensing): document seat-based licence model

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 85 — Licensing UI and docs
+
+**Seat-based CT-Ops licensing migration** (`apps/web/app/(dashboard)/settings/licence/page.tsx`, `apps/web/app/(dashboard)/settings/settings-client.tsx`, `apps/docs/docs/licensing.md`)
+- Updated the licence settings page to show the trusted effective tier, active users, pending invitations, seat limit, licence expiry, and Enterprise capability status.
+- Rewrote licensing docs around Community core features, Pro user-seat capacity, Enterprise-only capabilities, offline licence validation, activation, expiry, and revocation.
+- Updated air-gap and docs introduction copy so paid licences are described as seat and Enterprise entitlements rather than feature-unlock licences.
+
+**Validation**
+- Validation run: `pnpm --dir apps/web type-check`.
+
 ### Session 84 — Core Pro gate removal
 
 **Seat-based CT-Ops licensing migration** (`apps/web/lib/features.ts`, `apps/web/lib/actions/`, `apps/web/app/(dashboard)/`, `apps/web/components/shared/sidebar.tsx`)

--- a/apps/docs/docs/README.md
+++ b/apps/docs/docs/README.md
@@ -29,7 +29,7 @@ Every feature works in a fully air-gapped environment. No cloud APIs, no CDNs, n
 The agent is Apache 2.0 licensed and always will be. Security teams must be able to audit what runs on their hosts.
 
 ### Offline-Capable Licensing
-Enterprise licence validation uses a signed JWT verified against a bundled public key. No external service required.
+Paid licence validation uses a signed JWT verified against a bundled public key. No external service required.
 
 ---
 

--- a/apps/docs/docs/deployment/air-gap.md
+++ b/apps/docs/docs/deployment/air-gap.md
@@ -135,4 +135,4 @@ docker compose -f docker-compose.single.yml up -d  # restarts with new images
 
 ## Licence Validation
 
-CT-Ops validates enterprise licences offline using a signed JWT verified against a public key that is bundled with the binary. No network request is made. To update a licence, paste the new licence key into **Settings → Licence**.
+CT-Ops validates paid licences offline using a signed JWT verified against a public key that is bundled with the web application. No network request is made. To update user-seat capacity or Enterprise capabilities, paste the new licence key into **Settings -> Licence**.

--- a/apps/docs/docs/licensing.md
+++ b/apps/docs/docs/licensing.md
@@ -1,123 +1,135 @@
-# Licensing & Tiers
+# Licensing
 
-CT-Ops is available in three tiers:
+CT-Ops uses open-source, seat-based licensing. Core CT-Ops functionality is
+available in Community installs; paid CT-Ops tiers are based on user seats, and
+Enterprise adds Enterprise-only capabilities.
 
-- **Community** — free, open source (Apache 2.0). Everything an engineer or small team needs day-to-day.
-- **Pro** — the bulk of paid value: expiry tracking, reports, governance basics, and common corporate IdP integration.
-- **Enterprise** — a small set of enterprise-scale capabilities: SAML, advanced RBAC, compliance packs, white labelling, and the operations bundlers.
+## Tiers
 
-LDAP / AD login is included in **Community** — it is expected in any serious open-source platform used by corporate engineering teams.
+### Community
 
-## Tier contents
+Community is open source and includes core CT-Ops functionality:
 
-### Community (free)
+- Agent registration, approval, heartbeat, self-update, and install bundles
+- Host inventory, networks, tags, notes, and host groups
+- Monitoring checks, metric graphs, alerts, silences, and notifications
+- Certificate tracking and service-account tracking
+- Software inventory, patch status, and report export
+- Interactive terminal, scheduled tasks, service management, and script runs
+- LDAP / Active Directory login and directory lookup
+- Air-gap deployment support
 
-- Email / password auth + TOTP MFA
-- LDAP / AD login (live bind authentication)
-- LDAP Directory User Lookup tool
-- Organisations, teams, user management, 4 built-in roles
-- Agent registration, approval, heartbeat, self-update, install bundles
-- Host inventory, host deduplication, networks with topology graphs
-- Check definitions (port, process, HTTP)
-- Alerts, acknowledge / silence
-- Notification channels: in-app, webhook, SMTP, Slack, Telegram
-- Interactive terminal (multi-tab, split-pane)
-- Custom script runner, service management
-- SSL Certificate Checker tool (one-off URL lookup)
-- Metric graphs + retention up to **180 days**
-- Air-gap deployment
+Community capacity is governed by the included user seats for the install.
 
-### Pro (Tier 1)
+### Pro
 
-Everything in Community, plus:
+Pro is the paid CT-Ops tier for teams that need additional user-seat capacity.
+It uses the same core CT-Ops feature set as Community, with a signed licence
+that can carry a `maxUsers` seat limit and expiry date.
 
-- **Certificate expiry tracker** — dashboards, scheduled expiry notifications, bulk export
-- **Service account tracker** — password / token expiry warnings
-- CSR generation, approval workflow, internal CA
-- SSH key inventory and rotation tracking
-- **Reports** — scheduled delivery and CSV / PDF export
-- **Extended metric retention** (up to 365 days) and metric export API
-- **OIDC single sign-on** (Google, Entra, Okta, Keycloak)
-- **Audit log** (user + admin actions, export, retention)
-- Scheduled task runner
-- Alert routing policies (on-call rotations, escalation)
-- Advanced notification templating
-- Business-hours email support
+### Enterprise
 
-### Enterprise (Tier 2)
+Enterprise is seat-based and includes Enterprise-only capabilities:
 
-Everything in Pro, plus:
-
-- **SAML 2.0** single sign-on
-- **Advanced RBAC** — tag-based resource scoping, custom role definitions
-- **Compliance packs** (SOC 2, ISO 27001, HIPAA-style evidence templates)
-- **White labelling** — custom logo, theme, login page, email sender
-- Air-gap bundlers for Jenkins, Docker, Ansible, Terraform
+- SAML 2.0 single sign-on
+- Advanced RBAC and custom role definitions
+- Compliance packs
+- White labelling
+- Air-gap bundlers for enterprise toolchains
 - HA deployment profile and migration tooling
-- 24 / 7 support with incident SLA and a dedicated CSM
+- Enterprise support commitments
 
-## How licensing works
+Enterprise restrictions are enforced on trusted backend paths. UI indicators are
+only a convenience and are not the source of authority.
 
-CT-Ops uses an **offline-capable** licence model. There is no phone-home, no activation server, and no network dependency for validation. This is essential for air-gapped deployments.
+## Seat Limits
 
-### Key format
+The `maxUsers` licence claim defines the paid user-seat limit.
 
-A licence key is a signed JSON Web Token (JWT, RS256). The public key is bundled into every CT-Ops build. The private signing key is held only by the licence issuance service.
+Seats are consumed by:
 
-Every key encodes:
+- Active, non-deleted users
+- Pending, unexpired invitations
 
-- **Install organisation** (`sub`) — the id of the specific CT-Ops install the key was minted for. Verified on activation; a key issued for one install cannot be activated on a different install.
-- **Tier** — `pro` or `enterprise`
-- **Feature list** — the explicit features unlocked by this key (allows custom bundles and à-la-carte add-ons)
-- **Expiry** (`exp`) — licence term end date
-- **Licence ID** (`jti`) — unique identifier, used for revocation
-- **Customer details** — name and email, shown in Settings
-- **Seat cap** (`maxHosts`, optional) — maximum number of approved hosts
+Seats are not consumed by:
 
-### Activation
+- Deactivated users
+- Deleted or removed users
+- Expired or accepted invitations
 
-Licences are bound to the specific install that purchases them via an **activation token** the customer copies from their install into the purchase flow. This prevents a single licence key being reused across unrelated installs.
+CT-Ops enforces seats on trusted backend flows including invitation creation,
+invite acceptance, user restoration, user reactivation, and LDAP
+auto-provisioning.
 
-1. In your CT-Ops install, go to **Settings → Licence** and click **Generate activation token**. Copy the token (starts with `infw-act_…`).
-2. Visit the licence purchase site and paste the activation token into the checkout. The site shows the install name decoded from the token so you can confirm you pasted the right one.
-3. Complete payment. The issuance service mints a licence key whose `sub` claim is your install's organisation id, and emails it to your technical contact.
-4. Paste the returned key into **Settings → Licence → Licence key**.
-5. The server validates the signature, issuer, audience, expiry, and that the `sub` matches this install. All checks are local — no outbound request is made.
+Licences without a `maxUsers` claim are treated as unlimited for compatibility
+with earlier licence payloads.
 
-For air-gapped installs: generate the activation token inside the air-gapped network, transfer it out, complete purchase on a connected machine, and transfer the returned licence key back in. No network path between the install and the licence service is required.
+## Licence Keys
 
-### Renewal & expiry
+CT-Ops uses an offline-capable licence model. A licence key is a signed JSON Web
+Token verified locally against the public key bundled with the CT-Ops web
+application. Validation does not require an outbound network connection.
 
-Licences are time-limited via the `exp` claim. When a licence expires, CT-Ops silently falls back to the **Community** tier — no hard shutdown. Paid features become unavailable until a new key is pasted in. Renew at least a few days before expiry to avoid interruption.
+Every paid key can encode:
 
-### Revocation
+- Install organisation (`sub`)
+- Tier (`pro` or `enterprise`)
+- User-seat limit (`maxUsers`)
+- Expiry (`exp`)
+- Licence ID (`jti`)
+- Optional Enterprise feature claims
+- Customer details for display and support
 
-Connected installs may opportunistically check a signed revocation list published by the issuance service. Air-gapped installs rely exclusively on the `exp` claim — licence terms are therefore sized short enough (typically one year) for revocation-by-expiry to be acceptable.
+The legacy `maxHosts` claim may still appear in older keys for compatibility,
+but CT-Ops commercial licensing is moving to user-seat capacity.
 
-When `LICENCE_REVOCATION_URL` is unset, CT-Ops defaults to `https://licence.carrtech.dev/.well-known/ct-ops-licence-revocations.jwt` and refreshes that signed bundle periodically. If the install is offline or the endpoint is unreachable, the last known list is reused; if no list has ever been fetched, validation falls back to the JWT `exp` claim only.
+## Activation
 
-### Seat limits
+1. Open **Settings -> Licence**.
+2. Generate an activation token.
+3. Paste the activation token into the licence checkout flow.
+4. Complete purchase or renewal.
+5. Paste the returned licence key into **Settings -> Licence**.
 
-If a licence includes a `maxHosts` cap, agent approval is blocked once that count is reached. Remove or archive decommissioned hosts to free up seats.
+The activation token binds the issued licence to the specific CT-Ops install.
+The server validates the licence signature, issuer, audience, expiry, and
+organisation binding locally before saving the key.
 
-## Enforcement
+For air-gapped installs, generate the activation token inside the air-gapped
+network, transfer it out to complete checkout, then transfer the returned
+licence key back in.
 
-The authoritative licence check happens server-side on every gated action. UI controls for paid features are disabled on Community and hidden or badged appropriately, but the server never trusts the client — attempting to invoke a gated action without a valid licence returns an error.
+## Expiry And Degraded State
 
-Currently enforced on Community tier:
+When a paid licence expires or becomes invalid, CT-Ops degrades to Community
+without shutting down the install. Core CT-Ops functionality remains available.
+Enterprise-only capabilities are disabled unless a valid Enterprise entitlement
+is present.
 
-- Certificate tracker (`/certificates`) — requires `certExpiryTracker`
-- Service account tracker (`/service-accounts`) — requires `serviceAccountTracker`
-- Reports (`/reports/*`) — requires `reportsExport`; scheduled software scans require `reportsScheduled`
+Renew before the expiry date shown in **Settings -> Licence** to avoid losing
+paid seat capacity or Enterprise capabilities.
 
-Community installs see a **"Pro"** badge on each locked entry in the sidebar and an "Upgrade required" screen when the page is visited.
+## Revocation
 
-## Circumvention and support
+Connected installs may check a signed revocation bundle published by the
+licence service. Air-gapped installs rely on the JWT expiry date.
 
-CT-Ops is source-available. A determined engineer with build access can, technically, patch out licence checks. We rely on:
+When `LICENCE_REVOCATION_URL` is unset, CT-Ops uses the default signed bundle
+URL. If the endpoint cannot be reached, CT-Ops reuses the last known valid
+bundle; if no bundle has been fetched, validation falls back to the JWT expiry
+claim.
 
-- **Legal** — the commercial licence agreement forbids removal or modification of licence checks.
-- **Detection** — tampered builds log telltale signals that are visible to our support team.
-- **Support gating** — we do not provide support for builds that do not validate against an issued licence.
+## Settings Display
 
-If you believe a feature you paid for is not unlocking, contact support before modifying source — it is almost always an issue we can resolve with a new key.
+The **Settings -> Licence** page shows:
+
+- Current effective tier
+- Active users
+- Pending invitations
+- Seat limit
+- Seats remaining
+- Licence expiry
+- Enterprise capability status
+
+If the saved tier in the database disagrees with the validated key, CT-Ops uses
+the validated effective licence for enforcement and display.

--- a/apps/web/app/(dashboard)/settings/licence/page.tsx
+++ b/apps/web/app/(dashboard)/settings/licence/page.tsx
@@ -5,6 +5,8 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { SettingsClient } from '../settings-client'
 import { AdminTabs } from '@/components/shared/admin-tabs'
+import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { getOrgSeatUsage } from '@/lib/actions/seat-enforcement'
 
 export const metadata: Metadata = {
   title: 'Licence Settings',
@@ -14,9 +16,13 @@ export default async function LicenceSettingsPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
 
-  const org = await db.query.organisations.findFirst({
+  const [org, effectiveLicence, seatUsage] = await Promise.all([
+    db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
-  })
+    }),
+    getEffectiveLicence(orgId),
+    getOrgSeatUsage(orgId),
+  ])
 
   if (!org) return null
 
@@ -35,7 +41,13 @@ export default async function LicenceSettingsPage() {
         isAdmin={isAdmin}
         sections={['licence']}
         title="Organisation"
-        description="Manage your licence and feature tier."
+        description="Manage seats, licence expiry, and Enterprise capabilities."
+        effectiveLicence={{
+          tier: effectiveLicence.tier,
+          maxUsers: effectiveLicence.maxUsers,
+          expiresAt: effectiveLicence.expiresAt?.toISOString(),
+        }}
+        seatUsage={seatUsage}
       />
     </div>
   )

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -11,7 +11,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Users, TerminalSquare, ScrollText, Bell, ScanLine, Tag as TagIcon, Copy, Check, Mail, FlaskConical } from 'lucide-react'
+import { CheckCircle2, XCircle, Info, Database, Cpu, HardDrive, MemoryStick, Users, TerminalSquare, ScrollText, Bell, ScanLine, Tag as TagIcon, Copy, Check, Mail, FlaskConical, ShieldCheck } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -70,6 +70,18 @@ interface SettingsClientProps {
   sections?: SettingsSection[]
   title?: string
   description?: string
+  effectiveLicence?: {
+    tier: LicenceTier
+    maxUsers?: number
+    expiresAt?: string
+  }
+  seatUsage?: {
+    activeUsers: number
+    pendingInvites: number
+    usedSeats: number
+    remainingSeats?: number
+    maxUsers?: number
+  }
 }
 
 function tierBadgeVariant(tier: string): 'outline' | 'default' | 'secondary' {
@@ -80,6 +92,11 @@ function tierBadgeVariant(tier: string): 'outline' | 'default' | 'secondary' {
 
 function formatTier(tier: string) {
   return tier.charAt(0).toUpperCase() + tier.slice(1)
+}
+
+function formatLicenceDate(value?: string) {
+  if (!value) return 'No paid licence expiry'
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value))
 }
 
 const RETENTION_OPTIONS = [
@@ -123,9 +140,11 @@ export function SettingsClient({
   sections,
   title = 'Settings',
   description = 'Manage your organisation settings',
+  effectiveLicence,
+  seatUsage,
 }: SettingsClientProps) {
   const queryClient = useQueryClient()
-  const tier = org.licenceTier as LicenceTier
+  const tier = effectiveLicence?.tier ?? (org.licenceTier as LicenceTier)
   const visibleSections = new Set<SettingsSection>(
     sections ?? [
       'organisation',
@@ -1290,16 +1309,82 @@ export function SettingsClient({
           <CardTitle className="text-base">Licence</CardTitle>
           <CardDescription>
             {isAdmin
-              ? 'Enter a licence key to activate paid seats or Enterprise capabilities'
+              ? 'Manage user seats, expiry, and Enterprise capabilities'
               : 'Your organisation licence'}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Current tier:</span>
-            <Badge variant={tierBadgeVariant(org.licenceTier)}>
-              {formatTier(org.licenceTier)}
-            </Badge>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <div className="rounded-md border p-3">
+              <div className="flex items-center gap-2 text-xs font-medium uppercase text-muted-foreground">
+                <ShieldCheck className="size-3.5" />
+                Current tier
+              </div>
+              <div className="mt-2">
+                <Badge variant={tierBadgeVariant(tier)}>
+                  {formatTier(tier)}
+                </Badge>
+              </div>
+            </div>
+            <div className="rounded-md border p-3">
+              <div className="flex items-center gap-2 text-xs font-medium uppercase text-muted-foreground">
+                <Users className="size-3.5" />
+                Seats used
+              </div>
+              <p className="mt-2 text-lg font-semibold text-foreground">
+                {seatUsage ? (
+                  <>
+                    {seatUsage.usedSeats}
+                    <span className="text-sm font-normal text-muted-foreground">
+                      {' / '}
+                      {seatUsage.maxUsers ?? 'Unlimited'}
+                    </span>
+                  </>
+                ) : (
+                  'Unavailable'
+                )}
+              </p>
+            </div>
+            <div className="rounded-md border p-3">
+              <div className="text-xs font-medium uppercase text-muted-foreground">Seat detail</div>
+              <p className="mt-2 text-sm text-foreground">
+                {seatUsage
+                  ? `${seatUsage.activeUsers} active, ${seatUsage.pendingInvites} pending`
+                  : 'Seat usage could not be loaded'}
+              </p>
+              {seatUsage ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {seatUsage.remainingSeats === undefined
+                    ? 'Seats remaining: unlimited'
+                    : `Seats remaining: ${seatUsage.remainingSeats}`}
+                </p>
+              ) : null}
+            </div>
+            <div className="rounded-md border p-3">
+              <div className="text-xs font-medium uppercase text-muted-foreground">Expiry</div>
+              <p className="mt-2 text-sm text-foreground">
+                {formatLicenceDate(effectiveLicence?.expiresAt)}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-md border p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-sm font-medium text-foreground">Enterprise capabilities</p>
+                <p className="text-xs text-muted-foreground">
+                  SAML, advanced RBAC, compliance packs, white labelling, air-gap bundlers, and HA deployment.
+                </p>
+              </div>
+              <Badge variant={tier === 'enterprise' ? 'default' : 'outline'}>
+                {tier === 'enterprise' ? 'Enabled' : 'Not enabled'}
+              </Badge>
+            </div>
+          </div>
+
+          <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">
+            CT Ops Community includes core fleet, reporting, certificate, service-account, terminal, alerting, and task features.
+            Paid licences add user-seat capacity, and Enterprise licences add Enterprise-only capabilities.
           </div>
 
           {isAdmin && (

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -227,7 +227,7 @@ Update the status and notes in this table as work lands.
 | 2. Capacity entitlement model | Complete | #796 | Added validated `maxUsers` licence capacity support; retained `maxHosts` as a legacy optional host cap until later compatibility cleanup. |
 | 3. Seat enforcement | Complete | #798 | Enforced `maxUsers` seats on invites, restored users, invite acceptance, reactivation, and LDAP auto-provisioning. Future SSO provisioning must use the same helper when added. |
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
-| 5. Licensing UI and docs | Not started | | Rewrite licence settings/docs around seats, expiry, and enterprise capabilities. |
+| 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Not started | | Define inventory export and finding ingestion boundary before moving code. |
 | 7. CT-CVE repo bootstrap | Not started | | Create standalone repo/service with extracted sync, parser, matching, and test logic. |
 | 8. CT-CVE GUI | Not started | | Move or rebuild CVE catalog, source status, NVD key settings, finding views, and filters. |
@@ -484,3 +484,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
   being complete on `origin/main`. Future migration sessions must fetch
   `origin/main`, create worktrees from `origin/main`, verify local `main` is not
   used when stale, and inspect open/recently merged PRs before selecting work.
+- Phase 5 completed on branch `docs/licensing-ui-seat-docs` by updating the
+  licence settings page to show the trusted effective tier, active users,
+  pending invites, seat limit, expiry, and Enterprise capability status. Rewrote
+  licensing and air-gap docs around seat-based CT Ops licensing, Community core
+  features, Pro seat capacity, and Enterprise-only capabilities.


### PR DESCRIPTION
## Summary
- update Settings -> Licence to show effective tier, active users, pending invites, seat limit, seats remaining, expiry, and Enterprise capability status
- rewrite licensing docs around Community core features, Pro seat capacity, Enterprise-only capabilities, activation, expiry, and revocation
- mark Phase 5 complete in the CT-CVE migration plan and update PROGRESS.md

## Validation
- pnpm --dir apps/web type-check