### PR TITLE
fix(install): report unwritable tls directory

### DIFF
--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/customer-bundle-check.yml"
       - "deploy/customer-bundle/**"
       - "deploy/scripts/test-install.sh"
+      - "deploy/scripts/test-start.sh"
       - "deploy/scripts/test-web-entrypoint.sh"
       - "deploy/scripts/test-upgrade.sh"
       - "deploy/scripts/test-support-data.sh"
@@ -62,6 +63,7 @@ jobs:
           set -euo pipefail
           bash -n install.sh
           bash deploy/scripts/test-install.sh
+          bash deploy/scripts/test-start.sh
           bash deploy/scripts/test-web-entrypoint.sh
           bash deploy/scripts/test-upgrade.sh
           bash deploy/scripts/test-support-data.sh

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -228,7 +228,16 @@ gen_cert() {
     echo "ERROR: 'openssl' is required to generate TLS certificates." >&2
     exit 1
   fi
-  mkdir -p "$out_dir"
+  if ! mkdir -p "$out_dir"; then
+    echo "ERROR: could not create TLS directory: $out_dir" >&2
+    exit 1
+  fi
+  if [ ! -w "$out_dir" ]; then
+    echo "ERROR: TLS directory is not writable: $out_dir" >&2
+    echo "Fix ownership or permissions, for example:" >&2
+    echo "  sudo chown -R $(id -u):$(id -g) $out_dir" >&2
+    exit 1
+  fi
 
   local local_ips=""
   if command -v ip >/dev/null 2>&1; then
@@ -239,12 +248,20 @@ gen_cert() {
   local san="DNS:ingest,DNS:localhost,IP:127.0.0.1"
   [ -n "$local_ips" ] && san="${san},${local_ips}"
 
-  openssl req -x509 -newkey rsa:4096 \
+  local openssl_err
+  openssl_err="$(mktemp -t ct-ops-openssl.XXXXXX)"
+  if ! openssl req -x509 -newkey rsa:4096 \
     -keyout "$out_dir/server.key" \
     -out "$out_dir/server.crt" \
     -sha256 -days 365 -nodes \
     -subj "/CN=${cn}" \
-    -addext "subjectAltName=${san}" 2>/dev/null
+    -addext "subjectAltName=${san}" 2>"$openssl_err"; then
+    echo "ERROR: failed to generate TLS certificate in $out_dir" >&2
+    sed 's/^/  /' "$openssl_err" >&2
+    rm -f "$openssl_err"
+    exit 1
+  fi
+  rm -f "$openssl_err"
   chmod 600 "$out_dir/server.key"
   chmod 644 "$out_dir/server.crt"
   echo "Wrote ${out_dir}/server.{crt,key} (CN=${cn}, SANs: ${san})"

--- a/deploy/scripts/test-start.sh
+++ b/deploy/scripts/test-start.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+START_SCRIPT="${REPO_ROOT}/deploy/customer-bundle/start.sh"
+
+make_mock_bin() {
+  local dir="$1"
+
+  cat > "${dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ge 2 ] && [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+
+echo "docker should not be called past version check in this test" >&2
+exit 99
+EOF
+
+  chmod +x "${dir}/docker"
+}
+
+main() {
+  local tmpdir mockbin install_dir output status
+  tmpdir="$(mktemp -d)"
+  trap 'chmod -R u+w "'"$tmpdir"'" 2>/dev/null || true; rm -rf "'"$tmpdir"'"' EXIT
+
+  mockbin="${tmpdir}/mockbin"
+  install_dir="${tmpdir}/ct-ops"
+  mkdir -p "$mockbin" "$install_dir/deploy/nginx" "$install_dir/deploy/dev-tls" "$install_dir/deploy/tls"
+  make_mock_bin "$mockbin"
+
+  cp "$START_SCRIPT" "$install_dir/start.sh"
+  printf 'services: {}\n' > "$install_dir/docker-compose.yml"
+  printf 'nginx config\n' > "$install_dir/deploy/nginx/nginx.conf"
+  printf 'dev cert\n' > "$install_dir/deploy/dev-tls/server.crt"
+  printf 'dev key\n' > "$install_dir/deploy/dev-tls/server.key"
+  cat > "$install_dir/.env" <<'EOF'
+BETTER_AUTH_URL=https://ct-ops
+BETTER_AUTH_TRUSTED_ORIGINS=https://ct-ops
+BETTER_AUTH_SECRET=test-secret
+POSTGRES_PASSWORD=test-password
+AGENT_DOWNLOAD_BASE_URL=https://ct-ops
+WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:1111111111111111111111111111111111111111111111111111111111111111
+INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:2222222222222222222222222222222222222222222222222222222222222222
+EOF
+
+  chmod 555 "$install_dir/deploy/tls"
+
+  set +e
+  output="$(
+    cd "$install_dir" &&
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" ./start.sh 2>&1
+  )"
+  status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "expected start.sh to fail when deploy/tls is not writable" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"TLS directory is not writable"* ]]; then
+    echo "expected writable-directory error, got:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"sudo chown -R"* ]]; then
+    echo "expected ownership repair hint, got:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  echo "start.sh TLS directory permission test passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- fail early with an actionable ownership/permission message when start.sh cannot write deploy/tls
- preserve quiet OpenSSL output on success but surface OpenSSL diagnostics on certificate generation failure
- add a customer start-script regression test for unwritable TLS directories and run it in the customer bundle workflow

## Validation
- bash -n deploy/customer-bundle/start.sh
- bash -n deploy/scripts/test-start.sh
- bash deploy/scripts/test-start.sh
- bash deploy/scripts/test-install.sh
- bash deploy/scripts/test-web-entrypoint.sh
- bash deploy/scripts/test-upgrade.sh
- bash deploy/scripts/test-support-data.sh
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD='Pyh)n2475##' docker compose -f docker-compose.single.yml config