### PR TITLE
docs(cve): clarify CT-CVE product dependency

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -2,7 +2,7 @@
 
 This document is the working plan for changing CT Ops from feature-gated Pro
 licensing to seat-based open-source licensing, and for extracting CVE monitoring
-into a standalone product named CT-CVE.
+into a separate CT Ops-dependent product named CT-CVE.
 
 This file is intentionally standalone. If an agent is given only this file as
 its task, it has enough instruction to choose the next piece of work, execute
@@ -122,13 +122,19 @@ Target CT Ops tiers:
 - **Pro**: seat-based paid tier.
 - **Enterprise**: seat-based paid tier plus enterprise-only capabilities.
 
-CT-CVE becomes a separate product:
+CT-CVE becomes a separate product and service, but not a standalone reporting
+product:
 
 - CT-CVE owns vulnerability feed sync, CVE/advisory catalog management, package
-  matching, vulnerability enrichment, and its own GUI/API.
+  matching, vulnerability enrichment, and its own configuration/status GUI/API.
 - CT Ops remains the fleet, asset, agent, operations, and reporting system.
-- CT-CVE can be subscribed to and run independently.
-- CT Ops can ingest CT-CVE findings when customers use both products.
+- CT-CVE requires CT Ops for host inventory, organisation context, vulnerability
+  reporting, and customer-facing finding workflows.
+- CT-CVE must not be marketed, deployed, or designed as useful by itself.
+- CT Ops ingests CT-CVE findings and remains the reporting surface.
+- CT-CVE's GUI is for operational configuration and observability only, such as
+  CVE ingestion API keys, feed update schedules, source health, detailed feed
+  sync status, and source/API logs.
 
 ## Deployment Model
 
@@ -151,6 +157,12 @@ background worker responsibilities. Splitting into `ct-cve-api` and
 
 CT-CVE must integrate with CT Ops through a deliberate API boundary, not by
 reaching into CT Ops internals as another module.
+
+CT-CVE container images must be built and published from the `ct-cve`
+repository when release-please creates a release. Release automation should
+publish versioned and `latest` tags for the CT-CVE container image, and CT Ops
+deployment documentation should consume those released images rather than
+building CT-CVE from the CT Ops repository.
 
 Expected data flow:
 
@@ -229,8 +241,8 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | In progress | ct-cve #1 / ct-ops #809 | Bootstrapped standalone CT-CVE service skeleton, initial database schema, Docker/Compose, CI, and extracted package version/matching tests. Feed sync, parser ports, persistence wiring, and full service config remain. |
-| 8. CT-CVE GUI | Not started | | Move or rebuild CVE catalog, source status, NVD key settings, finding views, and filters. |
+| 7. CT-CVE repo bootstrap | In progress | ct-cve #1 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, and extracted package version/matching tests. Feed sync, parser ports, persistence wiring, release-please container publishing, and full service config remain. |
+| 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
@@ -251,7 +263,7 @@ Create an architecture decision record or product direction document covering:
 - CT Ops open-source direction.
 - Community, Pro, and Enterprise tier semantics.
 - Seat-based CT Ops licensing.
-- CT-CVE as a separate subscription product.
+- CT-CVE as a separate CT Ops-dependent subscription product.
 - CT-CVE container/deployment model.
 - CT Ops and CT-CVE integration boundary.
 
@@ -349,7 +361,9 @@ tables with CT-CVE.
 
 ### 7. CT-CVE Repo Bootstrap
 
-Create the standalone CT-CVE repository/service.
+Create the separate CT-CVE repository/service. CT-CVE is independently released
+and containerized, but it is not a standalone reporting product; it requires CT
+Ops for inventory context and reporting.
 
 The target repository already exists and is ready for migration work:
 `git@github.com:carrtech-dev/ct-cve.git`.
@@ -363,26 +377,35 @@ Expected work:
 - Add service config.
 - Add Dockerfile and local compose example.
 - Add CI.
+- Add release-please release automation that builds and publishes CT-CVE
+  container images from the `ct-cve` repository on release.
 - Add README.
 
-CT-CVE should have its own release cadence and should not require CT Ops to run
-unless the customer enables CT Ops integration.
+CT-CVE should have its own release cadence and published container images, but
+runtime deployments require CT Ops integration for inventory, organisation
+context, and reporting. Any local development mode that runs without CT Ops must
+be documented as developer-only and must not imply standalone production use.
 
 ### 8. CT-CVE GUI
 
-Build the standalone CT-CVE UI/API surface.
+Build the CT-CVE configuration and observability UI/API surface.
 
 Expected capabilities:
 
-- CVE catalog.
 - Vulnerability source status.
 - NVD API key management.
-- Finding views.
-- Host/package filters.
-- Subscription/licence placeholders for standalone CT-CVE.
+- Other CVE ingestion API key management as sources are added.
+- Feed update schedule configuration.
+- Detailed CVE source/API status.
+- Feed sync and API logs.
+- CT-CVE subscription/licence status placeholders that make the CT Ops
+  dependency clear.
 
-If UI code is moved from CT Ops, remove the original CT Ops copies once the CT
-Ops connector replaces them.
+CT-CVE must not duplicate CT Ops vulnerability reporting. Finding views,
+host/package filters, and customer-facing vulnerability reports remain in CT Ops
+after the connector is in place. If UI code is moved from CT Ops for
+configuration/status purposes, remove the original CT Ops copies once the CT Ops
+connector replaces them.
 
 ### 9. CT Ops Connector
 
@@ -495,9 +518,16 @@ Append dated notes here as phases progress. Keep notes short and factual.
   defines host/package/finding identity, idempotency keys, rate limits, replay
   protection, retry semantics, and connection status fields.
 - Phase 7 started with the CT-CVE repository bootstrap in ct-cve PR #1.
-  Added a standalone Go service with health check, required database
+  Added a separate Go service with health check, required database
   configuration, initial PostgreSQL schema, Docker/Compose files, GitHub Actions
   CI, README, and extracted package version comparison and matching tests from
   CT Ops. Remaining Phase 7 work includes feed sync, parser ports, persistence
   wiring, fuller service configuration, and release-oriented operational
   hardening.
+- Updated the CT-CVE product direction: CT-CVE is a separately released service
+  but not standalone. It requires CT Ops for inventory context, vulnerability
+  reporting, and customer-facing finding workflows. CT-CVE's own GUI is limited
+  to configuration and observability for ingestion API keys, feed schedules,
+  source health, detailed CVE API status, and feed/source logs. Phase 7 now also
+  requires release-please-triggered container image publishing from the `ct-cve`
+  repository.


### PR DESCRIPTION
## Summary

- Clarify that CT-CVE is a separate service, but not a standalone reporting product.
- Keep CT Ops as the required inventory, organisation context, and vulnerability reporting surface.
- Scope the CT-CVE GUI to configuration and observability: ingestion API keys, schedules, source health, API status, and feed/source logs.
- Add a Phase 7 requirement for release-please-triggered CT-CVE container image publishing from the `ct-cve` repo.

## Validation

- Documentation-only change.
- `git diff --check`
