### PR TITLE
docs(cve): define plugin auth licensing model

### DIFF
--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -143,6 +143,20 @@ product:
 - CT-CVE's GUI is for operational configuration and observability only, such as
   CVE ingestion API keys, feed update schedules, source health, detailed feed
   sync status, and source/API logs.
+- CT Ops is also the required identity, organisation, and licensing anchor for
+  CT-CVE and future first-party plugin products. Plugin GUIs must not require a
+  separate username/password database per plugin.
+- Plugins keep their own databases for plugin-owned data, but authenticate users
+  through CT Ops-issued signed assertions and authorize from CT Ops-derived
+  claims. Plugins must not authenticate users by directly reading the CT Ops
+  database.
+- Plugin GUIs may generate signed licence request tokens for CT Portal, but CT
+  Portal-issued plugin entitlements should be bound to the CT Ops installation,
+  organisation, product, and plugin instance.
+- Extension-specific forms and workflow logic should live in the extension, not
+  CT Ops. CT Ops should launch or embed registered extension UIs and provide
+  signed identity context rather than rendering every plugin configuration form
+  itself.
 
 ## Deployment Model
 
@@ -177,6 +191,8 @@ Expected data flow:
 ```text
 CT Ops inventory -> CT-CVE
 CT-CVE findings -> CT Ops
+CT Ops user assertions -> CT-CVE GUI
+CT Ops plugin entitlement status -> CT-CVE
 ```
 
 ## Non-Negotiable Cleanup Rule
@@ -250,10 +266,14 @@ Update the status and notes in this table as work lands.
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
-| 8. CT-CVE GUI | In progress | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. CT Ops-backed subscription status remains. |
+| 8. CT-CVE GUI | Blocked | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. Real CT Ops-backed subscription status is blocked until the shared plugin identity and entitlement model is implemented. |
 | 9. CT Ops connector | Complete | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task, feat/ct-cve-connector-setup-ui | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, an env-configured scheduled inventory push job, and an admin connector setup/status UI. |
 | 10. Remove internal CT Ops CVE ownership | Complete | feat/remove-internal-cve-ownership, feat/remove-ct-cve-source-settings, #837 | Removed ingest-owned vulnerability feed sync and host matching startup/config, the legacy CT Ops vulnerability source/settings page and NVD key actions, and obsolete CT Ops source-state/affected-package match-rule storage. CT Ops retains imported CVE/finding storage and reporting. |
 | 11. Final residue audit | Complete | docs/ct-cve-final-residue-audit | Added `docs/ct-cve-final-residue-audit.md` recording the final code, config, docs, and test searches. Remaining matches are legitimate CT Ops connector, imported-finding storage, reporting/display, migration history, or seat-licensing code; moved CT-CVE internals are absent. |
+| 12. Plugin identity and licensing decision | Complete | docs/plugin-auth-licensing | Documented the shared CT Ops plugin identity, authorization, licence request-token, subscription-status, and extension-hosted UI direction so CT-CVE does not grow a separate user database, direct CT Ops DB authentication, or CT Ops-owned plugin configuration forms. |
+| 13. CT Ops plugin identity broker | Not started |  | Add CT Ops installation identity, plugin instance registration, key/trust-anchor storage, signed short-lived plugin user assertions, launch/redirect flow, revocation, and backend authorization checks. |
+| 14. Plugin entitlement storage and CT Portal contract | Not started |  | Add CT Ops-side plugin entitlement storage/validation, CT Portal licence request-token contract, CT Portal-issued plugin licence import/validation, and signed subscription-status API for plugins. |
+| 15. CT-CVE auth and subscription integration | Not started |  | Update CT-CVE to require CT Ops-issued user assertions for its GUI, generate CT Portal licence request tokens, consume CT Ops subscription status, and replace placeholder subscription UI with real entitlement state. |
 
 Allowed status values:
 
@@ -415,6 +435,10 @@ after the connector is in place. If UI code is moved from CT Ops for
 configuration/status purposes, remove the original CT Ops copies once the CT Ops
 connector replaces them.
 
+The CT Ops-backed subscription-status portion of this phase is blocked until
+the shared plugin identity and entitlement phases exist. Do not add a separate
+CT-CVE user database to unblock this phase.
+
 ### 9. CT Ops Connector
 
 Wire CT Ops to CT-CVE using the phase 6 contract.
@@ -463,6 +487,89 @@ rg -n "maxHosts|maxUsers|seat|licence|license" apps docs
 
 The final audit PR must explain which remaining matches are legitimate CT Ops
 integration/display code and which moved CT-CVE internals were removed.
+
+### 12. Plugin Identity and Licensing Decision
+
+Record the shared plugin AuthN/AuthZ and licensing direction before
+implementation.
+
+Expected decisions:
+
+- CT Ops is the identity provider for CT-CVE and future first-party plugin
+  GUIs.
+- Plugin services keep separate databases for plugin-owned data.
+- Plugin services must not authenticate users by directly querying the CT Ops
+  database.
+- CT Ops issues short-lived signed user assertions with plugin-bound audience,
+  organisation, user, role/permission, product, expiry, and nonce claims.
+- Plugin instances store the CT Ops issuer and public signing key or equivalent
+  trust anchor.
+- CT Ops stores plugin instance identifiers, plugin trust material, allowed
+  organisation scope, enabled product, and revocation state.
+- Plugin GUIs generate signed licence request tokens for CT Portal purchasing.
+- CT Portal-issued plugin licences bind to CT Ops installation, organisation,
+  product, and plugin instance or key fingerprint.
+- CT Ops exposes derived subscription status to plugins through signed APIs.
+
+This phase is documentation-only unless a small helper or schema discovery is
+strictly needed.
+
+### 13. CT Ops Plugin Identity Broker
+
+Implement the CT Ops side of user authentication for plugin GUIs.
+
+Expected work:
+
+- Add or identify a stable CT Ops installation identifier.
+- Add plugin instance registration storage and admin setup UI/API.
+- Generate and rotate CT Ops signing keys or certificates for plugin
+  assertions.
+- Store plugin instance public keys or shared verification material.
+- Issue short-lived signed user assertions bound to a plugin instance audience.
+- Include organisation, user, role/permission, product, expiry, and replay
+  claims.
+- Add revocation and rotation paths.
+- Add tests for signature validity, issuer/audience binding, org scoping,
+  expiry, replay, role/permission claims, and revoked plugin instances.
+
+### 14. Plugin Entitlement Storage and CT Portal Contract
+
+Implement the CT Ops side of plugin licensing.
+
+Expected work:
+
+- Define the CT Portal licence request-token payload.
+- Generate request tokens from a registered CT Ops/plugin instance pair.
+- Validate and store CT Portal-issued plugin licence keys.
+- Bind plugin licences to CT Ops installation, organisation, product, and
+  plugin instance or key fingerprint.
+- Add server-side plugin entitlement checks in CT Ops where CT Ops launches or
+  displays plugin-dependent workflows.
+- Expose signed subscription-status APIs for plugins.
+- Add tests for tampered request tokens, wrong organisation, wrong plugin
+  instance, expired/revoked licences, and safe degradation.
+
+### 15. CT-CVE Auth and Subscription Integration
+
+Finish the CT-CVE GUI subscription work after CT Ops plugin identity and
+entitlement primitives exist.
+
+Expected work:
+
+- Require CT Ops-issued signed user assertions for CT-CVE GUI access.
+- Remove unauthenticated access to CT-CVE operational configuration except for
+  health endpoints intended for infrastructure probes.
+- Keep CT-CVE-owned forms, validation, source configuration handlers, and
+  workflow logic inside CT-CVE. CT Ops should only launch, redirect, proxy, or
+  iframe the registered CT-CVE UI with a signed assertion.
+- Add CT-CVE-side verification of CT Ops issuer, audience, organisation,
+  product, expiry, and revocation status.
+- Add CT-CVE licence request-token generation for CT Portal.
+- Consume CT Ops subscription-status APIs.
+- Replace placeholder CT-CVE subscription UI with real status.
+- Enforce plugin entitlement server-side for CT-CVE-owned processing.
+- Add tests for fake CT Ops databases or wrong trust anchors not granting
+  access, plus expired/invalid subscription states.
 
 ## Running Notes
 
@@ -619,6 +726,13 @@ Append dated notes here as phases progress. Keep notes short and factual.
 
 ### 2026-05-01
 
+- Completed Phase 12 on branch `docs/plugin-auth-licensing` by updating the
+  product decision record, CT Ops/CT-CVE API contract, and migration plan with
+  the shared plugin identity and licensing model. CT Ops remains the required
+  visualization, identity, organisation, and licensing anchor. Plugins keep
+  their own databases and own their configuration forms/workflow logic, while
+  CT Ops launches or embeds registered plugin UIs with short-lived signed
+  assertions and exposes derived subscription status through signed APIs.
 - Continued Phase 8 in ct-cve PR #12 by adding database-backed operational
   logs for feed sync outcomes and source configuration API changes, exposing
   recent feed/API logs on `/status` and `/api/status`, and ensuring source

--- a/docs/ct-ops-ct-cve-api-contract.md
+++ b/docs/ct-ops-ct-cve-api-contract.md
@@ -13,8 +13,9 @@ CT Ops owns:
   inventory.
 - Software inventory collection and the current package rows reported by CT Ops
   agents.
-- The CT-CVE connection configuration, health display, and imported finding
-  display surfaces.
+- The CT-CVE connection configuration, plugin identity pairing, user
+  authentication assertions, plugin entitlement status, health display, and
+  imported finding display surfaces.
 
 CT-CVE owns:
 
@@ -23,10 +24,15 @@ CT-CVE owns:
 - Distro and package matching rules.
 - Vulnerability enrichment and severity normalization.
 - Finding generation and lifecycle decisions.
-- CT-CVE standalone GUI/API and product licensing.
+- CT-CVE operational GUI/API, licence request-token generation, and
+  product-specific entitlement enforcement.
 
 CT Ops may store imported finding rows for reporting and host context, but CT-CVE
 remains the source of truth for vulnerability intelligence and matching.
+
+CT-CVE is independently deployed and released, but it is not a standalone
+customer product. CT Ops is always required for user identity, organisation
+context, inventory, visualization, and customer-facing reporting.
 
 ## Integration Direction
 
@@ -257,7 +263,7 @@ Response shape:
 ## Authentication And Authorization
 
 The first connector uses signed service tokens issued during CT Ops/CT-CVE
-connection setup.
+connection setup for service-to-service APIs.
 
 Required request headers:
 
@@ -291,6 +297,133 @@ Token requirements:
 
 Authorization decisions must be made server-side from the token scope and bound
 `orgId`; request body fields are not trusted on their own.
+
+### User Authentication For The CT-CVE GUI
+
+CT-CVE must not keep its own username/password user database and must not
+authenticate users by querying the CT Ops database directly. CT Ops is the
+identity provider and authorization source for CT-CVE users.
+
+The target user-flow is:
+
+1. A CT Ops administrator registers a CT-CVE instance for an organisation.
+2. CT Ops and CT-CVE exchange or pin instance trust material during setup. The
+   minimum trust material is a CT Ops issuer identifier and public signing key
+   stored by CT-CVE, plus a CT-CVE instance identifier and public key or
+   verification material stored by CT Ops.
+3. A permitted user signs in to CT Ops.
+4. CT Ops shows the registered CT-CVE instance in Settings -> Integrations or a
+   Plugins area.
+5. The user clicks Manage or Configure for CT-CVE.
+6. CT Ops issues a short-lived signed launch assertion with an audience bound to
+   the CT-CVE instance.
+7. CT Ops redirects the browser to the registered CT-CVE URL with the assertion,
+   embeds the registered CT-CVE URL in an iframe, or uses a CT Ops-hosted proxy
+   route that forwards the assertion server-side.
+8. CT-CVE verifies the assertion with the pinned CT Ops public key, creates a
+   short-lived plugin-local web session, and authorizes access from the included
+   organisation, user, role, permission, product, and expiry claims.
+
+Required assertion claims:
+
+| Claim | Meaning |
+| --- | --- |
+| `iss` | CT Ops installation or issuer identifier. |
+| `aud` | CT-CVE plugin instance identifier. |
+| `sub` | CT Ops user identifier. |
+| `orgId` | CT Ops organisation identifier. |
+| `product` | Plugin product identifier, initially `ct-cve`. |
+| `roles` or `permissions` | CT Ops-derived plugin permissions. |
+| `iat` / `exp` | Issued-at and expiry timestamps. |
+| `jti` or `nonce` | Replay-resistant token identifier. |
+
+CT-CVE must reject assertions with the wrong issuer, audience, organisation,
+product, expiry, signature, or revoked plugin instance. Assertions should be
+short-lived; long-lived refresh, session, and revocation policy remains owned by
+CT Ops.
+
+Direct navigation to the CT-CVE GUI should redirect back to CT Ops for a fresh
+launch assertion, except for infrastructure health endpoints that intentionally
+do not expose configuration or customer data.
+
+CT-CVE owns its operational forms, form validation, source configuration APIs,
+and plugin workflow logic. CT Ops should not duplicate those forms as generic
+schema-rendered configuration screens unless a later plugin framework
+explicitly needs a minimal common settings primitive.
+
+If CT Ops embeds CT-CVE in an iframe, both products must treat it as an explicit
+security boundary:
+
+- CT Ops only frames registered plugin origins for the paired instance.
+- CT-CVE should restrict `frame-ancestors` to the paired CT Ops origin where
+  deployments have a stable CT Ops URL.
+- CT-CVE should use its own plugin-local session cookie after validating the
+  launch assertion, rather than keeping the assertion in the iframe URL.
+- Cross-frame communication must use `postMessage` only for small shell events
+  such as resize, navigation intent, or status refresh, and must validate
+  origin, audience, and message shape.
+- Plugin-owned secrets, such as NVD API keys, stay inside the plugin service and
+  are never posted to CT Ops.
+
+### Plugin Licence Request Tokens
+
+CT-CVE's GUI should generate a licence request token for CT Portal rather than
+collecting payment or issuing licence keys itself.
+
+The request token should include:
+
+| Field | Meaning |
+| --- | --- |
+| `product` | Plugin product identifier, initially `ct-cve`. |
+| `ctOpsInstallationId` | Stable CT Ops installation identifier. |
+| `orgId` | CT Ops organisation identifier. |
+| `pluginInstanceId` | CT-CVE instance identifier paired with CT Ops. |
+| `pluginKeyFingerprint` | Fingerprint of CT-CVE instance public key or equivalent binding material. |
+| `requestedPlan` | Optional requested CT-CVE plan or capacity. |
+| `createdAt` | Request-token creation time. |
+| `nonce` | Single-use request nonce. |
+
+The token must be signed by CT Ops, CT-CVE, or both depending on the final CT
+Portal verification contract. In all cases CT Portal must be able to verify the
+token was generated by the paired CT Ops/plugin installation and has not been
+edited by the customer.
+
+CT Portal-issued plugin licence keys should be bound to the CT Ops installation,
+organisation, product, and plugin instance or key fingerprint. CT Ops should
+store and validate the active plugin entitlement and expose the resulting status
+to CT-CVE through a signed subscription-status API.
+
+### Subscription Status
+
+CT Ops should expose CT-CVE subscription status through a signed endpoint once
+plugin entitlement storage exists:
+
+```text
+GET /api/integrations/ct-cve/v1/subscription-status?orgId=<orgId>&pluginInstanceId=<instanceId>
+```
+
+The endpoint must require a token scoped to the requested organisation and the
+CT-CVE product. The response should avoid returning licence secrets and should
+only include derived status fields:
+
+```json
+{
+  "product": "ct-cve",
+  "orgId": "org_123",
+  "pluginInstanceId": "ctcve_inst_123",
+  "configured": true,
+  "licensed": true,
+  "status": "active",
+  "plan": "pro",
+  "expiresAt": "2027-05-01T00:00:00Z",
+  "lastCheckedAt": "2026-05-01T10:30:00Z"
+}
+```
+
+CT-CVE should display this derived status in its operational GUI and should use
+it for server-side entitlement decisions that control plugin-owned processing.
+CT Ops remains responsible for CT Ops seat limits and customer-facing report
+access.
 
 ## Replay Protection
 

--- a/docs/ct-ops-licensing-and-ct-cve-product-decision.md
+++ b/docs/ct-ops-licensing-and-ct-cve-product-decision.md
@@ -11,18 +11,22 @@ enable selected product areas. Vulnerability monitoring is also implemented
 inside CT Ops, spanning the ingest service, web database schema, server actions,
 reports, settings UI, and tests.
 
-The product direction is changing in two related ways:
+The product direction is changing in three related ways:
 
 - CT Ops core functionality should be available in the open-source product
   without Pro feature gates.
-- Vulnerability intelligence should become a standalone product, CT-CVE, with
-  its own subscription, service boundary, data ownership, and release cadence.
+- Vulnerability intelligence should become a separately released CT Ops plugin
+  product, CT-CVE, with its own subscription, service boundary, data ownership,
+  and release cadence.
+- CT Ops should become the required visualization, identity, and licensing
+  anchor for first-party plugin products so customers do not maintain separate
+  user accounts per plugin.
 
 ## Decision
 
 CT Ops will move from feature-gated Pro licensing to seat-based licensing for
-the core operations product. CT-CVE will be extracted into an independent
-product and service.
+the core operations product. CT-CVE will be extracted into an independently
+released CT Ops plugin product and service.
 
 ## CT Ops Product Model
 
@@ -79,7 +83,8 @@ valid Enterprise entitlement exists.
 
 ## CT-CVE Product Model
 
-CT-CVE is a separate subscription product. The repository target is:
+CT-CVE is a separate CT Ops plugin subscription product. The repository target
+is:
 
 ```text
 git@github.com:carrtech-dev/ct-cve.git
@@ -93,16 +98,113 @@ CT-CVE owns:
 - Package version matching.
 - Vulnerability enrichment and confidence classification.
 - CT-CVE GUI and API surfaces.
-- CT-CVE subscription and licence placeholders.
+- CT-CVE licence request-token generation and subscription status display.
 
 CT Ops must not retain internal ownership of these responsibilities after the
 migration is complete. CT Ops may keep imported finding display and operational
 reporting surfaces when they are backed by the CT Ops/CT-CVE integration
 contract rather than by CT Ops-owned feed and matching internals.
 
-CT-CVE must be useful without CT Ops. Customers can subscribe to and run CT-CVE
-independently. When customers run both products, CT Ops can provide inventory
-to CT-CVE and receive findings back.
+CT-CVE must not be designed as useful without CT Ops. Customers can run the
+CT-CVE service separately, but CT Ops is always required as the visualization,
+organisation, inventory, user identity, and customer-facing reporting layer.
+
+CT-CVE's own GUI is intentionally small. It exists for operational
+configuration, observability, and generating a signed licence request token that
+customers submit to the CT Portal licensing server when purchasing or renewing a
+CT-CVE licence key.
+
+## Plugin Authentication And Authorization
+
+First-party plugin products, including CT-CVE, must not maintain independent
+username and password databases for customer users. CT Ops is the source of
+truth for users, organisations, roles, and seats.
+
+Plugins must also not authenticate users by directly reading the CT Ops
+database. Direct database reads couple plugins to CT Ops internals and do not
+prove that the CT Ops instance is the trusted installation paired with the
+plugin. A copied or forged CT Ops database could otherwise create plausible
+users without proving control of the paired CT Ops instance.
+
+The target model is:
+
+- CT Ops acts as the identity provider and authorization policy source for
+  plugin GUIs and plugin APIs.
+- Users access plugin management UIs from CT Ops, for example from Settings ->
+  Integrations or a Plugins area. CT Ops launches the plugin UI by redirecting
+  the browser to the registered plugin URL with a short-lived signed launch
+  assertion, or by opening a CT Ops-hosted proxy route that forwards the
+  assertion server-side.
+- CT Ops must not own extension-specific configuration forms, validation rules,
+  source settings, or plugin workflow logic. Those forms and handlers live in
+  the plugin service so CT Ops stays a thin visualization, identity, launch,
+  and reporting layer.
+- CT Ops may embed a plugin-hosted UI in an iframe or open the plugin UI in a
+  separate route/window. In either case, CT Ops provides the signed launch
+  assertion and the plugin renders its own management experience.
+- Each plugin keeps its own database for plugin-owned operational data.
+- Each plugin stores a trust anchor for the paired CT Ops installation, such as
+  the CT Ops issuer identifier and public signing key or certificate
+  fingerprint.
+- CT Ops stores the registered plugin instance identifier, plugin public key or
+  shared verification material, allowed organisation scope, enabled products,
+  and revocation state.
+- User access to a plugin GUI uses short-lived CT Ops-issued signed assertions
+  with an audience bound to the plugin instance. Assertions must include at
+  least the CT Ops installation identifier, organisation identifier, user
+  identifier, role or permission claims, plugin product identifier, expiry, and
+  nonce or token identifier.
+- Plugins create their own local web session only after verifying the CT
+  Ops-issued launch assertion. The plugin session should be short-lived,
+  same-site where possible, scoped to that plugin instance, and revocable when
+  CT Ops disables the plugin instance or the user's CT Ops access changes.
+- Embedded plugin UIs must use explicit frame and message boundaries. CT Ops
+  should only embed registered plugin origins, and plugins should set
+  `Content-Security-Policy` `frame-ancestors` to the paired CT Ops origin where
+  possible. Any `postMessage` integration must validate origin, audience, and
+  message shape.
+- Plugins verify CT Ops-issued assertions locally using the pinned CT Ops trust
+  anchor and authorize access from the claims. Plugins must reject assertions
+  with the wrong issuer, audience, organisation, product, expiry, or revoked
+  plugin instance.
+- Service-to-service calls continue to use scoped signed service tokens for
+  inventory, finding, health, and subscription-status APIs.
+
+A CT Ops private key with a plugin-stored CT Ops public key is useful because it
+prevents a plugin from accepting users from a fake CT Ops database unless the
+attacker also controls the paired CT Ops signing key. The public key alone is
+not a complete security boundary: pairing, key rotation, revocation, token
+audience binding, expiry, and plugin database protection are still required.
+
+## Plugin Licensing
+
+Plugin licences are product-specific and separate from CT Ops seat licences,
+but they are anchored to CT Ops because CT Ops is always present.
+
+The target licensing flow is:
+
+1. CT Ops registers or pairs a plugin instance for an organisation.
+2. The plugin GUI displays a licence request-token generator.
+3. The generated request token includes the product identifier, plugin instance
+   identifier, CT Ops installation identifier, organisation identifier, plugin
+   public-key fingerprint or service-token binding, requested edition/capacity
+   metadata, creation timestamp, and nonce.
+4. The request token is signed by CT Ops, the plugin, or both, depending on the
+   final CT Portal contract. CT Portal must be able to verify that the request
+   came from a paired CT Ops/plugin installation and was not edited by the
+   customer.
+5. CT Portal issues a licence key bound to the CT Ops installation,
+   organisation, plugin product, and plugin instance or key fingerprint.
+6. CT Ops stores and validates the active plugin entitlement status and exposes
+   that status to the plugin through a signed subscription-status API.
+7. The plugin enforces product-specific entitlement checks server-side for
+   plugin-owned work, while CT Ops remains responsible for CT Ops seat limits
+   and customer-facing reporting access.
+
+Plugin entitlement status should degrade safely. If CT Ops cannot validate a
+plugin entitlement, the plugin should stop paid plugin-owned processing and show
+clear status in its operational GUI without corrupting existing plugin data or
+removing CT Ops access to historical imported findings.
 
 ## Deployment Model
 
@@ -123,8 +225,8 @@ For the first CT-CVE release, one `ct-cve` container may host both API and
 background worker responsibilities. Splitting that into `ct-cve-api` and
 `ct-cve-worker` remains a later scaling and operations decision.
 
-CT-CVE has its own configuration, migrations, Dockerfile, CI, README, and
-release cadence.
+CT-CVE has its own configuration, migrations, Dockerfile, CI, README, database,
+and release cadence.
 
 ## Integration Boundary
 


### PR DESCRIPTION
## Summary
- define CT Ops as the shared identity, organisation, and licensing anchor for CT-CVE and future plugins
- document extension-hosted configuration UI launched or embedded from CT Ops with signed assertions
- add follow-up migration phases for plugin identity broker, plugin entitlement storage, and CT-CVE auth/subscription integration

## Validation
- git diff --check
- targeted rg consistency checks across edited docs