### PR TITLE
docs(cve): define CT Ops CT-CVE API contract

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -228,7 +228,7 @@ Update the status and notes in this table as work lands.
 | 3. Seat enforcement | Complete | #798 | Enforced `maxUsers` seats on invites, restored users, invite acceptance, reactivation, and LDAP auto-provisioning. Future SSO provisioning must use the same helper when added. |
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
-| 6. CT Ops/CT-CVE API contract | Not started | | Define inventory export and finding ingestion boundary before moving code. |
+| 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Not started | | Create standalone repo/service with extracted sync, parser, matching, and test logic. |
 | 8. CT-CVE GUI | Not started | | Move or rebuild CVE catalog, source status, NVD key settings, finding views, and filters. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
@@ -489,3 +489,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
   pending invites, seat limit, expiry, and Enterprise capability status. Rewrote
   licensing and air-gap docs around seat-based CT Ops licensing, Community core
   features, Pro seat capacity, and Enterprise-only capabilities.
+- Phase 6 completed on branch `ct-cve-api-contract` by adding the first CT
+  Ops/CT-CVE API contract. The contract chooses CT Ops push inventory snapshots
+  and CT-CVE push finding batches, requires org-scoped signed service tokens,
+  defines host/package/finding identity, idempotency keys, rate limits, replay
+  protection, retry semantics, and connection status fields.

--- a/docs/ct-ops-ct-cve-api-contract.md
+++ b/docs/ct-ops-ct-cve-api-contract.md
@@ -1,0 +1,406 @@
+# CT Ops and CT-CVE API Contract
+
+This contract defines the first stable integration boundary between CT Ops and
+CT-CVE. It is intentionally implementation-facing: later extraction work should
+build to this boundary instead of sharing private CT Ops database tables,
+packages, modules, or service internals.
+
+## Ownership
+
+CT Ops owns:
+
+- Organisations, users, seats, hosts, agents, groups, tags, and operational
+  inventory.
+- Software inventory collection and the current package rows reported by CT Ops
+  agents.
+- The CT-CVE connection configuration, health display, and imported finding
+  display surfaces.
+
+CT-CVE owns:
+
+- Vulnerability feed sync and feed credentials.
+- CVE and advisory catalog storage.
+- Distro and package matching rules.
+- Vulnerability enrichment and severity normalization.
+- Finding generation and lifecycle decisions.
+- CT-CVE standalone GUI/API and product licensing.
+
+CT Ops may store imported finding rows for reporting and host context, but CT-CVE
+remains the source of truth for vulnerability intelligence and matching.
+
+## Integration Direction
+
+The first release uses a push integration in both directions:
+
+```text
+CT Ops -> CT-CVE: inventory snapshot batches
+CT-CVE -> CT Ops: finding batch deliveries
+```
+
+CT-CVE must not connect to the CT Ops database or import CT Ops server modules.
+CT-CVE pull APIs can be added later for deployment profiles that require them,
+but the initial connector should be implemented with explicit HTTPS APIs.
+
+## Organisation Scoping
+
+Every request is scoped to exactly one CT Ops organisation.
+
+The scoped identity fields are:
+
+| Field | Source | Purpose |
+| --- | --- | --- |
+| `orgId` | CT Ops `organisations.id` | Stable tenant identifier in CT Ops. |
+| `orgSlug` | CT Ops `organisations.slug` | Human-readable diagnostic context only. |
+| `ctCveTenantId` | CT-CVE | Optional CT-CVE tenant/subscription identifier once configured. |
+
+`orgId` is the required scoping key for both inventory exports and finding
+ingestion. CT Ops must reject any finding delivery where the token subject is
+not allowed to write findings for the supplied `orgId`. CT-CVE must keep CT Ops
+inventory from different `orgId` values physically or logically isolated.
+
+## Host Identity
+
+CT Ops exports host identity using stable CT Ops IDs plus enough metadata for
+CT-CVE to present standalone context.
+
+Required host fields:
+
+```json
+{
+  "hostId": "host_123",
+  "agentId": "agent_123",
+  "hostname": "web-01",
+  "displayName": "Web 01",
+  "os": "linux",
+  "osVersion": "Ubuntu 24.04",
+  "arch": "x86_64",
+  "ipAddresses": ["10.0.0.12"],
+  "status": "online",
+  "lastSeenAt": "2026-04-30T09:15:00Z",
+  "deletedAt": null
+}
+```
+
+`hostId` is the canonical host key for finding delivery back to CT Ops.
+`agentId` is optional because older or imported hosts may not have an active
+agent. CT-CVE must treat a non-null `deletedAt` as a tombstone and stop
+generating new open findings for that host.
+
+## Package Identity
+
+CT Ops exports current, non-deleted software package rows for each host.
+Removed package rows are included only when they are needed to close findings.
+
+Required package fields:
+
+```json
+{
+  "softwarePackageId": "pkg_123",
+  "name": "openssl",
+  "version": "3.0.13-0ubuntu3.2",
+  "architecture": "amd64",
+  "source": "dpkg",
+  "distroId": "ubuntu",
+  "distroVersionId": "24.04",
+  "distroCodename": "noble",
+  "distroIdLike": ["debian"],
+  "sourceName": "openssl",
+  "sourceVersion": "3.0.13-0ubuntu3.2",
+  "packageEpoch": null,
+  "packageRelease": null,
+  "repository": "main",
+  "origin": "Ubuntu",
+  "installDate": null,
+  "firstSeenAt": "2026-04-20T12:00:00Z",
+  "lastSeenAt": "2026-04-30T09:12:00Z",
+  "removedAt": null
+}
+```
+
+`softwarePackageId` is the canonical package key for finding delivery back to
+CT Ops. CT-CVE should also store a natural package fingerprint made from
+`hostId`, `name`, `version`, `architecture`, and `source` so that findings can
+remain explainable if CT Ops later changes package row IDs during migration.
+
+## Inventory Export
+
+CT Ops sends inventory snapshots to CT-CVE:
+
+```text
+POST /api/v1/ct-ops/inventory-snapshots
+```
+
+Request shape:
+
+```json
+{
+  "contractVersion": "2026-04-30",
+  "orgId": "org_123",
+  "orgSlug": "acme",
+  "snapshotId": "inv_20260430_091500_org_123",
+  "snapshotType": "incremental",
+  "generatedAt": "2026-04-30T09:15:00Z",
+  "cursor": "opaque-next-cursor",
+  "hosts": [],
+  "packages": []
+}
+```
+
+Rules:
+
+- `snapshotType` is `full`, `incremental`, or `tombstone`.
+- CT Ops should send a full snapshot after connector setup and then incremental
+  snapshots after successful software inventory scans or relevant host changes.
+- Each request may contain at most 500 hosts and 25,000 packages.
+- CT-CVE must upsert by `(orgId, hostId)` and `(orgId, softwarePackageId)`.
+- Replaying the same `snapshotId` must be safe and return the original result.
+- CT-CVE must report accepted, rejected, and skipped row counts in the response.
+
+Response shape:
+
+```json
+{
+  "accepted": true,
+  "snapshotId": "inv_20260430_091500_org_123",
+  "hostsAccepted": 10,
+  "packagesAccepted": 1200,
+  "rowsRejected": 0,
+  "nextAction": "none"
+}
+```
+
+## Finding Ingestion
+
+CT-CVE delivers findings to CT Ops:
+
+```text
+POST /api/integrations/ct-cve/v1/finding-batches
+```
+
+Request shape:
+
+```json
+{
+  "contractVersion": "2026-04-30",
+  "orgId": "org_123",
+  "batchId": "findings_20260430_092000_org_123",
+  "generatedAt": "2026-04-30T09:20:00Z",
+  "findings": [
+    {
+      "findingId": "ctcve_find_123",
+      "hostId": "host_123",
+      "softwarePackageId": "pkg_123",
+      "cveId": "CVE-2026-12345",
+      "status": "open",
+      "packageName": "openssl",
+      "installedVersion": "3.0.13-0ubuntu3.2",
+      "fixedVersion": "3.0.13-0ubuntu3.3",
+      "source": "ubuntu-osv",
+      "severity": "high",
+      "cvssScore": 8.1,
+      "knownExploited": false,
+      "confidence": "confirmed",
+      "matchReason": "installed version is lower than fixed version",
+      "firstSeenAt": "2026-04-30T09:20:00Z",
+      "lastSeenAt": "2026-04-30T09:20:00Z",
+      "resolvedAt": null,
+      "cve": {
+        "title": "OpenSSL vulnerability",
+        "description": "Short normalized summary.",
+        "publishedAt": "2026-04-25T00:00:00Z",
+        "modifiedAt": "2026-04-29T00:00:00Z",
+        "rejected": false,
+        "kevDueDate": null,
+        "kevVendorProject": null,
+        "kevProduct": null,
+        "kevRequiredAction": null
+      },
+      "references": [
+        "https://example.invalid/advisories/CVE-2026-12345"
+      ],
+      "metadata": {
+        "advisoryIds": ["USN-0000-1"]
+      }
+    }
+  ]
+}
+```
+
+Rules:
+
+- `batchId` is the idempotency key for the whole delivery.
+- `findingId` is the CT-CVE stable finding key and must be stored by CT Ops in
+  imported finding metadata.
+- CT Ops upserts by `(orgId, hostId, softwarePackageId, cveId)` for compatibility
+  with current CT Ops finding uniqueness.
+- `status` is `open` or `resolved`.
+- `severity` is `critical`, `high`, `medium`, `low`, `none`, or `unknown`.
+- `confidence` is `confirmed`, `probable`, or `unsupported`.
+- CT Ops must reject findings for unknown, deleted, or cross-org hosts unless
+  the finding is a `resolved` tombstone for an already-imported finding.
+- CT Ops must reject unknown active `softwarePackageId` values for open findings.
+- Replaying the same `batchId` must not duplicate findings or regress newer
+  finding state.
+
+Response shape:
+
+```json
+{
+  "accepted": true,
+  "batchId": "findings_20260430_092000_org_123",
+  "findingsAccepted": 100,
+  "findingsRejected": 0,
+  "findingsSkipped": 2
+}
+```
+
+## Authentication And Authorization
+
+The first connector uses signed service tokens issued during CT Ops/CT-CVE
+connection setup.
+
+Required request headers:
+
+```text
+Authorization: CT-ServiceToken <token-id>
+X-CT-Timestamp: 2026-04-30T09:20:00Z
+X-CT-Nonce: 01HV...
+X-CT-Content-SHA256: <lowercase hex sha256 of request body>
+X-CT-Signature: v1=<base64url hmac-sha256 signature>
+```
+
+Signature input:
+
+```text
+<method>\n
+<path>\n
+<X-CT-Timestamp>\n
+<X-CT-Nonce>\n
+<X-CT-Content-SHA256>
+```
+
+Token requirements:
+
+- Tokens are scoped to one `orgId` and one direction: `inventory:write` for CT
+  Ops to CT-CVE or `findings:write` for CT-CVE to CT Ops.
+- Token secrets are generated with at least 256 bits of entropy and stored only
+  as encrypted secrets or one-way verification material.
+- Tokens can be rotated without downtime by allowing two active token IDs during
+  a grace period.
+- Tokens must be revocable per organisation.
+
+Authorization decisions must be made server-side from the token scope and bound
+`orgId`; request body fields are not trusted on their own.
+
+## Replay Protection
+
+Receivers must reject requests when:
+
+- `X-CT-Timestamp` is more than five minutes away from receiver time.
+- `X-CT-Nonce` has already been used with the same token ID inside the replay
+  window.
+- `X-CT-Content-SHA256` does not match the body.
+- The HMAC signature is invalid.
+
+Receivers should keep nonce records for at least ten minutes. Clock skew errors
+should return a clear machine-readable error code without exposing token
+details.
+
+## Rate Limits
+
+Initial limits are per token ID:
+
+| Endpoint | Limit |
+| --- | --- |
+| Inventory snapshots | 60 requests per minute, burst 10 |
+| Finding batches | 120 requests per minute, burst 20 |
+| Connection health | 60 requests per minute, burst 10 |
+
+Payload limits:
+
+- Request body size: 25 MiB.
+- Finding batch size: 5,000 findings.
+- Inventory snapshot size: 500 hosts and 25,000 packages.
+
+Limit responses use HTTP `429` and include `Retry-After`.
+
+## Error And Retry Semantics
+
+Both products use JSON error responses:
+
+```json
+{
+  "error": {
+    "code": "invalid_signature",
+    "message": "Request signature could not be verified.",
+    "retryable": false
+  }
+}
+```
+
+Retry rules:
+
+- `400`, `401`, `403`, `404`, and validation errors are not retryable until the
+  caller changes the request or connector configuration.
+- `409` for stale cursor or stale batch state is not automatically retryable;
+  the caller should resync from the latest accepted cursor.
+- `408`, `425`, `429`, and `5xx` are retryable with exponential backoff and
+  jitter.
+- Callers should retry for up to 24 hours before surfacing a persistent
+  connection error in the UI.
+
+Partial acceptance is allowed only when the response includes per-row rejection
+details. Callers must not assume the whole batch succeeded when row-level
+rejections are present.
+
+## Connection Status
+
+CT Ops should show a CT-CVE connection status card in the settings/integration
+area once the connector is implemented.
+
+The status model should include:
+
+| Field | Meaning |
+| --- | --- |
+| `configured` | A connector URL and token pair exist. |
+| `enabled` | CT Ops is allowed to send inventory and receive findings. |
+| `lastInventoryPushAt` | Last successful CT Ops to CT-CVE snapshot. |
+| `lastFindingIngestAt` | Last successful CT-CVE to CT Ops finding batch. |
+| `lastHealthCheckAt` | Last successful signed health check. |
+| `lastErrorCode` | Stable machine-readable failure code. |
+| `lastErrorAt` | Timestamp of the latest connector failure. |
+
+CT-CVE should expose:
+
+```text
+GET /api/v1/ct-ops/connection-health?orgId=<orgId>
+```
+
+CT Ops should expose:
+
+```text
+GET /api/integrations/ct-cve/v1/connection-health?orgId=<orgId>
+```
+
+Both endpoints require the same signed service-token headers and return only
+status data for the token-bound organisation.
+
+## Versioning
+
+Every payload carries `contractVersion`. The first version is `2026-04-30`.
+
+Rules:
+
+- Additive fields are allowed within the same version.
+- Removing fields, changing enum meanings, or changing identity semantics
+  requires a new contract version.
+- Receivers must ignore unknown additive fields.
+- Senders must not depend on unknown fields being persisted by the receiver.
+
+## Implementation Order
+
+1. Add CT-CVE storage and APIs that accept inventory snapshots.
+2. Add CT Ops connector configuration and signed inventory export.
+3. Add CT Ops finding ingestion APIs and imported finding persistence.
+4. Move CT-CVE GUI/catalog/feed ownership out of CT Ops.
+5. Remove CT Ops internal vulnerability feed and matcher ownership.


### PR DESCRIPTION
## Summary
- add the first CT Ops/CT-CVE API contract document
- define inventory snapshot export, finding batch ingestion, org scoping, host/package/finding identity, signed service tokens, replay protection, rate limits, retries, and connection status
- mark Phase 6 complete in the migration plan

## Validation
- git diff --check
- pnpm install --frozen-lockfile
- pnpm --filter @ct-ops/docs build