### PR TITLE
docs(cve): track feed source config

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -241,7 +241,7 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, and extracted package version/matching tests. Feed sync, parser ports, persistence wiring, and full service config remain. |
+| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2, #3 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, and validated feed source runtime config. Feed sync, parser ports, and persistence wiring remain. |
 | 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
@@ -534,3 +534,7 @@ Append dated notes here as phases progress. Keep notes short and factual.
 - Added release-please container publishing in ct-cve PR #2. CT-CVE now has a
   release manifest/config and a GitHub Actions release workflow that publishes
   versioned and `latest` GHCR image tags when release-please creates a release.
+- Continued Phase 7 in ct-cve PR #3 by adding
+  validated runtime configuration for feed sync cadence, feed HTTP timeouts, NVD
+  source settings, NVD request pacing, and CISA KEV source settings. Feed
+  workers, parser ports, and persistence wiring remain.


### PR DESCRIPTION
## Summary
- record ct-cve PR #3 as the next Phase 7 bootstrap slice
- update the migration table to show validated feed source runtime config is covered
- note that feed workers, parser ports, and persistence wiring remain

## Validation
- git diff --check