### PR TITLE
fix(install): refresh release pins on upgrade

### DIFF
--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -7,10 +7,12 @@ on:
       - ".github/workflows/customer-bundle-check.yml"
       - "deploy/customer-bundle/**"
       - "deploy/scripts/test-install.sh"
+      - "deploy/scripts/test-web-entrypoint.sh"
       - "deploy/scripts/test-upgrade.sh"
       - "deploy/scripts/test-support-data.sh"
       - "deploy/nginx/nginx.conf"
       - "docker-compose.single.yml"
+      - "apps/web/entrypoint.sh"
       - ".env.example"
       - "install.sh"
   workflow_dispatch:
@@ -60,6 +62,7 @@ jobs:
           set -euo pipefail
           bash -n install.sh
           bash deploy/scripts/test-install.sh
+          bash deploy/scripts/test-web-entrypoint.sh
           bash deploy/scripts/test-upgrade.sh
           bash deploy/scripts/test-support-data.sh
 

--- a/apps/web/entrypoint.sh
+++ b/apps/web/entrypoint.sh
@@ -2,9 +2,11 @@
 set -e
 
 # Fail fast if critical environment variables are missing.
-# Silent fallbacks (empty DATABASE_URL, empty auth secret, etc.) produce
-# subtle, hard-to-diagnose failures that surface only at first use.
-: "${DATABASE_URL:?DATABASE_URL must be set}"
+# Silent fallbacks (empty auth secret, missing database credentials, etc.)
+# produce subtle, hard-to-diagnose failures that surface only at first use.
+if [ -z "${DATABASE_URL:-}" ]; then
+  : "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set when DATABASE_URL is not set}"
+fi
 : "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
 : "${BETTER_AUTH_URL:?BETTER_AUTH_URL must be set}"
 

--- a/deploy/scripts/test-web-entrypoint.sh
+++ b/deploy/scripts/test-web-entrypoint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENTRYPOINT="${REPO_ROOT}/apps/web/entrypoint.sh"
+
+run_entrypoint() {
+  local workspace="$1"
+  shift
+
+  mkdir -p "${workspace}/bin" "${workspace}/agent-dist"
+  cat > "${workspace}/bin/node" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "${MOCK_NODE_LOG:?MOCK_NODE_LOG must be set}"
+EOF
+  chmod +x "${workspace}/bin/node"
+
+  (
+    cd "$workspace"
+    env -i \
+      PATH="${workspace}/bin:/usr/bin:/bin" \
+      MOCK_NODE_LOG="${workspace}/node.log" \
+      AGENT_DIST_DIR="${workspace}/agent-dist" \
+      "$@" \
+      sh "$ENTRYPOINT"
+  )
+}
+
+main() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "'"$tmpdir"'"' EXIT
+
+  run_entrypoint "${tmpdir}/database-url" \
+    DATABASE_URL="postgresql://ctops:secret@db:5432/ctops" \
+    BETTER_AUTH_SECRET="test-secret" \
+    BETTER_AUTH_URL="https://ct-ops"
+  grep -Fxq "migrate.js" "${tmpdir}/database-url/node.log"
+  grep -Fxq "server.js" "${tmpdir}/database-url/node.log"
+
+  run_entrypoint "${tmpdir}/postgres-env" \
+    POSTGRES_USER="ctops" \
+    POSTGRES_PASSWORD='Pyth)n2475##' \
+    POSTGRES_HOST="db" \
+    POSTGRES_PORT="5432" \
+    POSTGRES_DB="ctops" \
+    BETTER_AUTH_SECRET="test-secret" \
+    BETTER_AUTH_URL="https://ct-ops"
+  grep -Fxq "migrate.js" "${tmpdir}/postgres-env/node.log"
+  grep -Fxq "server.js" "${tmpdir}/postgres-env/node.log"
+
+  set +e
+  local output
+  output="$(
+    run_entrypoint "${tmpdir}/missing-db" \
+      BETTER_AUTH_SECRET="test-secret" \
+      BETTER_AUTH_URL="https://ct-ops" 2>&1
+  )"
+  local status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "expected entrypoint to fail without DATABASE_URL or POSTGRES_PASSWORD" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"POSTGRES_PASSWORD must be set when DATABASE_URL is not set"* ]]; then
+    echo "expected missing database credential message, got:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  echo "web entrypoint environment tests passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- allow the web container entrypoint to start when compose supplies POSTGRES_* instead of DATABASE_URL
- make upgrade.sh fail loudly if a new bundle lacks release-managed image pins, refresh stale WEB_IMAGE/INGEST_IMAGE overrides in .env together, and report the refresh
- expand upgrade regression coverage so .env, .env.example, and docker-compose.yml all move to the new pinned web/ingest images while customer settings and volumes are preserved
- document that customers should use upgrade.sh rather than editing pinned image refs by hand

## Validation
- bash -n apps/web/entrypoint.sh
- bash -n deploy/scripts/test-web-entrypoint.sh
- bash deploy/scripts/test-web-entrypoint.sh
- bash -n deploy/customer-bundle/upgrade.sh
- bash -n deploy/scripts/test-upgrade.sh
- bash deploy/scripts/test-upgrade.sh
- bash deploy/scripts/test-install.sh
- bash deploy/scripts/test-support-data.sh
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD='Pyth)n2475##' docker compose -f docker-compose.single.yml config