### PR TITLE
feat(web): add ct-cve service token boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,12 @@ INGEST_WS_URL=
 
 # === Vulnerability intelligence ===
 
+# CT-CVE inbound service-token allow-list for signed connector requests that
+# deliver vulnerability findings or call CT Ops connection health. Each secret
+# must contain at least 32 random bytes. Example shape:
+# CT_CVE_SERVICE_TOKENS=[{"id":"ctcve_prod_1","secret":"...","orgId":"org_...","scopes":["findings:write"]}]
+# CT_CVE_SERVICE_TOKENS=
+
 # Linux OS package CVE matching runs in ingest. It downloads vendor advisories
 # server-side, enriches them with NVD/CISA metadata, and matches dpkg/rpm/apk
 # software inventory reported by agents. Set this to false only if the install

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 86 — CT-CVE inbound connector boundary
+
+**CT-CVE connector foundation** (`apps/web/lib/integrations/ct-cve/service-token.ts`, `apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts`)
+- Added signed CT-CVE service-token verification for inbound CT Ops connector requests, including `Authorization: CT-ServiceToken`, body SHA-256 checks, HMAC signatures, timestamp skew enforcement, nonce replay protection, token revocation, org binding, and scope checks.
+- Added the first signed CT Ops connector endpoint, `GET /api/integrations/ct-cve/v1/connection-health?orgId=...`, with per-token rate limiting and contract-shaped status output.
+- Documented the `CT_CVE_SERVICE_TOKENS` configuration shape for early connector deployments.
+
+**Validation**
+- Added focused unit coverage for valid signatures, stale timestamps, content hash mismatches, invalid signatures, replayed nonces, scope checks, and org binding.
+- Validation run: `node --experimental-strip-types --test lib/integrations/ct-cve/service-token.test.mjs`, targeted ESLint for the new connector files, `pnpm --dir apps/web type-check`, `pnpm --dir apps/web db:validate`, and `pnpm --dir apps/web test:unit`.
+
 ### Session 85 — Licensing UI and docs
 
 **Seat-based CT-Ops licensing migration** (`apps/web/app/(dashboard)/settings/licence/page.tsx`, `apps/web/app/(dashboard)/settings/settings-client.tsx`, `apps/docs/docs/licensing.md`)

--- a/apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts
+++ b/apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { createRateLimiter } from '@/lib/rate-limit'
+import {
+  getConfiguredCtCveServiceTokens,
+  verifyCtCveServiceRequest,
+  type CtCveServiceAuthError,
+} from '@/lib/integrations/ct-cve/service-token'
+
+export const dynamic = 'force-dynamic'
+
+const healthRateLimiter = createRateLimiter({
+  scope: 'ct-cve:connection-health',
+  windowMs: 60_000,
+  max: 60,
+})
+
+function serviceError(error: CtCveServiceAuthError) {
+  return NextResponse.json(
+    {
+      error: {
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+      },
+    },
+    { status: error.status },
+  )
+}
+
+export async function GET(request: NextRequest) {
+  const orgId = request.nextUrl.searchParams.get('orgId')?.trim()
+  if (!orgId) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'missing_org_id',
+          message: 'orgId query parameter is required.',
+          retryable: false,
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  const tokens = getConfiguredCtCveServiceTokens()
+  if (tokens.length === 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'ct_cve_not_configured',
+          message: 'CT-CVE service tokens are not configured.',
+          retryable: false,
+        },
+      },
+      { status: 503 },
+    )
+  }
+
+  const auth = await verifyCtCveServiceRequest({
+    method: request.method,
+    path: request.nextUrl.pathname,
+    body: '',
+    headers: request.headers,
+    requiredScope: 'findings:write',
+    orgId,
+    tokens,
+  })
+
+  if (!auth.ok) {
+    return serviceError(auth.error)
+  }
+
+  if (!(await healthRateLimiter.check(auth.token.id))) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'rate_limited',
+          message: 'CT-CVE connection health rate limit exceeded.',
+          retryable: true,
+        },
+      },
+      {
+        status: 429,
+        headers: { 'Retry-After': '60' },
+      },
+    )
+  }
+
+  return NextResponse.json({
+    contractVersion: '2026-04-30',
+    orgId: auth.token.orgId,
+    configured: true,
+    enabled: true,
+    lastInventoryPushAt: null,
+    lastFindingIngestAt: null,
+    lastHealthCheckAt: new Date().toISOString(),
+    lastErrorCode: null,
+    lastErrorAt: null,
+  })
+}
+

--- a/apps/web/lib/integrations/ct-cve/service-token.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/service-token.test.mjs
@@ -1,0 +1,199 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac, createHash } from 'node:crypto'
+
+import {
+  createInMemoryCtCveNonceStore,
+  parseCtCveServiceTokens,
+  verifyCtCveServiceRequest,
+} from './service-token.ts'
+
+const TOKEN = {
+  id: 'ctcve_test_token',
+  secret: Buffer.from('ct-cve unit test signing key only').toString('base64url'),
+  orgId: 'org_123',
+  scopes: ['findings:write'],
+}
+
+function sha256(body) {
+  return createHash('sha256').update(body).digest('hex')
+}
+
+function sign({ method = 'POST', path = '/api/integrations/ct-cve/v1/finding-batches', timestamp, nonce, bodyHash }) {
+  const input = `${method}\n${path}\n${timestamp}\n${nonce}\n${bodyHash}`
+  return createHmac('sha256', TOKEN.secret).update(input).digest('base64url')
+}
+
+function signedHeaders({ body = '{}', timestamp = '2026-04-30T09:20:00.000Z', nonce = 'nonce_1', signature } = {}) {
+  const bodyHash = sha256(body)
+  return {
+    authorization: `CT-ServiceToken ${TOKEN.id}`,
+    'x-ct-timestamp': timestamp,
+    'x-ct-nonce': nonce,
+    'x-ct-content-sha256': bodyHash,
+    'x-ct-signature': `v1=${signature ?? sign({ timestamp, nonce, bodyHash })}`,
+  }
+}
+
+test('accepts a correctly signed CT-CVE service request', async () => {
+  const body = JSON.stringify({ orgId: TOKEN.orgId })
+  const result = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers: signedHeaders({ body }),
+    requiredScope: 'findings:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore: createInMemoryCtCveNonceStore(),
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.ok && result.token.orgId, TOKEN.orgId)
+})
+
+test('rejects replayed nonces within the replay window', async () => {
+  const nonceStore = createInMemoryCtCveNonceStore()
+  const body = JSON.stringify({ orgId: TOKEN.orgId })
+  const headers = signedHeaders({ body })
+  const request = {
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers,
+    requiredScope: 'findings:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore,
+  }
+
+  assert.equal((await verifyCtCveServiceRequest(request)).ok, true)
+  const replay = await verifyCtCveServiceRequest(request)
+  assert.equal(replay.ok, false)
+  assert.equal(!replay.ok && replay.error.code, 'replayed_nonce')
+})
+
+test('rejects stale timestamps', async () => {
+  const body = JSON.stringify({ orgId: TOKEN.orgId })
+  const timestamp = '2026-04-30T09:00:00.000Z'
+  const result = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers: signedHeaders({ body, timestamp }),
+    requiredScope: 'findings:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore: createInMemoryCtCveNonceStore(),
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(!result.ok && result.error.code, 'timestamp_out_of_range')
+})
+
+test('rejects body hash mismatches before signature verification', async () => {
+  const result = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body: JSON.stringify({ orgId: TOKEN.orgId, changed: true }),
+    headers: signedHeaders({ body: JSON.stringify({ orgId: TOKEN.orgId }) }),
+    requiredScope: 'findings:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore: createInMemoryCtCveNonceStore(),
+  })
+
+  assert.equal(result.ok, false)
+  assert.equal(!result.ok && result.error.code, 'content_hash_mismatch')
+})
+
+test('rejects invalid signatures without recording the nonce', async () => {
+  const nonceStore = createInMemoryCtCveNonceStore()
+  const body = JSON.stringify({ orgId: TOKEN.orgId })
+  const bad = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers: signedHeaders({ body, signature: 'bad_signature' }),
+    requiredScope: 'findings:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore,
+  })
+
+  assert.equal(bad.ok, false)
+  assert.equal(!bad.ok && bad.error.code, 'invalid_signature')
+
+  const good = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers: signedHeaders({ body }),
+    requiredScope: 'findings:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore,
+  })
+
+  assert.equal(good.ok, true)
+})
+
+test('rejects tokens without the required scope or organisation binding', async () => {
+  const body = JSON.stringify({ orgId: TOKEN.orgId })
+
+  const wrongScope = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers: signedHeaders({ body, nonce: 'nonce_scope' }),
+    requiredScope: 'inventory:write',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore: createInMemoryCtCveNonceStore(),
+  })
+  assert.equal(wrongScope.ok, false)
+  assert.equal(!wrongScope.ok && wrongScope.error.code, 'insufficient_scope')
+
+  const wrongOrg = await verifyCtCveServiceRequest({
+    method: 'POST',
+    path: '/api/integrations/ct-cve/v1/finding-batches',
+    body,
+    headers: signedHeaders({ body, nonce: 'nonce_org' }),
+    requiredScope: 'findings:write',
+    orgId: 'org_other',
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore: createInMemoryCtCveNonceStore(),
+  })
+  assert.equal(wrongOrg.ok, false)
+  assert.equal(!wrongOrg.ok && wrongOrg.error.code, 'org_scope_mismatch')
+})
+
+test('parses configured CT-CVE service tokens and rejects weak secrets', () => {
+  const tokens = parseCtCveServiceTokens(JSON.stringify([
+    {
+      id: TOKEN.id,
+      secret: TOKEN.secret,
+      orgId: TOKEN.orgId,
+      scopes: ['findings:write', 'unsupported'],
+    },
+  ]))
+
+  assert.deepEqual(tokens, [{ ...TOKEN, revoked: false }])
+  assert.throws(
+    () => parseCtCveServiceTokens(JSON.stringify([{
+      id: 'weak',
+      secret: 'short',
+      orgId: TOKEN.orgId,
+      scopes: ['findings:write'],
+    }])),
+    /secret must contain at least 32 bytes/,
+  )
+})

--- a/apps/web/lib/integrations/ct-cve/service-token.ts
+++ b/apps/web/lib/integrations/ct-cve/service-token.ts
@@ -1,0 +1,244 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
+
+export type CtCveServiceTokenScope = 'findings:write' | 'inventory:write' | 'connection:read'
+
+export interface CtCveServiceToken {
+  id: string
+  secret: string
+  orgId: string
+  scopes: CtCveServiceTokenScope[]
+  revoked?: boolean
+}
+
+export interface CtCveNonceStore {
+  remember(tokenId: string, nonce: string, expiresAt: Date, now?: Date): Promise<boolean>
+}
+
+export interface CtCveServiceAuthError {
+  code:
+    | 'missing_authorization'
+    | 'invalid_authorization'
+    | 'unknown_token'
+    | 'revoked_token'
+    | 'missing_header'
+    | 'invalid_timestamp'
+    | 'timestamp_out_of_range'
+    | 'content_hash_mismatch'
+    | 'invalid_signature'
+    | 'insufficient_scope'
+    | 'org_scope_mismatch'
+    | 'replayed_nonce'
+  message: string
+  retryable: boolean
+  status: number
+}
+
+export type CtCveServiceAuthResult =
+  | { ok: true; token: CtCveServiceToken }
+  | { ok: false; error: CtCveServiceAuthError }
+
+type HeaderBag = Headers | Record<string, string | undefined | null>
+
+const AUTH_SCHEME = 'CT-ServiceToken'
+const SIGNATURE_PREFIX = 'v1='
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000
+const NONCE_TTL_MS = 10 * 60 * 1000
+const HEX_SHA256_RE = /^[a-f0-9]{64}$/
+
+function fail(error: CtCveServiceAuthError['code'], status: number, message: string, retryable = false): CtCveServiceAuthResult {
+  return {
+    ok: false,
+    error: { code: error, status, message, retryable },
+  }
+}
+
+function getHeader(headers: HeaderBag, name: string): string | null {
+  if (headers instanceof Headers) {
+    return headers.get(name)
+  }
+
+  const lower = name.toLowerCase()
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) {
+      return typeof value === 'string' ? value : null
+    }
+  }
+  return null
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a)
+  const bBuffer = Buffer.from(b)
+  return aBuffer.length === bBuffer.length && timingSafeEqual(aBuffer, bBuffer)
+}
+
+function bodySha256(body: string | Buffer): string {
+  return createHash('sha256').update(body).digest('hex')
+}
+
+function signatureInput(options: {
+  method: string
+  path: string
+  timestamp: string
+  nonce: string
+  bodyHash: string
+}) {
+  return `${options.method.toUpperCase()}\n${options.path}\n${options.timestamp}\n${options.nonce}\n${options.bodyHash}`
+}
+
+export function createInMemoryCtCveNonceStore(): CtCveNonceStore {
+  const seen = new Map<string, number>()
+
+  return {
+    async remember(tokenId, nonce, expiresAt, now = new Date()) {
+      const nowMs = now.getTime()
+      for (const [key, expiresMs] of seen.entries()) {
+        if (expiresMs <= nowMs) {
+          seen.delete(key)
+        }
+      }
+
+      const key = `${tokenId}:${nonce}`
+      if (seen.has(key)) {
+        return false
+      }
+
+      seen.set(key, expiresAt.getTime())
+      return true
+    },
+  }
+}
+
+export const ctCveNonceStore = createInMemoryCtCveNonceStore()
+
+export async function verifyCtCveServiceRequest(options: {
+  method: string
+  path: string
+  body: string | Buffer
+  headers: HeaderBag
+  requiredScope: CtCveServiceTokenScope
+  orgId: string
+  tokens: CtCveServiceToken[]
+  nonceStore?: CtCveNonceStore
+  now?: Date
+}): Promise<CtCveServiceAuthResult> {
+  const authorization = getHeader(options.headers, 'authorization')
+  if (!authorization) {
+    return fail('missing_authorization', 401, 'Missing CT-CVE service token authorization header.')
+  }
+
+  const [scheme, tokenId, extra] = authorization.trim().split(/\s+/)
+  if (scheme !== AUTH_SCHEME || !tokenId || extra) {
+    return fail('invalid_authorization', 401, 'Invalid CT-CVE service token authorization header.')
+  }
+
+  const token = options.tokens.find((candidate) => candidate.id === tokenId)
+  if (!token) {
+    return fail('unknown_token', 401, 'CT-CVE service token was not found.')
+  }
+  if (token.revoked) {
+    return fail('revoked_token', 401, 'CT-CVE service token is revoked.')
+  }
+  if (!token.scopes.includes(options.requiredScope)) {
+    return fail('insufficient_scope', 403, 'CT-CVE service token is not allowed to perform this action.')
+  }
+  if (token.orgId !== options.orgId) {
+    return fail('org_scope_mismatch', 403, 'CT-CVE service token is not scoped to the requested organisation.')
+  }
+
+  const timestamp = getHeader(options.headers, 'x-ct-timestamp')
+  const nonce = getHeader(options.headers, 'x-ct-nonce')
+  const contentHash = getHeader(options.headers, 'x-ct-content-sha256')
+  const signatureHeader = getHeader(options.headers, 'x-ct-signature')
+  if (!timestamp || !nonce || !contentHash || !signatureHeader) {
+    return fail('missing_header', 401, 'Missing required CT-CVE service signature header.')
+  }
+
+  const requestTime = new Date(timestamp)
+  if (Number.isNaN(requestTime.getTime())) {
+    return fail('invalid_timestamp', 401, 'CT-CVE service timestamp is invalid.')
+  }
+
+  const now = options.now ?? new Date()
+  if (Math.abs(now.getTime() - requestTime.getTime()) > MAX_CLOCK_SKEW_MS) {
+    return fail('timestamp_out_of_range', 401, 'CT-CVE service timestamp is outside the allowed replay window.')
+  }
+
+  if (!HEX_SHA256_RE.test(contentHash) || !safeEqual(contentHash, bodySha256(options.body))) {
+    return fail('content_hash_mismatch', 401, 'CT-CVE service content hash does not match the request body.')
+  }
+
+  if (!signatureHeader.startsWith(SIGNATURE_PREFIX)) {
+    return fail('invalid_signature', 401, 'CT-CVE service signature could not be verified.')
+  }
+
+  const actualSignature = signatureHeader.slice(SIGNATURE_PREFIX.length)
+  const expectedSignature = createHmac('sha256', token.secret)
+    .update(signatureInput({
+      method: options.method,
+      path: options.path,
+      timestamp,
+      nonce,
+      bodyHash: contentHash,
+    }))
+    .digest('base64url')
+
+  if (!safeEqual(actualSignature, expectedSignature)) {
+    return fail('invalid_signature', 401, 'CT-CVE service signature could not be verified.')
+  }
+
+  const nonceStore = options.nonceStore ?? ctCveNonceStore
+  const remembered = await nonceStore.remember(token.id, nonce, new Date(now.getTime() + NONCE_TTL_MS), now)
+  if (!remembered) {
+    return fail('replayed_nonce', 401, 'CT-CVE service nonce has already been used.')
+  }
+
+  return { ok: true, token }
+}
+
+export function parseCtCveServiceTokens(input: string | undefined): CtCveServiceToken[] {
+  if (!input?.trim()) {
+    return []
+  }
+
+  const parsed = JSON.parse(input) as unknown
+  if (!Array.isArray(parsed)) {
+    throw new Error('CT_CVE_SERVICE_TOKENS must be a JSON array')
+  }
+
+  return parsed.map((value, index) => {
+    if (!value || typeof value !== 'object') {
+      throw new Error(`CT_CVE_SERVICE_TOKENS[${index}] must be an object`)
+    }
+
+    const record = value as Record<string, unknown>
+    const id = typeof record.id === 'string' ? record.id.trim() : ''
+    const secret = typeof record.secret === 'string' ? record.secret : ''
+    const orgId = typeof record.orgId === 'string' ? record.orgId.trim() : ''
+    const scopes = Array.isArray(record.scopes)
+      ? record.scopes.filter((scope): scope is CtCveServiceTokenScope => (
+          scope === 'findings:write' || scope === 'inventory:write' || scope === 'connection:read'
+        ))
+      : []
+
+    if (!id || !orgId || scopes.length === 0) {
+      throw new Error(`CT_CVE_SERVICE_TOKENS[${index}] is missing id, orgId, or scopes`)
+    }
+    if (Buffer.byteLength(secret, 'utf8') < 32) {
+      throw new Error(`CT_CVE_SERVICE_TOKENS[${index}] secret must contain at least 32 bytes of entropy`)
+    }
+
+    return {
+      id,
+      secret,
+      orgId,
+      scopes,
+      revoked: record.revoked === true,
+    }
+  })
+}
+
+export function getConfiguredCtCveServiceTokens(): CtCveServiceToken[] {
+  return parseCtCveServiceTokens(process.env.CT_CVE_SERVICE_TOKENS)
+}
+

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -243,7 +243,7 @@ Update the status and notes in this table as work lands.
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
-| 9. CT Ops connector | Not started | | Wire CT Ops to CT-CVE via signed service tokens, scoped org IDs, idempotency, and rate limits. |
+| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector | Added the first CT Ops inbound connector boundary: signed CT-CVE service-token verification, replay protection, per-token rate limiting for connection health, and `GET /api/integrations/ct-cve/v1/connection-health`. Finding batch persistence and inventory export remain. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
 
@@ -564,3 +564,10 @@ Append dated notes here as phases progress. Keep notes short and factual.
   controls that do not echo the secret, and syncer reloads so saved settings
   apply to later feed sync cycles. Remaining Phase 8 work includes feed/API
   logs and CT Ops-backed subscription status.
+- Phase 9 started on branch `feat/ct-ops-ct-cve-connector` by adding CT Ops'
+  inbound signed service-token verifier for CT-CVE, including request body
+  hashes, HMAC signatures, five-minute timestamp skew enforcement, nonce replay
+  protection, org/scope binding, configured token parsing, and a signed
+  connection health endpoint. Finding batch persistence and CT Ops inventory
+  export remain. Validation: targeted service-token unit test, targeted ESLint,
+  web type-check, migration validation, and web unit suite.


### PR DESCRIPTION
## Summary
- add CT-CVE signed service-token verification with content hashes, HMAC signatures, timestamp skew checks, nonce replay protection, org binding, scopes, revocation, and env-based token parsing
- add signed CT Ops connection-health endpoint for CT-CVE with per-token rate limiting
- document CT_CVE_SERVICE_TOKENS and mark Phase 9 in progress in the migration plan

## Validation
- node --experimental-strip-types --test lib/integrations/ct-cve/service-token.test.mjs
- pnpm --dir apps/web exec eslint lib/integrations/ct-cve/service-token.ts lib/integrations/ct-cve/service-token.test.mjs app/api/integrations/ct-cve/v1/connection-health/route.ts
- pnpm --dir apps/web type-check
- pnpm --dir apps/web db:validate
- pnpm --dir apps/web test:unit