### PR TITLE
fix(web): repair licence key upgrade permissions

### DIFF
--- a/apps/web/lib/licence.ts
+++ b/apps/web/lib/licence.ts
@@ -5,7 +5,8 @@ import type { Feature, LicenceTier } from './features'
 
 // Fallback production public key (RS256) for licence JWTs issued by the
 // official carrtech.dev licence-purchase service. Customer bundles mount the
-// current verifier key from ./licence-keys/current.pem via LICENCE_PUBLIC_KEY_PATH.
+// current verifier key from ./licence-keys/current.pem via LICENCE_PUBLIC_KEY_PATH;
+// upgrade.sh repairs legacy ownership so the shipped key can be refreshed.
 // Release builds also bake the current verifier key into the web image from
 // carrtech-dev/licence-public-keys so air-gapped installs can validate newly
 // issued licences after upgrading CT-Ops.

--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -218,6 +218,43 @@ stop_stack() {
   docker compose down --remove-orphans >/dev/null 2>&1 || true
 }
 
+ensure_licence_key_path_writable() {
+  if [ ! -f "$NEW_BUNDLE_DIR/licence-keys/current.pem" ]; then
+    return 0
+  fi
+
+  mkdir -p licence-keys
+  if [ -w licence-keys ] && { [ ! -e licence-keys/current.pem ] || [ -w licence-keys/current.pem ]; }; then
+    return 0
+  fi
+
+  if [ -O licence-keys ]; then
+    chmod u+rwx licence-keys
+    if [ -e licence-keys/current.pem ]; then
+      chmod u+rw licence-keys/current.pem
+    fi
+  fi
+
+  if [ -w licence-keys ] && { [ ! -e licence-keys/current.pem ] || [ -w licence-keys/current.pem ]; }; then
+    return 0
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    echo "Repairing licence key directory ownership..."
+    sudo chown -R "$(id -u):$(id -g)" licence-keys
+    chmod u+rwx licence-keys
+    if [ -e licence-keys/current.pem ]; then
+      chmod u+rw licence-keys/current.pem
+    fi
+    return 0
+  fi
+
+  echo "ERROR: licence-keys is not writable, so the upgraded verifier key cannot be installed." >&2
+  echo "Fix ownership, then rerun ./upgrade.sh:" >&2
+  echo "  sudo chown -R $(id -u):$(id -g) licence-keys" >&2
+  exit 1
+}
+
 install_new_bundle_files() {
   echo "Installing new release files..."
 
@@ -330,6 +367,7 @@ fi
 
 unpack_new_bundle
 make_backup
+ensure_licence_key_path_writable
 stop_stack
 install_new_bundle_files
 refresh_release_image_env_refs

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -85,6 +85,8 @@ main() {
   printf 'tls-cert\n' > "${old_install}/deploy/tls/server.crt"
   printf 'dev-cert\n' > "${old_install}/deploy/dev-tls/server.crt"
   printf 'stale image archive\n' > "${old_install}/images.tar.gz"
+  rm -f "${old_install}/licence-keys/current.pem"
+  chmod 500 "${old_install}/licence-keys"
 
   write_bundle "$new_src" "v9.9.9"
   (cd "$new_src" && zip -qr "$bundle_zip" ct-ops)
@@ -104,6 +106,7 @@ main() {
   grep -q 'tls-cert' "${old_install}/deploy/tls/server.crt"
   grep -q 'dev-cert' "${old_install}/deploy/dev-tls/server.crt"
   grep -q 'public-key-v9.9.9' "${old_install}/licence-keys/current.pem"
+  test -w "${old_install}/licence-keys"
   test ! -f "${old_install}/images.tar.gz"
   grep -q 'docker compose down' "$docker_log"
 


### PR DESCRIPTION
## Summary
- repair legacy licence-keys directory writability before installing the upgraded verifier key
- fail before stopping the stack if ownership cannot be repaired automatically
- add regression coverage for upgrading with an unwritable licence-keys directory
- touch apps/web so this ships in the next web release bundle

## Validation
- bash deploy/scripts/test-upgrade.sh
- bash -n deploy/customer-bundle/upgrade.sh deploy/scripts/test-upgrade.sh
- git diff --check