### PR TITLE
docs(cve): track CT-CVE bootstrap

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -229,7 +229,7 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | Not started | | Create standalone repo/service with extracted sync, parser, matching, and test logic. |
+| 7. CT-CVE repo bootstrap | In progress | ct-cve #1 / ct-ops #809 | Bootstrapped standalone CT-CVE service skeleton, initial database schema, Docker/Compose, CI, and extracted package version/matching tests. Feed sync, parser ports, persistence wiring, and full service config remain. |
 | 8. CT-CVE GUI | Not started | | Move or rebuild CVE catalog, source status, NVD key settings, finding views, and filters. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
@@ -494,3 +494,10 @@ Append dated notes here as phases progress. Keep notes short and factual.
   and CT-CVE push finding batches, requires org-scoped signed service tokens,
   defines host/package/finding identity, idempotency keys, rate limits, replay
   protection, retry semantics, and connection status fields.
+- Phase 7 started with the CT-CVE repository bootstrap in ct-cve PR #1.
+  Added a standalone Go service with health check, required database
+  configuration, initial PostgreSQL schema, Docker/Compose files, GitHub Actions
+  CI, README, and extracted package version comparison and matching tests from
+  CT Ops. Remaining Phase 7 work includes feed sync, parser ports, persistence
+  wiring, fuller service configuration, and release-oriented operational
+  hardening.


### PR DESCRIPTION
## Summary

- Mark Phase 7 as in progress in the CT-CVE migration plan.
- Record the standalone CT-CVE bootstrap scope and the remaining Phase 7 work.
- Link the tracker to CT-CVE PR #1 and this CT Ops tracking PR.

## Validation

- Documentation-only change; inspected the Markdown diff.
- CT-CVE bootstrap validation: `go test ./...`.

## Related

- CT-CVE bootstrap PR: https://github.com/carrtech-dev/ct-cve/pull/1
