### PR TITLE
fix(installer): release latest web bundle

### DIFF
--- a/deploy/scripts/test-install.sh
+++ b/deploy/scripts/test-install.sh
@@ -40,7 +40,13 @@ if [[ -z "$out" || -z "$url" ]]; then
   exit 2
 fi
 
-if [[ "$url" == *.sha256 ]]; then
+if [[ -n "${MOCK_CURL_LOG:-}" ]]; then
+  printf '%s\n' "$url" >> "$MOCK_CURL_LOG"
+fi
+
+if [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100" ]]; then
+  printf '%s' "${MOCK_RELEASES_JSON}" > "$out"
+elif [[ "$url" == *.sha256 ]]; then
   printf '%s  ct-ops-single.zip\n' "${MOCK_CHECKSUM}" > "$out"
 else
   printf '%s' "${MOCK_PAYLOAD}" > "$out"
@@ -70,6 +76,11 @@ run_match_case() {
   make_mock_bin "$mockbin"
 
   export MOCK_PAYLOAD="verified bundle payload"
+  export MOCK_RELEASES_JSON='[
+    { "tag_name": "ingest/v9.9.9" },
+    { "tag_name": "web/v1.2.3" }
+  ]'
+  export MOCK_CURL_LOG="${workspace}/curl.log"
   export MOCK_CHECKSUM
   MOCK_CHECKSUM="$(printf '%s' "$MOCK_PAYLOAD" | openssl dgst -sha256 | awk '{print $NF}')"
 
@@ -79,6 +90,13 @@ run_match_case() {
   )
 
   test -d "${workspace}/ct-ops"
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v1.2.3/ct-ops-single.zip" "$MOCK_CURL_LOG"
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v1.2.3/ct-ops-single.zip.sha256" "$MOCK_CURL_LOG"
+  if grep -Fq "/releases/latest/" "$MOCK_CURL_LOG"; then
+    echo "installer should not use GitHub's repo-wide latest release URL" >&2
+    exit 1
+  fi
+  unset MOCK_CURL_LOG
 }
 
 run_mismatch_case() {
@@ -88,6 +106,7 @@ run_mismatch_case() {
   make_mock_bin "$mockbin"
 
   export MOCK_PAYLOAD="tampered bundle payload"
+  export MOCK_RELEASES_JSON='[{ "tag_name": "web/v1.2.3" }]'
   export MOCK_CHECKSUM="deadbeef"
   export UNZIP_SHOULD_FAIL="1"
 
@@ -115,6 +134,32 @@ run_mismatch_case() {
   unset UNZIP_SHOULD_FAIL
 }
 
+run_pinned_case() {
+  local workspace="$1"
+  local mockbin="${workspace}/mockbin"
+  mkdir -p "$workspace" "$mockbin"
+  make_mock_bin "$mockbin"
+
+  export MOCK_PAYLOAD="verified pinned bundle payload"
+  export MOCK_RELEASES_JSON='[{ "tag_name": "ingest/v9.9.9" }]'
+  export MOCK_CURL_LOG="${workspace}/curl.log"
+  export MOCK_CHECKSUM
+  MOCK_CHECKSUM="$(printf '%s' "$MOCK_PAYLOAD" | openssl dgst -sha256 | awk '{print $NF}')"
+
+  (
+    cd "$workspace"
+    PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" CT_OPS_VERSION=v4.5.6 bash "$INSTALLER"
+  )
+
+  test -d "${workspace}/ct-ops"
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v4.5.6/ct-ops-single-v4.5.6.zip" "$MOCK_CURL_LOG"
+  if grep -Fq "api.github.com" "$MOCK_CURL_LOG"; then
+    echo "pinned installs should not query the releases API" >&2
+    exit 1
+  fi
+  unset MOCK_CURL_LOG
+}
+
 main() {
   local tmpdir
   tmpdir="$(mktemp -d)"
@@ -122,6 +167,7 @@ main() {
 
   run_match_case "${tmpdir}/match"
   run_mismatch_case "${tmpdir}/mismatch"
+  run_pinned_case "${tmpdir}/pinned"
   echo "install.sh checksum verification tests passed"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,29 @@ set -euo pipefail
 REPO_OWNER="carrtech-dev"
 REPO_NAME="ct-ops"
 
+latest_web_tag() {
+  local releases_tmp
+  releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
+
+  if ! curl -fsSL \
+    -o "$releases_tmp" \
+    "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100"; then
+    rm -f "$releases_tmp"
+    return 1
+  fi
+
+  local tag
+  tag="$(awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9][^"]*"/ { print $4; exit }' "$releases_tmp")"
+  rm -f "$releases_tmp"
+
+  if [ -z "$tag" ]; then
+    echo "ERROR: could not find a published web release for ${REPO_OWNER}/${REPO_NAME}." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$tag"
+}
+
 if [ "$(id -u)" = "0" ]; then
   echo "ERROR: do not run this installer as root." >&2
   echo "Run it as the user that will operate ct-ops (must be in the docker group)." >&2
@@ -39,13 +62,20 @@ if [ -d "ct-ops" ]; then
 fi
 
 if [ -n "${CT_OPS_VERSION:-}" ]; then
-  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/web/${CT_OPS_VERSION}/ct-ops-single-${CT_OPS_VERSION}.zip"
+  WEB_TAG="${CT_OPS_VERSION}"
+  if [[ "$WEB_TAG" != web/* ]]; then
+    WEB_TAG="web/${WEB_TAG}"
+  fi
+  VERSION="${WEB_TAG#web/}"
+  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${WEB_TAG}/ct-ops-single-${VERSION}.zip"
   CHECKSUM_URL="${URL}.sha256"
-  echo "Downloading ct-ops ${CT_OPS_VERSION}..."
+  echo "Downloading ct-ops ${VERSION}..."
 else
-  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download/ct-ops-single.zip"
+  WEB_TAG="$(latest_web_tag)"
+  VERSION="${WEB_TAG#web/}"
+  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${WEB_TAG}/ct-ops-single.zip"
   CHECKSUM_URL="${URL}.sha256"
-  echo "Downloading the latest ct-ops release..."
+  echo "Downloading the latest ct-ops release (${VERSION})..."
 fi
 
 TMP=$(mktemp -t ct-ops.XXXXXX.zip)


### PR DESCRIPTION
## Summary

- Resolve latest installs by selecting the newest `web/v*` release instead of GitHub's repo-wide latest release.
- Keep pinned installs using versioned web release asset URLs.
- Add installer regression coverage for the case where a newer `ingest/*` release exists without customer bundle assets.

## Root Cause

The one-line installer used `/releases/latest/download/ct-ops-single.zip`. After the database password encoding fix shipped an `ingest/*` release, GitHub's repo-wide latest release pointed at `ingest/v0.8.2`, which does not include `ct-ops-single.zip`, causing a 404.

## Validation

- `bash deploy/scripts/test-install.sh`
- `bash -n install.sh deploy/scripts/test-install.sh`
- Verified the current web bundle asset exists while the old `/releases/latest` path redirects to the ingest release and 404s.
