### PR TITLE
feat(web): add CT-CVE inventory export helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,7 @@ INGEST_WS_URL=
 # CT-CVE inbound service-token allow-list for signed connector requests that
 # deliver vulnerability findings or call CT Ops connection health. Each secret
 # must contain at least 32 random bytes. Example shape:
-# CT_CVE_SERVICE_TOKENS=[{"id":"ctcve_prod_1","secret":"...","orgId":"org_...","scopes":["findings:write"]}]
+# CT_CVE_SERVICE_TOKENS=[{"id":"ctcve_prod_1","secret":"...","orgId":"org_...","scopes":["findings:write","connection:read"]}]
 # CT_CVE_SERVICE_TOKENS=
 
 # Feed sync, NVD/CISA enrichment, and Linux package matching now run in CT-CVE.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 87 — CT-CVE inventory export connector
+
+**CT-CVE outbound inventory snapshots** (`apps/web/lib/integrations/ct-cve/inventory-export.ts`)
+- Added CT Ops inventory snapshot construction for CT-CVE, scoped by organisation and limited to active hosts plus current software package rows.
+- Included contract metadata, stable package fingerprints, Linux distro/package manager metadata, bounded host/package page sizes, and opaque cursors for follow-up inventory pages.
+- Added a signed outbound push helper for `POST /api/v1/ct-ops/inventory-snapshots` using the CT-CVE `inventory:write` service-token contract.
+- Corrected CT Ops connection health to require `connection:read` rather than `findings:write`.
+
+**Validation**
+- Validation run: `pnpm install --frozen-lockfile`, `pnpm --dir apps/web run type-check`, `pnpm --dir apps/web run test:unit`, and targeted ESLint for the connector files.
+
 ### Session 86 — CT-CVE inbound connector boundary
 
 **CT-CVE connector foundation** (`apps/web/lib/integrations/ct-cve/service-token.ts`, `apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts`)

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -22,7 +22,7 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `AGENT_DOWNLOAD_BASE_URL` | — | `https://localhost` | Public URL agents use to download new binaries. Must be reachable from every agent host |
 | `INGEST_WS_URL` | — | *(empty)* | WebSocket URL of the ingest service. Empty = same-origin via the bundled nginx (recommended). Set to an absolute `wss://` URL only to bypass the bundled proxy |
 | `WEB_TLS_CERT` | — | `/var/lib/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. The enrolment bundle route reads this file and embeds it so agents can verify the HTTPS download URL |
-| `CT_CVE_SERVICE_TOKENS` | — 🔒 | *(empty)* | JSON allow-list of signed CT-CVE service tokens that can deliver findings or call CT Ops connection health |
+| `CT_CVE_SERVICE_TOKENS` | — 🔒 | *(empty)* | JSON allow-list of signed CT-CVE service tokens that can deliver findings or call CT Ops connection health; use `findings:write` and `connection:read` scopes for the initial inbound connector |
 
 ### Licence verification
 

--- a/apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts
+++ b/apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest) {
     path: request.nextUrl.pathname,
     body: '',
     headers: request.headers,
-    requiredScope: 'findings:write',
+    requiredScope: 'connection:read',
     orgId,
     tokens,
   })
@@ -99,4 +99,3 @@ export async function GET(request: NextRequest) {
     lastErrorAt: null,
   })
 }
-

--- a/apps/web/lib/integrations/ct-cve/inventory-export.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/inventory-export.test.mjs
@@ -1,0 +1,195 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createHmac, createHash } from 'node:crypto'
+
+import {
+  buildCtCveInventorySnapshot,
+  pushCtCveInventorySnapshot,
+} from './inventory-export.ts'
+
+const generatedAt = new Date('2026-04-30T10:15:00.000Z')
+const token = {
+  id: 'ctops_inventory_token',
+  secret: Buffer.from('ct-ops outbound inventory signing key only').toString('base64url'),
+  orgId: 'org_1',
+  scopes: ['inventory:write'],
+}
+
+function repo() {
+  return {
+    async getOrganisation(orgId) {
+      assert.equal(orgId, 'org_1')
+      return { id: 'org_1', slug: 'acme' }
+    },
+    async listInventoryHosts(orgId, options) {
+      assert.equal(orgId, 'org_1')
+      assert.equal(options.limit, 500)
+      return [
+        {
+          id: 'host_1',
+          hostname: 'web-01',
+          displayName: 'Web 01',
+          os: 'Ubuntu',
+          osVersion: '24.04',
+          arch: 'x86_64',
+          status: 'online',
+          lastSeenAt: new Date('2026-04-30T10:10:00.000Z'),
+          updatedAt: new Date('2026-04-30T10:11:00.000Z'),
+          deletedAt: null,
+        },
+        {
+          id: 'host_deleted',
+          hostname: 'retired',
+          displayName: null,
+          os: 'Ubuntu',
+          osVersion: '22.04',
+          arch: 'x86_64',
+          status: 'offline',
+          lastSeenAt: null,
+          updatedAt: new Date('2026-04-30T09:00:00.000Z'),
+          deletedAt: new Date('2026-04-30T09:30:00.000Z'),
+        },
+      ]
+    },
+    async listInventoryPackages(orgId, options) {
+      assert.equal(orgId, 'org_1')
+      assert.equal(options.limit, 25_000)
+      return [
+        {
+          id: 'pkg_1',
+          hostId: 'host_1',
+          name: 'openssl',
+          version: '3.0.13-0ubuntu3.2',
+          architecture: 'amd64',
+          source: 'dpkg',
+          distroId: 'ubuntu',
+          distroVersionId: '24.04',
+          distroCodename: 'noble',
+          distroIdLike: ['debian'],
+          sourceName: 'openssl',
+          sourceVersion: '3.0.13',
+          packageEpoch: null,
+          packageRelease: '0ubuntu3.2',
+          repository: 'main',
+          origin: 'Ubuntu',
+          firstSeenAt: new Date('2026-04-29T08:00:00.000Z'),
+          lastSeenAt: new Date('2026-04-30T10:10:00.000Z'),
+          removedAt: null,
+          deletedAt: null,
+        },
+        {
+          id: 'pkg_removed',
+          hostId: 'host_1',
+          name: 'oldssl',
+          version: '1.0.0',
+          architecture: 'amd64',
+          source: 'dpkg',
+          distroId: 'ubuntu',
+          distroVersionId: '24.04',
+          distroCodename: 'noble',
+          distroIdLike: [],
+          sourceName: null,
+          sourceVersion: null,
+          packageEpoch: null,
+          packageRelease: null,
+          repository: null,
+          origin: null,
+          firstSeenAt: new Date('2026-04-29T08:00:00.000Z'),
+          lastSeenAt: new Date('2026-04-29T09:00:00.000Z'),
+          removedAt: new Date('2026-04-30T09:00:00.000Z'),
+          deletedAt: null,
+        },
+      ]
+    },
+  }
+}
+
+test('builds an org-scoped CT-CVE inventory snapshot without deleted or removed rows', async () => {
+  const snapshot = await buildCtCveInventorySnapshot({
+    orgId: 'org_1',
+    repository: repo(),
+    generatedAt,
+  })
+
+  assert.equal(snapshot.contractVersion, '2026-04-30')
+  assert.equal(snapshot.orgId, 'org_1')
+  assert.equal(snapshot.orgSlug, 'acme')
+  assert.equal(snapshot.snapshotType, 'full')
+  assert.equal(snapshot.generatedAt, generatedAt.toISOString())
+  assert.equal(snapshot.hosts.length, 1)
+  assert.equal(snapshot.packages.length, 1)
+  assert.equal(snapshot.hosts[0].hostId, 'host_1')
+  assert.equal(snapshot.packages[0].softwarePackageId, 'pkg_1')
+  assert.equal(snapshot.packages[0].fingerprint, ['host_1', 'openssl', '3.0.13-0ubuntu3.2', 'amd64', 'dpkg'].join('\0'))
+  assert.equal(snapshot.cursor, null)
+})
+
+test('adds an opaque cursor when either inventory page reaches its limit', async () => {
+  const repository = repo()
+  const snapshot = await buildCtCveInventorySnapshot({
+    orgId: 'org_1',
+    repository: {
+      ...repository,
+      async listInventoryHosts() {
+        return [(await repository.listInventoryHosts('org_1', { limit: 500 }))[0]]
+      },
+    },
+    limits: { hosts: 1, packages: 25_000 },
+    generatedAt,
+  })
+
+  assert.match(snapshot.cursor ?? '', /^[A-Za-z0-9_-]+$/)
+  const next = await buildCtCveInventorySnapshot({
+    orgId: 'org_1',
+    repository,
+    cursor: snapshot.cursor ?? undefined,
+    generatedAt,
+  })
+  assert.equal(next.snapshotType, 'full')
+  assert.notEqual(next.snapshotId, snapshot.snapshotId)
+})
+
+test('pushes a snapshot to CT-CVE with the inventory service-token signature', async () => {
+  const snapshot = await buildCtCveInventorySnapshot({
+    orgId: 'org_1',
+    repository: repo(),
+    generatedAt,
+  })
+
+  let captured
+  const result = await pushCtCveInventorySnapshot({
+    baseUrl: 'https://ct-cve.example.invalid',
+    token,
+    snapshot,
+    nonce: 'nonce_inventory_1',
+    timestamp: '2026-04-30T10:16:00.000Z',
+    fetchImpl: async (url, init) => {
+      captured = { url, init }
+      return new Response(JSON.stringify({
+        accepted: true,
+        snapshotId: snapshot.snapshotId,
+        hostsAccepted: 1,
+        packagesAccepted: 1,
+        rowsRejected: 0,
+        nextAction: 'none',
+      }), { status: 202, headers: { 'content-type': 'application/json' } })
+    },
+  })
+
+  assert.equal(result.accepted, true)
+  assert.equal(captured.url, 'https://ct-cve.example.invalid/api/v1/ct-ops/inventory-snapshots')
+  assert.equal(captured.init.method, 'POST')
+  assert.equal(captured.init.headers.authorization, `CT-ServiceToken ${token.id}`)
+  assert.equal(captured.init.headers['x-ct-content-sha256'], createHash('sha256').update(captured.init.body).digest('hex'))
+
+  const expectedSignature = createHmac('sha256', token.secret)
+    .update([
+      'POST',
+      '/api/v1/ct-ops/inventory-snapshots',
+      '2026-04-30T10:16:00.000Z',
+      'nonce_inventory_1',
+      captured.init.headers['x-ct-content-sha256'],
+    ].join('\n'))
+    .digest('base64url')
+  assert.equal(captured.init.headers['x-ct-signature'], `v1=${expectedSignature}`)
+})

--- a/apps/web/lib/integrations/ct-cve/inventory-export.ts
+++ b/apps/web/lib/integrations/ct-cve/inventory-export.ts
@@ -1,0 +1,353 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+
+import type { Database } from '../../db/index.ts'
+import type { PackageSource } from '../../db/schema/software.ts'
+
+export interface CtCveInventoryHostRecord {
+  id: string
+  hostname: string
+  displayName: string | null
+  os: string | null
+  osVersion: string | null
+  arch: string | null
+  status: 'online' | 'offline' | 'unknown'
+  lastSeenAt: Date | null
+  updatedAt: Date
+  deletedAt: Date | null
+}
+
+export interface CtCveInventoryPackageRecord {
+  id: string
+  hostId: string
+  name: string
+  version: string
+  architecture: string | null
+  source: PackageSource
+  distroId: string | null
+  distroVersionId: string | null
+  distroCodename: string | null
+  distroIdLike: string[] | null
+  sourceName: string | null
+  sourceVersion: string | null
+  packageEpoch: string | null
+  packageRelease: string | null
+  repository: string | null
+  origin: string | null
+  firstSeenAt: Date
+  lastSeenAt: Date
+  removedAt: Date | null
+  deletedAt: Date | null
+}
+
+export interface CtCveInventoryRepository {
+  getOrganisation(orgId: string): Promise<{ id: string; slug: string } | null>
+  listInventoryHosts(orgId: string, options: { limit: number; afterId?: string }): Promise<CtCveInventoryHostRecord[]>
+  listInventoryPackages(orgId: string, options: { limit: number; afterId?: string }): Promise<CtCveInventoryPackageRecord[]>
+}
+
+export interface CtCveInventorySnapshot {
+  contractVersion: '2026-04-30'
+  orgId: string
+  orgSlug: string
+  snapshotId: string
+  snapshotType: 'full' | 'incremental'
+  generatedAt: string
+  cursor: string | null
+  hosts: Array<{
+    hostId: string
+    hostname: string
+    displayName: string | null
+    os: string | null
+    osVersion: string | null
+    arch: string | null
+    status: 'online' | 'offline' | 'unknown'
+    lastSeenAt: string | null
+    updatedAt: string
+  }>
+  packages: Array<{
+    softwarePackageId: string
+    hostId: string
+    name: string
+    version: string
+    architecture: string | null
+    source: PackageSource
+    fingerprint: string
+    distroId: string | null
+    distroVersionId: string | null
+    distroCodename: string | null
+    distroIdLike: string[]
+    sourceName: string | null
+    sourceVersion: string | null
+    packageEpoch: string | null
+    packageRelease: string | null
+    repository: string | null
+    origin: string | null
+    firstSeenAt: string
+    lastSeenAt: string
+  }>
+}
+
+export interface CtCveInventoryPushResult {
+  accepted: boolean
+  snapshotId: string
+  hostsAccepted: number
+  packagesAccepted: number
+  rowsRejected: number
+  nextAction: string
+}
+
+interface CursorState {
+  hostAfterId?: string
+  packageAfterId?: string
+}
+
+const CONTRACT_VERSION = '2026-04-30'
+const DEFAULT_HOST_LIMIT = 500
+const DEFAULT_PACKAGE_LIMIT = 25_000
+const INVENTORY_PATH = '/api/v1/ct-ops/inventory-snapshots'
+
+function encodeCursor(state: CursorState): string | null {
+  if (!state.hostAfterId && !state.packageAfterId) {
+    return null
+  }
+  return Buffer.from(JSON.stringify(state), 'utf8').toString('base64url')
+}
+
+function decodeCursor(cursor: string | undefined): CursorState {
+  if (!cursor) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as unknown
+    if (!parsed || typeof parsed !== 'object') {
+      return {}
+    }
+    const record = parsed as Record<string, unknown>
+    return {
+      hostAfterId: typeof record.hostAfterId === 'string' ? record.hostAfterId : undefined,
+      packageAfterId: typeof record.packageAfterId === 'string' ? record.packageAfterId : undefined,
+    }
+  } catch {
+    return {}
+  }
+}
+
+function iso(value: Date | null): string | null {
+  return value ? value.toISOString() : null
+}
+
+function packageFingerprint(row: CtCveInventoryPackageRecord): string {
+  return [row.hostId, row.name, row.version, row.architecture ?? '', row.source].join('\0')
+}
+
+function snapshotIdFor(orgId: string, generatedAt: Date, cursor: string | undefined) {
+  const compact = generatedAt.toISOString().replace(/[-:.]/g, '').replace('T', '_').replace('Z', '')
+  const pageSuffix = cursor
+    ? `_page_${createHash('sha256').update(cursor).digest('base64url').slice(0, 12)}`
+    : ''
+  return `inv_${compact}_${orgId}${pageSuffix}`
+}
+
+export async function buildCtCveInventorySnapshot(options: {
+  orgId: string
+  cursor?: string
+  snapshotType?: 'full' | 'incremental'
+  generatedAt?: Date
+  limits?: { hosts?: number; packages?: number }
+  repository?: CtCveInventoryRepository
+}): Promise<CtCveInventorySnapshot> {
+  const orgId = options.orgId.trim()
+  if (!orgId) {
+    throw new Error('orgId is required to build a CT-CVE inventory snapshot')
+  }
+
+  const repository = options.repository ?? await getDefaultRepository()
+  const organisation = await repository.getOrganisation(orgId)
+  if (!organisation) {
+    throw new Error('organisation not found for CT-CVE inventory snapshot')
+  }
+
+  const hostLimit = Math.min(Math.max(options.limits?.hosts ?? DEFAULT_HOST_LIMIT, 1), DEFAULT_HOST_LIMIT)
+  const packageLimit = Math.min(Math.max(options.limits?.packages ?? DEFAULT_PACKAGE_LIMIT, 1), DEFAULT_PACKAGE_LIMIT)
+  const cursor = decodeCursor(options.cursor)
+
+  const [hostRows, packageRows] = await Promise.all([
+    repository.listInventoryHosts(orgId, { limit: hostLimit, afterId: cursor.hostAfterId }),
+    repository.listInventoryPackages(orgId, { limit: packageLimit, afterId: cursor.packageAfterId }),
+  ])
+
+  const activeHosts = hostRows.filter((row) => row.deletedAt === null)
+  const activePackages = packageRows.filter((row) => row.deletedAt === null && row.removedAt === null)
+  const nextCursor = encodeCursor({
+    hostAfterId: hostRows.length >= hostLimit ? hostRows.at(-1)?.id : undefined,
+    packageAfterId: packageRows.length >= packageLimit ? packageRows.at(-1)?.id : undefined,
+  })
+  const generatedAt = options.generatedAt ?? new Date()
+
+  return {
+    contractVersion: CONTRACT_VERSION,
+    orgId,
+    orgSlug: organisation.slug,
+    snapshotId: snapshotIdFor(orgId, generatedAt, options.cursor),
+    snapshotType: options.snapshotType ?? 'full',
+    generatedAt: generatedAt.toISOString(),
+    cursor: nextCursor,
+    hosts: activeHosts.map((row) => ({
+      hostId: row.id,
+      hostname: row.hostname,
+      displayName: row.displayName,
+      os: row.os,
+      osVersion: row.osVersion,
+      arch: row.arch,
+      status: row.status,
+      lastSeenAt: iso(row.lastSeenAt),
+      updatedAt: row.updatedAt.toISOString(),
+    })),
+    packages: activePackages.map((row) => ({
+      softwarePackageId: row.id,
+      hostId: row.hostId,
+      name: row.name,
+      version: row.version,
+      architecture: row.architecture,
+      source: row.source,
+      fingerprint: packageFingerprint(row),
+      distroId: row.distroId,
+      distroVersionId: row.distroVersionId,
+      distroCodename: row.distroCodename,
+      distroIdLike: row.distroIdLike ?? [],
+      sourceName: row.sourceName,
+      sourceVersion: row.sourceVersion,
+      packageEpoch: row.packageEpoch,
+      packageRelease: row.packageRelease,
+      repository: row.repository,
+      origin: row.origin,
+      firstSeenAt: row.firstSeenAt.toISOString(),
+      lastSeenAt: row.lastSeenAt.toISOString(),
+    })),
+  }
+}
+
+export async function pushCtCveInventorySnapshot(options: {
+  baseUrl: string
+  token: { id: string; secret: string; orgId: string; scopes: string[] }
+  snapshot: CtCveInventorySnapshot
+  nonce?: string
+  timestamp?: string
+  fetchImpl?: typeof fetch
+}): Promise<CtCveInventoryPushResult> {
+  if (options.token.orgId !== options.snapshot.orgId || !options.token.scopes.includes('inventory:write')) {
+    throw new Error('CT-CVE inventory token is not scoped to this snapshot')
+  }
+
+  const url = new URL(INVENTORY_PATH, options.baseUrl)
+  const body = JSON.stringify(options.snapshot)
+  const timestamp = options.timestamp ?? new Date().toISOString()
+  const nonce = options.nonce ?? randomUUID()
+  const bodyHash = createHash('sha256').update(body).digest('hex')
+  const signature = createHmac('sha256', options.token.secret)
+    .update(['POST', url.pathname, timestamp, nonce, bodyHash].join('\n'))
+    .digest('base64url')
+
+  const response = await (options.fetchImpl ?? fetch)(url.toString(), {
+    method: 'POST',
+    headers: {
+      authorization: `CT-ServiceToken ${options.token.id}`,
+      'content-type': 'application/json',
+      'x-ct-timestamp': timestamp,
+      'x-ct-nonce': nonce,
+      'x-ct-content-sha256': bodyHash,
+      'x-ct-signature': `v1=${signature}`,
+    },
+    body,
+  })
+
+  const payload = await response.json().catch(() => null) as CtCveInventoryPushResult | null
+  if (!response.ok || !payload || typeof payload.accepted !== 'boolean') {
+    throw new Error(`CT-CVE inventory snapshot push failed with HTTP ${response.status}`)
+  }
+  return payload
+}
+
+async function getDefaultRepository(): Promise<CtCveInventoryRepository> {
+  const { db: database } = await import('../../db/index.ts')
+  return createDrizzleCtCveInventoryRepository(database)
+}
+
+function createDrizzleCtCveInventoryRepository(database: Database): CtCveInventoryRepository {
+  return {
+    async getOrganisation(orgId) {
+      const { and, eq, isNull } = await import('drizzle-orm')
+      const { organisations } = await import('../../db/schema/index.ts')
+      const [row] = await database
+        .select({ id: organisations.id, slug: organisations.slug })
+        .from(organisations)
+        .where(and(eq(organisations.id, orgId), isNull(organisations.deletedAt)))
+        .limit(1)
+      return row ?? null
+    },
+    async listInventoryHosts(orgId, options) {
+      const { and, asc, eq, gt, isNull } = await import('drizzle-orm')
+      const { hosts } = await import('../../db/schema/index.ts')
+      return database
+        .select({
+          id: hosts.id,
+          hostname: hosts.hostname,
+          displayName: hosts.displayName,
+          os: hosts.os,
+          osVersion: hosts.osVersion,
+          arch: hosts.arch,
+          status: hosts.status,
+          lastSeenAt: hosts.lastSeenAt,
+          updatedAt: hosts.updatedAt,
+          deletedAt: hosts.deletedAt,
+        })
+        .from(hosts)
+        .where(and(
+          eq(hosts.organisationId, orgId),
+          isNull(hosts.deletedAt),
+          options.afterId ? gt(hosts.id, options.afterId) : undefined,
+        ))
+        .orderBy(asc(hosts.id))
+        .limit(options.limit)
+    },
+    async listInventoryPackages(orgId, options) {
+      const { and, asc, eq, gt, isNull } = await import('drizzle-orm')
+      const { hosts, softwarePackages } = await import('../../db/schema/index.ts')
+      return database
+        .select({
+          id: softwarePackages.id,
+          hostId: softwarePackages.hostId,
+          name: softwarePackages.name,
+          version: softwarePackages.version,
+          architecture: softwarePackages.architecture,
+          source: softwarePackages.source,
+          distroId: softwarePackages.distroId,
+          distroVersionId: softwarePackages.distroVersionId,
+          distroCodename: softwarePackages.distroCodename,
+          distroIdLike: softwarePackages.distroIdLike,
+          sourceName: softwarePackages.sourceName,
+          sourceVersion: softwarePackages.sourceVersion,
+          packageEpoch: softwarePackages.packageEpoch,
+          packageRelease: softwarePackages.packageRelease,
+          repository: softwarePackages.repository,
+          origin: softwarePackages.origin,
+          firstSeenAt: softwarePackages.firstSeenAt,
+          lastSeenAt: softwarePackages.lastSeenAt,
+          removedAt: softwarePackages.removedAt,
+          deletedAt: softwarePackages.deletedAt,
+        })
+        .from(softwarePackages)
+        .innerJoin(hosts, eq(hosts.id, softwarePackages.hostId))
+        .where(and(
+          eq(softwarePackages.organisationId, orgId),
+          isNull(softwarePackages.removedAt),
+          isNull(softwarePackages.deletedAt),
+          isNull(hosts.deletedAt),
+          options.afterId ? gt(softwarePackages.id, options.afterId) : undefined,
+        ))
+        .orderBy(asc(softwarePackages.id))
+        .limit(options.limit)
+    },
+  }
+}

--- a/apps/web/lib/integrations/ct-cve/service-token.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/service-token.test.mjs
@@ -12,7 +12,7 @@ const TOKEN = {
   id: 'ctcve_test_token',
   secret: Buffer.from('ct-cve unit test signing key only').toString('base64url'),
   orgId: 'org_123',
-  scopes: ['findings:write'],
+  scopes: ['findings:write', 'connection:read'],
 }
 
 function sha256(body) {
@@ -73,6 +73,32 @@ test('rejects replayed nonces within the replay window', async () => {
   const replay = await verifyCtCveServiceRequest(request)
   assert.equal(replay.ok, false)
   assert.equal(!replay.ok && replay.error.code, 'replayed_nonce')
+})
+
+test('accepts connection-health requests with the connection read scope', async () => {
+  const result = await verifyCtCveServiceRequest({
+    method: 'GET',
+    path: '/api/integrations/ct-cve/v1/connection-health',
+    body: '',
+    headers: signedHeaders({
+      body: '',
+      nonce: 'nonce_connection_health',
+      signature: sign({
+        method: 'GET',
+        path: '/api/integrations/ct-cve/v1/connection-health',
+        timestamp: '2026-04-30T09:20:00.000Z',
+        nonce: 'nonce_connection_health',
+        bodyHash: sha256(''),
+      }),
+    }),
+    requiredScope: 'connection:read',
+    orgId: TOKEN.orgId,
+    now: new Date('2026-04-30T09:20:30.000Z'),
+    tokens: [TOKEN],
+    nonceStore: createInMemoryCtCveNonceStore(),
+  })
+
+  assert.equal(result.ok, true)
 })
 
 test('rejects stale timestamps', async () => {
@@ -182,7 +208,7 @@ test('parses configured CT-CVE service tokens and rejects weak secrets', () => {
       id: TOKEN.id,
       secret: TOKEN.secret,
       orgId: TOKEN.orgId,
-      scopes: ['findings:write', 'unsupported'],
+      scopes: ['findings:write', 'connection:read', 'unsupported'],
     },
   ]))
 

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -243,7 +243,7 @@ Update the status and notes in this table as work lands.
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
-| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, connection health, and the first CT-CVE finding batch ingestion endpoint. Inventory export and connection status persistence remain. |
+| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, connection health, the first CT-CVE finding batch ingestion endpoint, and signed CT Ops inventory snapshot export helpers. Connection status persistence and automated inventory push wiring remain. |
 | 10. Remove internal CT Ops CVE ownership | In progress | feat/remove-internal-cve-ownership | Removed ingest-owned vulnerability feed sync and host matching startup/config. CT Ops still retains imported finding storage/reporting and the legacy vulnerability settings surface until the connector status/inventory slices replace them. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
 
@@ -585,3 +585,10 @@ Append dated notes here as phases progress. Keep notes short and factual.
   `apps/ingest/internal/vuln` package. CT Ops still retains imported finding
   storage/reporting plus the legacy vulnerability settings page until CT-CVE
   connector inventory/status slices replace them.
+- Continued Phase 9 on branch `feat/ct-cve-inventory-export` by adding CT Ops
+  inventory snapshot export helpers that build org-scoped host/package payloads
+  from active hosts and current software packages, carry opaque pagination
+  cursors, and push snapshots to CT-CVE with the signed `inventory:write`
+  service-token contract. Also corrected CT Ops connection health to require
+  `connection:read`. Automated inventory push scheduling and durable
+  connection status timestamps remain.


### PR DESCRIPTION
## Summary
- add CT Ops CT-CVE inventory snapshot construction for active hosts and current software package rows
- add signed outbound snapshot push helper for the CT-CVE inventory endpoint
- require the intended connection:read scope for CT Ops connection health and update token docs/examples
- update migration/progress tracking for the Phase 9 inventory export slice

## Validation
- pnpm install --frozen-lockfile
- pnpm --dir apps/web run type-check
- pnpm --dir apps/web run test:unit
- pnpm --dir apps/web exec eslint lib/integrations/ct-cve/inventory-export.ts lib/integrations/ct-cve/inventory-export.test.mjs lib/integrations/ct-cve/service-token.test.mjs app/api/integrations/ct-cve/v1/connection-health/route.ts

## Remaining Phase 9 Work
- automated inventory push wiring after connector setup/software inventory changes
- durable CT-CVE connection status timestamps