### PR TITLE
fix(web): release cve cleanup

### DIFF
--- a/apps/web/lib/vulnerabilities/assessment.test.mjs
+++ b/apps/web/lib/vulnerabilities/assessment.test.mjs
@@ -32,19 +32,22 @@ test('host assessment is clear when scans are fresh and no confirmed findings ar
 })
 
 test('host assessment is not assessed without inventory or finding import data', () => {
-  assert.equal(deriveHostVulnerabilityAssessmentStatus({
+  const missingInventory = deriveHostVulnerabilityAssessmentStatus({
     openConfirmedFindings: 0,
     lastInventoryScanAt: null,
     lastFindingImportAt: recentFindingImport,
     now,
-  }).status, 'not_assessed')
+  })
+  assert.equal(missingInventory.status, 'not_assessed')
 
-  assert.equal(deriveHostVulnerabilityAssessmentStatus({
+  const missingFindingImport = deriveHostVulnerabilityAssessmentStatus({
     openConfirmedFindings: 0,
     lastInventoryScanAt: recentInventory,
     lastFindingImportAt: null,
     now,
-  }).status, 'not_assessed')
+  })
+  assert.equal(missingFindingImport.status, 'not_assessed')
+  assert.equal(missingFindingImport.reason, 'CT-CVE has not imported vulnerability findings into CT Ops yet.')
 })
 
 test('host assessment is stale when inventory or finding import data is too old', () => {


### PR DESCRIPTION
## Summary
- add a web-package regression assertion for CT-CVE finding-import assessment wording
- ensure release-please sees a release-triggering fix under apps/web after the CVE source cleanup

## Why
Release-please splits commits by package path. PR #838 had a fix(web) title but only changed top-level docs, so it was skipped for apps/web.

## Validation
- pnpm --dir apps/web exec node --experimental-strip-types --test lib/vulnerabilities/assessment.test.mjs
- git diff --check