### PR TITLE
fix(web): trigger licence verifier image release

### DIFF
--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -6,6 +6,9 @@ import type { Feature, LicenceTier } from './features'
 // Fallback production public key (RS256) for licence JWTs issued by the
 // official carrtech.dev licence-purchase service. Customer bundles mount the
 // current verifier key from ./licence-keys/current.pem via LICENCE_PUBLIC_KEY_PATH.
+// Release builds also bake the current verifier key into the web image from
+// carrtech-dev/licence-public-keys so air-gapped installs can validate newly
+// issued licences after upgrading CT-Ops.
 // When a licence is saved, CT-Ops stores the exact verifier key used for that
 // licence and reuses it for future validation, so key rotation does not break
 // active licences after an image upgrade.


### PR DESCRIPTION
## Summary
- add an apps/web change so release-please cuts a new web release
- document in-code that release builds bake the current verifier key into the image from carrtech-dev/licence-public-keys

## Why
PR #858 updated the web image build to bake the verifier key, but the merge commit was ci-scoped, so release-please did not create a new web release and no new web image was published. This fix-scoped web package change is intentionally small and exists to trigger the release pipeline for a new web image containing the already-merged baked-key behavior.

## Validation
- `pnpm --dir apps/web test:unit -- lib/licence.test.mjs`