### PR TITLE
fix(web): release cve cleanup guidance

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -80,6 +80,14 @@ Each agent session must:
     appear to show unmerged commits, verify the GitHub PR state and the merged
     squash commit before treating the branch as stale.
 
+Release-please uses the merged pull request title as its Conventional Commit
+input. If a migration PR changes shipped behavior, removes shipped code, drops
+schema, changes runtime configuration, or otherwise needs a release, do not use
+`refactor` or `docs` as the PR title type. Use a release-triggering type such
+as `fix(<scope>)` or `feat(<scope>)`, and add `!` plus a breaking-change footer
+when the change is intentionally breaking. `refactor` is only acceptable for
+internal code movement that should not produce a release.
+
 The expected output of a session is a small, reviewable PR. A good session might
 complete one document, one API contract, one entitlement helper, one enforcement
 path, one UI removal slice, or one cleanup audit. It should not combine


### PR DESCRIPTION
## Summary
- add migration-plan guidance that release-required removals must not use refactor/docs PR titles
- use a fix(web) PR title so release-please opens the missed web release for the CVE cleanup

## Validation
- git diff --check