### PR TITLE
docs(cve): track CISA KEV feed sync

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -241,7 +241,7 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2, #3 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, and validated feed source runtime config. Feed sync, parser ports, and persistence wiring remain. |
+| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2, #3, feat/feed-sync-persistence / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, and started CISA KEV feed sync persistence. NVD sync and distro parser persistence remain. |
 | 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
@@ -524,6 +524,10 @@ Append dated notes here as phases progress. Keep notes short and factual.
   CT Ops. Remaining Phase 7 work includes feed sync, parser ports, persistence
   wiring, fuller service configuration, and release-oriented operational
   hardening.
+- Phase 7 continued on CT-CVE branch `feat/feed-sync-persistence` by adding
+  embedded database migrations, CISA KEV feed fetching/parsing, source status
+  persistence, startup sync scheduling, and pgx-backed CVE upserts. Remaining
+  Phase 7 work includes NVD sync and distro advisory parser persistence.
 - Updated the CT-CVE product direction: CT-CVE is a separately released service
   but not standalone. It requires CT Ops for inventory context, vulnerability
   reporting, and customer-facing finding workflows. CT-CVE's own GUI is limited


### PR DESCRIPTION
## Summary
- update the CT-CVE migration plan Phase 7 owner and notes for the feed sync persistence branch
- clarify that CISA KEV feed sync has started while NVD and distro advisory persistence remain

## Validation
- git diff --check