### PR TITLE
ci(release): fetch licence verifier key from public repo

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -188,7 +188,7 @@ jobs:
           cp deploy/customer-bundle/upgrade.sh dist/ct-ops/upgrade.sh
           cp deploy/customer-bundle/refresh_licence_key dist/ct-ops/refresh_licence_key
           cp deploy/customer-bundle/generate_support_data dist/ct-ops/generate_support_data
-          cp -R deploy/customer-bundle/licence-keys dist/ct-ops/licence-keys
+          bash deploy/scripts/fetch-licence-public-key.sh dist/ct-ops/licence-keys/current.pem
           cp deploy/nginx/nginx.conf          dist/ct-ops/deploy/nginx/nginx.conf
           echo "$VERSION" > dist/ct-ops/VERSION
 

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -11,6 +11,7 @@ on:
       - "deploy/scripts/test-web-entrypoint.sh"
       - "deploy/scripts/test-upgrade.sh"
       - "deploy/scripts/test-support-data.sh"
+      - "deploy/scripts/fetch-licence-public-key.sh"
       - "deploy/nginx/nginx.conf"
       - "docker-compose.single.yml"
       - "apps/web/entrypoint.sh"
@@ -40,7 +41,7 @@ jobs:
           cp deploy/customer-bundle/refresh_licence_key dist/ct-ops/refresh_licence_key
           cp deploy/customer-bundle/upgrade.sh dist/ct-ops/upgrade.sh
           cp deploy/customer-bundle/generate_support_data dist/ct-ops/generate_support_data
-          cp -R deploy/customer-bundle/licence-keys dist/ct-ops/licence-keys
+          bash deploy/scripts/fetch-licence-public-key.sh dist/ct-ops/licence-keys/current.pem
           cp deploy/nginx/nginx.conf dist/ct-ops/deploy/nginx/nginx.conf
           echo "test" > dist/ct-ops/VERSION
           perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,13 @@
 
 ## What Has Been Built
 
+### Session 98 — Licence public-key repository integration
+
+**Release key source of truth** (`deploy/scripts/fetch-licence-public-key.sh`, `.github/workflows/agent-release.yml`, `.github/workflows/customer-bundle-check.yml`)
+- Added a release helper that fetches and validates `ct-ops/current.pem` from `carrtech-dev/licence-public-keys` before packaging a customer bundle.
+- Updated release and bundle-check workflows to pull the current licence verifier key from the dedicated public-key repository instead of treating the checked-in bundle key as the source of truth.
+- Updated customer docs to describe the public-key repository distribution model while keeping installed keys mounted from `./licence-keys/current.pem`.
+
 ### Session 97 — Durable licence verifier key rotation
 
 **Licence verifier continuity** (`apps/web/lib/licence.ts`, `apps/web/lib/actions/settings.ts`, `apps/web/lib/actions/licence-guard.ts`, `apps/web/lib/seat-admission.ts`)

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -29,7 +29,7 @@ All CT-Ops configuration is via environment variables. There are no config files
 
 CT-Ops validates licence JWTs using an RSA public key. Customer bundles mount the current CarrTech verifier key from `./licence-keys/current.pem`; the web image also carries a fallback production key. When an admin saves a licence, CT-Ops stores the exact public key that verified that licence and keeps using it for that stored JWT, so future key rotations or image upgrades do not invalidate active licences.
 
-In the CT-Ops source tree, the release-bundle public key lives at `deploy/customer-bundle/licence-keys/current.pem`. In an installed customer bundle, it lives at `./licence-keys/current.pem` and is mounted read-only into the web container. The private signing key belongs only in CT Portal.
+For releases, the public key source of truth is `carrtech-dev/licence-public-keys` at `ct-ops/current.pem`. CT-Ops release packaging fetches that file into the customer bundle. In an installed customer bundle, it lives at `./licence-keys/current.pem` and is mounted read-only into the web container. The private signing key belongs only in CT Portal.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -132,10 +132,11 @@ To fetch the latest verifier key without upgrading CT-Ops:
 ./refresh_licence_key
 ```
 
-For release engineering, the matching public key is placed in the CT-Ops source
-tree at `deploy/customer-bundle/licence-keys/current.pem` before packaging a
-customer bundle. CT Portal keeps the private key; never place the private key in
-CT Ops or in a customer bundle.
+For release engineering, the current public key is published in
+`carrtech-dev/licence-public-keys` at `ct-ops/current.pem`. CT-Ops release
+packaging fetches that file into the customer bundle as
+`licence-keys/current.pem`. CT Portal keeps the private key; never place the
+private key in CT Ops or in a customer bundle.
 
 ## Air-gap installs
 

--- a/deploy/scripts/fetch-licence-public-key.sh
+++ b/deploy/scripts/fetch-licence-public-key.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetches the current CT-Ops licence verifier public key from the public
+# CarrTech key repository and writes it into a customer bundle directory.
+
+REPO_URL="${LICENCE_PUBLIC_KEYS_REPO:-https://github.com/carrtech-dev/licence-public-keys.git}"
+REF="${LICENCE_PUBLIC_KEYS_REF:-main}"
+OUT_FILE="${1:-deploy/customer-bundle/licence-keys/current.pem}"
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command '$1' not found in PATH." >&2
+    exit 1
+  fi
+}
+
+need git
+need openssl
+
+WORK_DIR="$(mktemp -d -t ct-ops-public-keys.XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+git clone --depth 1 --branch "$REF" "$REPO_URL" "$WORK_DIR/licence-public-keys" >/dev/null
+
+SOURCE_FILE="$WORK_DIR/licence-public-keys/ct-ops/current.pem"
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "ERROR: public key repository does not contain ct-ops/current.pem." >&2
+  exit 1
+fi
+
+if ! grep -q '^-----BEGIN PUBLIC KEY-----$' "$SOURCE_FILE" ||
+   ! grep -q '^-----END PUBLIC KEY-----$' "$SOURCE_FILE"; then
+  echo "ERROR: ct-ops/current.pem is not a PEM public key." >&2
+  exit 1
+fi
+
+openssl pkey -pubin -in "$SOURCE_FILE" -noout >/dev/null
+
+mkdir -p "$(dirname "$OUT_FILE")"
+install -m 644 "$SOURCE_FILE" "$OUT_FILE"
+
+fingerprint="$(
+  openssl pkey -pubin -in "$OUT_FILE" -outform DER |
+    openssl dgst -sha256 -binary |
+    od -An -tx1 |
+    tr -d ' \n'
+)"
+
+echo "Fetched CT-Ops licence verifier key from ${REPO_URL}@${REF}"
+echo "Wrote: ${OUT_FILE}"
+echo "SHA256 SPKI: ${fingerprint}"


### PR DESCRIPTION
## Summary

- fetch the CT-Ops licence verifier key from `carrtech-dev/licence-public-keys` during release bundle packaging
- validate the fetched PEM before writing `dist/ct-ops/licence-keys/current.pem`
- update customer docs and progress notes to make the public-key repo the release source of truth

## Validation

- `bash -n deploy/scripts/fetch-licence-public-key.sh`
- `deploy/scripts/fetch-licence-public-key.sh <tmp>/current.pem`
- `bash deploy/scripts/test-upgrade.sh`
- `bash deploy/scripts/test-install.sh`
- `bash deploy/scripts/test-start.sh`
- `bash deploy/scripts/test-support-data.sh`
- `node --experimental-strip-types --test apps/web/lib/licence.test.mjs`
- `node scripts/validate-migrations.js` from `apps/web`
- `pnpm --dir apps/web type-check`

## Notes

This PR is stacked on `feat/licence-verifier-key-rotation` because it depends on the customer-bundle key mount and persisted verifier-key model introduced there.
