### PR TITLE
docs(cve): track CT-CVE release publishing

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -241,7 +241,7 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | In progress | ct-cve #1 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, and extracted package version/matching tests. Feed sync, parser ports, persistence wiring, release-please container publishing, and full service config remain. |
+| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, and extracted package version/matching tests. Feed sync, parser ports, persistence wiring, and full service config remain. |
 | 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
@@ -531,3 +531,6 @@ Append dated notes here as phases progress. Keep notes short and factual.
   source health, detailed CVE API status, and feed/source logs. Phase 7 now also
   requires release-please-triggered container image publishing from the `ct-cve`
   repository.
+- Added release-please container publishing in ct-cve PR #2. CT-CVE now has a
+  release manifest/config and a GitHub Actions release workflow that publishes
+  versioned and `latest` GHCR image tags when release-please creates a release.


### PR DESCRIPTION
## Summary
- record ct-cve PR #2 as covering release-please container publishing
- update Phase 7 remaining-work notes
- add a dated migration running note

## Validation
- git diff --check
