### PR TITLE
feat(web): add CT-CVE connector setup UI

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,16 @@
 
 ## What Has Been Built
 
+### Session 91 — CT-CVE connector setup UI
+
+**CT-CVE connector setup/status surface** (`apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx`, `apps/web/lib/integrations/ct-cve/setup-status.ts`)
+- Added an admin-only Settings -> Integrations -> CT-CVE page showing connector configured state, inbound signed-token scopes/counts, outbound inventory targets, recent health/finding/inventory timestamps, and connector errors without exposing token ids or secrets.
+- Added a sanitised setup overview helper that summarises `CT_CVE_SERVICE_TOKENS`, `CT_CVE_INVENTORY_PUSH_TARGETS`, and durable connection status for the active organisation.
+- Added the CT-CVE tab alongside LDAP and SMTP integration settings.
+
+**Validation**
+- Validation run: CT-CVE integration unit tests, full web unit suite, targeted ESLint for the new connector UI/helper files, `pnpm --filter web type-check`, and `pnpm --filter web db:validate`.
+
 ### Session 90 — CT-CVE inventory push scheduling
 
 **CT-CVE outbound inventory push job** (`apps/web/lib/integrations/ct-cve/inventory-push-job.ts`, `apps/web/scripts/push-ct-cve-inventory.mjs`)

--- a/apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx
@@ -1,0 +1,208 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  DatabaseZap,
+  KeyRound,
+  ServerCog,
+  XCircle,
+} from 'lucide-react'
+import { getRequiredSession } from '@/lib/auth/session'
+import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { AdminTabs } from '@/components/shared/admin-tabs'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { buildCtCveConnectorSetupOverview } from '@/lib/integrations/ct-cve/setup-status'
+import type { CtCveConnectorSetupOverview } from '@/lib/integrations/ct-cve/setup-status'
+
+export const metadata: Metadata = {
+  title: 'CT-CVE Integration Settings',
+}
+
+const tabs = [
+  { title: 'LDAP / Directory', href: '/settings/integrations' },
+  { title: 'SMTP relay', href: '/settings/integrations/smtp' },
+  { title: 'CT-CVE', href: '/settings/integrations/ct-cve' },
+]
+
+function formatDateTime(value: string | null) {
+  if (!value) return 'Not received'
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}
+
+function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <Badge variant={ok ? 'default' : 'outline'} className="gap-1">
+      {ok ? <CheckCircle2 className="size-3" /> : <XCircle className="size-3" />}
+      {label}
+    </Badge>
+  )
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-border py-2 last:border-0">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="text-right text-sm font-medium">{value}</span>
+    </div>
+  )
+}
+
+function EndpointRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/30 p-3">
+      <div className="text-xs font-medium uppercase text-muted-foreground">{label}</div>
+      <code className="mt-1 block overflow-x-auto whitespace-nowrap text-sm">{value}</code>
+    </div>
+  )
+}
+
+function ConnectorWarnings({ overview }: { overview: CtCveConnectorSetupOverview }) {
+  const errors = [
+    overview.inbound.error,
+    overview.inventoryPush.error,
+    overview.status.lastErrorCode
+      ? `Last connector error: ${overview.status.lastErrorCode} at ${formatDateTime(overview.status.lastErrorAt)}`
+      : null,
+  ].filter((error): error is string => Boolean(error))
+
+  if (errors.length === 0) return null
+
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="size-4" />
+      <AlertTitle>Connector attention required</AlertTitle>
+      <AlertDescription>
+        <ul className="mt-2 list-disc space-y-1 pl-4">
+          {errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+export default async function CtCveIntegrationSettingsPage() {
+  const session = await getRequiredSession()
+
+  if (!ADMIN_ROLES.includes(session.user.role)) {
+    redirect('/settings')
+  }
+
+  const orgId = session.user.organisationId!
+  const overview = await buildCtCveConnectorSetupOverview({ orgId })
+
+  return (
+    <div className="space-y-6">
+      <AdminTabs tabs={tabs} />
+
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-2xl font-semibold text-foreground">CT-CVE Connector</h1>
+          <StatusBadge ok={overview.configured} label={overview.configured ? 'Configured' : 'Not configured'} />
+        </div>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          CT-CVE supplies vulnerability findings while CT Ops remains the inventory and reporting surface.
+        </p>
+      </div>
+
+      <ConnectorWarnings overview={overview} />
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <KeyRound className="size-4 text-muted-foreground" />
+              Inbound CT-CVE Tokens
+            </CardTitle>
+            <CardDescription>Signed requests from CT-CVE to CT Ops.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <StatRow label="Active tokens" value={overview.inbound.tokenCount} />
+            <StatRow label="Revoked tokens" value={overview.inbound.revokedTokenCount} />
+            <StatRow
+              label="Scopes"
+              value={overview.inbound.scopes.length > 0 ? overview.inbound.scopes.join(', ') : 'None'}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <DatabaseZap className="size-4 text-muted-foreground" />
+              Inventory Push
+            </CardTitle>
+            <CardDescription>Scheduled CT Ops inventory delivery to CT-CVE.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <StatRow label="Configured targets" value={overview.inventoryPush.targetCount} />
+            <StatRow label="Last inventory push" value={formatDateTime(overview.status.lastInventoryPushAt)} />
+            <StatRow label="Last finding import" value={formatDateTime(overview.status.lastFindingIngestAt)} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Clock className="size-4 text-muted-foreground" />
+              Connection Health
+            </CardTitle>
+            <CardDescription>Latest signed CT-CVE connector heartbeat.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <StatRow label="Last health check" value={formatDateTime(overview.status.lastHealthCheckAt)} />
+            <StatRow label="Connector enabled" value={overview.status.enabled ? 'Yes' : 'No'} />
+            <StatRow label="Contract version" value={overview.status.contractVersion} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <ServerCog className="size-4 text-muted-foreground" />
+            CT-CVE Targets
+          </CardTitle>
+          <CardDescription>Configured outbound inventory destinations for this organisation.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {overview.inventoryPush.targets.length > 0 ? (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {overview.inventoryPush.targets.map((target) => (
+                <div key={`${target.name}:${target.baseUrl}`} className="rounded-md border border-border p-3">
+                  <div className="font-medium">{target.name}</div>
+                  <div className="mt-1 overflow-x-auto whitespace-nowrap text-sm text-muted-foreground">
+                    {target.baseUrl}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No CT-CVE inventory push targets are configured.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Connector Endpoints</CardTitle>
+          <CardDescription>Allow these CT Ops endpoints from the CT-CVE service.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <EndpointRow label="Connection health" value="/api/integrations/ct-cve/v1/connection-health" />
+          <EndpointRow label="Finding batches" value="/api/integrations/ct-cve/v1/finding-batches" />
+          <EndpointRow label="Inbound tokens" value="CT_CVE_SERVICE_TOKENS" />
+          <EndpointRow label="Inventory push targets" value="CT_CVE_INVENTORY_PUSH_TARGETS" />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/settings/integrations/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/page.tsx
@@ -26,6 +26,7 @@ export default async function IntegrationsSettingsPage() {
         tabs={[
           { title: 'LDAP / Directory', href: '/settings/integrations' },
           { title: 'SMTP relay', href: '/settings/integrations/smtp' },
+          { title: 'CT-CVE', href: '/settings/integrations/ct-cve' },
         ]}
       />
       <LdapSettingsClient orgId={orgId} initialConfigs={configs} />

--- a/apps/web/app/(dashboard)/settings/integrations/smtp/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/smtp/page.tsx
@@ -29,6 +29,7 @@ export default async function SmtpRelaySettingsPage() {
         tabs={[
           { title: 'LDAP / Directory', href: '/settings/integrations' },
           { title: 'SMTP relay', href: '/settings/integrations/smtp' },
+          { title: 'CT-CVE', href: '/settings/integrations/ct-cve' },
         ]}
       />
       <SettingsClient

--- a/apps/web/lib/integrations/ct-cve/setup-status.test.mjs
+++ b/apps/web/lib/integrations/ct-cve/setup-status.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildCtCveConnectorSetupOverview } from './setup-status.ts'
+
+const secret = Buffer.from('ct-cve connector setup unit test secret').toString('base64url')
+
+test('summarises CT-CVE connector setup without exposing service-token secrets', async () => {
+  const overview = await buildCtCveConnectorSetupOverview({
+    orgId: 'org_1',
+    env: {
+      CT_CVE_SERVICE_TOKENS: JSON.stringify([
+        {
+          id: 'ct-cve-inbound',
+          secret,
+          orgId: 'org_1',
+          scopes: ['findings:write', 'connection:read'],
+        },
+        {
+          id: 'other-org',
+          secret,
+          orgId: 'org_2',
+          scopes: ['findings:write'],
+        },
+      ]),
+      CT_CVE_INVENTORY_PUSH_TARGETS: JSON.stringify([
+        {
+          name: 'Primary CT-CVE',
+          baseUrl: 'https://ct-cve.example.invalid/',
+          token: {
+            id: 'ct-ops-inventory',
+            secret,
+            orgId: 'org_1',
+            scopes: ['inventory:write'],
+          },
+        },
+      ]),
+    },
+    statusRepository: {
+      async get(orgId) {
+        assert.equal(orgId, 'org_1')
+        return {
+          contractVersion: '2026-04-30',
+          orgId: 'org_1',
+          configured: true,
+          enabled: true,
+          lastInventoryPushAt: '2026-05-01T09:00:00.000Z',
+          lastFindingIngestAt: null,
+          lastHealthCheckAt: null,
+          lastErrorCode: null,
+          lastErrorAt: null,
+        }
+      },
+      async save() {
+        throw new Error('unexpected save')
+      },
+    },
+  })
+
+  assert.equal(overview.configured, true)
+  assert.equal(overview.status.lastInventoryPushAt, '2026-05-01T09:00:00.000Z')
+  assert.deepEqual(overview.inbound, {
+    configured: true,
+    tokenCount: 1,
+    revokedTokenCount: 0,
+    scopes: ['connection:read', 'findings:write'],
+    error: null,
+  })
+  assert.deepEqual(overview.inventoryPush, {
+    configured: true,
+    targetCount: 1,
+    targets: [{ name: 'Primary CT-CVE', baseUrl: 'https://ct-cve.example.invalid' }],
+    error: null,
+  })
+  assert.equal(JSON.stringify(overview).includes(secret), false)
+  assert.equal(JSON.stringify(overview).includes('ct-cve-inbound'), false)
+  assert.equal(JSON.stringify(overview).includes('ct-ops-inventory'), false)
+})
+
+test('reports malformed connector environment without throwing', async () => {
+  const overview = await buildCtCveConnectorSetupOverview({
+    orgId: 'org_1',
+    env: {
+      CT_CVE_SERVICE_TOKENS: '{not json',
+      CT_CVE_INVENTORY_PUSH_TARGETS: JSON.stringify([
+        {
+          name: 'broken',
+          baseUrl: 'https://ct-cve.example.invalid',
+          token: { id: 'id', secret: 'short', orgId: 'org_1', scopes: ['inventory:write'] },
+        },
+      ]),
+    },
+    statusRepository: {
+      async get() {
+        return null
+      },
+      async save() {
+        throw new Error('unexpected save')
+      },
+    },
+  })
+
+  assert.equal(overview.configured, false)
+  assert.equal(overview.inbound.configured, false)
+  assert.match(overview.inbound.error ?? '', /CT_CVE_SERVICE_TOKENS/)
+  assert.equal(overview.inventoryPush.configured, false)
+  assert.match(overview.inventoryPush.error ?? '', /token\.secret/)
+  assert.equal(overview.status.configured, false)
+})

--- a/apps/web/lib/integrations/ct-cve/setup-status.ts
+++ b/apps/web/lib/integrations/ct-cve/setup-status.ts
@@ -1,0 +1,118 @@
+import {
+  getCtCveConnectionStatus,
+  type CtCveConnectionStatus,
+  type CtCveConnectionStatusRepository,
+} from './connection-status.ts'
+import { parseCtCveInventoryPushTargets } from './inventory-push-job.ts'
+import {
+  parseCtCveServiceTokens,
+  type CtCveServiceTokenScope,
+} from './service-token.ts'
+
+interface BuildOverviewOptions {
+  orgId: string
+  env?: NodeJS.ProcessEnv
+  statusRepository?: CtCveConnectionStatusRepository
+}
+
+export interface CtCveConnectorSetupOverview {
+  configured: boolean
+  inbound: {
+    configured: boolean
+    tokenCount: number
+    revokedTokenCount: number
+    scopes: CtCveServiceTokenScope[]
+    error: string | null
+  }
+  inventoryPush: {
+    configured: boolean
+    targetCount: number
+    targets: Array<{
+      name: string
+      baseUrl: string
+    }>
+    error: string | null
+  }
+  status: CtCveConnectionStatus
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function sortedScopes(scopes: Iterable<CtCveServiceTokenScope>): CtCveServiceTokenScope[] {
+  return Array.from(new Set(scopes)).sort()
+}
+
+function summariseInboundTokens(orgId: string, env: NodeJS.ProcessEnv): CtCveConnectorSetupOverview['inbound'] {
+  try {
+    const tokens = parseCtCveServiceTokens(env.CT_CVE_SERVICE_TOKENS)
+      .filter((token) => token.orgId === orgId)
+    const activeTokens = tokens.filter((token) => !token.revoked)
+
+    return {
+      configured: activeTokens.length > 0,
+      tokenCount: activeTokens.length,
+      revokedTokenCount: tokens.length - activeTokens.length,
+      scopes: sortedScopes(activeTokens.flatMap((token) => token.scopes)),
+      error: null,
+    }
+  } catch (error) {
+    return {
+      configured: false,
+      tokenCount: 0,
+      revokedTokenCount: 0,
+      scopes: [],
+      error: `CT_CVE_SERVICE_TOKENS: ${errorMessage(error)}`,
+    }
+  }
+}
+
+function summariseInventoryPushTargets(
+  orgId: string,
+  env: NodeJS.ProcessEnv,
+): CtCveConnectorSetupOverview['inventoryPush'] {
+  try {
+    const targets = parseCtCveInventoryPushTargets(env.CT_CVE_INVENTORY_PUSH_TARGETS)
+      .filter((target) => target.token.orgId === orgId)
+      .map((target) => ({
+        name: target.name,
+        baseUrl: target.baseUrl,
+      }))
+
+    return {
+      configured: targets.length > 0,
+      targetCount: targets.length,
+      targets,
+      error: null,
+    }
+  } catch (error) {
+    return {
+      configured: false,
+      targetCount: 0,
+      targets: [],
+      error: `CT_CVE_INVENTORY_PUSH_TARGETS: ${errorMessage(error)}`,
+    }
+  }
+}
+
+export async function buildCtCveConnectorSetupOverview({
+  orgId,
+  env = process.env,
+  statusRepository,
+}: BuildOverviewOptions): Promise<CtCveConnectorSetupOverview> {
+  const inbound = summariseInboundTokens(orgId, env)
+  const inventoryPush = summariseInventoryPushTargets(orgId, env)
+  const configured = inbound.configured || inventoryPush.configured
+  const status = await getCtCveConnectionStatus(orgId, {
+    configured,
+    repository: statusRepository,
+  })
+
+  return {
+    configured,
+    inbound,
+    inventoryPush,
+    status,
+  }
+}

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -243,7 +243,7 @@ Update the status and notes in this table as work lands.
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. CT Ops-backed subscription status remains. |
-| 9. CT Ops connector | In progress | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, and an env-configured scheduled inventory push job. CT Ops connector setup UI remains. |
+| 9. CT Ops connector | Complete | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task, feat/ct-cve-connector-setup-ui | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, an env-configured scheduled inventory push job, and an admin connector setup/status UI. |
 | 10. Remove internal CT Ops CVE ownership | In progress | feat/remove-internal-cve-ownership | Removed ingest-owned vulnerability feed sync and host matching startup/config. CT Ops still retains imported finding storage/reporting and the legacy vulnerability settings surface until the connector status/inventory slices replace them. |
 | 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
 
@@ -617,3 +617,9 @@ Append dated notes here as phases progress. Keep notes short and factual.
   configuration logs report only whether the NVD API key is configured without
   storing the key value in log detail. CT Ops-backed subscription status
   remains. Validation: `go test ./...`.
+- Completed Phase 9 on branch `feat/ct-cve-connector-setup-ui` by adding an
+  admin-only Settings -> Integrations -> CT-CVE page that summarises inbound
+  service-token setup, outbound inventory push targets, durable connector
+  health/finding/inventory timestamps, and connector errors without exposing
+  token IDs or secrets. Validation: CT-CVE integration unit tests, full web
+  unit suite, targeted ESLint, web type-check, and migration validation.


### PR DESCRIPTION
## Summary
- add an admin-only Settings -> Integrations -> CT-CVE setup/status page
- summarise inbound service-token scopes/counts, outbound inventory targets, and durable connector timestamps without exposing token ids or secrets
- update migration tracking and mark CT Ops connector Phase 9 complete

## Validation
- pnpm install
- node --experimental-strip-types --test lib/integrations/ct-cve/*.test.mjs
- pnpm --filter web lint -- 'app/(dashboard)/settings/integrations/page.tsx' 'app/(dashboard)/settings/integrations/smtp/page.tsx' 'app/(dashboard)/settings/integrations/ct-cve/page.tsx' lib/integrations/ct-cve/setup-status.ts lib/integrations/ct-cve/setup-status.test.mjs
- pnpm --filter web type-check
- pnpm --filter web db:validate
- pnpm --filter web test:unit