### PR TITLE
fix(install): upgrade installs missing backup helper

### DIFF
--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -183,8 +183,14 @@ verify_local_bundle_checksum() {
 
 make_backup() {
   if [ ! -x ./backup.sh ]; then
-    echo "ERROR: backup.sh is missing or not executable; refusing to upgrade without a backup." >&2
-    exit 1
+    if [ -x "$NEW_BUNDLE_DIR/backup.sh" ]; then
+      echo "Restoring backup helper from the new release bundle..."
+      cp "$NEW_BUNDLE_DIR/backup.sh" backup.sh
+      chmod +x backup.sh
+    else
+      echo "ERROR: backup.sh is missing or not executable; refusing to upgrade without a backup." >&2
+      exit 1
+    fi
   fi
   echo "Backing up current install..."
   BACKUP_FILE="$(./backup.sh --print-path-only)"
@@ -199,8 +205,10 @@ unpack_new_bundle() {
 
   unzip -q "$BUNDLE_ZIP" -d "$UNPACK_DIR"
   NEW_BUNDLE_DIR="$UNPACK_DIR/ct-ops"
-  if [ ! -f "$NEW_BUNDLE_DIR/docker-compose.yml" ] || [ ! -f "$NEW_BUNDLE_DIR/start.sh" ]; then
-    echo "ERROR: upgrade bundle is missing docker-compose.yml or start.sh." >&2
+  if [ ! -f "$NEW_BUNDLE_DIR/docker-compose.yml" ] \
+    || [ ! -f "$NEW_BUNDLE_DIR/start.sh" ] \
+    || [ ! -f "$NEW_BUNDLE_DIR/backup.sh" ]; then
+    echo "ERROR: upgrade bundle is missing docker-compose.yml, start.sh or backup.sh." >&2
     exit 1
   fi
 }
@@ -320,8 +328,8 @@ else
   download_bundle
 fi
 
-make_backup
 unpack_new_bundle
+make_backup
 stop_stack
 install_new_bundle_files
 refresh_release_image_env_refs

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -114,6 +114,39 @@ main() {
     exit 1
   fi
 
+  rm -rf "$old_install" "$new_src" "$backup_dir"
+  mkdir -p "${tmpdir}/current" "$backup_dir"
+
+  write_bundle "${tmpdir}/current" "v1.0.0"
+  rm -f "${old_install}/backup.sh"
+  {
+    printf 'customer-secret=true\n'
+    printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' 100
+    printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' 100
+  } > "${old_install}/.env"
+
+  write_bundle "$new_src" "v9.9.9"
+  rm -f "$bundle_zip"
+  (cd "$new_src" && zip -qr "$bundle_zip" ct-ops)
+
+  (
+    cd "$old_install"
+    PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" \
+      MOCK_DOCKER_LOG="$docker_log" \
+      CT_OPS_BACKUP_DIR="$backup_dir" \
+      ./upgrade.sh --from-zip "$bundle_zip" --no-start
+  )
+
+  test -x "${old_install}/backup.sh"
+  grep -q 'example/web:v9.9.9' "${old_install}/docker-compose.yml"
+  grep -q 'public-key-v9.9.9' "${old_install}/licence-keys/current.pem"
+
+  backups="$(find "$backup_dir" -name '*.tar.gz' -type f | wc -l | tr -d ' ')"
+  if [ "$backups" != "1" ]; then
+    echo "expected one backup tarball for legacy install, found $backups" >&2
+    exit 1
+  fi
+
   echo "upgrade.sh local bundle tests passed"
 }
 


### PR DESCRIPTION
## Summary
- unpack the target bundle before taking the upgrade backup
- restore a missing legacy backup.sh from the new bundle before running the backup
- add a regression test for upgrading an install that lacks backup.sh

## Validation
- bash deploy/scripts/test-upgrade.sh
- bash -n deploy/customer-bundle/upgrade.sh deploy/scripts/test-upgrade.sh
- git diff --check