### PR TITLE
fix(install): encode generated database passwords

### DIFF
--- a/apps/ingest/internal/config/config.go
+++ b/apps/ingest/internal/config/config.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -242,6 +244,9 @@ func defaults() *Config {
 }
 
 func applyEnv(cfg *Config) {
+	if v := databaseURLFromPostgresEnv(); v != "" {
+		cfg.DatabaseURL = v
+	}
 	if v := os.Getenv("INGEST_DATABASE_URL"); v != "" {
 		cfg.DatabaseURL = v
 	}
@@ -282,6 +287,33 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("INGEST_TERMINAL_TRUSTED_ORIGINS"); v != "" {
 		cfg.Terminal.TrustedOrigins = splitCSV(v)
 	}
+}
+
+func databaseURLFromPostgresEnv() string {
+	password := os.Getenv("POSTGRES_PASSWORD")
+	if password == "" {
+		return ""
+	}
+
+	user := getenvDefault("POSTGRES_USER", "ctops")
+	host := getenvDefault("POSTGRES_HOST", "localhost")
+	port := getenvDefault("POSTGRES_PORT", "5432")
+	database := getenvDefault("POSTGRES_DB", "ctops")
+
+	u := &url.URL{
+		Scheme: "postgresql",
+		User:   url.UserPassword(user, password),
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/" + database,
+	}
+	return u.String()
+}
+
+func getenvDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
 }
 
 func splitCSV(raw string) []string {

--- a/apps/ingest/internal/config/config_test.go
+++ b/apps/ingest/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -16,5 +17,31 @@ func TestLoadAppliesTerminalTrustedOriginsEnv(t *testing.T) {
 	want := []string{"https://app.example.com", "http://localhost:3000"}
 	if !reflect.DeepEqual(cfg.Terminal.TrustedOrigins, want) {
 		t.Fatalf("cfg.Terminal.TrustedOrigins = %#v, want %#v", cfg.Terminal.TrustedOrigins, want)
+	}
+}
+
+func TestLoadBuildsEncodedDatabaseURLFromPostgresEnv(t *testing.T) {
+	t.Setenv("POSTGRES_USER", "ctops")
+	t.Setenv("POSTGRES_PASSWORD", "Pyth)n2475##")
+	t.Setenv("POSTGRES_HOST", "db")
+	t.Setenv("POSTGRES_PORT", "5432")
+	t.Setenv("POSTGRES_DB", "ctops")
+
+	cfg, err := Load("/tmp/does-not-exist.yaml")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	parsed, err := url.Parse(cfg.DatabaseURL)
+	if err != nil {
+		t.Fatalf("cfg.DatabaseURL should parse: %v", err)
+	}
+	if got, _ := parsed.User.Password(); got != "Pyth)n2475##" {
+		t.Fatalf("parsed password = %q, want %q", got, "Pyth)n2475##")
+	}
+
+	want := "postgresql://ctops:Pyth%29n2475%23%23@db:5432/ctops"
+	if cfg.DatabaseURL != want {
+		t.Fatalf("cfg.DatabaseURL = %q, want %q", cfg.DatabaseURL, want)
 	}
 }

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -1,5 +1,6 @@
 import { config } from 'dotenv'
 import { defineConfig } from 'drizzle-kit'
+import { getDatabaseUrl } from './lib/db/connection-string.ts'
 
 config({ path: '.env.local' })
 
@@ -8,7 +9,7 @@ export default defineConfig({
   out: './lib/db/migrations',
   dialect: 'postgresql',
   dbCredentials: {
-    url: process.env['DATABASE_URL'] ?? '',
+    url: getDatabaseUrl(),
   },
   verbose: true,
   strict: true,

--- a/apps/web/lib/db/connection-string.test.mjs
+++ b/apps/web/lib/db/connection-string.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getDatabaseUrl } from './connection-string.ts'
+
+test('getDatabaseUrl builds an encoded URL from POSTGRES_* environment variables', () => {
+  const env = {
+    POSTGRES_USER: 'ctops',
+    POSTGRES_PASSWORD: 'Pyth)n2475##',
+    POSTGRES_HOST: 'db',
+    POSTGRES_PORT: '5432',
+    POSTGRES_DB: 'ctops',
+  }
+
+  const databaseUrl = getDatabaseUrl(env)
+  const parsed = new URL(databaseUrl)
+
+  assert.equal(databaseUrl, 'postgresql://ctops:Pyth)n2475%23%23@db:5432/ctops')
+  assert.equal(decodeURIComponent(parsed.password), 'Pyth)n2475##')
+})
+
+test('getDatabaseUrl prefers explicit DATABASE_URL', () => {
+  const env = {
+    DATABASE_URL: 'postgresql://custom:secret@example.test:5432/custom',
+    POSTGRES_USER: 'ctops',
+    POSTGRES_PASSWORD: 'Pyth)n2475##',
+    POSTGRES_HOST: 'db',
+    POSTGRES_PORT: '5432',
+    POSTGRES_DB: 'ctops',
+  }
+
+  assert.equal(getDatabaseUrl(env), 'postgresql://custom:secret@example.test:5432/custom')
+})

--- a/apps/web/lib/db/connection-string.ts
+++ b/apps/web/lib/db/connection-string.ts
@@ -1,0 +1,22 @@
+type DatabaseEnv = Record<string, string | undefined>
+
+export function getDatabaseUrl(env: DatabaseEnv = process.env): string {
+  if (env['DATABASE_URL']) {
+    return env['DATABASE_URL']
+  }
+
+  const user = env['POSTGRES_USER'] || 'ctops'
+  const password = env['POSTGRES_PASSWORD']
+  const host = env['POSTGRES_HOST'] || 'localhost'
+  const port = env['POSTGRES_PORT'] || '5432'
+  const database = env['POSTGRES_DB'] || 'ctops'
+
+  if (!password) {
+    throw new Error('POSTGRES_PASSWORD environment variable is required when DATABASE_URL is not set')
+  }
+
+  const url = new URL(`postgresql://${host}:${port}/${database}`)
+  url.username = user
+  url.password = password
+  return url.toString()
+}

--- a/apps/web/lib/db/index.ts
+++ b/apps/web/lib/db/index.ts
@@ -2,11 +2,9 @@ import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import * as schema from './schema/index.ts'
 import { runWithOrgDatabaseScope } from './rls.ts'
+import { getDatabaseUrl } from './connection-string.ts'
 
-const connectionString = process.env['DATABASE_URL']
-if (!connectionString) {
-  throw new Error('DATABASE_URL environment variable is required')
-}
+const connectionString = getDatabaseUrl()
 
 // Disable prefetch as it is not supported for "transaction" pool mode
 export const client = postgres(connectionString, { prepare: false })

--- a/apps/web/migrate.js
+++ b/apps/web/migrate.js
@@ -3,18 +3,36 @@
 // inside the standalone Docker image without drizzle-kit.
 //
 // Usage: node migrate.js
-// Requires: DATABASE_URL environment variable
+// Requires either DATABASE_URL or POSTGRES_* environment variables.
 
 const { drizzle } = require('drizzle-orm/postgres-js')
 const { migrate } = require('drizzle-orm/postgres-js/migrator')
 const postgres = require('postgres')
 const path = require('path')
 
-async function main() {
-  const connectionString = process.env['DATABASE_URL']
-  if (!connectionString) {
-    throw new Error('DATABASE_URL environment variable is required')
+function getDatabaseUrl(env = process.env) {
+  if (env['DATABASE_URL']) {
+    return env['DATABASE_URL']
   }
+
+  const user = env['POSTGRES_USER'] || 'ctops'
+  const password = env['POSTGRES_PASSWORD']
+  const host = env['POSTGRES_HOST'] || 'localhost'
+  const port = env['POSTGRES_PORT'] || '5432'
+  const database = env['POSTGRES_DB'] || 'ctops'
+
+  if (!password) {
+    throw new Error('POSTGRES_PASSWORD environment variable is required when DATABASE_URL is not set')
+  }
+
+  const url = new URL(`postgresql://${host}:${port}/${database}`)
+  url.username = user
+  url.password = password
+  return url.toString()
+}
+
+async function main() {
+  const connectionString = getDatabaseUrl()
 
   const client = postgres(connectionString, { prepare: false, max: 1 })
   const db = drizzle(client)

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -34,7 +34,11 @@ services:
       # exposing plaintext HTTP externally.
       - "127.0.0.1:3000:3000"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ctops}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-ctops}
+      POSTGRES_USER: ${POSTGRES_USER:-ctops}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-ctops}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set in your .env file}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-https://localhost}
       BETTER_AUTH_TRUSTED_ORIGINS: ${BETTER_AUTH_TRUSTED_ORIGINS:-https://localhost}
@@ -83,7 +87,11 @@ services:
       db:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ctops}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-ctops}
+      POSTGRES_USER: ${POSTGRES_USER:-ctops}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-ctops}
     command: ["node", "migrate.js"]
 
   ingest:
@@ -101,7 +109,11 @@ services:
       # no reason to expose plaintext JWKS/healthz/WS externally.
       - "127.0.0.1:8080:8080"
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-ctops}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@db:5432/${POSTGRES_DB:-ctops}
+      POSTGRES_USER: ${POSTGRES_USER:-ctops}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-ctops}
       INGEST_TLS_CERT: /etc/ct-ops/tls/server.crt
       INGEST_TLS_KEY: /etc/ct-ops/tls/server.key
       INGEST_JWT_KEY_FILE: /var/lib/ct-ops/jwt_key.pem

--- a/start.sh
+++ b/start.sh
@@ -230,7 +230,7 @@ if $DB_ONLY; then
   echo "  INGEST_TLS_CERT=$CERT_DIR/server.crt \\"
   echo "  INGEST_TLS_KEY=$CERT_DIR/server.key \\"
   echo "  INGEST_JWT_KEY_FILE=$SCRIPT_DIR/deploy/dev-ingest-data/jwt_key.pem \\"
-  echo "  DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB} \\"
+  echo "  POSTGRES_USER=$POSTGRES_USER POSTGRES_PASSWORD=<redacted> POSTGRES_HOST=localhost POSTGRES_PORT=$POSTGRES_PORT POSTGRES_DB=$POSTGRES_DB \\"
   echo "  ./dist/ingest"
   echo ""
   echo "Run the Next.js dev server manually:  cd apps/web && pnpm dev"
@@ -259,7 +259,11 @@ echo "Starting ingest service (native process)..."
 INGEST_TLS_CERT="$CERT_DIR/server.crt" \
 INGEST_TLS_KEY="$CERT_DIR/server.key" \
 INGEST_JWT_KEY_FILE="$INGEST_DATA_DIR/jwt_key.pem" \
-DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}" \
+POSTGRES_USER="$POSTGRES_USER" \
+POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+POSTGRES_HOST="localhost" \
+POSTGRES_PORT="$POSTGRES_PORT" \
+POSTGRES_DB="$POSTGRES_DB" \
 INGEST_AGENT_DOWNLOAD_BASE_URL="${AGENT_DOWNLOAD_BASE_URL:-http://localhost:3000}" \
 INGEST_RELEASE_MANIFEST_PATH="$SCRIPT_DIR/.release-please-manifest.json" \
 "$SCRIPT_DIR/dist/ingest" &


### PR DESCRIPTION
## Summary

- Stop composing customer-stack database URLs directly in `docker-compose.single.yml`; pass discrete `POSTGRES_*` fields instead.
- Add shared web database URL construction that percent-encodes generated passwords before handing them to `postgres`/Drizzle.
- Teach ingest to build an encoded database URL from the same `POSTGRES_*` fields, and align local `start.sh` with that path.

## Root Cause

The release bundle could generate or preserve a `POSTGRES_PASSWORD` containing URL-reserved characters such as `#`. The compose file interpolated that raw password into `postgresql://user:password@host/db`, so Node's URL parser treated the password as an invalid URL fragment and migrations exited before the stack could start.

## Validation

- `pnpm --filter web type-check`
- `pnpm --filter web test:unit`
- `go test ./internal/config` from `apps/ingest`
- `BETTER_AUTH_SECRET=$(openssl rand -hex 32) POSTGRES_PASSWORD='Pyth)n2475##' docker compose -f docker-compose.single.yml config`
