### PR TITLE
docs(plugin): add entitlement storage design

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,24 @@
 
 ## What Has Been Built
 
+### Session 101 — Plugin entitlement storage design
+
+**Plugin licensing contract** (`docs/ct-ops-plugin-entitlement-storage.md`, `docs/ct-ops-licensing-and-ct-cve-product-decision.md`, `docs/ct-ops-ct-cve-api-contract.md`, `docs/ct-cve-migration-plan.md`)
+- Added the shared CT Ops plugin entitlement storage design covering normalized
+  entitlement records, CT Portal request-token and licence binding, encrypted
+  licence artifact storage, derived subscription-status responses, audit
+  requirements, and safe degradation rules for air-gapped installs.
+- Defined CT-Passwd's stricter visibility rule: CT Ops must keep CT-Passwd
+  hidden unless a valid entitlement exists, including on nav, settings, search,
+  and launch paths.
+- Linked the new design from the product decision record, the CT-CVE API
+  contract, and the migration plan so later implementation work uses one CT
+  Ops-owned contract.
+
+**Validation**
+- Validation run: `git diff --check` and a targeted Markdown sanity check for
+  balanced fenced code blocks and tab characters.
+
 ### Session 100 — Shared plugin identity broker design
 
 **Plugin identity groundwork** (`docs/ct-ops-plugin-identity-broker.md`, `docs/ct-ops-licensing-and-ct-cve-product-decision.md`, `docs/ct-ops-ct-cve-api-contract.md`, `docs/ct-cve-migration-plan.md`)

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -266,13 +266,13 @@ Update the status and notes in this table as work lands.
 | 5. Licensing UI and docs | Complete | docs/licensing-ui-seat-docs | Reworked the licence settings surface and docs around seats, expiry, and Enterprise capabilities. |
 | 6. CT Ops/CT-CVE API contract | Complete | ct-cve-api-contract | Added `docs/ct-ops-ct-cve-api-contract.md` defining scoped inventory export, finding ingestion, signed service tokens, idempotency, rate limits, retries, replay protection, and connection status. |
 | 7. CT-CVE repo bootstrap | Complete | ct-cve #1, #2, #3, #4, #5, #6 / ct-ops #809 | Bootstrapped separate CT-CVE service skeleton, initial database schema, Docker/Compose, CI, release-please container publishing, extracted package version/matching tests, validated feed source runtime config, persisted CISA KEV and NVD feed sync, and added distro parser affected-package persistence. |
-| 8. CT-CVE GUI | Blocked | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. Real CT Ops-backed subscription status remains blocked until plugin entitlement storage and the CT-CVE auth/subscription integration phases land. |
+| 8. CT-CVE GUI | Blocked | ct-cve #7, #8, #12 / feat/ct-cve-gui-phase8, feat/feed-api-logs | Added the first CT-CVE operational status GUI/API slice for source health, feed schedule visibility, NVD API-key configured status, CT Ops dependency/subscription placeholders, editable source configuration, and feed/API activity logs. The shared entitlement storage design now exists in `docs/ct-ops-plugin-entitlement-storage.md`, but real CT Ops-backed subscription status stays blocked until phase 14 implementation and the CT-CVE auth/subscription integration phase land. |
 | 9. CT Ops connector | Complete | feat/ct-ops-ct-cve-connector, feat/ct-cve-finding-ingest, feat/ct-cve-inventory-export, feat/ct-cve-connection-status, feat/ct-cve-next-task, feat/ct-cve-connector-setup-ui | Added signed CT-CVE service-token verification, replay protection, per-token rate limiting, durable connection health/status, the first CT-CVE finding batch ingestion endpoint, signed CT Ops inventory snapshot export helpers, an env-configured scheduled inventory push job, and an admin connector setup/status UI. |
 | 10. Remove internal CT Ops CVE ownership | Complete | feat/remove-internal-cve-ownership, feat/remove-ct-cve-source-settings, #837 | Removed ingest-owned vulnerability feed sync and host matching startup/config, the legacy CT Ops vulnerability source/settings page and NVD key actions, and obsolete CT Ops source-state/affected-package match-rule storage. CT Ops retains imported CVE/finding storage and reporting. |
 | 11. Final residue audit | Complete | docs/ct-cve-final-residue-audit | Added `docs/ct-cve-final-residue-audit.md` recording the final code, config, docs, and test searches. Remaining matches are legitimate CT Ops connector, imported-finding storage, reporting/display, migration history, or seat-licensing code; moved CT-CVE internals are absent. |
 | 12. Plugin identity and licensing decision | Complete | docs/plugin-auth-licensing | Documented the shared CT Ops plugin identity, authorization, licence request-token, subscription-status, and extension-hosted UI direction so CT-CVE does not grow a separate user database, direct CT Ops DB authentication, or CT Ops-owned plugin configuration forms. |
 | 13. CT Ops plugin identity broker | Complete | docs/plugin-identity-broker | Added `docs/ct-ops-plugin-identity-broker.md` covering CT Ops installation identity, plugin instance registration, trust-anchor storage, short-lived signed launch assertions, redirect/iframe/proxy launch modes, session-status revocation checks, backend authorization rules, and CT-Passwd-specific zero-knowledge constraints. |
-| 14. Plugin entitlement storage and CT Portal contract | Not started |  | Add CT Ops-side plugin entitlement storage/validation, CT Portal licence request-token contract, CT Portal-issued plugin licence import/validation, and signed subscription-status API for plugins. |
+| 14. Plugin entitlement storage and CT Portal contract | In progress | automation/impliment-ct-passwd-task1-ct-ops | Drafting the CT Ops-owned entitlement storage and CT Portal contract design first so CT-CVE and CT-Passwd can share one product/licensing model before implementation lands. |
 | 15. CT-CVE auth and subscription integration | Not started |  | Update CT-CVE to require CT Ops-issued user assertions for its GUI, generate CT Portal licence request tokens, consume CT Ops subscription status, and replace placeholder subscription UI with real entitlement state. |
 
 Allowed status values:
@@ -574,6 +574,18 @@ Expected work:
 ## Running Notes
 
 Append dated notes here as phases progress. Keep notes short and factual.
+
+### 2026-05-04
+
+- Continued Phase 14 on branch `automation/impliment-ct-passwd-task1-ct-ops`
+  by adding `docs/ct-ops-plugin-entitlement-storage.md` and linking it from the
+  product decision record and CT-CVE API contract. The design now covers CT
+  Portal request-token fields, plugin-licence binding to installation/org/
+  product/instance, derived subscription-status responses, encrypted licence
+  artifact storage, audit expectations, and the rule that CT-Passwd stays
+  hidden unless licensed. Remaining work for Phase 14 is the actual storage,
+  import/validation handlers, subscription-status endpoint, and backend
+  entitlement enforcement.
 
 ### 2026-04-29
 

--- a/docs/ct-ops-ct-cve-api-contract.md
+++ b/docs/ct-ops-ct-cve-api-contract.md
@@ -401,7 +401,8 @@ to CT-CVE through a signed subscription-status API.
 ### Subscription Status
 
 CT Ops should expose CT-CVE subscription status through a signed endpoint once
-plugin entitlement storage exists:
+the entitlement model in `docs/ct-ops-plugin-entitlement-storage.md` is
+implemented:
 
 ```text
 GET /api/integrations/ct-cve/v1/subscription-status?orgId=<orgId>&pluginInstanceId=<instanceId>

--- a/docs/ct-ops-licensing-and-ct-cve-product-decision.md
+++ b/docs/ct-ops-licensing-and-ct-cve-product-decision.md
@@ -193,6 +193,11 @@ audience binding, expiry, and plugin database protection are still required.
 Plugin licences are product-specific and separate from CT Ops seat licences,
 but they are anchored to CT Ops because CT Ops is always present.
 
+The CT Ops-owned entitlement storage, request-token, plugin-licence binding,
+derived subscription-status, and visibility-gate design now lives in
+`docs/ct-ops-plugin-entitlement-storage.md`. This section remains the
+product-level summary.
+
 The target licensing flow is:
 
 1. CT Ops registers or pairs a plugin instance for an organisation.
@@ -212,6 +217,11 @@ The target licensing flow is:
 7. The plugin enforces product-specific entitlement checks server-side for
    plugin-owned work, while CT Ops remains responsible for CT Ops seat limits
    and customer-facing reporting access.
+
+For CT-Passwd specifically, CT Ops must keep the product hidden unless a valid
+entitlement exists. No CT-Passwd nav item, settings card, search result, or
+launch path should become visible based only on frontend state or a customer
+toggle.
 
 Plugin entitlement status should degrade safely. If CT Ops cannot validate a
 plugin entitlement, the plugin should stop paid plugin-owned processing and show

--- a/docs/ct-ops-plugin-entitlement-storage.md
+++ b/docs/ct-ops-plugin-entitlement-storage.md
@@ -1,0 +1,327 @@
+# CT Ops Plugin Entitlement Storage Design
+
+Status: Accepted
+
+Date: 2026-05-04
+
+Related:
+
+- `docs/ct-ops-licensing-and-ct-cve-product-decision.md`
+- `docs/ct-ops-plugin-identity-broker.md`
+- `docs/ct-ops-ct-cve-api-contract.md`
+
+## Context
+
+CT Ops already has the product-level decision to act as the licensing anchor for
+first-party plugins and now has a shared plugin identity broker for pairing and
+user launch assertions. The remaining gap is entitlement storage and validation:
+CT Ops needs one trusted way to bind a CT Portal-issued plugin licence to a
+paired plugin instance, expose derived entitlement status to the plugin, and
+gate CT Ops-owned launch surfaces.
+
+This phase is especially important for CT-Passwd because CT-Passwd must stay
+invisible in CT Ops unless the organization has a valid CT-Passwd entitlement.
+No CT-Passwd nav item, settings card, search result, route teaser, or launch
+action can appear based only on frontend state or a customer-managed flag.
+
+## Goals
+
+- Keep plugin entitlements bound to the paired CT Ops installation, organization,
+  product, and plugin instance.
+- Reuse one entitlement model for CT-CVE, CT-Passwd, and future first-party
+  plugins.
+- Ensure CT Ops-owned launch and visibility checks are enforceable server-side.
+- Let plugins fetch derived subscription status without learning licence secrets.
+- Support offline validation and safe degradation in air-gapped installs.
+- Preserve an audit trail for licence import, replacement, revocation, and
+  visibility changes.
+
+## Non-Goals
+
+- Collecting payment inside CT Ops.
+- Exposing raw licence keys or private verification material to plugin UIs.
+- Replacing product-specific billing semantics inside CT Portal.
+- Making CT-Passwd discoverable before a valid entitlement exists.
+
+## Core Model
+
+CT Ops should treat plugin licensing as a normalized entitlement record backed by
+an imported CT Portal-issued licence artifact.
+
+### Stored Objects
+
+| Object | Owned by | Responsibility |
+| --- | --- | --- |
+| Plugin request token | CT Ops + plugin | Proves a paired installation is requesting a plugin licence for a specific product, org, and instance. |
+| Imported plugin licence artifact | CT Ops | Stores the signed CT Portal response needed for revalidation and audit. |
+| Derived entitlement record | CT Ops | Stores normalized product/org/instance binding, current status, and visibility decisions. |
+| Entitlement audit events | CT Ops | Records import, replacement, validation failure, revocation, expiry, and visibility transitions. |
+
+### Suggested Entitlement Record Fields
+
+Required normalized fields:
+
+- `pluginEntitlementId`
+- `product`, for example `ct-cve` or `ct-passwd`
+- `organisationId`
+- `ctOpsInstallationId`
+- `pluginInstanceId`
+- `pluginKeyFingerprint`
+- `plan`
+- `capacity`, when the product licence carries seat, vault, host, or similar
+  limits
+- `status`: `active`, `grace`, `expired`, `revoked`, `invalid`, `missing`, or
+  `mismatch`
+- `visibilityPolicy`
+- `issuedAt`
+- `notBefore`
+- `expiresAt`
+- `lastValidatedAt`
+- `lastValidationErrorCode`
+- `sourceFingerprint`, for example a licence serial or payload digest
+- `rawLicenceCiphertext` or equivalent encrypted-at-rest storage for the
+  imported licence artifact when revalidation requires the original payload
+- `createdByUserId` and `updatedByUserId`
+
+Recommended integrity fields:
+
+- `portalIssuer`
+- `portalKid`
+- `revokedAt`
+- `replacedByPluginEntitlementId`
+- `offlineValidationWindowEndsAt`
+- `statusReason`
+
+### Visibility Policy
+
+Entitlement storage should drive CT Ops-owned visibility through a product policy
+rather than ad hoc UI checks.
+
+Suggested policy values:
+
+- `hidden-unless-licensed`
+- `admin-visible-when-paired`
+- `always-visible`
+
+CT-Passwd must use `hidden-unless-licensed`.
+
+Policy effect for CT-Passwd:
+
+- Without an `active` or explicitly allowed `grace` entitlement, CT Ops must not
+  render a CT-Passwd nav item, settings entry, dashboard card, search result,
+  or launcher.
+- Direct CT-Passwd launch routes should return the same not-found or
+  unauthorized shape used for unavailable products instead of revealing that
+  CT-Passwd exists but is unlicensed.
+- The frontend may still receive a generic plugin inventory response, but the
+  backend must filter CT-Passwd rows before they reach normal customer-facing
+  surfaces when entitlement is missing.
+- Any pre-entitlement import path must be generic and admin-only, for example a
+  generic plugin licence import page or installer workflow that does not name
+  CT-Passwd until a valid licence is present.
+
+## Request Token Contract
+
+CT Ops and the paired plugin need a request token that CT Portal can verify
+before issuing a plugin licence.
+
+Required request-token fields:
+
+| Field | Meaning |
+| --- | --- |
+| `product` | Plugin product identifier. |
+| `ctOpsInstallationId` | Stable CT Ops installation identity from the broker. |
+| `orgId` | Organization that will own the entitlement. |
+| `pluginInstanceId` | Paired plugin instance audience. |
+| `pluginKeyFingerprint` | Fingerprint of the paired plugin trust material. |
+| `visibilityPolicy` | Product gating policy expected by CT Ops. |
+| `requestedPlan` | Optional requested edition or commercial tier. |
+| `requestedCapacity` | Optional product-specific capacity metadata. |
+| `pairingId` or `pairingFingerprint` | Binds the request to the approved paired relationship. |
+| `createdAt` | Creation time. |
+| `exp` | Short expiry, for example 15 minutes. |
+| `nonce` | Single-use identifier for replay rejection. |
+
+Request-token rules:
+
+- The token must be signed by CT Ops, by the plugin, or by both under the final
+  CT Portal contract. Dual signing is preferred when practical because it proves
+  both the CT Ops installation and the paired plugin instance agree on the
+  request.
+- CT Portal must reject tokens whose `product`, `orgId`, `pluginInstanceId`, or
+  `pluginKeyFingerprint` do not match the paired installation contract.
+- CT Ops must log request-token creation without logging the raw token value.
+- Request tokens must be single use within their validity window.
+
+## CT Portal-Issued Licence Contract
+
+CT Portal should issue a signed plugin licence artifact whose claims can be
+validated offline by CT Ops.
+
+Required binding claims:
+
+- `product`
+- `ctOpsInstallationId`
+- `organisationId`
+- `pluginInstanceId`
+- `pluginKeyFingerprint`
+- `plan`
+- `capacity`
+- `licenceId`
+- `issuedAt`
+- `notBefore`
+- `expiresAt`
+- `status`
+
+Validation rules:
+
+- CT Ops must verify the licence signature against a pinned CT Portal verifier
+  key set.
+- CT Ops must reject a licence whose installation, organization, product,
+  instance, or plugin-key fingerprint does not exactly match the paired plugin
+  record.
+- Replaced or superseded licences must keep audit history but only one
+  entitlement record may be authoritative for a given
+  `product + organisationId + pluginInstanceId`.
+- Import failures must return machine-readable error codes such as
+  `invalid_signature`, `wrong_installation`, `wrong_organisation`,
+  `wrong_product`, `wrong_plugin_instance`, `wrong_plugin_key`,
+  `expired_licence`, or `revoked_licence`.
+
+## Import And Validation Flow
+
+1. An admin uses a generic CT Ops plugin-licence import path or installer
+   workflow.
+2. CT Ops authenticates the admin, checks organization scope, and requires an
+   existing paired plugin instance for the target product.
+3. CT Ops validates the CT Portal signature and exact installation/org/product/
+   instance binding.
+4. CT Ops stores the raw licence artifact encrypted at rest, writes the
+   normalized entitlement row, and emits an audit event.
+5. CT Ops recalculates visibility for the product and organization.
+6. CT Ops exposes only derived status to plugin or UI consumers.
+
+Periodic revalidation:
+
+- Revalidate imported plugin licences on import, on scheduled background checks,
+  before plugin launch, and before returning subscription status to a plugin on
+  sensitive paths.
+- Keep validation deterministic for air-gapped installs by relying on the local
+  verifier key set and signed revocation material that can be imported out of
+  band.
+- Never require live CT Portal reachability for every launch.
+
+## Derived Subscription Status API
+
+Plugins should consume only a derived CT Ops status response, not the raw
+licence artifact.
+
+Suggested generic endpoint:
+
+```text
+GET /api/plugins/v1/subscription-status?product=<product>&orgId=<orgId>&pluginInstanceId=<instanceId>
+```
+
+Required checks:
+
+- Service-to-service authentication using the signed token or mTLS contract
+  already required for plugin integrations.
+- Organization binding.
+- Product binding.
+- Plugin-instance binding.
+- Per-token rate limits and replay protection.
+
+Suggested response:
+
+```json
+{
+  "product": "ct-passwd",
+  "orgId": "org_123",
+  "pluginInstanceId": "passwd_inst_123",
+  "configured": true,
+  "licensed": true,
+  "status": "active",
+  "plan": "team",
+  "capacity": {
+    "maxVaults": 25
+  },
+  "visibilityPolicy": "hidden-unless-licensed",
+  "expiresAt": "2027-05-01T00:00:00Z",
+  "lastValidatedAt": "2026-05-04T09:30:00Z"
+}
+```
+
+Response rules:
+
+- Do not return the raw licence key, request token, verifier key details, or
+  any secret binding material.
+- `licensed` is derived from the status, not customer input.
+- Plugins may use this response to gate plugin-owned processing, but CT Ops must
+  keep enforcing CT Ops-owned launch and visibility decisions itself.
+
+## Safe Degradation
+
+CT Ops should degrade plugin entitlements predictably:
+
+- `active`: normal launch and plugin processing allowed.
+- `grace`: optional short operator grace period when local validation is
+  temporarily stale but the last known licence was valid; CT-Passwd visibility
+  should stay enabled only if the grace policy is explicit and bounded.
+- `expired` or `revoked`: hide CT-Passwd surfaces immediately and stop issuing
+  launch assertions.
+- `invalid` or `mismatch`: treat as unlicensed, keep audit evidence, and avoid
+  exposing plugin hints to non-admin users.
+- `missing`: plugin remains absent for `hidden-unless-licensed` products.
+
+Safe-degradation rules:
+
+- No status may cause deletion of plugin-owned data.
+- Historical CT Ops reporting that depends on prior imported plugin data may
+  stay visible when that is a separate product requirement, but new plugin
+  launches and plugin-owned paid processing must stop when entitlement is not
+  active.
+- Validation errors must not leak raw licence content or internal verifier
+  details.
+
+## Audit Requirements
+
+Audit events should exist for:
+
+- request token created
+- plugin licence imported
+- plugin licence replaced
+- plugin licence validation failed
+- plugin entitlement expired
+- plugin entitlement revoked
+- plugin visibility enabled
+- plugin visibility disabled
+
+Audit rows must include actor, organization, product, plugin instance, status
+transition, and normalized error code, but never raw licence values.
+
+## Security Considerations
+
+- Treat all plugin entitlement decisions as backend-enforced controls.
+- Encrypt stored licence artifacts at rest and redact them from logs and API
+  responses.
+- Reject imports without an existing paired plugin instance so a customer cannot
+  attach a licence to an arbitrary URL.
+- Bind entitlement checks to both `pluginInstanceId` and
+  `pluginKeyFingerprint` so copied databases or moved containers do not inherit
+  trust silently.
+- Rate-limit import, status, and request-token endpoints and keep request-token
+  nonces single use.
+- Keep CT-Passwd hidden when entitlement is absent so the UI does not leak the
+  product's existence in unlicensed environments.
+
+## Follow-On Implementation Work
+
+This document defines the CT Ops-owned contract. Remaining implementation work
+still includes:
+
+- database schema and encrypted storage for plugin entitlement artifacts
+- request-token generation and nonce persistence
+- plugin-licence import and validation handlers
+- generic subscription-status endpoint implementation
+- CT-Passwd hidden licence gate enforcement in CT Ops UI and launch routes
+- CT-CVE and CT-Passwd plugin-side consumption of derived entitlement status


### PR DESCRIPTION
## Summary
- add the CT Ops-owned plugin entitlement storage and CT Portal contract design
- define CT-Passwd hidden-unless-licensed visibility rules
- link the design from the product decision, API contract, migration plan, and progress log

## Validation
- git diff --check
- targeted Markdown sanity check for balanced fenced code blocks and tab characters