### PR TITLE
feat(web): schedule CT-CVE inventory pushes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,13 @@ INGEST_WS_URL=
 # CT_CVE_SERVICE_TOKENS=[{"id":"ctcve_prod_1","secret":"...","orgId":"org_...","scopes":["findings:write","connection:read"]}]
 # CT_CVE_SERVICE_TOKENS=
 
+# CT-CVE outbound inventory push targets. Configure one entry per organisation
+# and run `pnpm --dir apps/web ct-cve:push-inventory` from cron/systemd/Kubernetes
+# on the desired cadence. Each token must be scoped to `inventory:write` in
+# CT-CVE and contain at least 32 random bytes.
+# CT_CVE_INVENTORY_PUSH_TARGETS=[{"name":"prod","baseUrl":"https://ct-cve.example.com","token":{"id":"ctops_inventory_1","secret":"...","orgId":"org_...","scopes":["inventory:write"]}}]
+# CT_CVE_INVENTORY_PUSH_TARGETS=
+
 # Feed sync, NVD/CISA enrichment, and Linux package matching now run in CT-CVE.
 # CT Ops only accepts imported findings through the signed connector endpoints.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 90 — CT-CVE inventory push scheduling
+
+**CT-CVE outbound inventory push job** (`apps/web/lib/integrations/ct-cve/inventory-push-job.ts`, `apps/web/scripts/push-ct-cve-inventory.mjs`)
+- Added env-configured CT-CVE inventory push targets for outbound `inventory:write` tokens.
+- Added a reusable push job that builds paged full inventory snapshots, signs and pushes every page to CT-CVE, accumulates accepted row counts, and reports per-target failures without stopping later targets.
+- Added the `ct-cve:push-inventory` web package script so operators can run the push job from cron, systemd timers, or Kubernetes CronJobs.
+
+**Validation**
+- Validation run: targeted inventory push job unit test, CT-CVE integration unit tests, targeted ESLint, `pnpm --dir apps/web type-check`, `pnpm --dir apps/web db:validate`, `pnpm --dir apps/web test:unit`, and a no-target `pnpm --dir apps/web ct-cve:push-inventory` smoke test.
+
 ### Session 89 — Auth redirect loop hardening
 
 **Stale session redirect handling** (`apps/web/lib/auth/redirects.ts`, `apps/web/lib/auth/session.ts`, `apps/web/app/(auth)/login/page.tsx`)

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -23,6 +23,7 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `INGEST_WS_URL` | — | *(empty)* | WebSocket URL of the ingest service. Empty = same-origin via the bundled nginx (recommended). Set to an absolute `wss://` URL only to bypass the bundled proxy |
 | `WEB_TLS_CERT` | — | `/var/lib/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. The enrolment bundle route reads this file and embeds it so agents can verify the HTTPS download URL |
 | `CT_CVE_SERVICE_TOKENS` | — 🔒 | *(empty)* | JSON allow-list of signed CT-CVE service tokens that can deliver findings or call CT Ops connection health; use `findings:write` and `connection:read` scopes for the initial inbound connector |
+| `CT_CVE_INVENTORY_PUSH_TARGETS` | — 🔒 | *(empty)* | JSON list of outbound CT-CVE inventory targets. Each entry contains `name`, `baseUrl`, and a token object with `id`, `secret`, `orgId`, and `scopes:["inventory:write"]`; schedule `pnpm --dir apps/web ct-cve:push-inventory` to send snapshots |
 
 ### Licence verification
 

--- a/apps/web/lib/integrations/ct-cve/inventory-push-job.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/inventory-push-job.test.mjs
@@ -1,0 +1,167 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  parseCtCveInventoryPushTargets,
+  runCtCveInventoryPushes,
+} from './inventory-push-job.ts'
+
+const token = {
+  id: 'ctops_inventory_token',
+  secret: Buffer.from('ct-ops outbound inventory signing key only').toString('base64url'),
+  orgId: 'org_1',
+  scopes: ['inventory:write'],
+}
+
+test('parses enabled CT-CVE inventory push targets', () => {
+  const targets = parseCtCveInventoryPushTargets(JSON.stringify([
+    {
+      name: 'prod',
+      baseUrl: 'https://ct-cve.example.invalid/',
+      token,
+    },
+    {
+      name: 'disabled',
+      enabled: false,
+      baseUrl: 'https://disabled.example.invalid',
+      token: { ...token, id: 'disabled_token' },
+    },
+  ]))
+
+  assert.equal(targets.length, 1)
+  assert.equal(targets[0].name, 'prod')
+  assert.equal(targets[0].baseUrl, 'https://ct-cve.example.invalid')
+  assert.equal(targets[0].token.id, 'ctops_inventory_token')
+})
+
+test('rejects malformed CT-CVE inventory push targets', () => {
+  assert.throws(
+    () => parseCtCveInventoryPushTargets(JSON.stringify([
+      {
+        name: 'bad',
+        baseUrl: 'not a url',
+        token: { ...token, secret: 'short' },
+      },
+    ])),
+    /CT_CVE_INVENTORY_PUSH_TARGETS\[0\]/,
+  )
+})
+
+test('pushes every paged inventory snapshot for configured targets', async () => {
+  const snapshots = []
+  const pushes = []
+  const statusRepository = {
+    async get() {
+      return null
+    },
+    async save() {},
+  }
+
+  const result = await runCtCveInventoryPushes({
+    targets: [{
+      name: 'prod',
+      enabled: true,
+      baseUrl: 'https://ct-cve.example.invalid',
+      token,
+    }],
+    buildSnapshot: async ({ orgId, cursor, snapshotType }) => {
+      snapshots.push({ orgId, cursor, snapshotType })
+      return {
+        contractVersion: '2026-04-30',
+        orgId,
+        orgSlug: 'acme',
+        snapshotId: cursor ? 'snapshot_page_2' : 'snapshot_page_1',
+        snapshotType,
+        generatedAt: '2026-04-30T10:00:00.000Z',
+        cursor: cursor ? null : 'next-page',
+        hosts: cursor ? [] : [{ hostId: 'host_1' }],
+        packages: cursor ? [{ softwarePackageId: 'pkg_2' }] : [{ softwarePackageId: 'pkg_1' }],
+      }
+    },
+    pushSnapshot: async ({ baseUrl, token: pushToken, snapshot }) => {
+      pushes.push({ baseUrl, token: pushToken, snapshot })
+      return {
+        accepted: true,
+        snapshotId: snapshot.snapshotId,
+        hostsAccepted: snapshot.hosts.length,
+        packagesAccepted: snapshot.packages.length,
+        rowsRejected: 0,
+        nextAction: 'none',
+      }
+    },
+    statusRepository,
+  })
+
+  assert.deepEqual(snapshots, [
+    { orgId: 'org_1', cursor: undefined, snapshotType: 'full' },
+    { orgId: 'org_1', cursor: 'next-page', snapshotType: 'full' },
+  ])
+  assert.equal(pushes.length, 2)
+  assert.equal(pushes[0].baseUrl, 'https://ct-cve.example.invalid')
+  assert.equal(pushes[0].token.id, token.id)
+  assert.deepEqual(result, {
+    targetsConfigured: 1,
+    targetsPushed: 1,
+    snapshotsPushed: 2,
+    hostsAccepted: 1,
+    packagesAccepted: 2,
+    rowsRejected: 0,
+    failures: [],
+  })
+})
+
+test('reports target failures without stopping later targets', async () => {
+  const result = await runCtCveInventoryPushes({
+    targets: [
+      {
+        name: 'broken',
+        enabled: true,
+        baseUrl: 'https://broken.example.invalid',
+        token,
+      },
+      {
+        name: 'prod',
+        enabled: true,
+        baseUrl: 'https://ct-cve.example.invalid',
+        token: { ...token, id: 'ctops_inventory_token_2' },
+      },
+    ],
+    buildSnapshot: async ({ orgId }) => ({
+      contractVersion: '2026-04-30',
+      orgId,
+      orgSlug: 'acme',
+      snapshotId: 'snapshot',
+      snapshotType: 'full',
+      generatedAt: '2026-04-30T10:00:00.000Z',
+      cursor: null,
+      hosts: [],
+      packages: [],
+    }),
+    pushSnapshot: async ({ token: pushToken }) => {
+      if (pushToken.id === 'ctops_inventory_token') {
+        throw new Error('upstream unavailable')
+      }
+      return {
+        accepted: true,
+        snapshotId: 'snapshot',
+        hostsAccepted: 0,
+        packagesAccepted: 0,
+        rowsRejected: 0,
+        nextAction: 'none',
+      }
+    },
+    statusRepository: {
+      async get() {
+        return null
+      },
+      async save() {},
+    },
+  })
+
+  assert.equal(result.targetsConfigured, 2)
+  assert.equal(result.targetsPushed, 1)
+  assert.equal(result.snapshotsPushed, 1)
+  assert.equal(result.failures.length, 1)
+  assert.equal(result.failures[0].target, 'broken')
+  assert.match(result.failures[0].message, /upstream unavailable/)
+})

--- a/apps/web/lib/integrations/ct-cve/inventory-push-job.ts
+++ b/apps/web/lib/integrations/ct-cve/inventory-push-job.ts
@@ -1,0 +1,216 @@
+import {
+  buildCtCveInventorySnapshot,
+  pushCtCveInventorySnapshot,
+  type CtCveInventoryPushResult,
+  type CtCveInventorySnapshot,
+} from './inventory-export.ts'
+import type { CtCveConnectionStatusRepository } from './connection-status.ts'
+
+export interface CtCveInventoryPushTarget {
+  name: string
+  enabled: boolean
+  baseUrl: string
+  token: {
+    id: string
+    secret: string
+    orgId: string
+    scopes: string[]
+  }
+}
+
+export interface CtCveInventoryPushJobResult {
+  targetsConfigured: number
+  targetsPushed: number
+  snapshotsPushed: number
+  hostsAccepted: number
+  packagesAccepted: number
+  rowsRejected: number
+  failures: Array<{
+    target: string
+    message: string
+  }>
+}
+
+interface BuildSnapshotOptions {
+  orgId: string
+  cursor?: string
+  snapshotType: 'full'
+}
+
+type BuildSnapshot = (options: BuildSnapshotOptions) => Promise<CtCveInventorySnapshot>
+type PushSnapshot = (options: {
+  baseUrl: string
+  token: CtCveInventoryPushTarget['token']
+  snapshot: CtCveInventorySnapshot
+  statusRepository?: CtCveConnectionStatusRepository
+}) => Promise<CtCveInventoryPushResult>
+
+const DEFAULT_MAX_PAGES_PER_TARGET = 1_000
+const SECRET_MIN_BYTES = 32
+
+function normaliseBaseUrl(value: string, path: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${path}.baseUrl must be an absolute http(s) URL`)
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`${path}.baseUrl must be an absolute http(s) URL`)
+  }
+  url.pathname = url.pathname.replace(/\/+$/, '')
+  url.search = ''
+  url.hash = ''
+  return url.toString().replace(/\/$/, '')
+}
+
+function secretHasEnoughEntropy(value: string): boolean {
+  if (Buffer.byteLength(value, 'utf8') >= SECRET_MIN_BYTES) {
+    return true
+  }
+  try {
+    return Buffer.from(value, 'base64url').byteLength >= SECRET_MIN_BYTES
+  } catch {
+    return false
+  }
+}
+
+export function parseCtCveInventoryPushTargets(value: string | undefined): CtCveInventoryPushTarget[] {
+  if (!value?.trim()) {
+    return []
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    throw new Error('CT_CVE_INVENTORY_PUSH_TARGETS must be valid JSON')
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('CT_CVE_INVENTORY_PUSH_TARGETS must be a JSON array')
+  }
+
+  const targets = parsed.map((entry, index) => {
+    const path = `CT_CVE_INVENTORY_PUSH_TARGETS[${index}]`
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`${path} must be an object`)
+    }
+
+    const record = entry as Record<string, unknown>
+    const token = record.token
+    if (!token || typeof token !== 'object') {
+      throw new Error(`${path}.token must be an object`)
+    }
+    const tokenRecord = token as Record<string, unknown>
+    const scopes = Array.isArray(tokenRecord.scopes)
+      ? tokenRecord.scopes.filter((scope): scope is string => typeof scope === 'string')
+      : []
+
+    if (
+      typeof record.name !== 'string' ||
+      !record.name.trim() ||
+      typeof record.baseUrl !== 'string' ||
+      typeof tokenRecord.id !== 'string' ||
+      !tokenRecord.id.trim() ||
+      typeof tokenRecord.secret !== 'string' ||
+      typeof tokenRecord.orgId !== 'string' ||
+      !tokenRecord.orgId.trim()
+    ) {
+      throw new Error(`${path} is missing name, baseUrl, token.id, token.secret, or token.orgId`)
+    }
+    if (!secretHasEnoughEntropy(tokenRecord.secret)) {
+      throw new Error(`${path}.token.secret must contain at least 32 bytes of entropy`)
+    }
+    if (!scopes.includes('inventory:write')) {
+      throw new Error(`${path}.token.scopes must include inventory:write`)
+    }
+
+    return {
+      name: record.name.trim(),
+      enabled: record.enabled !== false,
+      baseUrl: normaliseBaseUrl(record.baseUrl, path),
+      token: {
+        id: tokenRecord.id.trim(),
+        secret: tokenRecord.secret,
+        orgId: tokenRecord.orgId.trim(),
+        scopes,
+      },
+    }
+  })
+
+  return targets.filter((target) => target.enabled)
+}
+
+export function getConfiguredCtCveInventoryPushTargets(
+  env: NodeJS.ProcessEnv = process.env,
+): CtCveInventoryPushTarget[] {
+  return parseCtCveInventoryPushTargets(env.CT_CVE_INVENTORY_PUSH_TARGETS)
+}
+
+export async function runCtCveInventoryPushes(options: {
+  targets?: CtCveInventoryPushTarget[]
+  env?: NodeJS.ProcessEnv
+  buildSnapshot?: BuildSnapshot
+  pushSnapshot?: PushSnapshot
+  statusRepository?: CtCveConnectionStatusRepository
+  maxPagesPerTarget?: number
+} = {}): Promise<CtCveInventoryPushJobResult> {
+  const targets = options.targets ?? getConfiguredCtCveInventoryPushTargets(options.env)
+  const buildSnapshot = options.buildSnapshot ?? ((snapshotOptions) => buildCtCveInventorySnapshot(snapshotOptions))
+  const pushSnapshot = options.pushSnapshot ?? pushCtCveInventorySnapshot
+  const maxPagesPerTarget = Math.max(1, options.maxPagesPerTarget ?? DEFAULT_MAX_PAGES_PER_TARGET)
+  const result: CtCveInventoryPushJobResult = {
+    targetsConfigured: targets.length,
+    targetsPushed: 0,
+    snapshotsPushed: 0,
+    hostsAccepted: 0,
+    packagesAccepted: 0,
+    rowsRejected: 0,
+    failures: [],
+  }
+
+  for (const target of targets) {
+    let cursor: string | undefined
+    let page = 0
+    let pushedForTarget = false
+
+    try {
+      do {
+        if (page >= maxPagesPerTarget) {
+          throw new Error(`CT-CVE inventory push exceeded ${maxPagesPerTarget} pages for target ${target.name}`)
+        }
+
+        const snapshot = await buildSnapshot({
+          orgId: target.token.orgId,
+          cursor,
+          snapshotType: 'full',
+        })
+        const pushed = await pushSnapshot({
+          baseUrl: target.baseUrl,
+          token: target.token,
+          snapshot,
+          statusRepository: options.statusRepository,
+        })
+        result.snapshotsPushed += 1
+        result.hostsAccepted += pushed.hostsAccepted
+        result.packagesAccepted += pushed.packagesAccepted
+        result.rowsRejected += pushed.rowsRejected
+        pushedForTarget = true
+        cursor = snapshot.cursor ?? undefined
+        page += 1
+      } while (cursor)
+
+      if (pushedForTarget) {
+        result.targetsPushed += 1
+      }
+    } catch (error) {
+      result.failures.push({
+        target: target.name,
+        message: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return result
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
+    "ct-cve:push-inventory": "node --experimental-strip-types scripts/push-ct-cve-inventory.mjs",
     "test:e2e": "node tests/e2e/runner.mjs",
     "test:e2e:no-email-verification": "REQUIRE_EMAIL_VERIFICATION=false node tests/e2e/runner.mjs tests/e2e/auth/register.spec.ts",
     "test:e2e:ui": "node tests/e2e/runner.mjs --ui",

--- a/apps/web/scripts/push-ct-cve-inventory.mjs
+++ b/apps/web/scripts/push-ct-cve-inventory.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { runCtCveInventoryPushes } from '../lib/integrations/ct-cve/inventory-push-job.ts'
+
+const result = await runCtCveInventoryPushes()
+
+console.log(JSON.stringify(result, null, 2))
+
+if (result.failures.length > 0) {
+  process.exitCode = 1
+}

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -243,7 +243,7 @@ Update the status and notes in this table as work lands.
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
-| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, and signed CT Ops inventory snapshot export helpers. Automated inventory push wiring remains. |
+| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, and an env-configured scheduled inventory push job. CT Ops connector setup UI remains. |
 | 10. Remove internal CT Ops CVE ownership | In progress | feat/remove-internal-cve-ownership | Removed ingest-owned vulnerability feed sync and host matching startup/config. CT Ops still retains imported finding storage/reporting and the legacy vulnerability settings surface until the connector status/inventory slices replace them. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
 
@@ -599,3 +599,12 @@ Append dated notes here as phases progress. Keep notes short and factual.
   successful data flow clears stale connector errors. Automated inventory push
   scheduling remains. Validation: CT-CVE integration unit tests, web
   type-check, migration validation, and web unit suite.
+- Continued Phase 9 on branch `feat/ct-cve-next-task` by adding an
+  env-configured CT-CVE inventory push job and `ct-cve:push-inventory` web
+  package script for cron/systemd/Kubernetes scheduling. The job validates
+  outbound target configuration, pages full inventory snapshots until complete,
+  signs each snapshot with the `inventory:write` token, accumulates accepted
+  counts, and reports per-target failures without stopping later targets.
+  Connector setup UI remains. Validation: targeted inventory push job unit
+  test, CT-CVE integration unit tests, web type-check, migration validation,
+  full web unit suite, targeted ESLint, and a no-target script smoke test.


### PR DESCRIPTION
## Summary
- add env-configured CT-CVE inventory push targets for outbound inventory:write tokens
- add a reusable paged inventory push job and ct-cve:push-inventory script for cron/systemd/Kubernetes scheduling
- document the new outbound config and update migration/progress tracking

## Validation
- node --experimental-strip-types --test apps/web/lib/integrations/ct-cve/inventory-push-job.test.mjs apps/web/lib/integrations/ct-cve/inventory-export.test.mjs apps/web/lib/integrations/ct-cve/connection-status.test.mjs apps/web/lib/integrations/ct-cve/service-token.test.mjs apps/web/lib/integrations/ct-cve/finding-ingest.test.mjs
- pnpm --dir apps/web type-check
- pnpm --dir apps/web db:validate
- pnpm --dir apps/web exec eslint lib/integrations/ct-cve/inventory-push-job.ts lib/integrations/ct-cve/inventory-push-job.test.mjs scripts/push-ct-cve-inventory.mjs
- pnpm --dir apps/web ct-cve:push-inventory
- pnpm --dir apps/web test:unit