### PR TITLE
docs(cve): track distro parser persistence

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -241,7 +241,7 @@ Update the status and notes in this table as work lands.
 | 4. Remove Pro gates | Complete | feat/remove-pro-gates | Removed Pro-only gates from core CT Ops features while preserving Enterprise-only feature checks. |
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
-| 7. CT-CVE repo bootstrap | In progress | ct-cve #1, #2, #3, #4, #5 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV feed sync, and added NVD feed sync persistence. Distro parser persistence remains. |
+| 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
@@ -547,3 +547,8 @@ Append dated notes here as phases progress. Keep notes short and factual.
   key, maps CVSS/severity/status/timestamps into persisted CVE records, and
   records source status through the existing syncer. Distro advisory parser
   persistence remains.
+- Phase 7 completed with ct-cve PR #6 by adding a feed result shape that
+  persists affected package rows alongside CVE records, porting distro parser
+  coverage for Debian Tracker, Alpine SecDB, Ubuntu OSV, and Red Hat CSAF, and
+  adding an idempotent `affected_packages` upsert path. Validation: `go test
+  ./...`.


### PR DESCRIPTION
## Summary
- mark CT-CVE migration Phase 7 complete
- record ct-cve PR #6 as the distro parser affected-package persistence slice

## Validation
- git diff --check