### PR TITLE
docs(cve): track NVD feed sync

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -241,7 +241,7 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2, #3, feat/feed-sync-persistence / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, and started CISA KEV feed sync persistence. NVD sync and distro parser persistence remain. |
+| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2, #3, #4, #5 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV feed sync, and added NVD feed sync persistence. Distro parser persistence remains. |
 | 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
@@ -542,3 +542,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
   validated runtime configuration for feed sync cadence, feed HTTP timeouts, NVD
   source settings, NVD request pacing, and CISA KEV source settings. Feed
   workers, parser ports, and persistence wiring remain.
+- Continued Phase 7 in ct-cve PR #5 by adding an
+  NVD source worker that pages through the NVD CVE API, sends the configured API
+  key, maps CVSS/severity/status/timestamps into persisted CVE records, and
+  records source status through the existing syncer. Distro advisory parser
+  persistence remains.


### PR DESCRIPTION
## Summary
- update the CT Ops CT-CVE migration plan to reference ct-cve PR #5
- note that NVD feed sync persistence is now covered and distro advisory parser persistence remains

## Validation
- git diff --check