### PR TITLE
docs(cve): track CT-CVE status GUI

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -242,7 +242,7 @@ Update the status and notes in this table as work lands.
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
-| 8. CT-CVE GUI | Not started | | Build CT-CVE configuration/status GUI for ingestion API keys, update schedules, source health, detailed API status, and feed/source logs. Reporting stays in CT Ops. |
+| 8. CT-CVE GUI | In progress | ct-cve #7 / feat/ct-cve-gui-phase8 | Added the first read-only CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, and CT Ops dependency/subscription placeholders. Editable source configuration, feed/API logs, and CT Ops-backed subscription status remain. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
@@ -552,3 +552,9 @@ Append dated notes here as phases progress. Keep notes short and factual.
   coverage for Debian Tracker, Alpine SecDB, Ubuntu OSV, and Red Hat CSAF, and
   adding an idempotent `affected_packages` upsert path. Validation: `go test
   ./...`.
+- Phase 8 started in ct-cve PR #7 by adding a built-in read-only CT-CVE
+  operational status page at `/status` and JSON endpoint at `/api/status`.
+  The page shows feed source health, feed sync schedule settings, whether the
+  NVD API key is configured without exposing the key value, and CT Ops
+  dependency/subscription placeholders. Remaining Phase 8 work includes editable
+  source configuration, feed/API logs, and CT Ops-backed subscription status.


### PR DESCRIPTION
## Summary
- marks Phase 8 as in progress in the CT-CVE migration plan
- records ct-cve PR #7 as the first read-only operational status GUI/API slice
- documents remaining Phase 8 work: editable source configuration, feed/API logs, and CT Ops-backed subscription status

## Validation
- Documentation-only change; reviewed diff
