### PR TITLE
feat(web): ingest CT-CVE finding batches

### DIFF
--- a/apps/web/app/api/integrations/ct-cve/v1/finding-batches/route.ts
+++ b/apps/web/app/api/integrations/ct-cve/v1/finding-batches/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { createRateLimiter } from '@/lib/rate-limit'
+import {
+  getConfiguredCtCveServiceTokens,
+  verifyCtCveServiceRequest,
+  type CtCveServiceAuthError,
+} from '@/lib/integrations/ct-cve/service-token'
+import {
+  CtCveFindingBatchValidationError,
+  ingestCtCveFindingBatch,
+} from '@/lib/integrations/ct-cve/finding-ingest'
+
+export const dynamic = 'force-dynamic'
+
+const MAX_BODY_BYTES = 25 * 1024 * 1024
+
+const findingBatchRateLimiter = createRateLimiter({
+  scope: 'ct-cve:finding-batches',
+  windowMs: 60_000,
+  max: 120,
+})
+
+function errorResponse(error: { code: string; message: string; retryable: boolean }, status: number, headers?: HeadersInit) {
+  return NextResponse.json({ error }, { status, headers })
+}
+
+function serviceError(error: CtCveServiceAuthError) {
+  return errorResponse({
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+  }, error.status)
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.text()
+  if (Buffer.byteLength(body, 'utf8') > MAX_BODY_BYTES) {
+    return errorResponse({
+      code: 'payload_too_large',
+      message: 'CT-CVE finding batch payload exceeds the 25 MiB limit.',
+      retryable: false,
+    }, 413)
+  }
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(body)
+  } catch {
+    return errorResponse({
+      code: 'invalid_json',
+      message: 'CT-CVE finding batch payload must be valid JSON.',
+      retryable: false,
+    }, 400)
+  }
+
+  const orgId = typeof payload === 'object' && payload && 'orgId' in payload
+    ? String((payload as { orgId?: unknown }).orgId ?? '').trim()
+    : ''
+  if (!orgId) {
+    return errorResponse({
+      code: 'missing_org_id',
+      message: 'CT-CVE finding batch payload must include orgId.',
+      retryable: false,
+    }, 400)
+  }
+
+  const tokens = getConfiguredCtCveServiceTokens()
+  if (tokens.length === 0) {
+    return errorResponse({
+      code: 'ct_cve_not_configured',
+      message: 'CT-CVE service tokens are not configured.',
+      retryable: false,
+    }, 503)
+  }
+
+  const auth = await verifyCtCveServiceRequest({
+    method: request.method,
+    path: request.nextUrl.pathname,
+    body,
+    headers: request.headers,
+    requiredScope: 'findings:write',
+    orgId,
+    tokens,
+  })
+
+  if (!auth.ok) {
+    return serviceError(auth.error)
+  }
+
+  if (!(await findingBatchRateLimiter.check(auth.token.id))) {
+    return errorResponse({
+      code: 'rate_limited',
+      message: 'CT-CVE finding batch rate limit exceeded.',
+      retryable: true,
+    }, 429, { 'Retry-After': '60' })
+  }
+
+  try {
+    const result = await ingestCtCveFindingBatch(payload)
+    return NextResponse.json(result, { status: result.accepted ? 202 : 207 })
+  } catch (error) {
+    if (error instanceof CtCveFindingBatchValidationError) {
+      return errorResponse({
+        code: 'invalid_payload',
+        message: error.issues.join('; '),
+        retryable: false,
+      }, 400)
+    }
+    throw error
+  }
+}

--- a/apps/web/lib/integrations/ct-cve/finding-ingest.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/finding-ingest.test.mjs
@@ -1,0 +1,135 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { ingestCtCveFindingBatch } from './finding-ingest.ts'
+
+const generatedAt = '2026-04-30T09:20:00.000Z'
+
+function finding(overrides = {}) {
+  return {
+    findingId: 'ctcve_find_1',
+    hostId: 'host_1',
+    softwarePackageId: 'pkg_1',
+    cveId: 'CVE-2026-12345',
+    status: 'open',
+    packageName: 'openssl',
+    installedVersion: '3.0.13-0ubuntu3.2',
+    fixedVersion: '3.0.13-0ubuntu3.3',
+    source: 'ubuntu-osv',
+    severity: 'high',
+    cvssScore: 8.1,
+    knownExploited: false,
+    confidence: 'confirmed',
+    matchReason: 'installed version is lower than fixed version',
+    firstSeenAt: generatedAt,
+    lastSeenAt: generatedAt,
+    resolvedAt: null,
+    cve: {
+      title: 'OpenSSL vulnerability',
+      description: 'Short normalized summary.',
+      publishedAt: '2026-04-25T00:00:00.000Z',
+      modifiedAt: '2026-04-29T00:00:00.000Z',
+      rejected: false,
+    },
+    references: ['https://example.invalid/advisories/CVE-2026-12345'],
+    metadata: { advisoryIds: ['USN-0000-1'] },
+    ...overrides,
+  }
+}
+
+function batch(findings = [finding()], overrides = {}) {
+  return {
+    contractVersion: '2026-04-30',
+    orgId: 'org_1',
+    batchId: 'findings_20260430_092000_org_1',
+    generatedAt,
+    findings,
+    ...overrides,
+  }
+}
+
+function repo(overrides = {}) {
+  const state = {
+    hosts: new Map([['host_1', { id: 'host_1', organisationId: 'org_1', deletedAt: null }]]),
+    packages: new Map([['pkg_1', { id: 'pkg_1', organisationId: 'org_1', hostId: 'host_1', removedAt: null, deletedAt: null }]]),
+    existing: new Map(),
+    cves: [],
+    findings: [],
+  }
+
+  return {
+    state,
+    repository: {
+      async transaction(run) {
+        return run(this)
+      },
+      async getHosts(_orgId, hostIds) {
+        return new Map(hostIds.map((id) => [id, state.hosts.get(id)]).filter(([, value]) => value))
+      },
+      async getSoftwarePackages(_orgId, packageIds) {
+        return new Map(packageIds.map((id) => [id, state.packages.get(id)]).filter(([, value]) => value))
+      },
+      async getExistingFindings(_orgId, keys) {
+        return new Map(keys.map((key) => [key.join('\0'), state.existing.get(key.join('\0'))]).filter(([, value]) => value))
+      },
+      async upsertCve(cve) {
+        state.cves.push(cve)
+      },
+      async upsertFinding(input) {
+        state.findings.push(input)
+      },
+      ...overrides,
+    },
+  }
+}
+
+test('ingests a valid CT-CVE finding batch', async () => {
+  const { state, repository } = repo()
+
+  const result = await ingestCtCveFindingBatch(batch(), { repository })
+
+  assert.deepEqual(result, {
+    accepted: true,
+    batchId: 'findings_20260430_092000_org_1',
+    findingsAccepted: 1,
+    findingsRejected: 0,
+    findingsSkipped: 0,
+  })
+  assert.equal(state.cves.length, 1)
+  assert.equal(state.findings.length, 1)
+  assert.equal(state.findings[0].metadata.ctCveFindingId, 'ctcve_find_1')
+  assert.equal(state.findings[0].metadata.ctCveBatchId, 'findings_20260430_092000_org_1')
+})
+
+test('rejects open findings for unknown or deleted hosts and inactive packages', async () => {
+  const { repository } = repo()
+
+  const result = await ingestCtCveFindingBatch(batch([
+    finding({ findingId: 'unknown_host', hostId: 'missing', softwarePackageId: 'pkg_1' }),
+    finding({ findingId: 'inactive_package', softwarePackageId: 'missing' }),
+  ]), { repository })
+
+  assert.equal(result.accepted, false)
+  assert.equal(result.findingsAccepted, 0)
+  assert.equal(result.findingsRejected, 2)
+  assert.deepEqual(result.rejections?.map((rejection) => rejection.code), [
+    'unknown_host',
+    'unknown_software_package',
+  ])
+})
+
+test('skips stale deliveries so an old replay cannot regress newer finding state', async () => {
+  const stale = finding({ lastSeenAt: '2026-04-30T09:00:00.000Z' })
+  const { state, repository } = repo()
+  state.existing.set('host_1\0pkg_1\0CVE-2026-12345', {
+    lastSeenAt: new Date('2026-04-30T09:30:00.000Z'),
+  })
+
+  const result = await ingestCtCveFindingBatch(batch([stale]), { repository })
+
+  assert.equal(result.accepted, true)
+  assert.equal(result.findingsAccepted, 0)
+  assert.equal(result.findingsRejected, 0)
+  assert.equal(result.findingsSkipped, 1)
+  assert.equal(state.findings.length, 0)
+})

--- a/apps/web/lib/integrations/ct-cve/finding-ingest.ts
+++ b/apps/web/lib/integrations/ct-cve/finding-ingest.ts
@@ -1,0 +1,432 @@
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { z } from 'zod'
+
+import type { Database } from '../../db/index.ts'
+import { hostVulnerabilityFindings, hosts, softwarePackages, vulnerabilityCves } from '../../db/schema/index.ts'
+import type { VulnerabilityFindingConfidence, VulnerabilityFindingStatus, VulnerabilitySeverity } from '../../db/schema/vulnerabilities.ts'
+
+export interface CtCveFindingBatchResult {
+  accepted: boolean
+  batchId: string
+  findingsAccepted: number
+  findingsRejected: number
+  findingsSkipped: number
+  rejections?: CtCveFindingRejection[]
+}
+
+export interface CtCveFindingRejection {
+  findingId: string
+  code:
+    | 'invalid_payload'
+    | 'unknown_host'
+    | 'deleted_host'
+    | 'unknown_software_package'
+    | 'inactive_software_package'
+    | 'software_package_host_mismatch'
+    | 'resolved_finding_not_imported'
+  message: string
+}
+
+interface HostRecord {
+  id: string
+  organisationId: string
+  deletedAt: Date | null
+}
+
+interface SoftwarePackageRecord {
+  id: string
+  organisationId: string
+  hostId: string
+  removedAt: Date | null
+  deletedAt: Date | null
+}
+
+interface ExistingFindingRecord {
+  lastSeenAt: Date
+}
+
+type FindingKey = [hostId: string, softwarePackageId: string, cveId: string]
+
+export interface CtCveFindingRepository {
+  transaction<T>(run: (repository: CtCveFindingRepository) => Promise<T>): Promise<T>
+  getHosts(orgId: string, hostIds: string[]): Promise<Map<string, HostRecord>>
+  getSoftwarePackages(orgId: string, packageIds: string[]): Promise<Map<string, SoftwarePackageRecord>>
+  getExistingFindings(orgId: string, keys: FindingKey[]): Promise<Map<string, ExistingFindingRecord>>
+  upsertCve(cve: NormalizedCtCveFinding['cve'] & {
+    cveId: string
+    severity: VulnerabilitySeverity
+    cvssScore: number | null
+    knownExploited: boolean
+    source: string
+    metadata: Record<string, unknown>
+  }): Promise<void>
+  upsertFinding(finding: {
+    organisationId: string
+    hostId: string
+    softwarePackageId: string
+    cveId: string
+    status: VulnerabilityFindingStatus
+    packageName: string
+    installedVersion: string
+    fixedVersion: string | null
+    source: string
+    severity: VulnerabilitySeverity
+    cvssScore: number | null
+    knownExploited: boolean
+    confidence: VulnerabilityFindingConfidence
+    matchReason: string | null
+    firstSeenAt: Date
+    lastSeenAt: Date
+    resolvedAt: Date | null
+    metadata: Record<string, unknown>
+  }): Promise<void>
+}
+
+const CONTRACT_VERSION = '2026-04-30'
+const MAX_FINDINGS = 5_000
+
+const severitySchema = z.enum(['critical', 'high', 'medium', 'low', 'none', 'unknown'])
+const statusSchema = z.enum(['open', 'resolved'])
+const confidenceSchema = z.enum(['confirmed', 'probable', 'unsupported'])
+const dateSchema = z.string().datetime({ offset: true }).transform((value) => new Date(value))
+
+const cveSchema = z.object({
+  title: z.string().trim().max(300).nullable().optional(),
+  description: z.string().trim().max(20_000).nullable().optional(),
+  publishedAt: dateSchema.nullable().optional(),
+  modifiedAt: dateSchema.nullable().optional(),
+  rejected: z.boolean().optional(),
+  kevDueDate: dateSchema.nullable().optional(),
+  kevVendorProject: z.string().trim().max(300).nullable().optional(),
+  kevProduct: z.string().trim().max(300).nullable().optional(),
+  kevRequiredAction: z.string().trim().max(2_000).nullable().optional(),
+}).strip()
+
+const findingSchema = z.object({
+  findingId: z.string().trim().min(1).max(200),
+  hostId: z.string().trim().min(1).max(200),
+  softwarePackageId: z.string().trim().min(1).max(200),
+  cveId: z.string().trim().regex(/^CVE-\d{4}-\d{4,}$/i).transform((value) => value.toUpperCase()),
+  status: statusSchema,
+  packageName: z.string().trim().min(1).max(300),
+  installedVersion: z.string().trim().min(1).max(500),
+  fixedVersion: z.string().trim().max(500).nullable().optional(),
+  source: z.string().trim().min(1).max(100),
+  severity: severitySchema.default('unknown'),
+  cvssScore: z.number().min(0).max(10).nullable().optional(),
+  knownExploited: z.boolean().default(false),
+  confidence: confidenceSchema.default('confirmed'),
+  matchReason: z.string().trim().max(2_000).nullable().optional(),
+  firstSeenAt: dateSchema,
+  lastSeenAt: dateSchema,
+  resolvedAt: dateSchema.nullable().optional(),
+  cve: cveSchema.optional(),
+  references: z.array(z.string().url()).max(100).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).strip()
+
+const batchSchema = z.object({
+  contractVersion: z.literal(CONTRACT_VERSION),
+  orgId: z.string().trim().min(1).max(200),
+  batchId: z.string().trim().min(1).max(200),
+  generatedAt: dateSchema,
+  findings: z.array(findingSchema).max(MAX_FINDINGS),
+}).strip()
+
+type NormalizedCtCveFinding = z.infer<typeof findingSchema>
+type NormalizedCtCveFindingBatch = z.infer<typeof batchSchema>
+
+export class CtCveFindingBatchValidationError extends Error {
+  readonly issues: string[]
+
+  constructor(issues: string[]) {
+    super('Invalid CT-CVE finding batch payload.')
+    this.name = 'CtCveFindingBatchValidationError'
+    this.issues = issues
+  }
+}
+
+function keyFor(input: FindingKey): string {
+  return input.join('\0')
+}
+
+function unique(values: string[]) {
+  return Array.from(new Set(values))
+}
+
+export async function ingestCtCveFindingBatch(
+  input: unknown,
+  options: { repository?: CtCveFindingRepository } = {},
+): Promise<CtCveFindingBatchResult> {
+  const parsed = batchSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new CtCveFindingBatchValidationError(parsed.error.issues.map((issue) => issue.message))
+  }
+
+  const batch = parsed.data
+  const repository = options.repository ?? await getDefaultRepository()
+
+  return repository.transaction(async (tx) => ingestValidatedBatch(batch, tx))
+}
+
+async function ingestValidatedBatch(
+  batch: NormalizedCtCveFindingBatch,
+  repository: CtCveFindingRepository,
+): Promise<CtCveFindingBatchResult> {
+  const hostIds = unique(batch.findings.map((finding) => finding.hostId))
+  const packageIds = unique(batch.findings.map((finding) => finding.softwarePackageId))
+  const findingKeys: FindingKey[] = batch.findings.map((finding) => [
+    finding.hostId,
+    finding.softwarePackageId,
+    finding.cveId,
+  ])
+
+  const [hostMap, packageMap, existingMap] = await Promise.all([
+    repository.getHosts(batch.orgId, hostIds),
+    repository.getSoftwarePackages(batch.orgId, packageIds),
+    repository.getExistingFindings(batch.orgId, findingKeys),
+  ])
+
+  const rejections: CtCveFindingRejection[] = []
+  let findingsAccepted = 0
+  let findingsSkipped = 0
+
+  for (const finding of batch.findings) {
+    const existing = existingMap.get(keyFor([finding.hostId, finding.softwarePackageId, finding.cveId]))
+    const rejection = validateFindingReferences(finding, hostMap, packageMap, existing)
+    if (rejection) {
+      rejections.push(rejection)
+      continue
+    }
+
+    if (existing && existing.lastSeenAt.getTime() > finding.lastSeenAt.getTime()) {
+      findingsSkipped += 1
+      continue
+    }
+
+    await repository.upsertCve({
+      cveId: finding.cveId,
+      title: finding.cve?.title ?? null,
+      description: finding.cve?.description ?? null,
+      severity: finding.severity,
+      cvssScore: finding.cvssScore ?? null,
+      publishedAt: finding.cve?.publishedAt ?? null,
+      modifiedAt: finding.cve?.modifiedAt ?? null,
+      rejected: finding.cve?.rejected ?? false,
+      knownExploited: finding.knownExploited,
+      kevDueDate: finding.cve?.kevDueDate ?? null,
+      kevVendorProject: finding.cve?.kevVendorProject ?? null,
+      kevProduct: finding.cve?.kevProduct ?? null,
+      kevRequiredAction: finding.cve?.kevRequiredAction ?? null,
+      source: finding.source,
+      metadata: {
+        references: finding.references ?? [],
+        ctCveBatchId: batch.batchId,
+      },
+    })
+
+    await repository.upsertFinding({
+      organisationId: batch.orgId,
+      hostId: finding.hostId,
+      softwarePackageId: finding.softwarePackageId,
+      cveId: finding.cveId,
+      status: finding.status,
+      packageName: finding.packageName,
+      installedVersion: finding.installedVersion,
+      fixedVersion: finding.fixedVersion ?? null,
+      source: finding.source,
+      severity: finding.severity,
+      cvssScore: finding.cvssScore ?? null,
+      knownExploited: finding.knownExploited,
+      confidence: finding.confidence,
+      matchReason: finding.matchReason ?? null,
+      firstSeenAt: finding.firstSeenAt,
+      lastSeenAt: finding.lastSeenAt,
+      resolvedAt: finding.status === 'resolved' ? finding.resolvedAt ?? finding.lastSeenAt : null,
+      metadata: {
+        ...(finding.metadata ?? {}),
+        references: finding.references ?? [],
+        ctCveFindingId: finding.findingId,
+        ctCveBatchId: batch.batchId,
+        ctCveGeneratedAt: batch.generatedAt.toISOString(),
+      },
+    })
+    findingsAccepted += 1
+  }
+
+  return {
+    accepted: rejections.length === 0,
+    batchId: batch.batchId,
+    findingsAccepted,
+    findingsRejected: rejections.length,
+    findingsSkipped,
+    ...(rejections.length > 0 ? { rejections } : {}),
+  }
+}
+
+function validateFindingReferences(
+  finding: NormalizedCtCveFinding,
+  hostMap: Map<string, HostRecord>,
+  packageMap: Map<string, SoftwarePackageRecord>,
+  existing: ExistingFindingRecord | undefined,
+): CtCveFindingRejection | null {
+  const host = hostMap.get(finding.hostId)
+  const softwarePackage = packageMap.get(finding.softwarePackageId)
+
+  if (!host) {
+    return finding.status === 'resolved' && existing
+      ? null
+      : { findingId: finding.findingId, code: 'unknown_host', message: 'Finding references an unknown host.' }
+  }
+  if (host.deletedAt) {
+    return finding.status === 'resolved' && existing
+      ? null
+      : { findingId: finding.findingId, code: 'deleted_host', message: 'Finding references a deleted host.' }
+  }
+
+  if (!softwarePackage) {
+    return finding.status === 'resolved' && existing
+      ? null
+      : { findingId: finding.findingId, code: 'unknown_software_package', message: 'Finding references an unknown software package.' }
+  }
+  if (softwarePackage.hostId !== finding.hostId) {
+    return { findingId: finding.findingId, code: 'software_package_host_mismatch', message: 'Finding host and software package do not match.' }
+  }
+  if (finding.status === 'open' && (softwarePackage.removedAt || softwarePackage.deletedAt)) {
+    return { findingId: finding.findingId, code: 'inactive_software_package', message: 'Open finding references an inactive software package.' }
+  }
+  if (finding.status === 'resolved' && !existing) {
+    return { findingId: finding.findingId, code: 'resolved_finding_not_imported', message: 'Resolved tombstone does not match an imported finding.' }
+  }
+
+  return null
+}
+
+async function getDefaultRepository() {
+  const { db: database } = await import('../../db/index.ts')
+  return createDrizzleCtCveFindingRepository(database)
+}
+
+function createDrizzleCtCveFindingRepository(database: Database): CtCveFindingRepository {
+  return {
+    async transaction(run) {
+      return database.transaction(async (tx) => run(createDrizzleCtCveFindingRepository(tx as unknown as Database)))
+    },
+    async getHosts(orgId, hostIds) {
+      if (hostIds.length === 0) return new Map()
+      const rows = await database
+        .select({
+          id: hosts.id,
+          organisationId: hosts.organisationId,
+          deletedAt: hosts.deletedAt,
+        })
+        .from(hosts)
+        .where(and(eq(hosts.organisationId, orgId), inArray(hosts.id, hostIds)))
+      return new Map(rows.map((row) => [row.id, row]))
+    },
+    async getSoftwarePackages(orgId, packageIds) {
+      if (packageIds.length === 0) return new Map()
+      const rows = await database
+        .select({
+          id: softwarePackages.id,
+          organisationId: softwarePackages.organisationId,
+          hostId: softwarePackages.hostId,
+          removedAt: softwarePackages.removedAt,
+          deletedAt: softwarePackages.deletedAt,
+        })
+        .from(softwarePackages)
+        .where(and(eq(softwarePackages.organisationId, orgId), inArray(softwarePackages.id, packageIds)))
+      return new Map(rows.map((row) => [row.id, row]))
+    },
+    async getExistingFindings(orgId, keys) {
+      if (keys.length === 0) return new Map()
+      const hostIds = unique(keys.map(([hostId]) => hostId))
+      const packageIds = unique(keys.map(([, packageId]) => packageId))
+      const cveIds = unique(keys.map(([, , cveId]) => cveId))
+      const rows = await database
+        .select({
+          hostId: hostVulnerabilityFindings.hostId,
+          softwarePackageId: hostVulnerabilityFindings.softwarePackageId,
+          cveId: hostVulnerabilityFindings.cveId,
+          lastSeenAt: hostVulnerabilityFindings.lastSeenAt,
+        })
+        .from(hostVulnerabilityFindings)
+        .where(and(
+          eq(hostVulnerabilityFindings.organisationId, orgId),
+          inArray(hostVulnerabilityFindings.hostId, hostIds),
+          inArray(hostVulnerabilityFindings.softwarePackageId, packageIds),
+          inArray(hostVulnerabilityFindings.cveId, cveIds),
+        ))
+      return new Map(rows.map((row) => [keyFor([row.hostId, row.softwarePackageId, row.cveId]), { lastSeenAt: row.lastSeenAt }]))
+    },
+    async upsertCve(cve) {
+      await database.insert(vulnerabilityCves).values({
+        cveId: cve.cveId,
+        title: cve.title,
+        description: cve.description,
+        severity: cve.severity,
+        cvssScore: cve.cvssScore,
+        publishedAt: cve.publishedAt,
+        modifiedAt: cve.modifiedAt,
+        rejected: cve.rejected,
+        knownExploited: cve.knownExploited,
+        kevDueDate: cve.kevDueDate,
+        kevVendorProject: cve.kevVendorProject,
+        kevProduct: cve.kevProduct,
+        kevRequiredAction: cve.kevRequiredAction,
+        source: cve.source,
+        metadata: cve.metadata,
+        updatedAt: new Date(),
+      }).onConflictDoUpdate({
+        target: vulnerabilityCves.cveId,
+        set: {
+          title: cve.title,
+          description: cve.description,
+          severity: cve.severity,
+          cvssScore: cve.cvssScore,
+          publishedAt: cve.publishedAt,
+          modifiedAt: cve.modifiedAt,
+          rejected: cve.rejected,
+          knownExploited: cve.knownExploited,
+          kevDueDate: cve.kevDueDate,
+          kevVendorProject: cve.kevVendorProject,
+          kevProduct: cve.kevProduct,
+          kevRequiredAction: cve.kevRequiredAction,
+          source: cve.source,
+          metadata: cve.metadata,
+          updatedAt: new Date(),
+        },
+      })
+    },
+    async upsertFinding(finding) {
+      await database.insert(hostVulnerabilityFindings).values({
+        ...finding,
+        updatedAt: new Date(),
+      }).onConflictDoUpdate({
+        target: [
+          hostVulnerabilityFindings.organisationId,
+          hostVulnerabilityFindings.hostId,
+          hostVulnerabilityFindings.softwarePackageId,
+          hostVulnerabilityFindings.cveId,
+        ],
+        set: {
+          status: finding.status,
+          packageName: finding.packageName,
+          installedVersion: finding.installedVersion,
+          fixedVersion: finding.fixedVersion,
+          source: finding.source,
+          severity: finding.severity,
+          cvssScore: finding.cvssScore,
+          knownExploited: finding.knownExploited,
+          confidence: finding.confidence,
+          matchReason: finding.matchReason,
+          firstSeenAt: sql`LEAST(${hostVulnerabilityFindings.firstSeenAt}, ${finding.firstSeenAt})`,
+          lastSeenAt: finding.lastSeenAt,
+          resolvedAt: finding.resolvedAt,
+          metadata: finding.metadata,
+          updatedAt: new Date(),
+        },
+      })
+    },
+  }
+}

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -243,7 +243,7 @@ Update the status and notes in this table as work lands.
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
-| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector | Added the first CT Ops inbound connector boundary: signed CT-CVE service-token verification, replay protection, per-token rate limiting for connection health, and `GET /api/integrations/ct-cve/v1/connection-health`. Finding batch persistence and inventory export remain. |
+| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, connection health, and the first CT-CVE finding batch ingestion endpoint. Inventory export and connection status persistence remain. |
 | 10. Remove internal CT Ops CVE ownership | Not started | | Delete internal feed/matcher ownership and all residue from CT Ops. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
 
@@ -571,3 +571,11 @@ Append dated notes here as phases progress. Keep notes short and factual.
   connection health endpoint. Finding batch persistence and CT Ops inventory
   export remain. Validation: targeted service-token unit test, targeted ESLint,
   web type-check, migration validation, and web unit suite.
+- Continued Phase 9 on branch `feat/ct-cve-finding-ingest` by adding
+  `POST /api/integrations/ct-cve/v1/finding-batches` for signed CT-CVE finding
+  delivery. The endpoint enforces the 25 MiB payload limit, per-token rate
+  limiting, token/org scope binding, contract payload validation, row-level
+  rejection for unknown/deleted hosts and inactive packages, CVE upserts,
+  imported finding upserts, CT-CVE finding/batch metadata, and stale replay
+  skipping so older deliveries cannot regress newer finding state. Inventory
+  export and durable connection status timestamps remain.


### PR DESCRIPTION
## Summary

- Add signed `POST /api/integrations/ct-cve/v1/finding-batches` ingestion for CT-CVE finding deliveries.
- Validate contract payloads, enforce body-size/rate limits, reject invalid host/package references, and upsert imported CVE/finding rows with CT-CVE batch metadata.
- Update the CT-CVE migration plan with the Phase 9 slice and remaining connector work.

## Validation

- `node --experimental-strip-types --test lib/integrations/ct-cve/finding-ingest.test.mjs`
- `pnpm --filter web type-check`
- `pnpm --filter web lint -- app/api/integrations/ct-cve/v1/finding-batches/route.ts lib/integrations/ct-cve/finding-ingest.ts lib/integrations/ct-cve/finding-ingest.test.mjs`
- `pnpm --filter web db:validate`
- `pnpm --filter web test:unit`

## Related follow-up

- Investigated CT-CVE release/GHCR publishing before opening this PR. Root cause is tracked in carrtech-dev/ct-cve#9: the CT-CVE default branch is `feat/bootstrap-service`, while the release workflow only triggers on `main`, and `main` does not contain the release workflow or later CT-CVE work.