### PR TITLE
docs(cve): track feed api activity logs

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -242,7 +242,7 @@ Update the status and notes in this table as work lands.
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
-| 8. CT-CVE GUI | In progress | ct-cve #7, #8 / feat/ct-cve-gui-phase8 | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, and editable source configuration. Feed/API logs and CT Ops-backed subscription status remain. |
+| 8. CT-CVE GUI | In progress | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. CT Ops-backed subscription status remains. |
 | 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, and an env-configured scheduled inventory push job. CT Ops connector setup UI remains. |
 | 10. Remove internal CT Ops CVE ownership | In progress | feat/remove-internal-cve-ownership | Removed ingest-owned vulnerability feed sync and host matching startup/config. CT Ops still retains imported finding storage/reporting and the legacy vulnerability settings surface until the connector status/inventory slices replace them. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
@@ -608,3 +608,12 @@ Append dated notes here as phases progress. Keep notes short and factual.
   Connector setup UI remains. Validation: targeted inventory push job unit
   test, CT-CVE integration unit tests, web type-check, migration validation,
   full web unit suite, targeted ESLint, and a no-target script smoke test.
+
+### 2026-05-01
+
+- Continued Phase 8 in ct-cve PR #12 by adding database-backed operational
+  logs for feed sync outcomes and source configuration API changes, exposing
+  recent feed/API logs on `/status` and `/api/status`, and ensuring source
+  configuration logs report only whether the NVD API key is configured without
+  storing the key value in log detail. CT Ops-backed subscription status
+  remains. Validation: `go test ./...`.


### PR DESCRIPTION
## Summary
- update the CT-CVE migration tracker for ct-cve PR #12
- mark feed/API activity logs as added in Phase 8
- record that CT Ops-backed subscription status remains outstanding

## Validation
- documentation-only change; reviewed diff