### PR TITLE
docs(ct-passwd): add product architecture docs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,24 @@
 
 ## What Has Been Built
 
+### Session 100 — CT-Passwd product architecture docs
+
+**CT-Passwd product boundary and security model** (`docs/ct-passwd-product-architecture.md`, `apps/docs/docs/architecture/ct-passwd.md`)
+- Added the CT-OPS-side CT-Passwd architecture definition covering product
+  ownership boundaries, deployment shape, nginx routing defaults, launch
+  assertion trust flow, zero-knowledge crypto constraints, shared-vault key
+  wrapping, licence-gated invisibility, audit ownership, and the initial threat
+  model.
+- Added a matching published docs page so the docs site now describes how
+  CT-Passwd fits into CT-Ops without exposing implementation detail that belongs
+  in the future private product repository.
+- Added a docs landing-page link for the CT-Passwd architecture page and updated
+  the implementation plan task tracker for Task 1.
+
+**Validation**
+- Validation run: `git diff --check`, targeted Markdown fence/tab sanity checks,
+  `pnpm install --frozen-lockfile`, and `pnpm --dir apps/docs build`.
+
 ### Session 99 — CT-Passwd implementation coordination plan
 
 **CT-Passwd planning handoff** (`docs/ct-passwd-implementation-plan.md`)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,23 @@
 
 ## What Has Been Built
 
+### Session 99 — CT-Passwd implementation coordination plan
+
+**CT-Passwd planning handoff** (`docs/ct-passwd-implementation-plan.md`)
+- Added the CT-Passwd implementation coordination plan for overnight agents,
+  including the required agent operating rules, security model, architecture
+  decisions, task table, MVP acceptance criteria, validation expectations, and
+  handoff log.
+- Locked the agreed CT-Passwd direction: a separate private repository at
+  `git@github.com:simonjcarr/ct-passwd.git`, Dockerized air-gapped deployment,
+  CT-OPS-owned identity/licence/nginx entry point, plugin-owned forms, dedicated
+  hostname routing by default, browser-side zero-knowledge encryption, shared
+  vault key wrapping, and no admin recovery in the MVP.
+
+**Validation**
+- Validation run: `git diff --check` and a targeted Markdown sanity check for
+  balanced fenced code blocks and tab characters.
+
 ### Session 98 — Licence public-key repository integration
 
 **Release key source of truth** (`deploy/scripts/fetch-licence-public-key.sh`, `.github/workflows/agent-release.yml`, `.github/workflows/customer-bundle-check.yml`)

--- a/apps/docs/docs/README.md
+++ b/apps/docs/docs/README.md
@@ -40,6 +40,7 @@ Paid licence validation uses a signed JWT verified against a bundled public key.
 | [Installation](./getting-started/installation) | Get CT-Ops running in under 5 minutes |
 | [Offline Agent Install Bundle](./getting-started/agent-install-bundle) | Download a portable zip to install agents on air-gapped hosts |
 | [Architecture Overview](./architecture/overview) | Understand how the components fit together |
+| [CT-Passwd Architecture](./architecture/ct-passwd) | Product boundary, launch flow, zero-knowledge model |
 | [Agent Architecture](./architecture/agent) | Registration flow, identity model, self-update |
 | [Ingest Service](./architecture/ingest) | gRPC gateway, JWT issuance, queue |
 | [Deployment Profiles](./architecture/deployment-profiles) | single / standard / HA configurations |

--- a/apps/docs/docs/architecture/ct-passwd.md
+++ b/apps/docs/docs/architecture/ct-passwd.md
@@ -1,0 +1,112 @@
+# CT-Passwd Architecture
+
+CT-Passwd is the CarrTech password-manager product that plugs into CT-Ops while
+remaining separately deployed and separately released.
+
+CT-Ops stays responsible for identity, licensing, and customer-facing ingress.
+CT-Passwd owns the password-manager UI, browser-side cryptography, encrypted
+data APIs, and audit trail.
+
+## Product Boundary
+
+CT-Ops owns:
+
+- CT-Passwd entitlement checks and visibility.
+- Plugin registration and trust material.
+- Launch entry points and signed launch assertions.
+- Nginx reverse-proxy publishing and installer changes.
+
+CT-Passwd owns:
+
+- Password-manager forms and workflows.
+- Browser-side encryption and decryption.
+- Vault, entry, membership, session, and audit APIs.
+- Product-local database storage.
+
+CT-Passwd is intentionally not a standalone customer product. It depends on
+CT-Ops for user identity, organisation context, and product access control.
+
+## Routing Model
+
+The default deployment uses a dedicated hostname behind the CT-Ops nginx
+reverse proxy:
+
+```text
+https://passwd.customer.local -> ct-ops nginx -> ct-passwd-web -> ct-passwd-api
+```
+
+Dedicated hostname routing is the default because it gives cleaner cookie
+isolation and security-policy boundaries. Path routing such as
+`https://ct-ops.customer.local/passwd` is supported only as a documented
+fallback when a customer cannot provision a second hostname.
+
+CT-Passwd is not meant to be exposed directly on the customer network outside
+the CT-Ops reverse-proxy path.
+
+## Identity And Sessions
+
+Users enter CT-Passwd from CT-Ops. CT-Ops issues a short-lived signed launch
+assertion that identifies the paired plugin instance, organisation, user, and
+expiry window. CT-Passwd validates the assertion and then creates a short-lived
+plugin-local session.
+
+Users must still unlock CT-Passwd separately with a CT-Passwd unlock password.
+That unlock step is distinct from CT-Ops authentication.
+
+## Zero-Knowledge Encryption Model
+
+CT-Passwd uses browser-side cryptography so the server stores encrypted blobs
+and wrapped keys rather than plaintext secrets.
+
+Encrypted in the browser:
+
+- usernames
+- passwords
+- URLs
+- notes
+- TOTP seeds
+- custom fields
+- attachment metadata
+
+Plaintext allowed on the server:
+
+- entry title
+- vault name
+- object identifiers
+- timestamps
+- audit event types
+
+The server must never receive unlock passwords, derived unlock keys, plaintext
+secret fields, unencrypted private keys, vault keys, or entry data-encryption
+keys.
+
+## Shared Vaults
+
+Shared vaults use per-user public keys and per-vault vault keys.
+
+- Each user has a browser-generated public/private key pair.
+- The private key is encrypted locally before upload.
+- Each vault key is wrapped separately for every authorized user.
+- Removing a member requires vault-key rotation for future access.
+
+This protects the server boundary, but it does not claim to revoke secrets a
+removed user has already seen or copied.
+
+## Threat Model Summary
+
+CT-Passwd is designed to reduce damage from:
+
+- database compromise, because stored secret data remains encrypted
+- CT-Passwd server compromise, because the server should still lack plaintext
+  secrets and unlock material
+- replay or forged launches, through signed short-lived launch assertions with
+  nonce or `jti` checks
+- malicious insiders or removed members, through per-object authorization and
+  vault-key rotation
+
+The MVP does not include admin recovery of lost unlock passwords.
+
+## Further Reading
+
+Implementation-tracking detail remains in the repository-level planning and
+architecture documents under the top-level `docs/` directory.

--- a/docs/ct-passwd-implementation-plan.md
+++ b/docs/ct-passwd-implementation-plan.md
@@ -1,0 +1,288 @@
+# CT-Passwd Implementation Plan
+
+This is the coordination file for agents building CT-Passwd and the CT-OPS
+integration around it.
+
+CT-Passwd code belongs in the private repository
+`git@github.com:simonjcarr/ct-passwd.git`. CT-OPS integration work belongs in
+this repository. Agents must keep this file current so parallel or overnight
+sessions do not duplicate work.
+
+## Agent Operating Rules
+
+Before starting:
+
+- Read `AGENTS.md` in the CT-OPS repository root and follow it exactly.
+- Read this file from top to bottom.
+- Pick the first task with status `Not started` whose dependencies are
+  complete.
+- Change that task to `In progress` with your agent/session name and timestamp
+  before editing code.
+- Use a dedicated Git worktree before making file changes.
+- Use test-first development for new behaviour unless the task is explicitly
+  docs-only.
+- Do not work on a task already marked `In progress`.
+- Do not skip validation.
+- Commit with a Conventional Commit message.
+- Push the branch and open a pull request.
+- Update this file at the end with status, PR link, validation run, what
+  changed, and what remains.
+- If you identify an unrelated security issue, follow `AGENTS.md`: create a
+  focused GitHub issue rather than expanding your task scope silently.
+
+Status values:
+
+- `Not started`
+- `In progress`
+- `Blocked`
+- `Complete`
+
+## Architecture Decisions
+
+- CT-Passwd is a separate product repository:
+  `git@github.com:simonjcarr/ct-passwd.git`.
+- CT-Passwd is installed as Docker containers in customer air-gapped networks.
+- CT-OPS is the only product entry point, identity provider, licence gate, and
+  nginx reverse-proxy owner.
+- CT-Passwd is invisible in CT-OPS unless a valid CT-Passwd licence exists. No
+  nav item, route, settings card, search result, teaser, or hint should be
+  visible without an entitlement.
+- CT-Passwd owns all password-manager forms and workflows. CT-OPS must not
+  render CT-Passwd forms from JSON.
+- Default routing is a dedicated hostname through the CT-OPS nginx reverse
+  proxy, for example `https://passwd.customer.local`.
+- Path routing, for example `https://ct-ops.customer.local/passwd`, is a
+  documented fallback only for customers that cannot create a second hostname.
+- CT-Passwd authenticates users only through CT-OPS-issued signed launch
+  assertions.
+- CT-Passwd must not query the CT-OPS database directly.
+- MVP has no admin recovery for lost CT-Passwd unlock passwords.
+- Future recovery must be opt-in, dual-control, heavily audited, and explicitly
+  documented as weakening the zero-knowledge posture.
+
+## Security Model
+
+CT-Passwd uses browser-side zero-knowledge encryption for password entries.
+The server stores encrypted blobs, authorization metadata, and audit metadata;
+it must not receive plaintext secrets.
+
+Secret fields encrypted in the browser:
+
+- username
+- password
+- URL
+- notes
+- TOTP seed
+- custom fields
+- attachment metadata
+- any other sensitive metadata
+
+Plaintext allowed:
+
+- entry title, with a UI warning not to include sensitive data
+- vault name
+- audit action type
+- object ids
+- timestamps
+- non-secret operational metadata
+
+Crypto requirements:
+
+- Use Argon2id for unlock-password key derivation.
+- Use authenticated encryption: AES-256-GCM or XChaCha20-Poly1305.
+- Use unique nonces per encryption operation.
+- Generate random per-entry or per-entry-version data encryption keys.
+- Give each vault a vault key.
+- Wrap each vault key separately for every authorized user.
+- Never send unlock passwords, derived keys, private keys, vault keys, entry
+  DEKs, or plaintext secret values to the server.
+- Never log secret values.
+- Do not invent custom cryptography.
+- Follow OWASP and NIST guidance for password storage, cryptographic storage,
+  API security, rate limiting, and secure error handling.
+
+Shared vault model:
+
+- Each user has a browser-generated public/private encryption key pair.
+- The user's private key is encrypted locally using a key derived from their
+  CT-Passwd unlock password.
+- Each vault has a vault key.
+- The vault key is wrapped separately for every authorized user.
+- Entry DEKs are wrapped by the vault key.
+- Adding a user requires an authorized unlocked user to wrap the vault key for
+  the new user's public key.
+- Removing a user requires rotating the vault key for future access. Past
+  access cannot be cryptographically clawed back after a user has viewed or
+  copied a secret.
+
+Required audit events:
+
+- create
+- update
+- delete
+- view
+- copy
+- export
+- failed unlock
+- successful unlock
+- permission changes
+- admin actions
+- key rotation
+- backup and restore actions
+
+Audit logs must never contain secret values.
+
+## High-Level Architecture
+
+```mermaid
+flowchart LR
+  User[Browser]
+  CTOps[CT-OPS]
+  Nginx[CT-OPS nginx]
+  PassUI[CT-Passwd UI]
+  PassAPI[CT-Passwd API]
+  PassDB[(CT-Passwd PostgreSQL)]
+  Audit[(Audit Log)]
+
+  User --> CTOps
+  CTOps --> Nginx
+  Nginx --> PassUI
+  PassUI --> PassAPI
+  PassAPI --> PassDB
+  PassAPI --> Audit
+```
+
+Expected air-gapped deployment shape:
+
+```text
+ct-ops-web
+ct-ops-ingest
+ct-ops-db
+ct-ops-nginx
+ct-passwd-api
+ct-passwd-web
+ct-passwd-db
+```
+
+Splitting CT-Passwd worker jobs from the API can come later if scale or
+operational reliability requires it.
+
+## API Boundaries
+
+CT-OPS to CT-Passwd:
+
+- plugin instance registration
+- signed launch assertions
+- subscription or entitlement status
+- service-to-service health and configuration status
+- nginx install/config status
+
+Browser to CT-Passwd:
+
+- launch assertion exchange
+- plugin-local CT-Passwd session
+- unlock setup
+- encrypted user key material fetch
+- encrypted vault and entry CRUD
+- audit-triggering view, copy, and export requests
+
+CT-Passwd to CT-OPS:
+
+- optional subscription-status check
+- optional health or connection state
+- no direct database access
+
+Service authentication should align with the existing CT-CVE contract: signed
+service tokens or mTLS-backed client assertions with timestamp, nonce, body hash,
+scope, organisation binding, and replay protection. Static bearer tokens alone
+are not acceptable.
+
+## Implementation Tasks
+
+| ID | Task | Repo | Dependencies | Status | Owner | PR | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Create CT-Passwd product architecture docs in CT-OPS | ct-ops | none | Not started |  |  | Add docs for product boundary, nginx routing, zero-knowledge model, threat model. |
+| 2 | Add CT-Passwd implementation plan file | ct-ops | none | Complete | Codex 2026-05-03 20:53 BST | https://github.com/carrtech-dev/ct-ops/pull/866 | Created this coordination file and seeded the initial handoff log. |
+| 3 | Add shared plugin identity broker design/update | ct-ops | none | Not started |  |  | Align with existing CT-CVE plugin identity direction. |
+| 4 | Add plugin entitlement storage design for CT-Passwd | ct-ops | 3 | Not started |  |  | CT-Passwd hidden unless licensed. |
+| 5 | Add CT-Passwd nginx reverse-proxy install design | ct-ops | 4 | Not started |  |  | Dedicated hostname default, path fallback documented. |
+| 6 | Bootstrap `simonjcarr/ct-passwd` repository | ct-passwd | 1 | Not started |  |  | Monorepo with API, UI, crypto, db, deploy packages. |
+| 7 | Add CT-Passwd CI, lint, type-check, test, and release skeleton | ct-passwd | 6 | Not started |  |  | Include release-please/container publishing path. |
+| 8 | Add Docker Compose and air-gap deployment skeleton | ct-passwd | 6 | Not started |  |  | API/UI/Postgres initially; split worker later if needed. |
+| 9 | Add database schema and migrations | ct-passwd | 6 | Not started |  |  | Users, vaults, memberships, entries, key wraps, audit, nonces, sessions. |
+| 10 | Add crypto package tests first | ct-passwd | 6 | Not started |  |  | Argon2id, AEAD, key wrapping, nonce uniqueness, tamper rejection. |
+| 11 | Implement browser-side crypto package | ct-passwd | 10 | Not started |  |  | Must be usable by UI without server plaintext access. |
+| 12 | Implement CT-OPS launch assertion verification | ct-passwd | 9 | Not started |  |  | Verify issuer, audience, product, org, user, expiry, jti. |
+| 13 | Implement CT-Passwd local session and secure cookies | ct-passwd | 12 | Not started |  |  | Short-lived plugin-local session after launch assertion. |
+| 14 | Implement unlock setup and encrypted user private key storage | ct-passwd | 11,13 | Not started |  |  | Server stores encrypted private key only. |
+| 15 | Implement vault CRUD and membership authorization | ct-passwd | 9,13 | Not started |  |  | Backend enforces object permissions; no plaintext secrets. |
+| 16 | Implement shared vault key wrapping | ct-passwd | 11,15 | Not started |  |  | Add/remove users, rotate vault key on removal. |
+| 17 | Implement encrypted entry CRUD | ct-passwd | 11,15 | Not started |  |  | Browser encrypts; API validates shape and authorization only. |
+| 18 | Implement explicit reveal/copy/export audit flows | ct-passwd | 17 | Not started |  |  | Audit event without secret values. |
+| 19 | Build CT-Passwd hosted UI shell | ct-passwd | 13 | Not started |  |  | Match CT-OPS design conventions; no JSON-rendered forms. |
+| 20 | Build unlock UI and lock/session timeout UX | ct-passwd | 14,19 | Not started |  |  | Private keys only in browser memory after unlock. |
+| 21 | Build vault and entry management UI | ct-passwd | 17,19,20 | Not started |  |  | Include title sensitivity warning. |
+| 22 | Build sharing and permission UI | ct-passwd | 16,21 | Not started |  |  | Viewer/editor/admin/owner roles. |
+| 23 | Add audit log UI/API | ct-passwd | 18 | Not started |  |  | Create/update/delete/view/copy/export/failed unlock/permission/admin events. |
+| 24 | Add rate limiting, replay protection, secure headers, and CSRF/CORS policy | ct-passwd | 13 | Not started |  |  | Follow CT-OPS security expectations. |
+| 25 | Add CT-OPS CT-Passwd hidden licence gate | ct-ops | 4 | Not started |  |  | No visible hint unless licensed. |
+| 26 | Add CT-OPS CT-Passwd launch route/action | ct-ops | 3,25 | Not started |  |  | Issues short-lived signed launch assertion. |
+| 27 | Add CT-OPS installer/nginx update for CT-Passwd | ct-ops | 5,25 | Not started |  |  | Updates customer bundle/start scripts safely. |
+| 28 | Add backup/restore and disaster recovery docs | ct-passwd | 9,11 | Not started |  |  | DB backup, encrypted key material, no unlock recovery in MVP. |
+| 29 | Add key rotation design and implementation | ct-passwd | 16,17 | Not started |  |  | Vault key rotation after member removal; algorithm migration path. |
+| 30 | Add E2E tests for launch, unlock, share, revoke, reveal, and audit | both | 21,22,26 | Not started |  |  | Include browser tests proving server never receives plaintext. |
+| 31 | Security review and final threat-model update | both | 30 | Not started |  |  | DB compromise, CT-OPS compromise, CT-Passwd compromise, browser session theft, replay, insider threat. |
+
+## MVP Acceptance Criteria
+
+- CT-Passwd is unavailable and invisible in CT-OPS unless licensed.
+- CT-Passwd runs as Docker containers in air-gapped installs.
+- CT-OPS nginx routes to CT-Passwd on a dedicated hostname by default.
+- CT-Passwd users enter through CT-OPS signed launch assertions.
+- Users must unlock CT-Passwd separately from normal CT-OPS login.
+- Password entries are encrypted and decrypted in the browser only.
+- Server never receives plaintext entry secrets.
+- Multiple users can view and edit shared vault entries through wrapped vault
+  keys.
+- Removing a user rotates vault keys for future access.
+- Audit events exist for create, update, delete, view, copy, export, failed
+  unlock, successful unlock, permission changes, admin actions, key rotation,
+  and backup/restore actions.
+- Audit logs contain no secret values.
+- Tests cover crypto tampering, authorization, sharing, revocation, launch
+  assertion rejection, replay rejection, and audit logging.
+
+## Validation Requirements
+
+Each PR must include the relevant subset:
+
+- Unit tests for crypto, auth, authorization, validation, audit, and rate
+  limits.
+- API tests for signed service requests, launch assertions, replay protection,
+  and object access.
+- Browser/E2E tests for unlock, reveal, copy, share, revoke, lock timeout, and
+  no-unlicensed-visibility.
+- Type-check and lint for changed packages.
+- Migration validation for schema changes.
+- Docker Compose smoke test for deployment changes.
+
+Docs-only PRs must at least run a targeted spell/format sanity check where a
+project-local command exists, or document that no docs-specific validator exists.
+
+## Deferred Features
+
+- Browser extension.
+- Passkeys.
+- Admin or organisation recovery.
+- Shamir split recovery.
+- Hardware-token recovery.
+- Importers from third-party password managers.
+- Secret rotation automation.
+- SIEM forwarding.
+- Advanced anomaly detection.
+
+## Handoff Log
+
+| Date | Agent | Task | Status | PR | Validation | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-03 | Codex | 2 | Complete | https://github.com/carrtech-dev/ct-ops/pull/866 | `git diff --check`; targeted Markdown sanity check for balanced fenced code blocks and tab characters. | Initial coordination file created for overnight agents. |

--- a/docs/ct-passwd-implementation-plan.md
+++ b/docs/ct-passwd-implementation-plan.md
@@ -201,7 +201,7 @@ are not acceptable.
 
 | ID | Task | Repo | Dependencies | Status | Owner | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Create CT-Passwd product architecture docs in CT-OPS | ct-ops | none | In progress | Codex 2026-05-03 21:34 BST |  | Adding internal and published CT-Passwd architecture docs for boundary, routing, zero-knowledge, and threat model. |
+| 1 | Create CT-Passwd product architecture docs in CT-OPS | ct-ops | none | Complete | Codex 2026-05-03 21:34 BST | https://github.com/carrtech-dev/ct-ops/pull/869 | Added internal and published CT-Passwd architecture docs for boundary, routing, zero-knowledge, and threat model. Validation: `git diff --check`, Markdown sanity checks, `pnpm install --frozen-lockfile`, `pnpm --dir apps/docs build`. |
 | 2 | Add CT-Passwd implementation plan file | ct-ops | none | Complete | Codex 2026-05-03 20:53 BST | https://github.com/carrtech-dev/ct-ops/pull/866 | Created this coordination file and seeded the initial handoff log. |
 | 3 | Add shared plugin identity broker design/update | ct-ops | none | Not started |  |  | Align with existing CT-CVE plugin identity direction. |
 | 4 | Add plugin entitlement storage design for CT-Passwd | ct-ops | 3 | Not started |  |  | CT-Passwd hidden unless licensed. |

--- a/docs/ct-passwd-implementation-plan.md
+++ b/docs/ct-passwd-implementation-plan.md
@@ -201,7 +201,7 @@ are not acceptable.
 
 | ID | Task | Repo | Dependencies | Status | Owner | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Create CT-Passwd product architecture docs in CT-OPS | ct-ops | none | Not started |  |  | Add docs for product boundary, nginx routing, zero-knowledge model, threat model. |
+| 1 | Create CT-Passwd product architecture docs in CT-OPS | ct-ops | none | In progress | Codex 2026-05-03 21:34 BST |  | Adding internal and published CT-Passwd architecture docs for boundary, routing, zero-knowledge, and threat model. |
 | 2 | Add CT-Passwd implementation plan file | ct-ops | none | Complete | Codex 2026-05-03 20:53 BST | https://github.com/carrtech-dev/ct-ops/pull/866 | Created this coordination file and seeded the initial handoff log. |
 | 3 | Add shared plugin identity broker design/update | ct-ops | none | Not started |  |  | Align with existing CT-CVE plugin identity direction. |
 | 4 | Add plugin entitlement storage design for CT-Passwd | ct-ops | 3 | Not started |  |  | CT-Passwd hidden unless licensed. |

--- a/docs/ct-passwd-product-architecture.md
+++ b/docs/ct-passwd-product-architecture.md
@@ -1,0 +1,313 @@
+# CT-Passwd Product Architecture
+
+This document defines the CT-OPS-side product architecture for CT-Passwd. It
+describes the product boundary, browser and service trust relationships,
+expected nginx routing, and the threat model that downstream implementation
+work must satisfy.
+
+This is the CT-OPS source of truth until the private `ct-passwd` repository is
+bootstrapped and can carry product-local implementation detail.
+
+## Goals
+
+- Keep CT-Passwd deployable in air-gapped customer environments.
+- Keep CT-OPS as the only visible product shell, identity provider, licence
+  gate, and reverse-proxy owner.
+- Preserve a zero-knowledge posture where CT-Passwd servers never receive
+  plaintext secrets or user unlock material.
+- Allow future multi-user shared vaults without weakening the baseline
+  cryptographic model.
+
+## Product Boundary
+
+CT-OPS owns:
+
+- Customer licensing and CT-Passwd entitlement state.
+- Product discovery, navigation visibility, and launch entry points.
+- Plugin instance registration and trust material for CT-Passwd.
+- Reverse-proxy ownership, TLS termination, and customer installer updates.
+- Shared operator-facing deployment, health, and support documentation.
+
+CT-Passwd owns:
+
+- Password-manager UI, forms, validation, and workflows.
+- Browser-side encryption, decryption, key generation, and unlock UX.
+- Encrypted vault, entry, membership, session, and audit APIs.
+- Product-local database schema and operational data.
+
+CT-Passwd must not:
+
+- Query the CT-OPS database directly.
+- Reuse CT-OPS server actions or import CT-OPS private modules as a shortcut.
+- Expose its UI in CT-OPS unless a valid CT-Passwd entitlement exists.
+- Depend on CT-OPS to render password-manager forms from JSON or to handle
+  plaintext secrets.
+
+## Deployment Shape
+
+The expected first customer deployment is:
+
+```text
+ct-ops-web
+ct-ops-ingest
+ct-ops-db
+ct-ops-nginx
+ct-passwd-api
+ct-passwd-web
+ct-passwd-db
+```
+
+CT-Passwd is released as a separate product repository but deployed as part of
+the same customer installation footprint. CT-OPS remains the customer-facing
+entry point for setup, licensing, and upgrade orchestration.
+
+## Routing Model
+
+The default routing model is a dedicated CT-Passwd hostname behind the CT-OPS
+nginx reverse proxy:
+
+```text
+https://passwd.customer.local -> ct-ops nginx -> ct-passwd-web -> ct-passwd-api
+```
+
+Requirements:
+
+- CT-OPS generates and owns the nginx configuration that publishes CT-Passwd.
+- TLS is terminated at the CT-OPS nginx layer unless a future deployment profile
+  requires passthrough.
+- CT-Passwd hostname routing is the default because it provides cleaner cookie
+  isolation, CSP policy, and operational separation.
+- Path routing such as `https://ct-ops.customer.local/passwd` is a fallback only
+  for customers that cannot create a second hostname.
+- Direct exposure of CT-Passwd containers without the CT-OPS reverse proxy is
+  unsupported.
+
+Routing consequences:
+
+- CT-Passwd must assume its origin may be a dedicated hostname or a routed path,
+  but the preferred behaviour, cookies, and CSP should be designed around the
+  dedicated-hostname case.
+- All published customer docs and installer defaults should present dedicated
+  hostname routing first and describe path routing as a compromise mode.
+
+## Identity And Launch Flow
+
+CT-OPS remains the identity provider and authorization source for CT-Passwd
+users.
+
+High-level flow:
+
+1. A licensed CT-OPS user clicks the CT-Passwd entry point.
+2. CT-OPS verifies that the organisation has an active CT-Passwd entitlement and
+   that the current user is allowed to launch the plugin.
+3. CT-OPS creates a short-lived signed launch assertion scoped to the paired
+   CT-Passwd instance, user, organisation, and nonce/jti.
+4. The browser is redirected to CT-Passwd with that assertion.
+5. CT-Passwd validates the assertion against pinned CT-OPS trust material and
+   creates a short-lived plugin-local session cookie.
+6. The user separately unlocks CT-Passwd inside the browser using their
+   CT-Passwd unlock password.
+
+Launch assertions must include:
+
+- issuer
+- audience
+- product identifier
+- organisation identifier
+- user identifier
+- expiry
+- jti or nonce
+
+CT-Passwd must reject assertions with the wrong issuer, audience, organisation,
+user, product, expiry, or replayed nonce.
+
+## Zero-Knowledge Model
+
+CT-Passwd uses browser-side cryptography for all secret-bearing data.
+
+Secret fields that must be encrypted in the browser:
+
+- usernames
+- passwords
+- URLs
+- notes
+- TOTP seeds
+- custom fields
+- attachment metadata
+- other secret-bearing metadata
+
+Plaintext that may remain server-visible:
+
+- entry title, with an explicit UI warning not to store secrets there
+- vault name
+- object identifiers
+- timestamps
+- audit event type
+- non-secret operational metadata
+
+Required cryptographic properties:
+
+- Argon2id for unlock-password key derivation.
+- Authenticated encryption using AES-256-GCM or XChaCha20-Poly1305.
+- Unique nonce generation per encryption operation.
+- Random per-entry or per-entry-version data encryption keys.
+- Per-vault vault keys wrapped separately for each authorized user.
+- Encrypted private keys stored on the server only after local encryption with a
+  key derived from the CT-Passwd unlock password.
+
+The server must never receive:
+
+- unlock passwords
+- derived unlock keys
+- unencrypted private keys
+- vault keys
+- entry data-encryption keys
+- plaintext secret fields
+
+## Shared Vault Model
+
+Shared access is required for team password management while preserving the
+zero-knowledge boundary.
+
+- Each user has a browser-generated public/private encryption key pair.
+- The private key is encrypted locally with a key derived from the unlock
+  password before upload.
+- Each vault has a vault key.
+- The vault key is wrapped separately for every authorized user.
+- Entry data-encryption keys are wrapped by the vault key.
+- Adding a user requires an already-authorized unlocked user to wrap the vault
+  key for the new member's public key.
+- Removing a user requires rotating the vault key for future access.
+
+This design protects the server from plaintext exposure, but it does not claim
+to revoke secrets already seen or copied by a removed user.
+
+## Licence Gating And Discoverability
+
+CT-Passwd must be invisible in CT-OPS unless an active CT-Passwd entitlement
+exists for the organisation.
+
+Without an entitlement, CT-OPS must not show:
+
+- navigation items
+- routes
+- settings cards
+- search results
+- teaser text
+- setup hints
+- empty states that reveal CT-Passwd exists
+
+This is stricter than a disabled button model. CT-Passwd should behave as if it
+is not installed from the perspective of an unlicensed user.
+
+## Audit Boundary
+
+CT-Passwd owns secret-related audit events and storage. CT-OPS may display
+high-level health or integration status, but detailed password-manager audit
+events belong to CT-Passwd.
+
+Required CT-Passwd audit events:
+
+- create
+- update
+- delete
+- view
+- copy
+- export
+- failed unlock
+- successful unlock
+- permission changes
+- admin actions
+- key rotation
+- backup and restore actions
+
+Audit logs must never contain secret values.
+
+## Threat Model
+
+### Primary assets
+
+- User unlock passwords.
+- User private keys.
+- Vault keys and wrapped key material.
+- Encrypted entry payloads.
+- Audit history.
+- CT-OPS to CT-Passwd trust material.
+
+### Trust boundaries
+
+- Browser to CT-OPS.
+- Browser to CT-Passwd.
+- CT-OPS to CT-Passwd service boundary.
+- CT-Passwd application to CT-Passwd database.
+- CT-OPS nginx to customer network.
+
+### Assumed attackers
+
+- An external network attacker able to replay or tamper with requests.
+- A customer-side operator with database access to CT-Passwd storage.
+- A compromised CT-Passwd server process.
+- A compromised CT-OPS server process.
+- A malicious or removed vault member.
+- A user endpoint compromised after unlock.
+
+### Required mitigations
+
+For network and replay risk:
+
+- Signed launch assertions with expiry, audience binding, and replay protection.
+- HTTPS everywhere inside the supported deployment shape.
+- Bounded clock-skew windows and nonce storage for anti-replay checks.
+
+For database compromise:
+
+- Only encrypted blobs and wrapped keys are stored for secret data.
+- Server-side logs, backups, and diagnostics must avoid secret values.
+- Schema and API design must avoid accidental plaintext copies in derived tables
+  or audit rows.
+
+For CT-Passwd server compromise:
+
+- The server must still be unable to read stored secrets without browser-held
+  unlock material.
+- Sessions, cookies, CSRF controls, and audit events must limit abuse and make
+  actions attributable.
+
+For CT-OPS compromise:
+
+- CT-OPS compromise must not immediately reveal stored secret plaintext, though
+  it can enable fraudulent launch assertions or entitlement abuse.
+- Future security review must separately assess the blast radius of a CT-OPS
+  signing-key compromise.
+
+For malicious insiders or removed members:
+
+- Authorization must be enforced on every vault, entry, and membership action.
+- Vault key rotation is required after member removal for future protection.
+- Product docs must explicitly state that historical viewing or copying cannot
+  be cryptographically undone.
+
+For compromised user browsers:
+
+- Unlock-derived material and decrypted secrets should live only in browser
+  memory for the active unlocked session.
+- CT-Passwd should provide lock and timeout controls to reduce exposure.
+
+### Out of scope for MVP
+
+- Admin recovery of lost unlock passwords.
+- Breaking zero-knowledge guarantees to enable server-side search over secret
+  fields.
+- Direct CT-Passwd access without CT-OPS-issued launch assertions.
+
+## Implementation Consequences
+
+Downstream implementation work in CT-OPS and `ct-passwd` should preserve these
+constraints:
+
+- CT-OPS work should focus on entitlement gating, plugin trust registration,
+  launch assertion issuance, and nginx/deployment orchestration.
+- CT-Passwd work should own its UI, crypto, API, database, sessions, audit, and
+  vault authorization rules.
+- Shared integration contracts should be explicit, signed, replay-resistant, and
+  versioned.


### PR DESCRIPTION
## Summary
- add the CT-OPS-side CT-Passwd product architecture document
- add a published docs page for CT-Passwd architecture and link it from the docs landing page
- update the implementation plan tracker and PROGRESS log

## Validation
- git diff --check
- targeted Markdown fence/tab sanity checks
- pnpm install --frozen-lockfile
- pnpm --dir apps/docs build