### PR TITLE
feat(web): persist CT-CVE connection status

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 88 — CT-CVE durable connection status
+
+**CT-CVE connector status persistence** (`apps/web/lib/integrations/ct-cve/connection-status.ts`, `apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts`)
+- Added durable, org-scoped CT-CVE connector status persisted through `system_config`, including last inventory push, finding ingest, health check, and connector error timestamps.
+- Updated signed connection health to return and refresh the stored status instead of returning process-local placeholder timestamps.
+- Updated CT-CVE finding ingestion and inventory snapshot pushes to maintain the durable status and clear stale connector errors after successful data flow.
+
+**Validation**
+- Validation run: `pnpm install --frozen-lockfile`, targeted CT-CVE integration unit tests, `npm run type-check`, `npm run db:validate`, and `npm run test:unit` from `apps/web`.
+
 ### Session 87 — CT-CVE inventory export connector
 
 **CT-CVE outbound inventory snapshots** (`apps/web/lib/integrations/ct-cve/inventory-export.ts`)

--- a/apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts
+++ b/apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts
@@ -6,6 +6,7 @@ import {
   verifyCtCveServiceRequest,
   type CtCveServiceAuthError,
 } from '@/lib/integrations/ct-cve/service-token'
+import { recordCtCveConnectionHealth } from '@/lib/integrations/ct-cve/connection-status'
 
 export const dynamic = 'force-dynamic'
 
@@ -87,15 +88,6 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  return NextResponse.json({
-    contractVersion: '2026-04-30',
-    orgId: auth.token.orgId,
-    configured: true,
-    enabled: true,
-    lastInventoryPushAt: null,
-    lastFindingIngestAt: null,
-    lastHealthCheckAt: new Date().toISOString(),
-    lastErrorCode: null,
-    lastErrorAt: null,
-  })
+  const status = await recordCtCveConnectionHealth(auth.token.orgId)
+  return NextResponse.json(status)
 }

--- a/apps/web/app/api/integrations/ct-cve/v1/finding-batches/route.ts
+++ b/apps/web/app/api/integrations/ct-cve/v1/finding-batches/route.ts
@@ -10,6 +10,10 @@ import {
   CtCveFindingBatchValidationError,
   ingestCtCveFindingBatch,
 } from '@/lib/integrations/ct-cve/finding-ingest'
+import {
+  recordCtCveConnectionError,
+  recordCtCveFindingIngest,
+} from '@/lib/integrations/ct-cve/connection-status'
 
 export const dynamic = 'force-dynamic'
 
@@ -98,9 +102,11 @@ export async function POST(request: NextRequest) {
 
   try {
     const result = await ingestCtCveFindingBatch(payload)
+    await recordCtCveFindingIngest(auth.token.orgId)
     return NextResponse.json(result, { status: result.accepted ? 202 : 207 })
   } catch (error) {
     if (error instanceof CtCveFindingBatchValidationError) {
+      await recordCtCveConnectionError(auth.token.orgId, 'invalid_finding_batch')
       return errorResponse({
         code: 'invalid_payload',
         message: error.issues.join('; '),

--- a/apps/web/lib/integrations/ct-cve/connection-status.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/connection-status.test.mjs
@@ -1,0 +1,78 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  getCtCveConnectionStatus,
+  recordCtCveConnectionError,
+  recordCtCveConnectionHealth,
+  recordCtCveFindingIngest,
+  recordCtCveInventoryPush,
+} from './connection-status.ts'
+
+function repo(initial = null) {
+  let stored = initial
+  return {
+    repository: {
+      async get(orgId) {
+        assert.equal(orgId, 'org_1')
+        return stored
+      },
+      async save(status) {
+        assert.equal(status.orgId, 'org_1')
+        stored = status
+      },
+    },
+    stored: () => stored,
+  }
+}
+
+test('returns default CT-CVE connection status when no durable row exists', async () => {
+  const { repository } = repo()
+
+  const status = await getCtCveConnectionStatus('org_1', { configured: false, repository })
+
+  assert.deepEqual(status, {
+    contractVersion: '2026-04-30',
+    orgId: 'org_1',
+    configured: false,
+    enabled: true,
+    lastInventoryPushAt: null,
+    lastFindingIngestAt: null,
+    lastHealthCheckAt: null,
+    lastErrorCode: null,
+    lastErrorAt: null,
+  })
+})
+
+test('records health, finding ingest, inventory push, and clears stale errors on successful data flow', async () => {
+  const { repository, stored } = repo()
+
+  await recordCtCveConnectionHealth('org_1', {
+    repository,
+    now: new Date('2026-04-30T11:00:00.000Z'),
+  })
+  await recordCtCveConnectionError('org_1', 'inventory_push_failed', {
+    repository,
+    now: new Date('2026-04-30T11:01:00.000Z'),
+  })
+  await recordCtCveFindingIngest('org_1', {
+    repository,
+    now: new Date('2026-04-30T11:02:00.000Z'),
+  })
+  await recordCtCveInventoryPush('org_1', {
+    repository,
+    now: new Date('2026-04-30T11:03:00.000Z'),
+  })
+
+  assert.deepEqual(stored(), {
+    contractVersion: '2026-04-30',
+    orgId: 'org_1',
+    configured: true,
+    enabled: true,
+    lastInventoryPushAt: '2026-04-30T11:03:00.000Z',
+    lastFindingIngestAt: '2026-04-30T11:02:00.000Z',
+    lastHealthCheckAt: '2026-04-30T11:00:00.000Z',
+    lastErrorCode: null,
+    lastErrorAt: null,
+  })
+})

--- a/apps/web/lib/integrations/ct-cve/connection-status.ts
+++ b/apps/web/lib/integrations/ct-cve/connection-status.ts
@@ -1,0 +1,185 @@
+import { eq } from 'drizzle-orm'
+
+import type { Database } from '../../db/index.ts'
+import { systemConfig } from '../../db/schema/index.ts'
+
+export interface CtCveConnectionStatus {
+  contractVersion: '2026-04-30'
+  orgId: string
+  configured: boolean
+  enabled: boolean
+  lastInventoryPushAt: string | null
+  lastFindingIngestAt: string | null
+  lastHealthCheckAt: string | null
+  lastErrorCode: string | null
+  lastErrorAt: string | null
+}
+
+export interface CtCveConnectionStatusRepository {
+  get(orgId: string): Promise<CtCveConnectionStatus | null>
+  save(status: CtCveConnectionStatus): Promise<void>
+}
+
+const CONTRACT_VERSION = '2026-04-30'
+const CONFIG_KEY_PREFIX = 'ct_cve_connection_status:'
+
+function configKey(orgId: string) {
+  return `${CONFIG_KEY_PREFIX}${orgId}`
+}
+
+function emptyStatus(orgId: string, configured = true): CtCveConnectionStatus {
+  return {
+    contractVersion: CONTRACT_VERSION,
+    orgId,
+    configured,
+    enabled: true,
+    lastInventoryPushAt: null,
+    lastFindingIngestAt: null,
+    lastHealthCheckAt: null,
+    lastErrorCode: null,
+    lastErrorAt: null,
+  }
+}
+
+function parseStoredStatus(orgId: string, value: string): CtCveConnectionStatus | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<CtCveConnectionStatus>
+    if (!parsed || parsed.contractVersion !== CONTRACT_VERSION || parsed.orgId !== orgId) {
+      return null
+    }
+
+    return {
+      ...emptyStatus(orgId, parsed.configured ?? true),
+      ...parsed,
+      contractVersion: CONTRACT_VERSION,
+      orgId,
+      configured: parsed.configured ?? true,
+      enabled: parsed.enabled ?? true,
+    }
+  } catch {
+    return null
+  }
+}
+
+function iso(value: Date) {
+  return value.toISOString()
+}
+
+async function repository(options?: { repository?: CtCveConnectionStatusRepository }) {
+  return options?.repository ?? await getDefaultRepository()
+}
+
+export async function getCtCveConnectionStatus(
+  orgId: string,
+  options: { configured?: boolean; repository?: CtCveConnectionStatusRepository } = {},
+): Promise<CtCveConnectionStatus> {
+  const repo = await repository(options)
+  const stored = await repo.get(orgId)
+  return {
+    ...(stored ?? emptyStatus(orgId, options.configured ?? true)),
+    configured: options.configured ?? stored?.configured ?? true,
+  }
+}
+
+export async function recordCtCveConnectionHealth(
+  orgId: string,
+  options: { now?: Date; repository?: CtCveConnectionStatusRepository } = {},
+): Promise<CtCveConnectionStatus> {
+  const repo = await repository(options)
+  const current = await getCtCveConnectionStatus(orgId, { repository: repo })
+  const next = {
+    ...current,
+    configured: true,
+    enabled: true,
+    lastHealthCheckAt: iso(options.now ?? new Date()),
+  }
+  await repo.save(next)
+  return next
+}
+
+export async function recordCtCveFindingIngest(
+  orgId: string,
+  options: { now?: Date; repository?: CtCveConnectionStatusRepository } = {},
+): Promise<CtCveConnectionStatus> {
+  const repo = await repository(options)
+  const current = await getCtCveConnectionStatus(orgId, { repository: repo })
+  const next = {
+    ...current,
+    configured: true,
+    enabled: true,
+    lastFindingIngestAt: iso(options.now ?? new Date()),
+    lastErrorCode: null,
+    lastErrorAt: null,
+  }
+  await repo.save(next)
+  return next
+}
+
+export async function recordCtCveInventoryPush(
+  orgId: string,
+  options: { now?: Date; repository?: CtCveConnectionStatusRepository } = {},
+): Promise<CtCveConnectionStatus> {
+  const repo = await repository(options)
+  const current = await getCtCveConnectionStatus(orgId, { repository: repo })
+  const next = {
+    ...current,
+    configured: true,
+    enabled: true,
+    lastInventoryPushAt: iso(options.now ?? new Date()),
+    lastErrorCode: null,
+    lastErrorAt: null,
+  }
+  await repo.save(next)
+  return next
+}
+
+export async function recordCtCveConnectionError(
+  orgId: string,
+  errorCode: string,
+  options: { now?: Date; repository?: CtCveConnectionStatusRepository } = {},
+): Promise<CtCveConnectionStatus> {
+  const repo = await repository(options)
+  const current = await getCtCveConnectionStatus(orgId, { repository: repo })
+  const next = {
+    ...current,
+    configured: true,
+    enabled: true,
+    lastErrorCode: errorCode,
+    lastErrorAt: iso(options.now ?? new Date()),
+  }
+  await repo.save(next)
+  return next
+}
+
+async function getDefaultRepository(): Promise<CtCveConnectionStatusRepository> {
+  const { db: database } = await import('../../db/index.ts')
+  return createSystemConfigCtCveConnectionStatusRepository(database)
+}
+
+export function createSystemConfigCtCveConnectionStatusRepository(database: Database): CtCveConnectionStatusRepository {
+  return {
+    async get(orgId) {
+      const row = await database.query.systemConfig.findFirst({
+        where: eq(systemConfig.key, configKey(orgId)),
+        columns: { value: true },
+      })
+      return row ? parseStoredStatus(orgId, row.value) : null
+    },
+    async save(status) {
+      await database
+        .insert(systemConfig)
+        .values({
+          key: configKey(status.orgId),
+          value: JSON.stringify(status),
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: systemConfig.key,
+          set: {
+            value: JSON.stringify(status),
+            updatedAt: new Date(),
+          },
+        })
+    },
+  }
+}

--- a/apps/web/lib/integrations/ct-cve/inventory-export.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/inventory-export.test.mjs
@@ -104,6 +104,23 @@ function repo() {
   }
 }
 
+function statusRepo() {
+  let stored = null
+  return {
+    repository: {
+      async get(orgId) {
+        assert.equal(orgId, 'org_1')
+        return stored
+      },
+      async save(status) {
+        assert.equal(status.orgId, 'org_1')
+        stored = status
+      },
+    },
+    stored: () => stored,
+  }
+}
+
 test('builds an org-scoped CT-CVE inventory snapshot without deleted or removed rows', async () => {
   const snapshot = await buildCtCveInventorySnapshot({
     orgId: 'org_1',
@@ -157,12 +174,14 @@ test('pushes a snapshot to CT-CVE with the inventory service-token signature', a
   })
 
   let captured
+  const status = statusRepo()
   const result = await pushCtCveInventorySnapshot({
     baseUrl: 'https://ct-cve.example.invalid',
     token,
     snapshot,
     nonce: 'nonce_inventory_1',
     timestamp: '2026-04-30T10:16:00.000Z',
+    statusRepository: status.repository,
     fetchImpl: async (url, init) => {
       captured = { url, init }
       return new Response(JSON.stringify({
@@ -192,4 +211,26 @@ test('pushes a snapshot to CT-CVE with the inventory service-token signature', a
     ].join('\n'))
     .digest('base64url')
   assert.equal(captured.init.headers['x-ct-signature'], `v1=${expectedSignature}`)
+  assert.equal(status.stored().lastInventoryPushAt.length, '2026-04-30T10:16:00.000Z'.length)
+  assert.equal(status.stored().lastErrorCode, null)
+})
+
+test('records a CT-CVE inventory connection error when the push fails', async () => {
+  const snapshot = await buildCtCveInventorySnapshot({
+    orgId: 'org_1',
+    repository: repo(),
+    generatedAt,
+  })
+  const status = statusRepo()
+
+  await assert.rejects(() => pushCtCveInventorySnapshot({
+    baseUrl: 'https://ct-cve.example.invalid',
+    token,
+    snapshot,
+    statusRepository: status.repository,
+    fetchImpl: async () => new Response(JSON.stringify({ error: 'unavailable' }), { status: 503 }),
+  }), /HTTP 503/)
+
+  assert.equal(status.stored().lastErrorCode, 'inventory_push_failed')
+  assert.equal(status.stored().lastErrorAt.length, '2026-04-30T10:16:00.000Z'.length)
 })

--- a/apps/web/lib/integrations/ct-cve/inventory-export.ts
+++ b/apps/web/lib/integrations/ct-cve/inventory-export.ts
@@ -2,6 +2,11 @@ import { createHash, createHmac, randomUUID } from 'node:crypto'
 
 import type { Database } from '../../db/index.ts'
 import type { PackageSource } from '../../db/schema/software.ts'
+import {
+  recordCtCveConnectionError,
+  recordCtCveInventoryPush,
+  type CtCveConnectionStatusRepository,
+} from './connection-status.ts'
 
 export interface CtCveInventoryHostRecord {
   id: string
@@ -235,6 +240,7 @@ export async function pushCtCveInventorySnapshot(options: {
   nonce?: string
   timestamp?: string
   fetchImpl?: typeof fetch
+  statusRepository?: CtCveConnectionStatusRepository
 }): Promise<CtCveInventoryPushResult> {
   if (options.token.orgId !== options.snapshot.orgId || !options.token.scopes.includes('inventory:write')) {
     throw new Error('CT-CVE inventory token is not scoped to this snapshot')
@@ -264,8 +270,14 @@ export async function pushCtCveInventorySnapshot(options: {
 
   const payload = await response.json().catch(() => null) as CtCveInventoryPushResult | null
   if (!response.ok || !payload || typeof payload.accepted !== 'boolean') {
+    await recordCtCveConnectionError(options.snapshot.orgId, 'inventory_push_failed', {
+      repository: options.statusRepository,
+    })
     throw new Error(`CT-CVE inventory snapshot push failed with HTTP ${response.status}`)
   }
+  await recordCtCveInventoryPush(options.snapshot.orgId, {
+    repository: options.statusRepository,
+  })
   return payload
 }
 

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -243,7 +243,7 @@ Update the status and notes in this table as work lands.
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
-| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, connection health, the first CT-CVE finding batch ingestion endpoint, and signed CT Ops inventory snapshot export helpers. Connection status persistence and automated inventory push wiring remain. |
+| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, and signed CT Ops inventory snapshot export helpers. Automated inventory push wiring remains. |
 | 10. Remove internal CT Ops CVE ownership | In progress | feat/remove-internal-cve-ownership | Removed ingest-owned vulnerability feed sync and host matching startup/config. CT Ops still retains imported finding storage/reporting and the legacy vulnerability settings surface until the connector status/inventory slices replace them. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
 
@@ -592,3 +592,10 @@ Append dated notes here as phases progress. Keep notes short and factual.
   service-token contract. Also corrected CT Ops connection health to require
   `connection:read`. Automated inventory push scheduling and durable
   connection status timestamps remain.
+- Continued Phase 9 on branch `feat/ct-cve-connection-status` by adding
+  durable org-scoped CT-CVE connector status in `system_config`. Signed
+  connection health now records and returns persisted status, finding ingestion
+  records last ingest time, inventory pushes record success/failure state, and
+  successful data flow clears stale connector errors. Automated inventory push
+  scheduling remains. Validation: CT-CVE integration unit tests, web
+  type-check, migration validation, and web unit suite.


### PR DESCRIPTION
## Summary
- add durable org-scoped CT-CVE connection status persisted in system_config
- return persisted status from signed connection health checks
- update finding ingest and inventory push flows to record connector success/error timestamps
- update migration plan and progress notes for Phase 9

## Validation
- pnpm install --frozen-lockfile
- node --experimental-strip-types --test lib/integrations/ct-cve/connection-status.test.mjs lib/integrations/ct-cve/inventory-export.test.mjs lib/integrations/ct-cve/finding-ingest.test.mjs
- npm run type-check
- npm run db:validate
- npm run lint -- app/api/integrations/ct-cve/v1/connection-health/route.ts app/api/integrations/ct-cve/v1/finding-batches/route.ts lib/integrations/ct-cve/connection-status.ts lib/integrations/ct-cve/inventory-export.ts
- npm run test:unit

Remaining Phase 9 work: automated CT-CVE inventory push scheduling.