### PR TITLE
feat(install): add customer upgrade helper

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -184,6 +184,7 @@ jobs:
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example
           cp deploy/customer-bundle/README.md dist/ct-ops/README.md
+          cp deploy/customer-bundle/upgrade.sh dist/ct-ops/upgrade.sh
           cp deploy/customer-bundle/generate_support_data dist/ct-ops/generate_support_data
           cp deploy/nginx/nginx.conf          dist/ct-ops/deploy/nginx/nginx.conf
           echo "$VERSION" > dist/ct-ops/VERSION
@@ -461,6 +462,9 @@ jobs:
           cp deploy/customer-bundle/start.sh dist/ct-ops/start.sh
           chmod +x dist/ct-ops/start.sh
           bash -n dist/ct-ops/start.sh
+
+          chmod +x dist/ct-ops/upgrade.sh
+          bash -n dist/ct-ops/upgrade.sh
 
           # build-offline-installer.sh — also generated inline. Engineer runs
           # this on an internet-connected host to pull and bundle the docker

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/customer-bundle-check.yml"
       - "deploy/customer-bundle/**"
       - "deploy/scripts/test-install.sh"
+      - "deploy/scripts/test-upgrade.sh"
       - "deploy/scripts/test-support-data.sh"
       - "deploy/nginx/nginx.conf"
       - "docker-compose.single.yml"
@@ -32,12 +33,13 @@ jobs:
           cp deploy/customer-bundle/README.md dist/ct-ops/README.md
           cp deploy/customer-bundle/start.sh dist/ct-ops/start.sh
           cp deploy/customer-bundle/build-offline-installer.sh dist/ct-ops/build-offline-installer.sh
+          cp deploy/customer-bundle/upgrade.sh dist/ct-ops/upgrade.sh
           cp deploy/customer-bundle/generate_support_data dist/ct-ops/generate_support_data
           cp deploy/nginx/nginx.conf dist/ct-ops/deploy/nginx/nginx.conf
           echo "test" > dist/ct-ops/VERSION
           perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml
           perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m' dist/ct-ops/.env.example
-          chmod +x dist/ct-ops/start.sh dist/ct-ops/build-offline-installer.sh dist/ct-ops/generate_support_data
+          chmod +x dist/ct-ops/start.sh dist/ct-ops/build-offline-installer.sh dist/ct-ops/upgrade.sh dist/ct-ops/generate_support_data
 
       - name: Validate scripts and required files
         working-directory: dist/ct-ops
@@ -46,9 +48,11 @@ jobs:
           test -f docker-compose.yml
           test -f deploy/nginx/nginx.conf
           test -f .env.example
+          test -x upgrade.sh
           test -x generate_support_data
           bash -n start.sh
           bash -n build-offline-installer.sh
+          bash -n upgrade.sh
           bash -n generate_support_data
 
       - name: Validate installer script
@@ -56,6 +60,7 @@ jobs:
           set -euo pipefail
           bash -n install.sh
           bash deploy/scripts/test-install.sh
+          bash deploy/scripts/test-upgrade.sh
           bash deploy/scripts/test-support-data.sh
 
       - name: Render compose config

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,17 @@
 
 ## What Has Been Built
 
+### Session 95 — Customer bundle upgrade helper
+
+**Release bundle upgrades** (`deploy/customer-bundle/upgrade.sh`, `deploy/customer-bundle/README.md`)
+- Added a bundled `upgrade.sh` that backs up the current install, downloads or accepts a local release zip, stops the Compose stack without deleting named volumes, installs the new release files in place, preserves `.env` and TLS material, and restarts through `start.sh`.
+- Added `--version`, `--from-zip`, and `--no-start` options so online, pinned-version, and air-gapped upgrades use the same safety flow.
+- Updated customer bundle and getting-started docs to describe release-pinned images and the upgrade path instead of relying on `:latest`.
+
+**Validation**
+- Added `deploy/scripts/test-upgrade.sh` for the local bundle path, backup creation, stale offline image archive removal, and volume-preserving Compose shutdown.
+- Customer bundle CI now packages and syntax-checks `upgrade.sh`; local validation ran installer, upgrade, support-data, staged-bundle syntax, and Compose image rendering checks.
+
 ### Session 94 — Complete CT-CVE final residue audit
 
 **CT-CVE migration audit** (`docs/ct-cve-final-residue-audit.md`, `docs/ct-cve-migration-plan.md`)

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -42,7 +42,7 @@ This will:
 1. Generate `BETTER_AUTH_SECRET` if it is still blank
 2. Generate dev TLS certificates under `./deploy/dev-tls/` for the ingest
    service
-3. Pull the latest `web`, `ingest`, and `db` images from GHCR
+3. Pull the release-pinned `web`, `ingest`, and `db` images from GHCR
    (or load `images.tar.gz` if it is present — see *Air-gap installs* below)
 4. Start the stack
 5. A one-shot migration container applies database migrations before web and ingest start
@@ -68,6 +68,7 @@ the external HTTPS port and `9443` to the instance.
 ./start.sh --down     # stop the stack (data is preserved)
 ./start.sh --version  # show bundle version, app version and licence tier
 ./start.sh --help     # links to documentation and support
+./upgrade.sh          # back up this install and upgrade to the latest release
 ./generate_support_data  # create a redacted support archive
 ```
 
@@ -80,13 +81,28 @@ binary from your ct-ops server using `AGENT_DOWNLOAD_BASE_URL`.
 ## Updating
 
 ```sh
-./start.sh
+./upgrade.sh
 ```
 
-re-pulls `:latest` and recreates any containers whose image has changed.
+backs up the current install, downloads the latest release bundle, stops the
+stack without deleting named volumes, installs the new release files in place,
+preserves `.env` and TLS material, and starts the upgraded stack. Database
+migrations run before web and ingest start.
 
-To pin to a specific image version instead of `:latest`, set `WEB_IMAGE`
-and `INGEST_IMAGE` in `.env` (see commented examples in `.env.example`).
+To upgrade to a specific version:
+
+```sh
+./upgrade.sh --version v0.3.0
+```
+
+For air-gapped hosts, copy the new air-gap zip to the server and run:
+
+```sh
+./upgrade.sh --from-zip /path/to/ct-ops-single-v0.3.0-airgap.zip
+```
+
+Do not edit only one image reference. `web` and `ingest` are released as a
+matched pair in each bundle.
 
 ## Air-gap installs
 

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 #   ./start.sh --down      Stop the stack (data is preserved)
 #   ./start.sh --version   Show bundle / app version and licence tier
 #   ./start.sh --help      Show this help and links to docs / support
+#   ./upgrade.sh           Back up this install and upgrade to a new release
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -45,6 +46,7 @@ Commands:
   ./start.sh --down      Stop the stack (named volumes are preserved)
   ./start.sh --version   Show bundle version, app version and licence tier
   ./start.sh --help      Show this message
+  ./upgrade.sh            Back up this install and upgrade to a new release
   ./generate_support_data  Create a redacted support archive for tickets
 
 Documentation: ${DOCS_URL}

--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# CT-Ops — Customer Upgrade Script
+#
+# Run from inside an existing CT-Ops release bundle. The script backs up the
+# current bundle, stops the stack without deleting named volumes, installs a
+# newer release bundle in place, restores operator-owned files, and starts the
+# upgraded stack.
+# =============================================================================
+
+REPO_OWNER="carrtech-dev"
+REPO_NAME="ct-ops"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+FROM_ZIP=""
+START_AFTER_UPGRADE=true
+VERSION_OVERRIDE="${CT_OPS_VERSION:-}"
+
+show_help() {
+  cat <<EOF
+CT-Ops — upgrade helper
+
+Usage:
+  ./upgrade.sh
+  ./upgrade.sh --version v0.3.0
+  ./upgrade.sh --from-zip /path/to/ct-ops-single-v0.3.0-airgap.zip
+  ./upgrade.sh --no-start
+
+By default, the latest release bundle is downloaded from GitHub. For air-gapped
+hosts, pass a bundle zip with --from-zip. A backup tarball is written before any
+files are replaced.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --from-zip)
+      FROM_ZIP="${2:-}"
+      if [ -z "$FROM_ZIP" ]; then
+        echo "ERROR: --from-zip requires a path." >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --version)
+      VERSION_OVERRIDE="${2:-}"
+      if [ -z "$VERSION_OVERRIDE" ]; then
+        echo "ERROR: --version requires a version, for example v0.3.0." >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --no-start)
+      START_AFTER_UPGRADE=false
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option '$1'." >&2
+      echo "" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command '$1' not found in PATH." >&2
+    exit 1
+  fi
+}
+
+require_existing_bundle() {
+  local missing=()
+  for file in docker-compose.yml start.sh .env; do
+    if [ ! -f "$file" ]; then
+      missing+=("$file")
+    fi
+  done
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: this does not look like an existing CT-Ops install." >&2
+    echo "Missing required files:" >&2
+    for file in "${missing[@]}"; do echo "  - $file" >&2; done
+    echo "Run upgrade.sh from inside the existing ct-ops directory." >&2
+    exit 1
+  fi
+}
+
+require_docker() {
+  need docker
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "ERROR: 'docker compose' plugin not found." >&2
+    exit 1
+  fi
+}
+
+latest_web_tag() {
+  local releases_tmp
+  releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
+
+  if ! curl -fsSL \
+    -o "$releases_tmp" \
+    "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100"; then
+    rm -f "$releases_tmp"
+    return 1
+  fi
+
+  local tag
+  tag="$(awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9][^"]*"/ { print $4; exit }' "$releases_tmp")"
+  rm -f "$releases_tmp"
+
+  if [ -z "$tag" ]; then
+    echo "ERROR: could not find a published web release for ${REPO_OWNER}/${REPO_NAME}." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$tag"
+}
+
+download_bundle() {
+  need curl
+  need openssl
+
+  local web_tag version url checksum_url checksum_tmp expected actual
+  if [ -n "$VERSION_OVERRIDE" ]; then
+    web_tag="$VERSION_OVERRIDE"
+    if [[ "$web_tag" != web/* ]]; then
+      web_tag="web/$web_tag"
+    fi
+    version="${web_tag#web/}"
+    url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${web_tag}/ct-ops-single-${version}.zip"
+  else
+    web_tag="$(latest_web_tag)"
+    version="${web_tag#web/}"
+    url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${web_tag}/ct-ops-single.zip"
+  fi
+  checksum_url="${url}.sha256"
+
+  BUNDLE_ZIP="$(mktemp -t ct-ops.XXXXXX.zip)"
+  checksum_tmp="$(mktemp -t ct-ops.XXXXXX.sha256)"
+  TEMP_FILES+=("$BUNDLE_ZIP" "$checksum_tmp")
+
+  echo "Downloading CT-Ops ${version}..."
+  curl -fsSL -o "$BUNDLE_ZIP" "$url"
+  curl -fsSL -o "$checksum_tmp" "$checksum_url"
+
+  expected="$(awk 'NF { print $1; exit }' "$checksum_tmp" | tr '[:upper:]' '[:lower:]')"
+  actual="$(openssl dgst -sha256 "$BUNDLE_ZIP" | awk '{print $NF}' | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$expected" ] || [ "$actual" != "$expected" ]; then
+    echo "ERROR: bundle checksum mismatch." >&2
+    echo "Expected: ${expected:-<empty>}" >&2
+    echo "Actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+verify_local_bundle_checksum() {
+  local checksum_file expected actual
+  checksum_file="${FROM_ZIP}.sha256"
+  if [ ! -f "$checksum_file" ]; then
+    return 0
+  fi
+
+  need openssl
+  expected="$(awk 'NF { print $1; exit }' "$checksum_file" | tr '[:upper:]' '[:lower:]')"
+  actual="$(openssl dgst -sha256 "$FROM_ZIP" | awk '{print $NF}' | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$expected" ] || [ "$actual" != "$expected" ]; then
+    echo "ERROR: local bundle checksum mismatch for $FROM_ZIP." >&2
+    echo "Expected: ${expected:-<empty>}" >&2
+    echo "Actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+make_backup() {
+  need tar
+  need date
+
+  local parent dirname timestamp version safe_version
+  parent="$(dirname "$SCRIPT_DIR")"
+  dirname="$(basename "$SCRIPT_DIR")"
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  version="$(cat VERSION 2>/dev/null || echo unknown)"
+  safe_version="$(printf '%s' "$version" | tr -c 'A-Za-z0-9._-' '_')"
+
+  BACKUP_ROOT="${CT_OPS_BACKUP_DIR:-${parent}/ct-ops-backups}"
+  mkdir -p "$BACKUP_ROOT"
+  chmod 700 "$BACKUP_ROOT" 2>/dev/null || true
+
+  BACKUP_FILE="${BACKUP_ROOT}/${dirname}-${safe_version}-${timestamp}.tar.gz"
+  echo "Backing up current install to:"
+  echo "  $BACKUP_FILE"
+  (
+    cd "$parent"
+    tar -czf "$BACKUP_FILE" \
+      --exclude "${dirname}/ct-ops-support-data-*.tar.gz" \
+      --exclude "${dirname}/ct-ops-single-*-airgap.zip" \
+      "$dirname"
+  )
+  chmod 600 "$BACKUP_FILE" 2>/dev/null || true
+}
+
+unpack_new_bundle() {
+  need unzip
+
+  UNPACK_DIR="$(mktemp -d -t ct-ops-upgrade.XXXXXX)"
+  TEMP_DIRS+=("$UNPACK_DIR")
+
+  unzip -q "$BUNDLE_ZIP" -d "$UNPACK_DIR"
+  NEW_BUNDLE_DIR="$UNPACK_DIR/ct-ops"
+  if [ ! -f "$NEW_BUNDLE_DIR/docker-compose.yml" ] || [ ! -f "$NEW_BUNDLE_DIR/start.sh" ]; then
+    echo "ERROR: upgrade bundle is missing docker-compose.yml or start.sh." >&2
+    exit 1
+  fi
+}
+
+stop_stack() {
+  echo "Stopping CT-Ops stack; named volumes are preserved..."
+  docker compose down --remove-orphans >/dev/null 2>&1 || true
+}
+
+install_new_bundle_files() {
+  echo "Installing new release files..."
+
+  cp "$NEW_BUNDLE_DIR/docker-compose.yml" docker-compose.yml
+  cp "$NEW_BUNDLE_DIR/.env.example" .env.example
+  cp "$NEW_BUNDLE_DIR/README.md" README.md
+  cp "$NEW_BUNDLE_DIR/start.sh" start.sh
+  cp "$NEW_BUNDLE_DIR/build-offline-installer.sh" build-offline-installer.sh
+  cp "$NEW_BUNDLE_DIR/generate_support_data" generate_support_data
+  if [ -f "$NEW_BUNDLE_DIR/upgrade.sh" ]; then
+    cp "$NEW_BUNDLE_DIR/upgrade.sh" upgrade.sh
+  fi
+  if [ -f "$NEW_BUNDLE_DIR/VERSION" ]; then
+    cp "$NEW_BUNDLE_DIR/VERSION" VERSION
+  fi
+
+  chmod +x start.sh build-offline-installer.sh generate_support_data
+  if [ -f upgrade.sh ]; then
+    chmod +x upgrade.sh
+  fi
+
+  mkdir -p deploy/nginx
+  cp "$NEW_BUNDLE_DIR/deploy/nginx/nginx.conf" deploy/nginx/nginx.conf
+
+  # Preserve operator-owned .env and TLS directories already in this install.
+  # For online upgrades, remove any old offline image archive so start.sh pulls
+  # the images pinned by the newly installed docker-compose.yml. For air-gapped
+  # upgrades, the new archive is copied from the provided bundle.
+  rm -f images.tar.gz
+  if [ -f "$NEW_BUNDLE_DIR/images.tar.gz" ]; then
+    cp "$NEW_BUNDLE_DIR/images.tar.gz" images.tar.gz
+  fi
+}
+
+refresh_release_image_env_refs() {
+  local var new_value current_value
+
+  for var in WEB_IMAGE INGEST_IMAGE; do
+    new_value="$(sed -n "s/^${var}=//p" .env.example | head -n1)"
+    if [ -z "$new_value" ] || ! grep -q "^${var}=" .env; then
+      continue
+    fi
+
+    current_value="$(sed -n "s/^${var}=//p" .env | head -n1)"
+    case "$current_value" in
+      ghcr.io/carrtech-dev/ct-ops/web@sha256:*|ghcr.io/carrtech-dev/ct-ops/ingest@sha256:*)
+        awk -v key="$var" -v value="$new_value" '
+          $0 ~ "^" key "=" { print key "=" value; next }
+          { print }
+        ' .env > .env.tmp
+        mv .env.tmp .env
+        chmod 600 .env
+        ;;
+      *)
+        echo "WARN: preserving custom ${var} override in .env." >&2
+        echo "      Ensure WEB_IMAGE and INGEST_IMAGE come from the same CT-Ops release." >&2
+        ;;
+    esac
+  done
+}
+
+start_stack() {
+  if ! $START_AFTER_UPGRADE; then
+    echo "Upgrade files installed. Start CT-Ops with ./start.sh when ready."
+    return 0
+  fi
+
+  echo "Starting upgraded CT-Ops stack..."
+  ./start.sh
+}
+
+cleanup() {
+  local file dir
+  for file in "${TEMP_FILES[@]:-}"; do
+    rm -f "$file"
+  done
+  for dir in "${TEMP_DIRS[@]:-}"; do
+    rm -rf "$dir"
+  done
+}
+
+TEMP_FILES=()
+TEMP_DIRS=()
+BUNDLE_ZIP=""
+BACKUP_FILE=""
+UNPACK_DIR=""
+NEW_BUNDLE_DIR=""
+trap cleanup EXIT
+
+require_existing_bundle
+require_docker
+
+if [ -n "$FROM_ZIP" ]; then
+  if [ ! -f "$FROM_ZIP" ]; then
+    echo "ERROR: local bundle not found: $FROM_ZIP" >&2
+    exit 1
+  fi
+  verify_local_bundle_checksum
+  BUNDLE_ZIP="$FROM_ZIP"
+else
+  download_bundle
+fi
+
+make_backup
+unpack_new_bundle
+stop_stack
+install_new_bundle_files
+refresh_release_image_env_refs
+start_stack
+
+echo ""
+echo "Upgrade complete."
+echo "Backup: $BACKUP_FILE"

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+UPGRADE_SCRIPT="${REPO_ROOT}/deploy/customer-bundle/upgrade.sh"
+
+make_mock_bin() {
+  local dir="$1"
+
+  cat > "${dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ge 2 ] && [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+
+if [ "$#" -ge 2 ] && [ "$1" = "compose" ] && [ "$2" = "down" ]; then
+  printf 'docker compose down %s\n' "${*:3}" >> "${MOCK_DOCKER_LOG}"
+  exit 0
+fi
+
+exit 0
+EOF
+
+  chmod +x "${dir}/docker"
+}
+
+write_bundle() {
+  local dir="$1"
+  local version="$2"
+
+  mkdir -p "${dir}/ct-ops/deploy/nginx"
+  printf 'services:\n  web:\n    image: example/web:%s\n' "$version" > "${dir}/ct-ops/docker-compose.yml"
+  {
+    printf 'BETTER_AUTH_URL=https://example.test\n'
+    printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' "${version//[^0-9]/}"
+    printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' "${version//[^0-9]/}"
+  } > "${dir}/ct-ops/.env.example"
+  printf '# README %s\n' "$version" > "${dir}/ct-ops/README.md"
+  printf '#!/usr/bin/env bash\necho start %s\n' "$version" > "${dir}/ct-ops/start.sh"
+  printf '#!/usr/bin/env bash\necho offline %s\n' "$version" > "${dir}/ct-ops/build-offline-installer.sh"
+  printf '#!/usr/bin/env bash\necho support %s\n' "$version" > "${dir}/ct-ops/generate_support_data"
+  cp "$UPGRADE_SCRIPT" "${dir}/ct-ops/upgrade.sh"
+  printf '%s\n' "$version" > "${dir}/ct-ops/VERSION"
+  printf 'nginx %s\n' "$version" > "${dir}/ct-ops/deploy/nginx/nginx.conf"
+  chmod +x "${dir}/ct-ops/start.sh" \
+    "${dir}/ct-ops/build-offline-installer.sh" \
+    "${dir}/ct-ops/generate_support_data" \
+    "${dir}/ct-ops/upgrade.sh"
+}
+
+main() {
+  local tmpdir mockbin old_install new_src backup_dir bundle_zip docker_log
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "'"$tmpdir"'"' EXIT
+
+  mockbin="${tmpdir}/mockbin"
+  old_install="${tmpdir}/current/ct-ops"
+  new_src="${tmpdir}/new"
+  backup_dir="${tmpdir}/backups"
+  bundle_zip="${tmpdir}/ct-ops-single-v9.9.9.zip"
+  docker_log="${tmpdir}/docker.log"
+  mkdir -p "$mockbin" "${tmpdir}/current" "$backup_dir"
+  make_mock_bin "$mockbin"
+
+  write_bundle "${tmpdir}/current" "v1.0.0"
+  {
+    printf 'customer-secret=true\n'
+    printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' 100
+    printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' 100
+  } > "${old_install}/.env"
+  mkdir -p "${old_install}/deploy/tls" "${old_install}/deploy/dev-tls"
+  printf 'tls-cert\n' > "${old_install}/deploy/tls/server.crt"
+  printf 'dev-cert\n' > "${old_install}/deploy/dev-tls/server.crt"
+  printf 'stale image archive\n' > "${old_install}/images.tar.gz"
+
+  write_bundle "$new_src" "v9.9.9"
+  (cd "$new_src" && zip -qr "$bundle_zip" ct-ops)
+
+  (
+    cd "$old_install"
+    PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" \
+      MOCK_DOCKER_LOG="$docker_log" \
+      CT_OPS_BACKUP_DIR="$backup_dir" \
+      ./upgrade.sh --from-zip "$bundle_zip" --no-start
+  )
+
+  grep -q 'example/web:v9.9.9' "${old_install}/docker-compose.yml"
+  grep -q 'customer-secret=true' "${old_install}/.env"
+  grep -q 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:.*999' "${old_install}/.env"
+  grep -q 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:.*999' "${old_install}/.env"
+  grep -q 'tls-cert' "${old_install}/deploy/tls/server.crt"
+  grep -q 'dev-cert' "${old_install}/deploy/dev-tls/server.crt"
+  test ! -f "${old_install}/images.tar.gz"
+  grep -q 'docker compose down' "$docker_log"
+
+  local backups
+  backups="$(find "$backup_dir" -name '*.tar.gz' -type f | wc -l | tr -d ' ')"
+  if [ "$backups" != "1" ]; then
+    echo "expected one backup tarball, found $backups" >&2
+    exit 1
+  fi
+
+  echo "upgrade.sh local bundle tests passed"
+}
+
+main "$@"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ $EDITOR .env      # set BETTER_AUTH_URL, AGENT_DOWNLOAD_BASE_URL, etc.
 
 To pin a specific bundle version: `CT_OPS_VERSION=v0.3.0 bash` instead of plain `bash`.
 
-The bundled `start.sh` generates dev TLS certs, generates `BETTER_AUTH_SECRET` if blank, pulls the latest `web`/`ingest`/`db` images from GHCR, and starts the stack. Database migrations run inside the web container automatically on startup.
+The bundled `start.sh` generates dev TLS certs, generates `BETTER_AUTH_SECRET` if blank, pulls the release-pinned `web`/`ingest`/`db` images from GHCR, and starts the stack. Database migrations run inside the web container automatically on startup. Future upgrades are handled by the bundled `./upgrade.sh`, which backs up the current install before replacing release files.
 
 When all three containers show `healthy` in `docker compose ps`, continue from [Create your account](#step-create-your-account). The full quickstart, troubleshooting, and uninstall instructions are in `ct-ops/README.md` inside the bundle.
 


### PR DESCRIPTION
## Summary
- add a bundled upgrade.sh that backs up the current install, installs a downloaded or local release bundle in place, preserves operator config/TLS material, and restarts through start.sh
- wire upgrade.sh into customer bundle packaging and CI validation
- document the release-pinned upgrade flow and add a shell test for local bundle upgrades

## Validation
- bash deploy/scripts/test-upgrade.sh
- bash deploy/scripts/test-install.sh
- bash deploy/scripts/test-support-data.sh
- staged customer bundle syntax checks and digest-pinned docker compose config rendering