### PR TITLE
fix(web): limit e2e database pool usage

### DIFF
--- a/apps/web/lib/db/index.ts
+++ b/apps/web/lib/db/index.ts
@@ -5,9 +5,10 @@ import { runWithOrgDatabaseScope } from './rls.ts'
 import { getDatabaseUrl } from './connection-string.ts'
 
 const connectionString = getDatabaseUrl()
+const maxConnections = getMaxConnections()
 
 // Disable prefetch as it is not supported for "transaction" pool mode
-export const client = postgres(connectionString, { prepare: false })
+export const client = postgres(connectionString, { prepare: false, max: maxConnections })
 
 const rootDb = drizzle(client, { schema })
 
@@ -20,4 +21,16 @@ export async function withOrgDatabaseScope<T>(
   run: (db: TransactionDatabase) => Promise<T>,
 ): Promise<T> {
   return runWithOrgDatabaseScope<TransactionDatabase, T>(rootDb, orgId, run)
+}
+
+function getMaxConnections(): number {
+  const raw = process.env['POSTGRES_POOL_MAX']
+  if (!raw) return 10
+
+  const max = Number(raw)
+  if (!Number.isInteger(max) || max < 1) {
+    throw new Error('POSTGRES_POOL_MAX must be a positive integer')
+  }
+
+  return max
 }

--- a/apps/web/tests/e2e/runner.mjs
+++ b/apps/web/tests/e2e/runner.mjs
@@ -55,6 +55,7 @@ async function main() {
     process.env.E2E_PORT = String(port)
     process.env.AUTH_EMAIL_CAPTURE_FILE = authEmailCaptureFile
     process.env.E2E_DISABLE_AGENT_CACHE_PREWARM = '1'
+    process.env.POSTGRES_POOL_MAX = process.env.POSTGRES_POOL_MAX ?? '2'
     process.env.LICENCE_PUBLIC_KEY = e2eLicencePublicKey
     process.env.E2E_LICENCE_PRIVATE_KEY = e2eLicencePrivateKey
 


### PR DESCRIPTION
## Summary

Limits the web app postgres-js pool through `POSTGRES_POOL_MAX` and sets a small default for the E2E runner before Next.js starts. This prevents the test harness from exhausting the temporary Postgres/TimescaleDB container connection slots during authenticated page loads.

## Validation

- `pnpm type-check`
- `E2E_PORT=3120 pnpm test:e2e tests/e2e/hosts/inventory.spec.ts`

## Notes

The existing instrumentation dynamic import warning still appears during Next dev, but the host inventory E2E suite now completes without Postgres `too many clients already` errors.