### PR TITLE
feat(web): enforce included ct-ops seats

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,19 @@
 
 ## What Has Been Built
 
+### Session 96 — CT-Ops included-seat admission
+
+**Install-bound seat enforcement** (`apps/web/lib/seat-admission.ts`, `apps/web/lib/seat-selection.ts`, `apps/web/lib/auth/session.ts`)
+- Removed Pro as a valid CT-Ops tier; Community now carries core CT-Ops access and Enterprise remains the only feature add-on tier.
+- Missing, expired, invalid, revoked, or non-CT-Ops licences now degrade to Community with 3 included user seats.
+- Added trusted session admission checks so over-capacity users outside the selected seats are blocked from login/API use without being deleted or deactivated.
+- Added deterministic included-seat selection with admin-pinned users, preserving an active super admin where possible, then pinned/admin users, then oldest active users.
+- Added licence settings controls so admins can pin up to 3 included-seat users for expiry fallback.
+- Updated licensing docs and the CT-Ops/CT-CVE product decision record for the 3 included seats, paid extra seats, Enterprise add-on, and expiry behavior.
+
+**Validation**
+- Validation run: `pnpm --dir apps/web type-check`, `pnpm --dir apps/web test:unit`, `pnpm --dir apps/web db:validate`, targeted ESLint for changed web files, and `pnpm --dir apps/web test:e2e tests/e2e/team/invitations.spec.ts`.
+
 ### Session 95 — Customer bundle upgrade helper
 
 **Release bundle upgrades** (`deploy/customer-bundle/upgrade.sh`, `deploy/customer-bundle/README.md`)
@@ -153,7 +166,7 @@
 **Seat enforcement** (`apps/web/lib/actions/seat-enforcement.ts`, `apps/web/lib/licence-seats.ts`)
 - Added shared seat usage calculation for active non-deleted users plus pending unexpired invitations.
 - Enforced `maxUsers` on admin invites, removed-user restoration, invite acceptance, user reactivation, and LDAP auto-provisioning.
-- Preserved compatibility for licences without `maxUsers` by treating them as unlimited until Community seat rules are finalized.
+- Community seat rules are now finalized: missing `maxUsers` falls back to the 3 included seats.
 
 **Validation**
 - Added unit coverage for seat usage calculations and E2E coverage for invite creation and invite acceptance at the seat limit.

--- a/apps/docs/docs/licensing.md
+++ b/apps/docs/docs/licensing.md
@@ -1,10 +1,11 @@
 # Licensing
 
-CT-Ops uses open-source, seat-based licensing. Core CT-Ops functionality is
-available in Community installs; paid CT-Ops tiers are based on user seats, and
-Enterprise adds Enterprise-only capabilities.
+CT-Ops core is free to use with the Community tier. Community includes the core
+operations feature set and 3 included active-user seats. Extra CT-Ops seats are
+sold separately, and Enterprise is an add-on entitlement for Enterprise-only
+capabilities.
 
-## Tiers
+## Tiers And Entitlements
 
 ### Community
 
@@ -19,17 +20,22 @@ Community is open source and includes core CT-Ops functionality:
 - LDAP / Active Directory login and directory lookup
 - Air-gap deployment support
 
-Community capacity is governed by the included user seats for the install.
+Community includes 3 active-user seats for the CT-Ops installation.
 
-### Pro
+### Extra Seats
 
-Pro is the paid CT-Ops tier for teams that need additional user-seat capacity.
-It uses the same core CT-Ops feature set as Community, with a signed licence
-that can carry a `maxUsers` seat limit and expiry date.
+Extra CT-Ops seats increase the active-user allowance beyond the 3 included
+Community seats. For example, a licence with 10 extra seats gives the install a
+`maxUsers` allowance of 13.
+
+Extra seats do not change the CT-Ops tier and do not unlock Enterprise-only
+capabilities.
 
 ### Enterprise
 
-Enterprise is seat-based and includes Enterprise-only capabilities:
+Enterprise is a separate add-on entitlement. It keeps the same seat allowance
+from Community plus any purchased extra seats and unlocks Enterprise-only
+capabilities such as:
 
 - SAML 2.0 single sign-on
 - Advanced RBAC and custom role definitions
@@ -44,7 +50,11 @@ only a convenience and are not the source of authority.
 
 ## Seat Limits
 
-The `maxUsers` licence claim defines the paid user-seat limit.
+The effective `maxUsers` allowance is:
+
+- 3 when no valid CT-Ops seat licence is present.
+- 3 plus the active paid extra-seat quantity when a valid seat licence is
+  present.
 
 Seats are consumed by:
 
@@ -58,11 +68,23 @@ Seats are not consumed by:
 - Expired or accepted invitations
 
 CT-Ops enforces seats on trusted backend flows including invitation creation,
-invite acceptance, user restoration, user reactivation, and LDAP
-auto-provisioning.
+invite acceptance, user restoration, user reactivation, LDAP auto-provisioning,
+and session admission.
 
-Licences without a `maxUsers` claim are treated as unlimited for compatibility
-with earlier licence payloads.
+## Included Seat Pinning
+
+Admins can pin up to 3 active users as the included Community-seat users. These
+users keep access if paid seats expire and the installation falls back to the 3
+included seats.
+
+If fewer than 3 users are pinned, CT-Ops fills the remaining included seats
+deterministically. The fallback preserves at least one active super admin when
+one exists, then other pinned/admin users, then the oldest active users.
+
+When an installation has more active users than its current allowance, users
+outside the admitted seats are not deleted or deactivated. Their login and
+authenticated requests are blocked until seats are renewed, active users are
+reduced, or an admin changes the pinned included-seat assignments.
 
 ## Licence Keys
 
@@ -70,10 +92,10 @@ CT-Ops uses an offline-capable licence model. A licence key is a signed JSON Web
 Token verified locally against the public key bundled with the CT-Ops web
 application. Validation does not require an outbound network connection.
 
-Every paid key can encode:
+Every CT-Ops key can encode:
 
 - Install organisation (`sub`)
-- Tier (`pro` or `enterprise`)
+- Tier (`community` or `enterprise`)
 - User-seat limit (`maxUsers`)
 - Expiry (`exp`)
 - Licence ID (`jti`)
@@ -81,7 +103,7 @@ Every paid key can encode:
 - Customer details for display and support
 
 The legacy `maxHosts` claim may still appear in older keys for compatibility,
-but CT-Ops commercial licensing is moving to user-seat capacity.
+but CT-Ops commercial licensing uses user-seat capacity.
 
 ## Activation
 
@@ -101,10 +123,16 @@ licence key back in.
 
 ## Expiry And Degraded State
 
-When a paid licence expires or becomes invalid, CT-Ops degrades to Community
-without shutting down the install. Core CT-Ops functionality remains available.
+When a paid seat licence expires or becomes invalid, CT-Ops degrades to
+Community with `maxUsers=3`. Core CT-Ops functionality remains available.
 Enterprise-only capabilities are disabled unless a valid Enterprise entitlement
 is present.
+
+For example, if an install has 13 active users and 10 paid extra seats, all 13
+users can log in while the paid seats are active. After the paid seats expire,
+only the 3 pinned or deterministically selected included-seat users can continue
+logging in. The other 10 users remain intact but are blocked from new sessions
+and authenticated requests.
 
 Renew before the expiry date shown in **Settings -> Licence** to avoid losing
 paid seat capacity or Enterprise capabilities.
@@ -130,6 +158,7 @@ The **Settings -> Licence** page shows:
 - Seats remaining
 - Licence expiry
 - Enterprise capability status
+- Included-seat user pinning
 
 If the saved tier in the database disagrees with the validated key, CT-Ops uses
 the validated effective licence for enforcement and display.

--- a/apps/web/app/(dashboard)/settings/licence/page.tsx
+++ b/apps/web/app/(dashboard)/settings/licence/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
 import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { organisations, parseOrgMetadata, users } from '@/lib/db/schema'
+import { and, asc, eq, isNull } from 'drizzle-orm'
 import { SettingsClient } from '../settings-client'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { getEffectiveLicence } from '@/lib/actions/licence-guard'
@@ -16,9 +16,14 @@ export default async function LicenceSettingsPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId!
 
-  const [org, effectiveLicence, seatUsage] = await Promise.all([
+  const [org, activeUsers, effectiveLicence, seatUsage] = await Promise.all([
     db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
+      where: eq(organisations.id, orgId),
+    }),
+    db.query.users.findMany({
+      where: and(eq(users.organisationId, orgId), eq(users.isActive, true), isNull(users.deletedAt)),
+      columns: { id: true, name: true, email: true, role: true, roles: true },
+      orderBy: [asc(users.createdAt), asc(users.email)],
     }),
     getEffectiveLicence(orgId),
     getOrgSeatUsage(orgId),
@@ -48,6 +53,10 @@ export default async function LicenceSettingsPage() {
           expiresAt: effectiveLicence.expiresAt?.toISOString(),
         }}
         seatUsage={seatUsage}
+        freeSeatUsers={{
+          users: activeUsers,
+          selectedUserIds: parseOrgMetadata(org.metadata).freeSeatUserIds ?? [],
+        }}
       />
     </div>
   )

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -16,7 +16,7 @@ import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { updateOrgName, saveLicenceKey, updateMetricRetention, generateActivationToken } from '@/lib/actions/settings'
+import { updateOrgName, saveLicenceKey, updateMetricRetention, generateActivationToken, updateFreeSeatUsers } from '@/lib/actions/settings'
 import { getOrgDefaultCollectionSettings, updateOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
 import { getOrgTerminalSettings, updateOrgTerminalSettings } from '@/lib/actions/terminal'
 import {
@@ -35,6 +35,7 @@ import type { OrgNotificationSettingsFull, OrgSmtpRelaySettingsInput, SmtpRelayT
 import type { Organisation, HostCollectionSettings, SoftwareInventorySettings } from '@/lib/db/schema'
 import { DEFAULT_COLLECTION_SETTINGS } from '@/lib/db/schema'
 import type { LicenceTier } from '@/lib/features'
+import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
 
 const ALL_ROLES = [
   { value: 'super_admin', label: 'Super Admin' },
@@ -82,11 +83,14 @@ interface SettingsClientProps {
     remainingSeats?: number
     maxUsers?: number
   }
+  freeSeatUsers?: {
+    users: Array<{ id: string; name: string; email: string; role: string; roles: string[] }>
+    selectedUserIds: string[]
+  }
 }
 
 function tierBadgeVariant(tier: string): 'outline' | 'default' | 'secondary' {
   if (tier === 'enterprise') return 'default'
-  if (tier === 'pro') return 'secondary'
   return 'outline'
 }
 
@@ -142,6 +146,7 @@ export function SettingsClient({
   description = 'Manage your organisation settings',
   effectiveLicence,
   seatUsage,
+  freeSeatUsers,
 }: SettingsClientProps) {
   const queryClient = useQueryClient()
   const tier = effectiveLicence?.tier ?? (org.licenceTier as LicenceTier)
@@ -167,6 +172,10 @@ export function SettingsClient({
   const [retentionDays, setRetentionDays] = useState(String(org.metricRetentionDays ?? 30))
   const [retentionSaveSuccess, setRetentionSaveSuccess] = useState(false)
   const [retentionError, setRetentionError] = useState<string | null>(null)
+  const [selectedFreeSeatUserIds, setSelectedFreeSeatUserIds] = useState(
+    freeSeatUsers?.selectedUserIds ?? [],
+  )
+  const [freeSeatResult, setFreeSeatResult] = useState<{ success?: boolean; error?: string } | null>(null)
 
   const orgForm = useForm<OrgNameValues>({
     resolver: zodResolver(orgNameSchema),
@@ -202,6 +211,20 @@ export function SettingsClient({
     },
   })
 
+  const freeSeatMutation = useMutation({
+    mutationFn: (userIds: string[]) => updateFreeSeatUsers(org.id, userIds),
+    onSuccess: (result) => {
+      if ('error' in result) {
+        setFreeSeatResult({ error: result.error })
+        return
+      }
+      setSelectedFreeSeatUserIds(result.userIds)
+      setFreeSeatResult({ success: true })
+      setTimeout(() => setFreeSeatResult(null), 3000)
+    },
+    onError: () => setFreeSeatResult({ error: 'An unexpected error occurred' }),
+  })
+
   const [activationToken, setActivationToken] = useState<string | null>(null)
   const [activationError, setActivationError] = useState<string | null>(null)
   const [activationCopied, setActivationCopied] = useState(false)
@@ -229,6 +252,16 @@ export function SettingsClient({
     } catch {
       setActivationError('Unable to copy — select the token and copy manually')
     }
+  }
+
+  function toggleFreeSeatUser(userId: string, checked: boolean) {
+    setFreeSeatResult(null)
+    setSelectedFreeSeatUserIds((current) => {
+      if (!checked) return current.filter((id) => id !== userId)
+      if (current.includes(userId)) return current
+      if (current.length >= FREE_INCLUDED_USER_SEATS) return current
+      return [...current, userId]
+    })
   }
 
   const retentionMutation = useMutation({
@@ -1386,6 +1419,65 @@ export function SettingsClient({
             CT Ops Community includes core fleet, reporting, certificate, service-account, terminal, alerting, and task features.
             Paid licences add user-seat capacity, and Enterprise licences add Enterprise-only capabilities.
           </div>
+
+          {isAdmin && freeSeatUsers ? (
+            <div className="rounded-md border p-3 space-y-3">
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">Included free seats</p>
+                <p className="text-xs text-muted-foreground">
+                  Choose up to {FREE_INCLUDED_USER_SEATS} active users who keep access if paid seats expire.
+                  If fewer are selected, CT-Ops fills the rest deterministically and always preserves an admin where possible.
+                </p>
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-2">
+                {freeSeatUsers.users.map((user) => {
+                  const checked = selectedFreeSeatUserIds.includes(user.id)
+                  const disabled = !checked && selectedFreeSeatUserIds.length >= FREE_INCLUDED_USER_SEATS
+                  return (
+                    <label
+                      key={user.id}
+                      className="flex items-start gap-2 rounded-md border bg-background p-2 text-sm"
+                      data-testid={`free-seat-user-${user.id}`}
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={disabled || freeSeatMutation.isPending}
+                        onCheckedChange={(value) => toggleFreeSeatUser(user.id, value === true)}
+                        data-testid={`free-seat-user-checkbox-${user.id}`}
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium text-foreground">{user.name}</span>
+                        <span className="block truncate text-xs text-muted-foreground">{user.email}</span>
+                      </span>
+                    </label>
+                  )
+                })}
+              </div>
+
+              {freeSeatUsers.users.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No active users are available to pin.</p>
+              ) : null}
+
+              {freeSeatResult?.error ? (
+                <p className="text-xs text-destructive">{freeSeatResult.error}</p>
+              ) : null}
+              {freeSeatResult?.success ? (
+                <p className="text-xs text-green-700">Included free seats saved.</p>
+              ) : null}
+
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => freeSeatMutation.mutate(selectedFreeSeatUserIds)}
+                disabled={freeSeatMutation.isPending}
+                data-testid="free-seat-users-save"
+              >
+                {freeSeatMutation.isPending ? 'Saving…' : 'Save included seats'}
+              </Button>
+            </div>
+          ) : null}
 
           {isAdmin && (
             <div className="rounded-md border bg-muted/30 p-3 space-y-3">

--- a/apps/web/app/(dashboard)/settings/system/system-client.tsx
+++ b/apps/web/app/(dashboard)/settings/system/system-client.tsx
@@ -62,7 +62,6 @@ interface HealthData {
 
 function tierBadgeVariant(tier: string): 'outline' | 'default' | 'secondary' {
   if (tier === 'enterprise') return 'default'
-  if (tier === 'pro') return 'secondary'
   return 'outline'
 }
 

--- a/apps/web/app/(setup)/seat-limit-exceeded/page.tsx
+++ b/apps/web/app/(setup)/seat-limit-exceeded/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import { SeatLimitExceededCard } from './seat-limit-exceeded-card'
+
+export const metadata: Metadata = {
+  title: 'Seat limit exceeded',
+}
+
+export default function SeatLimitExceededPage() {
+  return <SeatLimitExceededCard />
+}

--- a/apps/web/app/(setup)/seat-limit-exceeded/seat-limit-exceeded-card.tsx
+++ b/apps/web/app/(setup)/seat-limit-exceeded/seat-limit-exceeded-card.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { signOut } from '@/lib/auth/client'
+
+export function SeatLimitExceededCard() {
+  const router = useRouter()
+
+  async function handleSignOut() {
+    await signOut()
+    router.push('/login')
+    router.refresh()
+  }
+
+  return (
+    <Card data-testid="seat-limit-card">
+      <CardHeader>
+        <CardTitle data-testid="seat-limit-heading">User seat limit exceeded</CardTitle>
+        <CardDescription>
+          This CT-Ops installation has more active users than its current licence allows.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">
+          Ask an administrator to renew seats, deactivate unused users, or assign you to an included free seat.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={handleSignOut}
+          data-testid="seat-limit-signout"
+        >
+          Sign out
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -11,6 +11,7 @@ import { getBetterAuthSecret } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
 import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
 import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
+import { SeatAdmissionError, assertUserCanAccessSeat } from '@/lib/seat-admission'
 
 // 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
 const ldapRateLimit = createRateLimiter({
@@ -167,6 +168,8 @@ export async function POST(request: NextRequest) {
         )
       }
 
+      await assertUserCanAccessSeat(user.organisationId!, user.id)
+
       // Create session
       const sessionToken = randomBytes(32).toString('hex')
       const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days
@@ -208,6 +211,12 @@ export async function POST(request: NextRequest) {
       NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
     )
   } catch (err) {
+    if (err instanceof SeatAdmissionError) {
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'User seat limit exceeded' }, { status: 403 }),
+      )
+    }
     const seatLimitMessage = toSeatLimitErrorMessage(err)
     if (seatLimitMessage) {
       return withAuthDelay(

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -243,7 +243,6 @@ function NavGroup({
 
 const TIER_LABEL: Record<LicenceTier, string> = {
   community: 'Community Edition',
-  pro: 'Pro Edition',
   enterprise: 'Enterprise Edition',
 }
 

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -5,7 +5,8 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 import { validateLicenceKey } from '@/lib/licence'
-import { hasFeature, type Feature, type LicenceTier } from '@/lib/features'
+import { featuresForTier, hasFeature, type Feature, type LicenceTier } from '@/lib/features'
+import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
 
 export class LicenceRequiredError extends Error {
   constructor(
@@ -39,11 +40,11 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
   })
 
   if (!org) {
-    return { tier: 'community', features: [] }
+    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
   }
 
   if (!org.licenceKey) {
-    return { tier: 'community', features: [] }
+    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
   }
 
   const result = await validateLicenceKey(org.licenceKey)
@@ -51,18 +52,18 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
     // Invalid or expired keys silently degrade to community. The licenceTier
     // column still reflects what was last saved; the guard trusts only the
     // validated JWT, not the cached column.
-    return { tier: 'community', features: [] }
+    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
   }
 
   if (result.payload.sub !== orgId) {
     // Key belongs to a different organisation — reject it entirely.
-    return { tier: 'community', features: [] }
+    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
   }
 
   return {
     tier: result.payload.tier,
     features: result.payload.features,
-    maxUsers: result.payload.maxUsers,
+    maxUsers: result.payload.maxUsers ?? FREE_INCLUDED_USER_SEATS,
     maxHosts: result.payload.maxHosts,
     licenceId: result.payload.jti,
     expiresAt: new Date(result.payload.exp * 1000),

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -6,11 +6,12 @@ import { requireOrgAdminAccess } from '@/lib/actions/action-auth'
 import { z } from 'zod'
 import { createId } from '@paralleldrive/cuid2'
 import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq, sql } from 'drizzle-orm'
+import { organisations, parseOrgMetadata, users } from '@/lib/db/schema'
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { validateLicenceKey } from '@/lib/licence'
 import { encodeActivationToken } from '@/lib/licence-activation-token'
 import { writeAuditEvent } from '@/lib/audit/events'
+import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
 
 const updateOrgNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -176,6 +177,87 @@ export async function generateActivationToken(
     return { success: true, token }
   } catch (err) {
     logError('Failed to generate activation token:', err)
+    return { error: 'An unexpected error occurred' }
+  }
+}
+
+const freeSeatUsersSchema = z.object({
+  userIds: z.array(z.string()).max(FREE_INCLUDED_USER_SEATS),
+})
+
+export async function updateFreeSeatUsers(
+  orgId: string,
+  userIds: string[],
+): Promise<{ success: true; userIds: string[] } | { error: string }> {
+  let session
+  try {
+    session = await requireOrgAdminAccess(orgId)
+  } catch {
+    return { error: 'You do not have permission to perform this action' }
+  }
+
+  const parsed = freeSeatUsersSchema.safeParse({ userIds })
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid free-seat users' }
+  }
+
+  const uniqueUserIds = Array.from(new Set(parsed.data.userIds))
+  if (uniqueUserIds.length > FREE_INCLUDED_USER_SEATS) {
+    return { error: `Select up to ${FREE_INCLUDED_USER_SEATS} included-seat users` }
+  }
+
+  try {
+    const [org, activeUsers] = await Promise.all([
+      db.query.organisations.findFirst({
+        where: eq(organisations.id, orgId),
+        columns: { metadata: true },
+      }),
+      uniqueUserIds.length === 0
+        ? Promise.resolve([])
+        : db.query.users.findMany({
+            where: and(
+              eq(users.organisationId, orgId),
+              eq(users.isActive, true),
+              isNull(users.deletedAt),
+              inArray(users.id, uniqueUserIds),
+            ),
+            columns: { id: true },
+          }),
+    ])
+
+    if (!org) {
+      return { error: 'Organisation not found' }
+    }
+
+    const activeIds = new Set(activeUsers.map((user) => user.id))
+    const invalidUserId = uniqueUserIds.find((userId) => !activeIds.has(userId))
+    if (invalidUserId) {
+      return { error: 'Included-seat users must be active members of this organisation' }
+    }
+
+    const metadata = {
+      ...parseOrgMetadata(org.metadata),
+      freeSeatUserIds: uniqueUserIds,
+    }
+
+    await db
+      .update(organisations)
+      .set({ metadata, updatedAt: new Date() })
+      .where(eq(organisations.id, orgId))
+
+    await writeAuditEvent(db, {
+      organisationId: orgId,
+      actorUserId: session.user.id,
+      action: 'licence.free_seats.updated',
+      targetType: 'organisation',
+      targetId: orgId,
+      summary: 'Updated included free-seat users',
+      metadata: { freeSeatUserIds: uniqueUserIds },
+    })
+
+    return { success: true, userIds: uniqueUserIds }
+  } catch (err) {
+    logError('Failed to update free-seat users:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -8,6 +8,7 @@ import type { User } from '@/lib/db/schema'
 import { requireActiveUser, requireOrgAdmin } from './guards'
 import { EXPIRED_SESSION_LOGIN_PATH } from './redirects'
 import { getPrimaryRole, normalizeAssignedRoles } from './roles'
+import { SEAT_LIMIT_EXCEEDED_PATH, assertUserCanAccessSeat } from '@/lib/seat-admission'
 
 // Re-export User as SessionUser for convenience
 export type { User as SessionUser }
@@ -73,6 +74,14 @@ export async function getRequiredSession(): Promise<RequiredSession> {
     redirect(EXPIRED_SESSION_LOGIN_PATH)
   }
 
+  if (session.user.organisationId) {
+    try {
+      await assertUserCanAccessSeat(session.user.organisationId, session.user.id)
+    } catch {
+      redirect(SEAT_LIMIT_EXCEEDED_PATH)
+    }
+  }
+
   return session
 }
 
@@ -86,6 +95,14 @@ export async function getApiSession(requestHeaders?: Headers): Promise<RequiredS
     requireActiveUser(session.user)
   } catch {
     throw new ApiAuthError(403, 'Forbidden')
+  }
+
+  if (session.user.organisationId) {
+    try {
+      await assertUserCanAccessSeat(session.user.organisationId, session.user.id)
+    } catch {
+      throw new ApiAuthError(403, 'User seat limit exceeded')
+    }
   }
 
   return session

--- a/apps/web/lib/db/schema/organisations.ts
+++ b/apps/web/lib/db/schema/organisations.ts
@@ -22,6 +22,7 @@ export interface SoftwareInventorySettings {
 export interface OrgMetadata {
   defaultCollectionSettings?: HostCollectionSettings
   defaultTags?: Array<{ key: string; value: string }>
+  freeSeatUserIds?: string[]
   terminalEnabled?: boolean
   terminalLoggingEnabled?: boolean
   terminalDirectAccess?: boolean
@@ -62,6 +63,7 @@ const softwareInventorySettingsSchema = z.object({
 export const orgMetadataSchema = z.object({
   defaultCollectionSettings: hostCollectionSettingsSchema.optional().catch(undefined),
   defaultTags: z.array(tagPairSchema).catch([]).optional(),
+  freeSeatUserIds: z.array(z.string()).max(3).catch([]).optional(),
   terminalEnabled: z.boolean().optional().catch(undefined),
   terminalLoggingEnabled: z.boolean().optional().catch(undefined),
   terminalDirectAccess: z.boolean().optional().catch(undefined),

--- a/apps/web/lib/features.test.mjs
+++ b/apps/web/lib/features.test.mjs
@@ -38,26 +38,17 @@ test('community tier does not include enterprise-only features', () => {
   }
 })
 
-test('pro tier is a seat capacity tier and does not add enterprise-only features', () => {
-  for (const feature of enterpriseFeatures) {
-    assert.equal(hasFeature('pro', feature), false, feature)
-  }
-})
-
 test('featuresForTier reflects core community access and enterprise restrictions', () => {
   const communityFeatures = featuresForTier('community')
-  const proFeatures = featuresForTier('pro')
   const enterpriseTierFeatures = featuresForTier('enterprise')
 
   for (const feature of coreFeatures) {
     assert.equal(communityFeatures.includes(feature), true, feature)
-    assert.equal(proFeatures.includes(feature), true, feature)
     assert.equal(enterpriseTierFeatures.includes(feature), true, feature)
   }
 
   for (const feature of enterpriseFeatures) {
     assert.equal(communityFeatures.includes(feature), false, feature)
-    assert.equal(proFeatures.includes(feature), false, feature)
     assert.equal(enterpriseTierFeatures.includes(feature), true, feature)
   }
 })

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -1,16 +1,16 @@
 const FEATURE_TIERS = {
-  // Core CT Ops features are available in Community. Pro is a seat-capacity tier.
-  ssoOidc: ['community', 'pro', 'enterprise'],
-  auditLog: ['community', 'pro', 'enterprise'],
-  certExpiryTracker: ['community', 'pro', 'enterprise'],
-  serviceAccountTracker: ['community', 'pro', 'enterprise'],
-  reportsExport: ['community', 'pro', 'enterprise'],
-  reportsScheduled: ['community', 'pro', 'enterprise'],
-  metricRetentionExtended: ['community', 'pro', 'enterprise'],
-  scheduledTasks: ['community', 'pro', 'enterprise'],
-  alertRouting: ['community', 'pro', 'enterprise'],
-  csrInternalCa: ['community', 'pro', 'enterprise'],
-  sshKeyInventory: ['community', 'pro', 'enterprise'],
+  // Core CT Ops features are available in Community. Paid seats only add capacity.
+  ssoOidc: ['community', 'enterprise'],
+  auditLog: ['community', 'enterprise'],
+  certExpiryTracker: ['community', 'enterprise'],
+  serviceAccountTracker: ['community', 'enterprise'],
+  reportsExport: ['community', 'enterprise'],
+  reportsScheduled: ['community', 'enterprise'],
+  metricRetentionExtended: ['community', 'enterprise'],
+  scheduledTasks: ['community', 'enterprise'],
+  alertRouting: ['community', 'enterprise'],
+  csrInternalCa: ['community', 'enterprise'],
+  sshKeyInventory: ['community', 'enterprise'],
 
   // Tier 2 (Enterprise) only
   ssoSaml: ['enterprise'],
@@ -22,7 +22,7 @@ const FEATURE_TIERS = {
 } as const
 
 export type Feature = keyof typeof FEATURE_TIERS
-export type LicenceTier = 'community' | 'pro' | 'enterprise'
+export type LicenceTier = 'community' | 'enterprise'
 
 export function hasFeature(tier: LicenceTier, feature: Feature): boolean {
   return (FEATURE_TIERS[feature] as readonly string[]).includes(tier)

--- a/apps/web/lib/licence-seats.test.mjs
+++ b/apps/web/lib/licence-seats.test.mjs
@@ -44,12 +44,13 @@ test('canReserveSeats blocks reservations that would exceed maxUsers', () => {
   assert.equal(formatSeatLimitError(usage), 'User seat limit reached. This licence allows 3 users.')
 })
 
-test('canReserveSeats treats a missing maxUsers claim as unlimited for this compatibility phase', () => {
+test('canReserveSeats falls back to the included Community seats when maxUsers is missing', () => {
   const usage = calculateSeatUsage({
-    activeUsers: 200,
-    pendingInvites: 40,
+    activeUsers: 2,
+    pendingInvites: 1,
   })
 
-  assert.equal(canReserveSeats(usage, 1), true)
-  assert.equal(usage.remainingSeats, undefined)
+  assert.equal(canReserveSeats(usage, 1), false)
+  assert.equal(usage.maxUsers, 3)
+  assert.equal(usage.remainingSeats, 0)
 })

--- a/apps/web/lib/licence-seats.ts
+++ b/apps/web/lib/licence-seats.ts
@@ -4,6 +4,8 @@ export type SeatUsageInput = {
   maxUsers?: number
 }
 
+export const FREE_INCLUDED_USER_SEATS = 3
+
 export type SeatUsage = SeatUsageInput & {
   usedSeats: number
   remainingSeats?: number
@@ -11,16 +13,17 @@ export type SeatUsage = SeatUsageInput & {
 
 export function calculateSeatUsage(input: SeatUsageInput): SeatUsage {
   const usedSeats = input.activeUsers + input.pendingInvites
+  const maxUsers = input.maxUsers ?? FREE_INCLUDED_USER_SEATS
   return {
     ...input,
+    maxUsers,
     usedSeats,
-    remainingSeats: input.maxUsers === undefined ? undefined : Math.max(input.maxUsers - usedSeats, 0),
+    remainingSeats: Math.max(maxUsers - usedSeats, 0),
   }
 }
 
 export function canReserveSeats(usage: SeatUsage, seats = 1): boolean {
-  if (usage.maxUsers === undefined) return true
-  return usage.usedSeats + seats <= usage.maxUsers
+  return usage.usedSeats + seats <= (usage.maxUsers ?? FREE_INCLUDED_USER_SEATS)
 }
 
 export function formatSeatLimitError(usage: Pick<SeatUsage, 'maxUsers'>): string {

--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -62,8 +62,6 @@ const REVOCATION_REFRESH_MS = 15 * 60 * 1000
 const REVOCATION_RETRY_MS = 5 * 60 * 1000
 const REVOCATION_FETCH_TIMEOUT_MS = 2_000
 
-export type PaidTier = Exclude<LicenceTier, 'community'>
-
 export type LicenceCustomer = {
   name: string
   email: string
@@ -77,7 +75,7 @@ export type LicencePayload = {
   nbf: number
   exp: number
   jti: string
-  tier: PaidTier
+  tier: LicenceTier
   features: Feature[]
   maxUsers?: number
   maxHosts?: number
@@ -103,8 +101,8 @@ type CachedRevocationBundle = {
 let revocationCache: CachedRevocationBundle | null = null
 let revocationInflight: Promise<CachedRevocationBundle | null> | null = null
 
-function isPaidTier(v: unknown): v is PaidTier {
-  return v === 'pro' || v === 'enterprise'
+function isLicenceTier(v: unknown): v is LicenceTier {
+  return v === 'community' || v === 'enterprise'
 }
 
 function isStringArray(v: unknown): v is string[] {
@@ -256,7 +254,8 @@ export async function validateLicenceKey(key: string): Promise<LicenceValidation
       typ: 'JWT',
     })
 
-    if (!isPaidTier(payload['tier'])) {
+    const tier = payload['tier']
+    if (!isLicenceTier(tier)) {
       return { valid: false, error: 'Invalid licence tier in key' }
     }
     if (typeof payload.sub !== 'string' || !payload.sub) {
@@ -294,7 +293,7 @@ export async function validateLicenceKey(key: string): Promise<LicenceValidation
         nbf: typeof payload.nbf === 'number' ? payload.nbf : payload.iat,
         exp: payload.exp,
         jti: payload.jti,
-        tier: payload['tier'],
+        tier,
         features,
         maxUsers,
         maxHosts,

--- a/apps/web/lib/seat-admission.test.mjs
+++ b/apps/web/lib/seat-admission.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { selectAdmittedSeatUserIds } from './seat-selection.ts'
+
+function user(id, role, createdAt, roles = [role]) {
+  return { id, role, roles, createdAt: new Date(createdAt) }
+}
+
+test('seat admission preserves a super admin before pinned free-seat users', () => {
+  const activeUsers = [
+    user('engineer_1', 'engineer', '2026-01-01T00:00:00Z'),
+    user('engineer_2', 'engineer', '2026-01-02T00:00:00Z'),
+    user('admin_1', 'super_admin', '2026-01-03T00:00:00Z'),
+    user('engineer_3', 'engineer', '2026-01-04T00:00:00Z'),
+  ]
+
+  assert.deepEqual(
+    selectAdmittedSeatUserIds(activeUsers, ['engineer_1', 'engineer_2', 'engineer_3'], 3),
+    ['admin_1', 'engineer_1', 'engineer_2'],
+  )
+})
+
+test('seat admission falls back to an org admin when no super admin exists', () => {
+  const activeUsers = [
+    user('engineer_1', 'engineer', '2026-01-01T00:00:00Z'),
+    user('admin_1', 'org_admin', '2026-01-03T00:00:00Z'),
+    user('engineer_2', 'engineer', '2026-01-04T00:00:00Z'),
+  ]
+
+  assert.deepEqual(
+    selectAdmittedSeatUserIds(activeUsers, [], 2),
+    ['admin_1', 'engineer_1'],
+  )
+})
+
+test('seat admission fills remaining seats by oldest active users', () => {
+  const activeUsers = [
+    user('newer', 'engineer', '2026-01-03T00:00:00Z'),
+    user('older', 'engineer', '2026-01-01T00:00:00Z'),
+    user('oldest', 'engineer', '2025-12-31T00:00:00Z'),
+  ]
+
+  assert.deepEqual(
+    selectAdmittedSeatUserIds(activeUsers, [], 2),
+    ['oldest', 'older'],
+  )
+})

--- a/apps/web/lib/seat-admission.ts
+++ b/apps/web/lib/seat-admission.ts
@@ -1,0 +1,65 @@
+import 'server-only'
+
+import { and, asc, eq, isNull } from 'drizzle-orm'
+
+import { db } from '@/lib/db'
+import { organisations, parseOrgMetadata, users } from '@/lib/db/schema'
+import { validateLicenceKey } from '@/lib/licence'
+import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
+import { selectAdmittedSeatUserIds } from '@/lib/seat-selection'
+
+export const SEAT_LIMIT_EXCEEDED_PATH = '/seat-limit-exceeded'
+
+export class SeatAdmissionError extends Error {
+  constructor() {
+    super('User seat limit exceeded')
+    this.name = 'SeatAdmissionError'
+  }
+}
+
+async function getSeatLimit(orgId: string): Promise<number> {
+  const org = await db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+    columns: { licenceKey: true },
+  })
+  if (!org?.licenceKey) return FREE_INCLUDED_USER_SEATS
+
+  const result = await validateLicenceKey(org.licenceKey)
+  if (!result.valid || result.payload.sub !== orgId) {
+    return FREE_INCLUDED_USER_SEATS
+  }
+
+  return result.payload.maxUsers ?? FREE_INCLUDED_USER_SEATS
+}
+
+export async function canUserAccessSeat(orgId: string, userId: string): Promise<boolean> {
+  const [org, maxUsers] = await Promise.all([
+    db.query.organisations.findFirst({
+      where: eq(organisations.id, orgId),
+      columns: { metadata: true },
+    }),
+    getSeatLimit(orgId),
+  ])
+  if (!org) return false
+
+  const activeUsers = await db.query.users.findMany({
+    where: and(eq(users.organisationId, orgId), eq(users.isActive, true), isNull(users.deletedAt)),
+    columns: { id: true, role: true, roles: true, createdAt: true },
+    orderBy: [asc(users.createdAt), asc(users.id)],
+  })
+  if (activeUsers.length <= maxUsers) return true
+
+  const metadata = parseOrgMetadata(org.metadata)
+  const admitted = selectAdmittedSeatUserIds(
+    activeUsers,
+    metadata.freeSeatUserIds ?? [],
+    maxUsers,
+  )
+  return admitted.includes(userId)
+}
+
+export async function assertUserCanAccessSeat(orgId: string, userId: string): Promise<void> {
+  if (!await canUserAccessSeat(orgId, userId)) {
+    throw new SeatAdmissionError()
+  }
+}

--- a/apps/web/lib/seat-selection.ts
+++ b/apps/web/lib/seat-selection.ts
@@ -1,0 +1,56 @@
+import { hasRole } from './auth/guards.ts'
+
+export type SeatSelectionUser = {
+  id: string
+  role: string
+  roles?: string[]
+  createdAt: Date
+}
+
+function pushUnique(target: string[], seen: Set<string>, userId: string, maxUsers: number): void {
+  if (target.length >= maxUsers || seen.has(userId)) return
+  target.push(userId)
+  seen.add(userId)
+}
+
+function byCreatedAtThenId(a: SeatSelectionUser, b: SeatSelectionUser): number {
+  const byCreatedAt = a.createdAt.getTime() - b.createdAt.getTime()
+  if (byCreatedAt !== 0) return byCreatedAt
+  return a.id.localeCompare(b.id)
+}
+
+export function selectAdmittedSeatUserIds(
+  activeUsers: SeatSelectionUser[],
+  pinnedUserIds: readonly string[],
+  maxUsers: number,
+): string[] {
+  if (maxUsers <= 0) return []
+  const byId = new Map(activeUsers.map((user) => [user.id, user]))
+  const sortedUsers = [...activeUsers].sort(byCreatedAtThenId)
+  const admitted: string[] = []
+  const seen = new Set<string>()
+
+  const firstAdmin = sortedUsers.find((user) => hasRole(user, 'super_admin'))
+    ?? sortedUsers.find((user) => hasRole(user, 'org_admin'))
+  if (firstAdmin) {
+    pushUnique(admitted, seen, firstAdmin.id, maxUsers)
+  }
+
+  for (const userId of pinnedUserIds) {
+    if (byId.has(userId)) {
+      pushUnique(admitted, seen, userId, maxUsers)
+    }
+  }
+
+  for (const user of sortedUsers) {
+    if (hasRole(user, ['super_admin', 'org_admin'])) {
+      pushUnique(admitted, seen, user.id, maxUsers)
+    }
+  }
+
+  for (const user of sortedUsers) {
+    pushUnique(admitted, seen, user.id, maxUsers)
+  }
+
+  return admitted
+}

--- a/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
+++ b/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
@@ -181,11 +181,11 @@ test('invite acceptance rejects when no user seat is available', async ({ page }
   expect(org?.id).toBeTruthy()
 
   try {
-    const licenceKey = await issueTestLicence({ orgId: org!.id, tier: 'pro', maxUsers: 1 })
+    const licenceKey = await issueTestLicence({ orgId: org!.id, tier: 'community', maxUsers: 1 })
     await sql`
       UPDATE organisations
       SET licence_key = ${licenceKey},
-          licence_tier = 'pro'
+          licence_tier = 'community'
       WHERE id = ${org!.id}
     `
 

--- a/apps/web/tests/e2e/fixtures/licence.ts
+++ b/apps/web/tests/e2e/fixtures/licence.ts
@@ -3,7 +3,7 @@ import { createId } from '@paralleldrive/cuid2'
 
 type TestLicenceOptions = {
   orgId: string
-  tier?: 'pro' | 'enterprise'
+  tier?: 'community' | 'enterprise'
   features?: string[]
   maxUsers?: number
   maxHosts?: number
@@ -14,7 +14,7 @@ const LICENCE_AUDIENCE = 'install.carrtech.dev'
 
 export async function issueTestLicence({
   orgId,
-  tier = 'pro',
+  tier = 'community',
   features = [],
   maxUsers = 10,
   maxHosts = 100,

--- a/apps/web/tests/e2e/team/invitations.spec.ts
+++ b/apps/web/tests/e2e/team/invitations.spec.ts
@@ -15,11 +15,11 @@ async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
 }
 
 async function setOrgSeatLimit(sql: ReturnType<typeof getTestDb>, orgId: string, maxUsers: number): Promise<void> {
-  const licenceKey = await issueTestLicence({ orgId, tier: 'pro', maxUsers })
+  const licenceKey = await issueTestLicence({ orgId, tier: 'community', maxUsers })
   await sql`
     UPDATE organisations
     SET licence_key = ${licenceKey},
-        licence_tier = 'pro'
+        licence_tier = 'community'
     WHERE id = ${orgId}
   `
 }
@@ -31,6 +31,64 @@ async function clearOrgLicence(sql: ReturnType<typeof getTestDb>, orgId: string)
         licence_tier = 'community'
     WHERE id = ${orgId}
   `
+}
+
+async function insertActiveMember(
+  sql: ReturnType<typeof getTestDb>,
+  orgId: string,
+  id: string,
+  email: string,
+): Promise<void> {
+  await sql`
+    INSERT INTO "user" (
+      id,
+      name,
+      email,
+      email_verified,
+      organisation_id,
+      role,
+      roles,
+      is_active,
+      deleted_at
+    )
+    VALUES (
+      ${id},
+      ${email},
+      ${email},
+      true,
+      ${orgId},
+      'engineer',
+      '["engineer"]'::jsonb,
+      true,
+      NULL
+    )
+  `
+}
+
+async function countActiveMembers(sql: ReturnType<typeof getTestDb>, orgId: string): Promise<number> {
+  const [row] = await sql<Array<{ count: string }>>`
+    SELECT COUNT(*)::text AS count
+    FROM "user"
+    WHERE organisation_id = ${orgId}
+      AND is_active = true
+      AND deleted_at IS NULL
+  `
+  return Number.parseInt(row?.count ?? '0', 10)
+}
+
+async function ensureAtLeastActiveMembers(
+  sql: ReturnType<typeof getTestDb>,
+  orgId: string,
+  targetCount: number,
+  idPrefix: string,
+): Promise<number> {
+  let activeCount = await countActiveMembers(sql, orgId)
+  for (let index = activeCount; index < targetCount; index += 1) {
+    const id = `${idPrefix}-${index + 1}`
+    await insertActiveMember(sql, orgId, id, `${id}@example.com`)
+    activeCount += 1
+  }
+  return activeCount
 }
 
 test('admin can create and cancel a team invitation', async ({ authenticatedPage: page }) => {
@@ -122,6 +180,53 @@ test('admin cannot create a duplicate pending invitation for the same email addr
   expect(inviteRows[0]?.deleted_at).toBeNull()
 })
 
+test('admin cannot create a fourth user invite on free Community seats', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const suffix = Date.now().toString()
+  const inviteeEmail = `community-fourth-seat-${suffix}@example.com`
+
+  await clearOrgLicence(sql, orgId)
+  await ensureAtLeastActiveMembers(sql, orgId, 3, `community-seat-member-${suffix}`)
+
+  await page.goto('/team')
+
+  await expect(page.getByTestId('team-heading')).toBeVisible()
+  await page.getByTestId('team-invite-open').click()
+  await page.getByTestId('team-invite-email').fill(inviteeEmail)
+  await page.getByTestId('team-invite-role-engineer').click()
+  await page.getByTestId('team-invite-submit').click()
+
+  await expect(page.getByText('User seat limit reached. This licence allows 3 users.')).toBeVisible()
+  await expect(page.getByTestId('team-invite-link')).toHaveCount(0)
+})
+
+test('an extra paid seat allows one more active user invitation', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+  const suffix = Date.now().toString()
+  const inviteeEmail = `paid-fourth-seat-${suffix}@example.com`
+
+  try {
+    const activeCount = await ensureAtLeastActiveMembers(sql, orgId, 3, `paid-seat-member-${suffix}`)
+    await setOrgSeatLimit(sql, orgId, activeCount + 1)
+
+    await page.goto('/team')
+
+    await expect(page.getByTestId('team-heading')).toBeVisible()
+    await page.getByTestId('team-invite-open').click()
+    await page.getByTestId('team-invite-email').fill(inviteeEmail)
+    await page.getByTestId('team-invite-role-engineer').click()
+    await page.getByTestId('team-invite-submit').click()
+
+    await expect(page.getByTestId('team-invite-link')).toBeVisible()
+    await page.getByTestId('team-invite-done').click()
+    await expect(page.getByTestId('team-pending-invite-row').filter({ hasText: inviteeEmail })).toBeVisible()
+  } finally {
+    await clearOrgLicence(sql, orgId)
+  }
+})
+
 test('admin cannot create an invitation when user seats are exhausted', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const orgId = await getOrgId(sql)
@@ -157,68 +262,76 @@ test('admin re-inviting a removed user restores their membership instead of crea
   const orgId = await getOrgId(sql)
   const removedEmail = 'restored-member@example.com'
 
-  await sql`
-    INSERT INTO "user" (
-      id,
-      name,
-      email,
-      email_verified,
-      organisation_id,
-      role,
-      roles,
-      is_active,
-      deleted_at
-    )
-    VALUES (
-      'removed-team-member',
-      'Restored Member',
-      ${removedEmail},
-      true,
-      ${orgId},
-      'read_only',
-      '["read_only"]'::jsonb,
-      false,
-      NOW()
-    )
-  `
+  const activeCount = await countActiveMembers(sql, orgId)
 
-  await page.goto('/team')
-  await expect(page.getByTestId('team-heading')).toBeVisible()
+  try {
+    await setOrgSeatLimit(sql, orgId, activeCount + 1)
 
-  await page.getByTestId('team-invite-open').click()
-  await page.getByTestId('team-invite-email').fill(removedEmail)
-  await page.getByTestId('team-invite-role-engineer').click()
-  await page.getByTestId('team-invite-role-read_only').click()
-  await page.getByTestId('team-invite-submit').click()
+    await sql`
+      INSERT INTO "user" (
+        id,
+        name,
+        email,
+        email_verified,
+        organisation_id,
+        role,
+        roles,
+        is_active,
+        deleted_at
+      )
+      VALUES (
+        'removed-team-member',
+        'Restored Member',
+        ${removedEmail},
+        true,
+        ${orgId},
+        'read_only',
+        '["read_only"]'::jsonb,
+        false,
+        NOW()
+      )
+    `
 
-  await expect(page.getByTestId('team-invite-link')).toHaveCount(0)
-  await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Restored Member')
-  await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Engineer')
-  await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Read Only')
-  await expect(page.getByTestId('team-member-status-removed-team-member')).toContainText('Active')
+    await page.goto('/team')
+    await expect(page.getByTestId('team-heading')).toBeVisible()
 
-  const restoredUserRows = await sql<Array<{ role: string; roles: string[]; is_active: boolean; deleted_at: Date | null }>>`
-    SELECT role, roles, is_active, deleted_at
-    FROM "user"
-    WHERE email = ${removedEmail}
-    LIMIT 1
-  `
+    await page.getByTestId('team-invite-open').click()
+    await page.getByTestId('team-invite-email').fill(removedEmail)
+    await page.getByTestId('team-invite-role-engineer').click()
+    await page.getByTestId('team-invite-role-read_only').click()
+    await page.getByTestId('team-invite-submit').click()
 
-  expect(restoredUserRows).toEqual([
-    {
-      role: 'engineer',
-      roles: ['engineer', 'read_only'],
-      is_active: true,
-      deleted_at: null,
-    },
-  ])
+    await expect(page.getByTestId('team-invite-link')).toHaveCount(0)
+    await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Restored Member')
+    await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Engineer')
+    await expect(page.getByTestId('team-member-row-removed-team-member')).toContainText('Read Only')
+    await expect(page.getByTestId('team-member-status-removed-team-member')).toContainText('Active')
 
-  const inviteRows = await sql<Array<{ id: string }>>`
-    SELECT id
-    FROM invitations
-    WHERE organisation_id = ${orgId}
-      AND email = ${removedEmail}
-  `
+    const restoredUserRows = await sql<Array<{ role: string; roles: string[]; is_active: boolean; deleted_at: Date | null }>>`
+      SELECT role, roles, is_active, deleted_at
+      FROM "user"
+      WHERE email = ${removedEmail}
+      LIMIT 1
+    `
 
-  expect(inviteRows).toHaveLength(0)
+    expect(restoredUserRows).toEqual([
+      {
+        role: 'engineer',
+        roles: ['engineer', 'read_only'],
+        is_active: true,
+        deleted_at: null,
+      },
+    ])
+
+    const inviteRows = await sql<Array<{ id: string }>>`
+      SELECT id
+      FROM invitations
+      WHERE organisation_id = ${orgId}
+        AND email = ${removedEmail}
+    `
+
+    expect(inviteRows).toHaveLength(0)
+  } finally {
+    await clearOrgLicence(sql, orgId)
+  }
 })

--- a/docs/ct-ops-licensing-and-ct-cve-product-decision.md
+++ b/docs/ct-ops-licensing-and-ct-cve-product-decision.md
@@ -6,15 +6,15 @@ Date: 2026-04-29
 
 ## Context
 
-CT Ops currently uses a feature-unlock licensing model where Pro licences
-enable selected product areas. Vulnerability monitoring is also implemented
+CT Ops previously used a feature-unlock licensing model where Pro licences
+enabled selected product areas. Vulnerability monitoring was also implemented
 inside CT Ops, spanning the ingest service, web database schema, server actions,
 reports, settings UI, and tests.
 
 The product direction is changing in three related ways:
 
 - CT Ops core functionality should be available in the open-source product
-  without Pro feature gates.
+  without Pro feature gates, with 3 included active-user seats.
 - Vulnerability intelligence should become a separately released CT Ops plugin
   product, CT-CVE, with its own subscription, service boundary, data ownership,
   and release cadence.
@@ -24,26 +24,25 @@ The product direction is changing in three related ways:
 
 ## Decision
 
-CT Ops will move from feature-gated Pro licensing to seat-based licensing for
-the core operations product. CT-CVE will be extracted into an independently
-released CT Ops plugin product and service.
+CT Ops will move from feature-gated Pro licensing to installation-bound seat
+licensing for the core operations product. Pro is removed. CT-CVE will be
+extracted into an independently released CT Ops plugin product and service.
 
 ## CT Ops Product Model
 
 CT Ops remains the fleet, asset, agent, operations, alerting, reporting, and
 workflow system.
 
-Core CT Ops functionality is available in the Community tier. Commercial CT Ops
-tiers are capacity and support tiers, not feature-unlock tiers for core
-operations workflows.
+Core CT Ops functionality is available in the Community tier. Extra CT Ops seats
+and Enterprise are separate installation-bound entitlements, not feature-unlock
+tiers for core operations workflows.
 
 Target tiers:
 
-- Community: open-source CT Ops with all core operations features available,
-  limited by included user seats.
-- Pro: paid CT Ops tier based on user seats.
-- Enterprise: paid CT Ops tier based on user seats plus enterprise-only
-  capabilities.
+- Community: open-source CT Ops with all core operations features available and
+  3 included active-user seats.
+- Extra seats: paid CT Ops capacity beyond the 3 included seats.
+- Enterprise: paid CT Ops add-on for enterprise-only capabilities.
 
 Enterprise capabilities are limited to areas that are genuinely enterprise
 specific, such as SAML, advanced or custom RBAC, compliance packs, white
@@ -51,35 +50,43 @@ labelling, high-availability migration tooling, enterprise air-gap bundlers,
 and enhanced support commitments. Enterprise restrictions must remain enforced
 by trusted backend paths, not only by UI controls.
 
-The old Pro feature-unlock model is deprecated. Existing licence verification,
-offline validation, expiry handling, and revocation mechanics should be kept,
-but the entitlement payload should move toward capacity fields such as
-`maxUsers`.
+The old Pro model is removed. Existing licence verification, offline validation,
+activation-token binding, expiry handling, and revocation mechanics should be
+kept, but the entitlement payload should carry `tier` and `maxUsers`.
 
 ## Seat-Based Licensing
 
-CT Ops paid licences should express user capacity rather than feature unlocks.
+CT Ops paid seat licences should express user capacity rather than feature
+unlocks.
 
 The target user-seat rule is:
 
 - Active, non-deleted users consume seats.
+- Every CT Ops install includes 3 active-user seats.
+- Extra seat quantity is added on top of the 3 included seats.
 - Pending, unexpired invitations consume seats.
 - Deactivated users do not consume seats.
 - Removed or deleted users do not consume seats.
 
 Seat enforcement must happen server-side on every path that can create or
-restore access, including invites, invite acceptance, user reactivation, LDAP
-auto-provisioning, and future SSO auto-provisioning.
+restore access or create sessions, including invites, invite acceptance, user
+reactivation, removed-user restore, LDAP auto-provisioning, and future SSO
+auto-provisioning.
+
+Admins can pin up to 3 included-seat users. If paid seats expire while the
+install has more than 3 active users, those pinned users remain admitted. If
+fewer than 3 are pinned, CT Ops fills remaining seats deterministically while
+preserving at least one active super admin where possible.
 
 `maxHosts` should not remain the primary commercial capacity control for CT Ops
 core licensing. A later compatibility phase must decide whether to keep it as a
 separate optional host cap, ignore it for newly issued licences, or remove it
 after existing licence payloads are migrated.
 
-Expired or invalid paid licences should degrade to the Community tier without
-shutting down the installation. The installation should continue operating
-within Community seat rules, with Enterprise-only capabilities disabled when no
-valid Enterprise entitlement exists.
+Expired, missing, invalid, or revoked CT Ops seat licences should degrade to the
+Community tier without shutting down the installation. The installation should
+continue operating with `maxUsers=3`, with Enterprise-only capabilities disabled
+when no valid Enterprise entitlement exists.
 
 ## CT-CVE Product Model
 


### PR DESCRIPTION
## Summary
- remove Pro as a CT-Ops tier and default invalid/missing licences to Community with 3 included seats
- add trusted seat admission checks for web/API/LDAP sessions, including deterministic pinned included-seat selection
- add admin controls and docs for included-seat pinning and expiry fallback
- extend invitation E2E coverage for free Community and paid extra-seat capacity

## Validation
- pnpm --dir apps/web type-check
- pnpm --dir apps/web test:unit
- pnpm --dir apps/web db:validate
- pnpm --dir apps/web lint -- changed web files
- pnpm --dir apps/web test:e2e tests/e2e/team/invitations.spec.ts
