### PR TITLE
fix(web): recognise secure auth session cookies

### DIFF
--- a/apps/web/lib/auth/session-cookie-names.test.mjs
+++ b/apps/web/lib/auth/session-cookie-names.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  SESSION_COOKIE_NAMES,
+  hasBetterAuthSessionCookie,
+} from './session-cookie-names.ts'
+
+function cookies(names) {
+  const values = new Map(names.map((name) => [name, { name, value: 'token' }]))
+  return {
+    get(name) {
+      return values.get(name)
+    },
+  }
+}
+
+test('proxy recognises Better Auth session cookie variants', () => {
+  assert.deepEqual(SESSION_COOKIE_NAMES, [
+    'better-auth.session_token',
+    '__Secure-better-auth.session_token',
+    '__Host-better-auth.session_token',
+  ])
+
+  assert.equal(hasBetterAuthSessionCookie(cookies(['better-auth.session_token'])), true)
+  assert.equal(hasBetterAuthSessionCookie(cookies(['__Secure-better-auth.session_token'])), true)
+  assert.equal(hasBetterAuthSessionCookie(cookies(['__Host-better-auth.session_token'])), true)
+  assert.equal(hasBetterAuthSessionCookie(cookies(['other'])), false)
+})

--- a/apps/web/lib/auth/session-cookie-names.ts
+++ b/apps/web/lib/auth/session-cookie-names.ts
@@ -1,0 +1,13 @@
+export const SESSION_COOKIE_NAMES = [
+  'better-auth.session_token',
+  '__Secure-better-auth.session_token',
+  '__Host-better-auth.session_token',
+] as const
+
+type CookieReader = {
+  get(name: string): { value?: string } | undefined
+}
+
+export function hasBetterAuthSessionCookie(cookies: CookieReader): boolean {
+  return SESSION_COOKIE_NAMES.some((name) => !!cookies.get(name)?.value)
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-
-// Cookie set by Better Auth on sign-in
-const SESSION_COOKIE = 'better-auth.session_token'
+import { hasBetterAuthSessionCookie } from '@/lib/auth/session-cookie-names'
 
 const AUTH_ROUTES = ['/login', '/register']
 
@@ -40,8 +38,7 @@ function checkAuthRateLimit(ip: string, now = Date.now()): boolean {
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
-  const sessionToken = request.cookies.get(SESSION_COOKIE)?.value
-  const isAuthenticated = !!sessionToken
+  const isAuthenticated = hasBetterAuthSessionCookie(request.cookies)
 
   const isAuthRoute = AUTH_ROUTES.some((r) => pathname.startsWith(r))
   const isProtectedRoute = PROTECTED_PATHS.some(


### PR DESCRIPTION
## Summary
- make the Next proxy recognise Better Auth secure session cookie variants
- move session cookie-name handling into a tested helper
- add focused coverage for unprefixed, `__Secure-`, and `__Host-` session cookies

## Root cause
In HTTPS production-like runs, Better Auth can set a secure-prefixed session cookie such as `__Secure-better-auth.session_token`. The login page asks Better Auth directly and treats that cookie as authenticated, redirecting `/login` to `/dashboard`. The Next proxy only checked `better-auth.session_token`, so it treated `/dashboard` as unauthenticated and redirected back to `/login`, causing a browser redirect loop.

## Validation
- `node --experimental-strip-types --test lib/auth/session-cookie-names.test.mjs`
- `npm run lint -- proxy.ts lib/auth/session-cookie-names.ts lib/auth/session-cookie-names.test.mjs`
- `npm run type-check`
- Docker production build of `ct-ops-web-local`
- Browser verification with `@browser-use`: `http://localhost:3000/dashboard` loads `Overview | CT-Ops` after sign-in
