### PR TITLE
fix(web): prevent stale auth redirect loops

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 89 — Auth redirect loop hardening
+
+**Stale session redirect handling** (`apps/web/lib/auth/redirects.ts`, `apps/web/lib/auth/session.ts`, `apps/web/app/(auth)/login/page.tsx`)
+- Fixed a stale/invalid auth-state redirect loop where a protected route could send the browser to `/login` while the auth page immediately sent session-looking state back to `/dashboard`.
+- Protected-page session rejection now redirects to `/login?session=expired`, and auth pages bypass their authenticated redirect on that explicit expired-session path.
+- Shared auth-page redirect decisions now require an active, non-deleted user before redirecting away from login/register.
+
+**Validation**
+- Validation run: `pnpm install --frozen-lockfile`, targeted auth redirect unit test, `npm run type-check`, targeted ESLint for changed auth files, and `npm run test:unit` from `apps/web`.
+
 ### Session 88 — CT-CVE durable connection status
 
 **CT-CVE connector status persistence** (`apps/web/lib/integrations/ct-cve/connection-status.ts`, `apps/web/app/api/integrations/ct-cve/v1/connection-health/route.ts`)

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -7,6 +7,10 @@ import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { LoginForm } from './login-form'
 import { hasLdapLoginEnabled } from '@/lib/actions/ldap'
+import {
+  getAuthenticatedRedirectPath,
+  shouldBypassAuthenticatedRedirect,
+} from '@/lib/auth/redirects'
 
 export const metadata: Metadata = {
   title: 'Sign in',
@@ -24,9 +28,10 @@ function readParam(value: string | string[] | undefined): string | null {
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = await searchParams
   const session = await auth.api.getSession({ headers: await headers() })
-  if (session) {
+  if (session && !shouldBypassAuthenticatedRedirect(params)) {
     const user = await db.query.users.findFirst({ where: eq(users.id, session.user.id) })
-    redirect(user?.organisationId ? '/dashboard' : '/onboarding')
+    const redirectPath = getAuthenticatedRedirectPath(user)
+    if (redirectPath) redirect(redirectPath)
   }
 
   const ldapEnabled = await hasLdapLoginEnabled()

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -7,6 +7,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { getRequireEmailVerification } from '@/lib/auth/env'
+import { getAuthenticatedRedirectPath } from '@/lib/auth/redirects'
 import { RegisterForm } from './register-form'
 
 export const metadata: Metadata = {
@@ -17,7 +18,8 @@ export default async function RegisterPage() {
   const session = await auth.api.getSession({ headers: await headers() })
   if (session) {
     const user = await db.query.users.findFirst({ where: eq(users.id, session.user.id) })
-    redirect(user?.organisationId ? '/dashboard' : '/onboarding')
+    const redirectPath = getAuthenticatedRedirectPath(user)
+    if (redirectPath) redirect(redirectPath)
   }
 
   return (

--- a/apps/web/lib/auth/redirects.test.mjs
+++ b/apps/web/lib/auth/redirects.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  EXPIRED_SESSION_LOGIN_PATH,
+  getAuthenticatedRedirectPath,
+  shouldBypassAuthenticatedRedirect,
+} from './redirects.ts'
+
+test('authenticated redirect only accepts active non-deleted users', () => {
+  assert.equal(getAuthenticatedRedirectPath({
+    organisationId: 'org_1',
+    isActive: true,
+    deletedAt: null,
+  }), '/dashboard')
+
+  assert.equal(getAuthenticatedRedirectPath({
+    organisationId: null,
+    isActive: true,
+    deletedAt: null,
+  }), '/onboarding')
+
+  assert.equal(getAuthenticatedRedirectPath({
+    organisationId: 'org_1',
+    isActive: false,
+    deletedAt: null,
+  }), null)
+
+  assert.equal(getAuthenticatedRedirectPath({
+    organisationId: 'org_1',
+    isActive: true,
+    deletedAt: new Date('2026-04-30T12:00:00.000Z'),
+  }), null)
+})
+
+test('expired session login state bypasses auth-page redirect loops', () => {
+  assert.equal(EXPIRED_SESSION_LOGIN_PATH, '/login?session=expired')
+  assert.equal(shouldBypassAuthenticatedRedirect({ session: 'expired' }), true)
+  assert.equal(shouldBypassAuthenticatedRedirect({ session: ['expired'] }), true)
+  assert.equal(shouldBypassAuthenticatedRedirect({ session: 'fresh' }), false)
+  assert.equal(shouldBypassAuthenticatedRedirect({}), false)
+})

--- a/apps/web/lib/auth/redirects.ts
+++ b/apps/web/lib/auth/redirects.ts
@@ -1,0 +1,19 @@
+import type { User } from '@/lib/db/schema'
+
+type RedirectUser = Pick<User, 'organisationId' | 'isActive' | 'deletedAt'>
+
+export const EXPIRED_SESSION_LOGIN_PATH = '/login?session=expired'
+
+export function shouldBypassAuthenticatedRedirect(searchParams: Record<string, string | string[] | undefined>): boolean {
+  const value = searchParams.session
+  const session = Array.isArray(value) ? value[0] : value
+  return session === 'expired'
+}
+
+export function getAuthenticatedRedirectPath(user: RedirectUser | null | undefined): '/dashboard' | '/onboarding' | null {
+  if (!user?.isActive || user.deletedAt) {
+    return null
+  }
+
+  return user.organisationId ? '/dashboard' : '/onboarding'
+}

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -6,6 +6,7 @@ import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import type { User } from '@/lib/db/schema'
 import { requireActiveUser, requireOrgAdmin } from './guards'
+import { EXPIRED_SESSION_LOGIN_PATH } from './redirects'
 import { getPrimaryRole, normalizeAssignedRoles } from './roles'
 
 // Re-export User as SessionUser for convenience
@@ -64,12 +65,12 @@ async function loadSessionWithUser(requestHeaders: Headers): Promise<RequiredSes
 
 export async function getRequiredSession(): Promise<RequiredSession> {
   const session = await loadSessionWithUser(await headers())
-  if (!session) redirect('/login')
+  if (!session) redirect(EXPIRED_SESSION_LOGIN_PATH)
 
   try {
     requireActiveUser(session.user)
   } catch {
-    redirect('/login')
+    redirect(EXPIRED_SESSION_LOGIN_PATH)
   }
 
   return session


### PR DESCRIPTION
## Summary
- prevent protected-page auth rejection from bouncing into the normal authenticated login redirect
- add an explicit expired-session login URL that renders the login form instead of immediately returning to the dashboard
- centralize auth-page redirect decisions so only active, non-deleted users are redirected away from login/register

## Investigation
- normal browser logs showed repeated /login -> /dashboard -> /login 307 responses
- private browsing worked and clean curl requests stopped at /login, pointing to stale browser auth state rather than CT-CVE migration code
- Browser Use could not open the HTTPS target because the local self-signed cert produced ERR_CERT_AUTHORITY_INVALID, and I did not bypass the browser safety interstitial

## Validation
- pnpm install --frozen-lockfile
- node --experimental-strip-types --test lib/auth/redirects.test.mjs
- npm run type-check
- npm run lint -- 'app/(auth)/login/page.tsx' 'app/(auth)/register/page.tsx' lib/auth/session.ts lib/auth/redirects.ts
- npm run test:unit