### PR TITLE
docs(cve): track editable CT-CVE source config

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -242,7 +242,7 @@ Update the status and notes in this table as work lands.
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
-| 8. CT-CVE GUI | In progress | ct-cve #7 / feat/ct-cve-gui-phase8 | Added the first read-only CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, and CT Ops dependency/subscription placeholders. Editable source configuration, feed/API logs, and CT Ops-backed subscription status remain. |
+| 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
 | 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
@@ -558,3 +558,9 @@ Append dated notes here as phases progress. Keep notes short and factual.
   NVD API key is configured without exposing the key value, and CT Ops
   dependency/subscription placeholders. Remaining Phase 8 work includes editable
   source configuration, feed/API logs, and CT Ops-backed subscription status.
+- Continued Phase 8 in ct-cve PR #8 by adding
+  database-backed editable source configuration for NVD and CISA KEV, including
+  source enablement, feed endpoints, NVD request delay, NVD API-key set/clear
+  controls that do not echo the secret, and syncer reloads so saved settings
+  apply to later feed sync cycles. Remaining Phase 8 work includes feed/API
+  logs and CT Ops-backed subscription status.


### PR DESCRIPTION
## Summary
- update the migration plan for CT-CVE PR #8
- record that Phase 8 now includes editable source configuration
- leave feed/API logs and CT Ops-backed subscription status as remaining Phase 8 work

## Validation
- git diff --check