### PR TITLE
fix(web): refresh licence seat activation state

### DIFF
--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -2,6 +2,7 @@
 
 import type { FormEvent } from 'react'
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -103,6 +104,41 @@ function formatLicenceDate(value?: string) {
   return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value))
 }
 
+function formatUserSeats(count: number) {
+  return `${count} user ${count === 1 ? 'seat' : 'seats'}`
+}
+
+function formatLicenceActivationMessage(result: {
+  tier?: string
+  maxUsers?: number
+  previousTier?: string
+  previousMaxUsers?: number
+}) {
+  const tierChanged = Boolean(result.tier && result.previousTier && result.tier !== result.previousTier)
+  const seatsChanged =
+    typeof result.maxUsers === 'number' &&
+    typeof result.previousMaxUsers === 'number' &&
+    result.maxUsers !== result.previousMaxUsers
+
+  if (seatsChanged && typeof result.maxUsers === 'number' && typeof result.previousMaxUsers === 'number') {
+    const seatText = `capacity increased from ${result.previousMaxUsers} to ${formatUserSeats(result.maxUsers)}`
+    if (tierChanged) {
+      return `Licence activated — tier upgraded to ${formatTier(result.tier ?? '')} and ${seatText}.`
+    }
+    return `Paid seats activated — ${seatText}.`
+  }
+
+  if (tierChanged) {
+    return `Licence activated — tier upgraded to ${formatTier(result.tier ?? '')}.`
+  }
+
+  if (typeof result.maxUsers === 'number') {
+    return `Licence activated — ${formatUserSeats(result.maxUsers)} available.`
+  }
+
+  return `Licence activated — tier set to ${formatTier(result.tier ?? '')}.`
+}
+
 const RETENTION_OPTIONS = [
   { value: '7', label: '7 days' },
   { value: '14', label: '14 days' },
@@ -148,6 +184,7 @@ export function SettingsClient({
   seatUsage,
   freeSeatUsers,
 }: SettingsClientProps) {
+  const router = useRouter()
   const queryClient = useQueryClient()
   const tier = effectiveLicence?.tier ?? (org.licenceTier as LicenceTier)
   const visibleSections = new Set<SettingsSection>(
@@ -167,6 +204,9 @@ export function SettingsClient({
   const [licenceResult, setLicenceResult] = useState<{
     success?: boolean
     tier?: string
+    maxUsers?: number
+    previousTier?: string
+    previousMaxUsers?: number
     error?: string
   } | null>(null)
   const [retentionDays, setRetentionDays] = useState(String(org.metricRetentionDays ?? 30))
@@ -206,8 +246,15 @@ export function SettingsClient({
         setLicenceResult({ error: result.error })
         return
       }
-      setLicenceResult({ success: true, tier: result.tier })
+      setLicenceResult({
+        success: true,
+        tier: result.tier,
+        maxUsers: result.maxUsers,
+        previousTier: result.previousTier,
+        previousMaxUsers: result.previousMaxUsers,
+      })
       licenceForm.reset()
+      router.refresh()
     },
   })
 
@@ -1364,7 +1411,7 @@ export function SettingsClient({
                 <Users className="size-3.5" />
                 Seats used
               </div>
-              <p className="mt-2 text-lg font-semibold text-foreground">
+              <p className="mt-2 text-lg font-semibold text-foreground" data-testid="licence-seat-usage">
                 {seatUsage ? (
                   <>
                     {seatUsage.usedSeats}
@@ -1587,10 +1634,7 @@ export function SettingsClient({
                   {licenceResult.success ? (
                     <>
                       <CheckCircle2 className="size-4 mt-0.5 shrink-0" />
-                      <span>
-                        Licence activated — tier upgraded to{' '}
-                        <strong>{formatTier(licenceResult.tier ?? '')}</strong>
-                      </span>
+                      <span>{formatLicenceActivationMessage(licenceResult)}</span>
                     </>
                   ) : (
                     <>

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -12,6 +12,7 @@ import { validateLicenceKey } from '@/lib/licence'
 import { encodeActivationToken } from '@/lib/licence-activation-token'
 import { writeAuditEvent } from '@/lib/audit/events'
 import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
+import { getTrustedEffectiveLicence } from '@/lib/actions/licence-guard'
 
 const updateOrgNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -100,7 +101,13 @@ export async function updateMetricRetention(
 export async function saveLicenceKey(
   orgId: string,
   key: string,
-): Promise<{ success: true; tier: string } | { error: string }> {
+): Promise<{
+  success: true
+  tier: string
+  maxUsers: number
+  previousTier: string
+  previousMaxUsers: number
+} | { error: string }> {
   let session
   try {
     session = await requireOrgAdminAccess(orgId)
@@ -118,10 +125,9 @@ export async function saveLicenceKey(
   }
 
   try {
-    const previous = await db.query.organisations.findFirst({
-      where: eq(organisations.id, orgId),
-      columns: { licenceTier: true },
-    })
+    const previousLicence = await getTrustedEffectiveLicence(orgId)
+    const nextMaxUsers = result.payload.maxUsers ?? FREE_INCLUDED_USER_SEATS
+
     await db
       .update(organisations)
       .set({
@@ -141,12 +147,20 @@ export async function saveLicenceKey(
       targetId: orgId,
       summary: `Updated organisation licence to ${result.payload.tier}`,
       metadata: {
-        previousTier: previous?.licenceTier ?? null,
+        previousTier: previousLicence.tier,
         nextTier: result.payload.tier,
+        previousMaxUsers: previousLicence.maxUsers ?? FREE_INCLUDED_USER_SEATS,
+        nextMaxUsers,
       },
     })
 
-    return { success: true, tier: result.payload.tier }
+    return {
+      success: true,
+      tier: result.payload.tier,
+      maxUsers: nextMaxUsers,
+      previousTier: previousLicence.tier,
+      previousMaxUsers: previousLicence.maxUsers ?? FREE_INCLUDED_USER_SEATS,
+    }
   } catch (err) {
     logError('Failed to save licence key:', err)
     return { error: 'An unexpected error occurred' }

--- a/apps/web/tests/e2e/settings/licence.spec.ts
+++ b/apps/web/tests/e2e/settings/licence.spec.ts
@@ -14,19 +14,19 @@ async function getOrg(sql: ReturnType<typeof getTestDb>): Promise<{ id: string; 
   return rows[0]!
 }
 
-test('admin can validate and save a licence key from licence settings', async ({ authenticatedPage: page }) => {
+test('admin can validate and save a seat-capacity licence key from licence settings', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const org = await getOrg(sql)
   const licenceKey = await issueTestLicence({
     orgId: org.id,
-    tier: 'enterprise',
-    features: ['serviceAccountTracker'],
+    tier: 'community',
+    maxUsers: 8,
   })
 
   await page.goto('/settings/licence')
 
   await expect(page.getByTestId('settings-heading')).toContainText('Organisation')
-  await expect(page.getByText('Current tier:')).toBeVisible()
+  await expect(page.getByText('Current tier', { exact: true })).toBeVisible()
   await expect(page.getByText('Community', { exact: true })).toBeVisible()
 
   await page.getByLabel('Licence key').fill('not-a-real-licence')
@@ -36,7 +36,10 @@ test('admin can validate and save a licence key from licence settings', async ({
   await page.getByLabel('Licence key').fill(licenceKey)
   await page.getByRole('button', { name: 'Validate & save' }).click()
 
-  await expect(page.getByText('Licence activated')).toContainText('Enterprise')
+  await expect(page.getByText('Paid seats activated')).toContainText(
+    'capacity increased from 3 to 8 user seats',
+  )
+  await expect(page.getByTestId('licence-seat-usage')).toContainText('/ 8')
 
   await expect
     .poll(async () => {
@@ -49,7 +52,7 @@ test('admin can validate and save a licence key from licence settings', async ({
       return rows[0] ?? null
     })
     .toEqual({
-      licence_tier: 'enterprise',
+      licence_tier: 'community',
       licence_key: licenceKey,
     })
 })


### PR DESCRIPTION
## Summary
- Return previous and new seat capacity from licence activation so the success message can describe purchased seats.
- Refresh the current settings route after a key is saved so server-rendered seat usage updates automatically.
- Update the licence settings E2E to cover a Community seat-capacity key and the refreshed seat limit display.

## Validation
- `pnpm --filter web type-check`
- `pnpm --filter web test:e2e tests/e2e/settings/licence.spec.ts`

Root cause: the client only used the returned tier for the activation success state, so Community seat purchases still read like a tier change, and the settings page relied on stale server props until the browser was manually refreshed.
