### PR TITLE
fix(auth): preserve invite redemption during signup

### DIFF
--- a/apps/web/app/(auth)/check-email/page.tsx
+++ b/apps/web/app/(auth)/check-email/page.tsx
@@ -19,6 +19,7 @@ function readParam(value: string | string[] | undefined): string | null {
 export default async function CheckEmailPage({ searchParams }: CheckEmailPageProps) {
   const params = await searchParams
   const email = readParam(params.email)
+  const callbackURL = readParam(params.callbackURL)
 
   return (
     <Card>
@@ -37,7 +38,7 @@ export default async function CheckEmailPage({ searchParams }: CheckEmailPagePro
             new verification link.
           </p>
         </div>
-        <VerificationResendForm initialEmail={email} />
+        <VerificationResendForm initialEmail={email} callbackURL={callbackURL} />
       </CardContent>
       <CardFooter>
         <Link href="/login" className="text-sm text-foreground underline underline-offset-4">

--- a/apps/web/app/(auth)/check-email/verification-resend-form.tsx
+++ b/apps/web/app/(auth)/check-email/verification-resend-form.tsx
@@ -9,9 +9,10 @@ import { EMAIL_VERIFICATION_RESEND_SENT_MESSAGE } from '@/lib/auth/email-verific
 
 type VerificationResendFormProps = {
   initialEmail?: string | null
+  callbackURL?: string | null
 }
 
-export function VerificationResendForm({ initialEmail }: VerificationResendFormProps) {
+export function VerificationResendForm({ initialEmail, callbackURL }: VerificationResendFormProps) {
   const [email, setEmail] = useState(initialEmail ?? '')
   const [password, setPassword] = useState('')
   const [message, setMessage] = useState<string | null>(null)
@@ -31,7 +32,7 @@ export function VerificationResendForm({ initialEmail }: VerificationResendFormP
         body: JSON.stringify({
           email,
           password,
-          callbackURL: '/dashboard',
+          callbackURL: callbackURL ?? '/dashboard',
         }),
       })
       const data = await res.json().catch(() => null) as { message?: string } | null

--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -11,6 +11,10 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { signIn } from '@/lib/auth/client'
+import {
+  getInviteAcceptPath,
+  getInviteRegisterPath,
+} from '@/lib/auth/invite-redirects'
 
 const localLoginSchema = z.object({
   email: z.string().email('Enter a valid email address'),
@@ -27,6 +31,7 @@ type DomainLoginValues = z.infer<typeof domainLoginSchema>
 
 interface LoginFormProps {
   ldapLoginEnabled?: boolean
+  inviteToken?: string | null
   notice?: string | null
 }
 
@@ -34,8 +39,9 @@ function isEmailNotVerifiedError(message: string, code?: string): boolean {
   return code === 'EMAIL_NOT_VERIFIED' || message.toLowerCase().includes('email not verified')
 }
 
-export function LoginForm({ ldapLoginEnabled = false, notice = null }: LoginFormProps) {
+export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice = null }: LoginFormProps) {
   const router = useRouter()
+  const inviteAcceptPath = getInviteAcceptPath(inviteToken)
   const [serverError, setServerError] = useState<string | null>(null)
   const [canResendVerification, setCanResendVerification] = useState(false)
   const [verificationEmail, setVerificationEmail] = useState<string | null>(null)
@@ -67,7 +73,7 @@ export function LoginForm({ ldapLoginEnabled = false, notice = null }: LoginForm
       return
     }
 
-    router.push('/dashboard')
+    router.push(inviteAcceptPath ?? '/dashboard')
   }
 
   async function onDomainSubmit(values: DomainLoginValues) {
@@ -169,7 +175,10 @@ export function LoginForm({ ldapLoginEnabled = false, notice = null }: LoginForm
                   size="sm"
                 >
                   <Link
-                    href={`/check-email${verificationEmail ? `?email=${encodeURIComponent(verificationEmail)}` : ''}`}
+                    href={`/check-email?${new URLSearchParams({
+                      ...(verificationEmail ? { email: verificationEmail } : {}),
+                      ...(inviteAcceptPath ? { callbackURL: inviteAcceptPath } : {}),
+                    }).toString()}`}
                     data-testid="manage-email-verification"
                   >
                     Manage email verification
@@ -225,7 +234,10 @@ export function LoginForm({ ldapLoginEnabled = false, notice = null }: LoginForm
             </Button>
             <p className="text-sm text-muted-foreground text-center">
               Don&apos;t have an account?{' '}
-              <Link href="/register" className="text-foreground font-medium underline underline-offset-4">
+              <Link
+                href={getInviteRegisterPath(inviteToken)}
+                className="text-foreground font-medium underline underline-offset-4"
+              >
                 Create one
               </Link>
             </p>

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -7,6 +7,7 @@ import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { LoginForm } from './login-form'
 import { hasLdapLoginEnabled } from '@/lib/actions/ldap'
+import { getInviteAcceptPath } from '@/lib/auth/invite-redirects'
 import {
   getAuthenticatedRedirectPath,
   shouldBypassAuthenticatedRedirect,
@@ -27,9 +28,15 @@ function readParam(value: string | string[] | undefined): string | null {
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = await searchParams
+  const inviteToken = readParam(params.invite)
+  const inviteAcceptPath = getInviteAcceptPath(inviteToken)
   const session = await auth.api.getSession({ headers: await headers() })
   if (session && !shouldBypassAuthenticatedRedirect(params)) {
     const user = await db.query.users.findFirst({ where: eq(users.id, session.user.id) })
+    if (inviteAcceptPath && user?.isActive && !user.deletedAt && !user.organisationId) {
+      redirect(inviteAcceptPath)
+    }
+
     const redirectPath = getAuthenticatedRedirectPath(user)
     if (redirectPath) redirect(redirectPath)
   }
@@ -40,6 +47,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   return (
     <LoginForm
       ldapLoginEnabled={ldapEnabled}
+      inviteToken={inviteToken}
       notice={resetComplete ? 'Your password has been reset. Sign in with your new password.' : null}
     />
   )

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -7,6 +7,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { getRequireEmailVerification } from '@/lib/auth/env'
+import { getInviteAcceptPath } from '@/lib/auth/invite-redirects'
 import { getAuthenticatedRedirectPath } from '@/lib/auth/redirects'
 import { RegisterForm } from './register-form'
 
@@ -14,10 +15,25 @@ export const metadata: Metadata = {
   title: 'Create account',
 }
 
-export default async function RegisterPage() {
+type RegisterPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function RegisterPage({ searchParams }: RegisterPageProps) {
+  const params = await searchParams
+  const inviteAcceptPath = getInviteAcceptPath(readParam(params.invite))
   const session = await auth.api.getSession({ headers: await headers() })
   if (session) {
     const user = await db.query.users.findFirst({ where: eq(users.id, session.user.id) })
+    if (inviteAcceptPath && user?.isActive && !user.deletedAt && !user.organisationId) {
+      redirect(inviteAcceptPath)
+    }
+
     const redirectPath = getAuthenticatedRedirectPath(user)
     if (redirectPath) redirect(redirectPath)
   }

--- a/apps/web/app/(auth)/register/register-form.tsx
+++ b/apps/web/app/(auth)/register/register-form.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/card'
 import { signIn, signUp } from '@/lib/auth/client'
 import { getInviteByToken } from '@/lib/actions/auth'
+import { getInviteAcceptPath, getInviteLoginPath } from '@/lib/auth/invite-redirects'
 
 const registerSchema = z
   .object({
@@ -68,9 +69,8 @@ export function RegisterForm({ requireEmailVerification }: RegisterFormProps) {
 
   async function onSubmit(values: RegisterValues) {
     setServerError(null)
-    const callbackURL = inviteToken
-      ? `/accept-invite?token=${encodeURIComponent(inviteToken)}`
-      : '/onboarding'
+    const inviteAcceptPath = getInviteAcceptPath(inviteToken)
+    const callbackURL = inviteAcceptPath ?? '/onboarding'
     const result = await signUp.email({
       name: values.name,
       email: values.email,
@@ -84,7 +84,9 @@ export function RegisterForm({ requireEmailVerification }: RegisterFormProps) {
     }
 
     if (requireEmailVerification) {
-      router.push(`/check-email?email=${encodeURIComponent(values.email)}`)
+      const params = new URLSearchParams({ email: values.email })
+      if (inviteAcceptPath) params.set('callbackURL', inviteAcceptPath)
+      router.push(`/check-email?${params.toString()}`)
       return
     }
 
@@ -168,7 +170,7 @@ export function RegisterForm({ requireEmailVerification }: RegisterFormProps) {
           <p className="text-sm text-muted-foreground text-center">
             Already have an account?{' '}
             <Link
-              href="/login"
+              href={getInviteLoginPath(inviteToken)}
               className="text-foreground font-medium underline underline-offset-4"
             >
               Sign in

--- a/apps/web/lib/auth/invite-redirects.ts
+++ b/apps/web/lib/auth/invite-redirects.ts
@@ -1,0 +1,17 @@
+export function getInviteAcceptPath(token: string | null | undefined): string | null {
+  const trimmed = token?.trim()
+  if (!trimmed || trimmed.length > 256 || /[\r\n]/.test(trimmed)) return null
+  return `/accept-invite?token=${encodeURIComponent(trimmed)}`
+}
+
+export function getInviteLoginPath(token: string | null | undefined): string {
+  const trimmed = token?.trim()
+  if (!trimmed || trimmed.length > 256 || /[\r\n]/.test(trimmed)) return '/login'
+  return `/login?invite=${encodeURIComponent(trimmed)}`
+}
+
+export function getInviteRegisterPath(token: string | null | undefined): string {
+  const trimmed = token?.trim()
+  if (!trimmed || trimmed.length > 256 || /[\r\n]/.test(trimmed)) return '/register'
+  return `/register?invite=${encodeURIComponent(trimmed)}`
+}

--- a/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
+++ b/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
@@ -165,6 +165,86 @@ test('invite acceptance attaches the matching user to the organisation', async (
   expect(invite?.accepted_at).not.toBeNull()
 })
 
+test('authenticated invited user without an organisation redeems invite link instead of onboarding', async ({
+  page,
+}) => {
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const invitedEmail = `signed-in-invitee-${suffix}@example.com`
+  const invitedPassword = 'TestPassword123!'
+  const inviteToken = `signed-in-invite-token-${suffix}`
+
+  const signUpResponse = await page.request.post('/api/auth/sign-up/email', {
+    data: {
+      email: invitedEmail,
+      password: invitedPassword,
+      name: 'Signed In Invitee',
+    },
+  })
+  expect(signUpResponse.ok()).toBeTruthy()
+
+  await sql`
+    UPDATE "user"
+    SET email_verified = true,
+        is_active = true
+    WHERE email = ${invitedEmail}
+  `
+
+  await sql`
+    INSERT INTO invitations (
+      id,
+      email,
+      role,
+      token,
+      organisation_id,
+      invited_by_id,
+      expires_at,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      ${`signed-in-invite-${suffix}`},
+      ${invitedEmail},
+      'engineer',
+      ${inviteToken},
+      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+      NOW() + INTERVAL '1 day',
+      NOW(),
+      NOW()
+    )
+  `
+
+  const signInResponse = await page.request.post('/api/auth/sign-in/email', {
+    data: {
+      email: invitedEmail,
+      password: invitedPassword,
+    },
+  })
+  expect(signInResponse.ok()).toBeTruthy()
+
+  await page.goto(`/register?invite=${inviteToken}`)
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+
+  const [invitee] = await sql<Array<{ organisation_id: string | null; role: string }>>`
+    SELECT organisation_id, role
+    FROM "user"
+    WHERE email = ${invitedEmail}
+    LIMIT 1
+  `
+  expect(invitee?.organisation_id).not.toBeNull()
+  expect(invitee?.role).toBe('engineer')
+
+  const [invite] = await sql<Array<{ accepted_at: Date | null }>>`
+    SELECT accepted_at
+    FROM invitations
+    WHERE token = ${inviteToken}
+    LIMIT 1
+  `
+  expect(invite?.accepted_at).not.toBeNull()
+})
+
 test('invite acceptance rejects when no user seat is available', async ({ page }) => {
   const sql = getTestDb()
   const suffix = Date.now().toString()


### PR DESCRIPTION
## Summary

Fixes invite redemption getting dropped when an invited user already has a session but no organisation. `/register?invite=...` and `/login?invite=...` now send eligible signed-in users through `/accept-invite` instead of onboarding, and invite callback state is preserved through register, login, and verification resend flows.

## Root Cause

Authenticated users without an organisation were treated as generic onboardable users on auth pages. When they opened an invite link after signing up or signing in, the register/login page redirected them to `/onboarding`, which allowed a new organisation to be created before the original invitation was accepted.

## Validation

- `pnpm --filter web test:e2e tests/e2e/auth/invite-acceptance.spec.ts`
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `git diff --check`
