### PR TITLE
docs(cve): complete final residue audit

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 94 — Complete CT-CVE final residue audit
+
+**CT-CVE migration audit** (`docs/ct-cve-final-residue-audit.md`, `docs/ct-cve-migration-plan.md`)
+- Added the final CT Ops residue audit for the CT-CVE migration, including the required CVE/feature/licence searches and targeted checks for source-state, affected-package, NVD/CISA, feed, and matcher residue.
+- Classified remaining matches as intended connector, imported-finding storage, reporting/display, historical migration/changelog, or seat-licensing code.
+- Confirmed no moved CT-CVE feed sync, package matching, source configuration, NVD key storage, source-management UI, or source-only E2E coverage remains in live CT Ops code.
+
+**Validation**
+- Documentation-only change validated by rerunning the recorded `rg`/`find`
+  audit commands and reviewing the remaining match classes.
+
 ### Session 93 — Complete CT Ops CVE ownership cleanup
 
 **CT-CVE ownership cleanup** (`apps/web/lib/actions/vulnerabilities.ts`, `apps/web/lib/db/schema/vulnerabilities.ts`)

--- a/docs/ct-cve-final-residue-audit.md
+++ b/docs/ct-cve-final-residue-audit.md
@@ -1,0 +1,119 @@
+# CT-CVE Final Residue Audit
+
+Date: 2026-05-01
+
+This audit records the final CT Ops-side check for CT-CVE migration residue.
+It was run from a fresh worktree created from `origin/main` at
+`253f0dec4812012ff72d66d16ccda507f513947d`.
+
+## Collision Check
+
+No open pull requests matched the migration collision search:
+
+```sh
+gh pr list --state open --search "ct-cve OR licensing OR licence OR license OR migration OR Pro gates OR seats"
+```
+
+Recent merged pull requests included the CT Ops connector, source-settings
+removal, and final source-residue cleanup:
+
+- #834 `feat(web): add CT-CVE connector setup UI`
+- #837 `refactor(web): remove cve source residue`
+- #839 `fix(web): release cve cleanup`
+
+## Search Commands
+
+The audit used the required migration-plan searches, excluding generated local
+test/build output:
+
+```sh
+rg -n "vuln|vulnerability|CVE|NVD|CISA|KEV|OSV|Red Hat|Ubuntu OSV|Alpine SecDB" . \
+  --glob '!node_modules/**' \
+  --glob '!apps/web/.next/**' \
+  --glob '!apps/web/test-results/**' \
+  --glob '!apps/web/playwright-report/**' \
+  --glob '!apps/web/coverage/**' \
+  --glob '!apps/web/.build-doc-assets/**'
+
+rg -n "requireFeature|FeatureGate|LockedFeature|reportsExport|certExpiryTracker|serviceAccountTracker" apps/web
+
+rg -n "maxHosts|maxUsers|seat|licence|license" apps docs \
+  --glob '!node_modules/**' \
+  --glob '!apps/web/.next/**' \
+  --glob '!apps/web/test-results/**' \
+  --glob '!apps/web/playwright-report/**' \
+  --glob '!apps/web/coverage/**'
+```
+
+Additional targeted searches checked for CT-CVE-owned internals outside
+historical migrations and generated migration metadata:
+
+```sh
+rg -n "vulnerability_sources|vulnerability_affected_packages|affected_package_id|NVD|CISA|KEV|OSV|Red Hat|Ubuntu OSV|Alpine SecDB|feed sync|source status|source config|source configuration|vulnerability source|vulnerability feed|host matching|match rule|affected package" apps \
+  --glob '!apps/web/lib/db/migrations/**' \
+  --glob '!apps/web/lib/db/migrations/meta/**' \
+  --glob '!apps/web/.next/**' \
+  --glob '!apps/web/test-results/**' \
+  --glob '!apps/web/playwright-report/**' \
+  --glob '!apps/web/coverage/**'
+
+find apps -path '*vuln*' -o -path '*vulnerab*' -o -path '*cve*' | sort
+```
+
+## Remaining Legitimate CT Ops Matches
+
+The remaining live CT-CVE/vulnerability matches are expected CT Ops
+integration, storage, and reporting surfaces:
+
+- Signed CT-CVE connector configuration in `.env.example`.
+- CT-CVE inbound endpoints under
+  `apps/web/app/api/integrations/ct-cve/v1/`.
+- CT-CVE service-token, finding-ingest, inventory-export, inventory-push, setup,
+  and connection-status helpers under `apps/web/lib/integrations/ct-cve/`.
+- Imported finding storage and reporting schema in
+  `apps/web/lib/db/schema/vulnerabilities.ts`, plus historical migrations.
+- Customer-facing CT Ops reporting in
+  `apps/web/app/(dashboard)/reports/vulnerabilities/`.
+- Host vulnerability display in
+  `apps/web/app/(dashboard)/hosts/[id]/vulnerabilities-tab.tsx`.
+- CT-CVE-aware vulnerability reporting actions in
+  `apps/web/lib/actions/vulnerabilities.ts`.
+- Tests and fixtures for the connector, host finding display, and vulnerability
+  report display.
+- Documentation that now states CT-CVE owns feed sync, enrichment, and package
+  matching while CT Ops stores and reports imported findings.
+
+The feature-gate search only returns the retained licence guard, Community-open
+feature definitions, and licence tests. `FeatureGate` and `LockedFeature`
+components no longer remain.
+
+The licence search returns expected seat-based licensing code and docs:
+`maxUsers` validation, seat enforcement, licence settings, offline licence
+validation, and compatibility references to legacy `maxHosts`.
+
+## Removed CT-CVE-Owned Internals
+
+No live CT Ops code remains for these moved internals:
+
+- Ingest-owned vulnerability feed sync startup.
+- Ingest-owned host vulnerability matching startup.
+- `apps/ingest/internal/vuln/`.
+- CT Ops NVD API-key storage or server actions.
+- CT Ops vulnerability source management pages.
+- CT Ops vulnerability source status reads.
+- CT Ops feed/source configuration.
+- Live `vulnerability_sources` and `vulnerability_affected_packages` schema
+  usage.
+- Live `host_vulnerability_findings.affected_package_id` usage.
+- E2E coverage that only exercised CT Ops-owned feed/source configuration.
+
+Historical changelog and progress entries still mention earlier CT Ops-owned CVE
+work, but current top-level progress entries and docs state that those
+internals were removed and that CT-CVE now owns feed/source configuration,
+enrichment, and package matching.
+
+## Result
+
+CT Ops no longer retains moved CT-CVE internals. The remaining CT-CVE-related
+code is deliberate connector, imported-finding storage, and customer-facing
+reporting/display code.

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -253,7 +253,7 @@ Update the status and notes in this table as work lands.
 | 8. CT-CVE GUI | In progress | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. CT Ops-backed subscription status remains. |
 | 9. CT Ops connector | Complete | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task, feat/ct-cve-connector-setup-ui | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, an env-configured scheduled inventory push job, and an admin connector setup/status UI. |
 | 10. Remove internal CT Ops CVE ownership | Complete | feat/remove-internal-cve-ownership, feat/remove-ct-cve-source-settings, #837 | Removed ingest-owned vulnerability feed sync and host matching startup/config, the legacy CT Ops vulnerability source/settings page and NVD key actions, and obsolete CT Ops source-state/affected-package match-rule storage. CT Ops retains imported CVE/finding storage and reporting. |
-| 11. Final residue audit | Not started | | Run code, config, docs, and test searches proving no moved CT-CVE internals remain in CT Ops. |
+| 11. Final residue audit | Complete | docs/ct-cve-final-residue-audit | Added `docs/ct-cve-final-residue-audit.md` recording the final code, config, docs, and test searches. Remaining matches are legitimate CT Ops connector, imported-finding storage, reporting/display, migration history, or seat-licensing code; moved CT-CVE internals are absent. |
 
 Allowed status values:
 
@@ -646,3 +646,10 @@ Append dated notes here as phases progress. Keep notes short and factual.
   imported CVE/finding storage and vulnerability reporting. Validation: web
   migration generation/validation, full web unit suite, web type-check,
   targeted lint, and targeted host/report vulnerability E2E coverage.
+- Completed Phase 11 on branch `docs/ct-cve-final-residue-audit` by adding a
+  final residue audit document. The audit ran the required CVE/feature/licence
+  searches plus targeted checks for source-state, affected-package, NVD/CISA,
+  feed, and matcher residue. Remaining matches are deliberate CT Ops connector,
+  imported-finding storage, reporting/display, historical migrations/changelogs,
+  or seat-licensing code; no moved CT-CVE feed sync, package matching, source
+  configuration, NVD key storage, or CT Ops-owned source UI remains.


### PR DESCRIPTION
## Summary
- add the final CT-CVE residue audit document with the required migration-plan searches
- mark Phase 11 complete in the migration plan
- add the Session 94 progress entry classifying remaining CT-CVE/vulnerability matches

## Validation
- git diff --check
- reran the targeted residue search for source-state, affected-package, NVD/CISA, feed, and matcher terms outside historical migrations
- reviewed the remaining match classes as connector, imported-finding storage, reporting/display, historical migration/changelog, or seat-licensing code