### PR TITLE
docs(password-vault): remove stale external plugin references

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,24 @@
 
 ## What Has Been Built
 
+### Session 103 — Password Vault stale plugin-doc cleanup
+
+**Built-in Password Vault direction cleanup** (`docs/password-vault-implementation-plan.md`, `docs/ct-ops-plugin-identity-broker.md`, `docs/ct-ops-plugin-entitlement-storage.md`, `docs/ct-ops-licensing-and-ct-cve-product-decision.md`, `docs/ct-cve-migration-plan.md`)
+- Removed the live CT-Passwd external-plugin direction from the shared CT Ops
+  design docs and rewrote those sections around CT-CVE plus generic future
+  external plugins.
+- Replaced the old external password-manager/product-plan history in
+  `PROGRESS.md` with an explicit superseded note so future sessions do not treat
+  the old repository, entitlement, or launch model as active CTOps direction.
+- Kept the plugin broker and entitlement designs focused on real external
+  plugin use cases while stating that Password Vault is now built in to CT Ops
+  and does not use that external plugin model.
+
+**Validation**
+- Validation run: targeted `rg` residue checks for `CT-Passwd` and the old
+  external repository slug, `git diff --check`, and a targeted Markdown sanity
+  check for balanced fenced code blocks and tab characters.
+
 ### Session 102 — Password Vault implementation plan
 
 **Built-in Password Vault coordination** (`docs/password-vault-implementation-plan.md`)
@@ -38,9 +56,9 @@
   entitlement records, CT Portal request-token and licence binding, encrypted
   licence artifact storage, derived subscription-status responses, audit
   requirements, and safe degradation rules for air-gapped installs.
-- Defined CT-Passwd's stricter visibility rule: CT Ops must keep CT-Passwd
-  hidden unless a valid entitlement exists, including on nav, settings, search,
-  and launch paths.
+- Defined the stricter hidden-plugin visibility rule for any future external
+  plugin that needs it: CT Ops must keep the product hidden unless a valid
+  entitlement exists, including on nav, settings, search, and launch paths.
 - Linked the new design from the product decision record, the CT-CVE API
   contract, and the migration plan so later implementation work uses one CT
   Ops-owned contract.
@@ -57,8 +75,8 @@
   launch assertions, redirect/iframe/proxy launch modes, plugin-local sessions,
   session-status revocation checks, and backend authorization responsibilities.
 - Linked the new broker document from the CT-CVE product decision record and API
-  contract so future CT-CVE and CT-Passwd implementation work shares one
-  source of truth.
+  contract so future CT-CVE and other external plugin implementation work
+  shares one source of truth.
 - Marked the CT-CVE migration plan's plugin-identity-broker phase complete and
   narrowed the remaining CT-CVE GUI blocker to plugin entitlement and follow-on
   integration work.
@@ -67,21 +85,14 @@
 - Validation run: `git diff --check` and a targeted Markdown sanity check for
   balanced fenced code blocks and tab characters.
 
-### Session 99 — CT-Passwd implementation coordination plan
+### Session 99 — Superseded external password-manager planning
 
-**CT-Passwd planning handoff** (`git@github.com:simonjcarr/ct-passwd.git`,
-`docs/ct-passwd-implementation-plan.md`)
-- Added the CT-Passwd implementation coordination plan for overnight agents.
-  The plan has now been moved to the dedicated CT-Passwd repository and removed
-  from CT-OPS so CT-Passwd project files and product docs stay with the product.
-  It includes the required agent operating rules, security model, architecture
-  decisions, task table, MVP acceptance criteria, validation expectations, and
-  handoff log.
-- Locked the agreed CT-Passwd direction: a separate private repository at
-  `git@github.com:simonjcarr/ct-passwd.git`, Dockerized air-gapped deployment,
-  CT-OPS-owned identity/licence/nginx entry point, plugin-owned forms, dedicated
-  hostname routing by default, browser-side zero-knowledge encryption, shared
-  vault key wrapping, and no admin recovery in the MVP.
+**Historical note**
+- This session previously tracked an external CT-Passwd repository and plugin
+  deployment direction for password management.
+- That direction has been superseded by the built-in CTOps Password Vault. The
+  old external repository slug, plugin launch model, and related product plan
+  are intentionally no longer active CTOps direction.
 
 **Validation**
 - Validation run: `git diff --check` and a targeted Markdown sanity check for

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -271,8 +271,8 @@ Update the status and notes in this table as work lands.
 | 10. Remove internal CT Ops CVE ownership | Complete | feat/remove-internal-cve-ownership, feat/remove-ct-cve-source-settings, #837 | Removed ingest-owned vulnerability feed sync and host matching startup/config, the legacy CT Ops vulnerability source/settings page and NVD key actions, and obsolete CT Ops source-state/affected-package match-rule storage. CT Ops retains imported CVE/finding storage and reporting. |
 | 11. Final residue audit | Complete | docs/ct-cve-final-residue-audit | Added `docs/ct-cve-final-residue-audit.md` recording the final code, config, docs, and test searches. Remaining matches are legitimate CT Ops connector, imported-finding storage, reporting/display, migration history, or seat-licensing code; moved CT-CVE internals are absent. |
 | 12. Plugin identity and licensing decision | Complete | docs/plugin-auth-licensing | Documented the shared CT Ops plugin identity, authorization, licence request-token, subscription-status, and extension-hosted UI direction so CT-CVE does not grow a separate user database, direct CT Ops DB authentication, or CT Ops-owned plugin configuration forms. |
-| 13. CT Ops plugin identity broker | Complete | docs/plugin-identity-broker | Added `docs/ct-ops-plugin-identity-broker.md` covering CT Ops installation identity, plugin instance registration, trust-anchor storage, short-lived signed launch assertions, redirect/iframe/proxy launch modes, session-status revocation checks, backend authorization rules, and CT-Passwd-specific zero-knowledge constraints. |
-| 14. Plugin entitlement storage and CT Portal contract | In progress | automation/impliment-ct-passwd-task1-ct-ops | Drafting the CT Ops-owned entitlement storage and CT Portal contract design first so CT-CVE and CT-Passwd can share one product/licensing model before implementation lands. |
+| 13. CT Ops plugin identity broker | Complete | docs/plugin-identity-broker | Added `docs/ct-ops-plugin-identity-broker.md` covering CT Ops installation identity, plugin instance registration, trust-anchor storage, short-lived signed launch assertions, redirect/iframe/proxy launch modes, session-status revocation checks, and backend authorization rules for external plugin products. |
+| 14. Plugin entitlement storage and CT Portal contract | In progress | docs/plugin-entitlement-storage | Drafting the CT Ops-owned entitlement storage and CT Portal contract design first so CT-CVE and future external plugins can share one product/licensing model before implementation lands. |
 | 15. CT-CVE auth and subscription integration | Not started |  | Update CT-CVE to require CT Ops-issued user assertions for its GUI, generate CT Portal licence request tokens, consume CT Ops subscription status, and replace placeholder subscription UI with real entitlement state. |
 
 Allowed status values:
@@ -577,15 +577,15 @@ Append dated notes here as phases progress. Keep notes short and factual.
 
 ### 2026-05-04
 
-- Continued Phase 14 on branch `automation/impliment-ct-passwd-task1-ct-ops`
+- Continued Phase 14 on the plugin-entitlement design branch
   by adding `docs/ct-ops-plugin-entitlement-storage.md` and linking it from the
   product decision record and CT-CVE API contract. The design now covers CT
   Portal request-token fields, plugin-licence binding to installation/org/
   product/instance, derived subscription-status responses, encrypted licence
-  artifact storage, audit expectations, and the rule that CT-Passwd stays
-  hidden unless licensed. Remaining work for Phase 14 is the actual storage,
-  import/validation handlers, subscription-status endpoint, and backend
-  entitlement enforcement.
+  artifact storage, audit expectations, and backend-hidden visibility policy
+  options for future external plugins. Remaining work for Phase 14 is the
+  actual storage, import/validation handlers, subscription-status endpoint, and
+  backend entitlement enforcement.
 
 ### 2026-04-29
 

--- a/docs/ct-ops-licensing-and-ct-cve-product-decision.md
+++ b/docs/ct-ops-licensing-and-ct-cve-product-decision.md
@@ -218,10 +218,10 @@ The target licensing flow is:
    plugin-owned work, while CT Ops remains responsible for CT Ops seat limits
    and customer-facing reporting access.
 
-For CT-Passwd specifically, CT Ops must keep the product hidden unless a valid
-entitlement exists. No CT-Passwd nav item, settings card, search result, or
-launch path should become visible based only on frontend state or a customer
-toggle.
+Future external plugin products may define stricter backend-hidden visibility
+policies in the shared entitlement model. CTOps Password Vault is not one of
+those products because it is now built in to CT Ops rather than launched as an
+external plugin.
 
 Plugin entitlement status should degrade safely. If CT Ops cannot validate a
 plugin entitlement, the plugin should stop paid plugin-owned processing and show

--- a/docs/ct-ops-plugin-entitlement-storage.md
+++ b/docs/ct-ops-plugin-entitlement-storage.md
@@ -19,17 +19,18 @@ CT Ops needs one trusted way to bind a CT Portal-issued plugin licence to a
 paired plugin instance, expose derived entitlement status to the plugin, and
 gate CT Ops-owned launch surfaces.
 
-This phase is especially important for CT-Passwd because CT-Passwd must stay
-invisible in CT Ops unless the organization has a valid CT-Passwd entitlement.
-No CT-Passwd nav item, settings card, search result, route teaser, or launch
-action can appear based only on frontend state or a customer-managed flag.
+This phase is especially important because some external plugin products may
+need to stay invisible in CT Ops unless the organization has a valid
+entitlement. No plugin nav item, settings card, search result, route teaser, or
+launch action should appear based only on frontend state or a
+customer-managed flag when the product policy requires backend-hidden
+visibility.
 
 ## Goals
 
 - Keep plugin entitlements bound to the paired CT Ops installation, organization,
   product, and plugin instance.
-- Reuse one entitlement model for CT-CVE, CT-Passwd, and future first-party
-  plugins.
+- Reuse one entitlement model for CT-CVE and future first-party plugins.
 - Ensure CT Ops-owned launch and visibility checks are enforceable server-side.
 - Let plugins fetch derived subscription status without learning licence secrets.
 - Support offline validation and safe degradation in air-gapped installs.
@@ -41,7 +42,8 @@ action can appear based only on frontend state or a customer-managed flag.
 - Collecting payment inside CT Ops.
 - Exposing raw licence keys or private verification material to plugin UIs.
 - Replacing product-specific billing semantics inside CT Portal.
-- Making CT-Passwd discoverable before a valid entitlement exists.
+- Making a backend-hidden plugin discoverable before a valid entitlement
+  exists.
 
 ## Core Model
 
@@ -62,7 +64,7 @@ an imported CT Portal-issued licence artifact.
 Required normalized fields:
 
 - `pluginEntitlementId`
-- `product`, for example `ct-cve` or `ct-passwd`
+- `product`, for example `ct-cve`
 - `organisationId`
 - `ctOpsInstallationId`
 - `pluginInstanceId`
@@ -103,22 +105,23 @@ Suggested policy values:
 - `admin-visible-when-paired`
 - `always-visible`
 
-CT-Passwd must use `hidden-unless-licensed`.
+Products that need backend-hidden visibility can use
+`hidden-unless-licensed`.
 
-Policy effect for CT-Passwd:
+Policy effect for a backend-hidden plugin:
 
-- Without an `active` or explicitly allowed `grace` entitlement, CT Ops must not
-  render a CT-Passwd nav item, settings entry, dashboard card, search result,
-  or launcher.
-- Direct CT-Passwd launch routes should return the same not-found or
-  unauthorized shape used for unavailable products instead of revealing that
-  CT-Passwd exists but is unlicensed.
+- Without an `active` or explicitly allowed `grace` entitlement, CT Ops must
+  not render the plugin's nav item, settings entry, dashboard card, search
+  result, or launcher.
+- Direct launch routes should return the same not-found or unauthorized shape
+  used for unavailable products instead of revealing that a hidden plugin
+  exists but is unlicensed.
 - The frontend may still receive a generic plugin inventory response, but the
-  backend must filter CT-Passwd rows before they reach normal customer-facing
-  surfaces when entitlement is missing.
+  backend must filter hidden-plugin rows before they reach normal
+  customer-facing surfaces when entitlement is missing.
 - Any pre-entitlement import path must be generic and admin-only, for example a
   generic plugin licence import page or installer workflow that does not name
-  CT-Passwd until a valid licence is present.
+  the hidden product until a valid licence is present.
 
 ## Request Token Contract
 
@@ -235,7 +238,7 @@ Suggested response:
 
 ```json
 {
-  "product": "ct-passwd",
+  "product": "ct-cve",
   "orgId": "org_123",
   "pluginInstanceId": "passwd_inst_123",
   "configured": true,
@@ -265,10 +268,11 @@ CT Ops should degrade plugin entitlements predictably:
 
 - `active`: normal launch and plugin processing allowed.
 - `grace`: optional short operator grace period when local validation is
-  temporarily stale but the last known licence was valid; CT-Passwd visibility
-  should stay enabled only if the grace policy is explicit and bounded.
-- `expired` or `revoked`: hide CT-Passwd surfaces immediately and stop issuing
-  launch assertions.
+  temporarily stale but the last known licence was valid; hidden-plugin
+  visibility should stay enabled only if the grace policy is explicit and
+  bounded.
+- `expired` or `revoked`: hide hidden-plugin surfaces immediately and stop
+  issuing launch assertions.
 - `invalid` or `mismatch`: treat as unlicensed, keep audit evidence, and avoid
   exposing plugin hints to non-admin users.
 - `missing`: plugin remains absent for `hidden-unless-licensed` products.
@@ -311,8 +315,8 @@ transition, and normalized error code, but never raw licence values.
   trust silently.
 - Rate-limit import, status, and request-token endpoints and keep request-token
   nonces single use.
-- Keep CT-Passwd hidden when entitlement is absent so the UI does not leak the
-  product's existence in unlicensed environments.
+- Keep backend-hidden plugins hidden when entitlement is absent so the UI does
+  not leak the product's existence in unlicensed environments.
 
 ## Follow-On Implementation Work
 
@@ -323,5 +327,6 @@ still includes:
 - request-token generation and nonce persistence
 - plugin-licence import and validation handlers
 - generic subscription-status endpoint implementation
-- CT-Passwd hidden licence gate enforcement in CT Ops UI and launch routes
-- CT-CVE and CT-Passwd plugin-side consumption of derived entitlement status
+- hidden-plugin licence gate enforcement in CT Ops UI and launch routes where
+  the product policy requires it
+- CT-CVE and future plugin-side consumption of derived entitlement status

--- a/docs/ct-ops-plugin-identity-broker.md
+++ b/docs/ct-ops-plugin-identity-broker.md
@@ -12,20 +12,18 @@ Related:
 
 ## Context
 
-CT-CVE and CT-Passwd both need CT Ops to remain the installation entry point,
-identity provider, and organization authority without forcing each plugin to
-run its own user database. The existing product decision record and CT-CVE API
-contract already define that direction, but they stop short of a concrete
-shared broker design for pairing, trust storage, launch assertions, session
-revocation, and backend authorization checks.
+CT-CVE and future external CT Ops plugins need CT Ops to remain the
+installation entry point, identity provider, and organization authority without
+forcing each plugin to run its own user database. The existing product
+decision record and CT-CVE API contract already define that direction, but
+they stop short of a concrete shared broker design for pairing, trust storage,
+launch assertions, session revocation, and backend authorization checks.
 
 That missing broker detail now blocks multiple follow-on tasks:
 
 - CT-CVE cannot replace its placeholder GUI subscription/auth status with a
   real CT Ops-launched flow.
-- CT-Passwd needs a trusted launch path before it can build plugin-local
-  sessions and unlock flows.
-- Future first-party plugins need one repeatable model instead of product-by-
+- Future external plugins need one repeatable model instead of product-by-
   product authentication inventions.
 
 ## Goals
@@ -33,8 +31,7 @@ That missing broker detail now blocks multiple follow-on tasks:
 - Keep CT Ops as the only customer user-login system.
 - Prevent plugins from trusting a copied or forged CT Ops database by requiring
   CT Ops-signed assertions and pinned installation trust.
-- Support CT-CVE, CT-Passwd, and future first-party plugins with one broker
-  model.
+- Support CT-CVE and future first-party plugins with one broker model.
 - Keep plugin-specific forms, workflows, and operational data in each plugin.
 - Ensure backend authorization decisions are enforceable even when the frontend
   is bypassed.
@@ -93,7 +90,7 @@ CT Ops stores one registry row per paired plugin instance.
 Required registry fields:
 
 - `pluginInstanceId`
-- `product`, for example `ct-cve` or `ct-passwd`
+- `product`, for example `ct-cve`
 - `organisationId`
 - `displayName`
 - `launchUrl`
@@ -163,7 +160,7 @@ Required claims:
 | `sub` | CT Ops user identifier. |
 | `orgId` | CT Ops organization identifier. |
 | `orgSlug` | Optional human-readable diagnostics only. |
-| `product` | Plugin product identifier such as `ct-cve` or `ct-passwd`. |
+| `product` | Plugin product identifier such as `ct-cve`. |
 | `roles` | CT Ops roles available to the plugin. |
 | `permissions` | Optional derived permissions for plugin launch decisions. |
 | `sid` | CT Ops session identifier or equivalent session binding. |
@@ -245,7 +242,7 @@ Request body:
 ```json
 {
   "pluginInstanceId": "plugin_inst_123",
-  "product": "ct-passwd",
+  "product": "ct-cve",
   "orgId": "org_123",
   "userId": "user_123",
   "sid": "sess_123"
@@ -304,15 +301,13 @@ Plugin backend checks after launch:
 - CT-CVE still owns feed credentials, source configuration, and vulnerability
   processing in its own service and database.
 
-### CT-Passwd
+### Built-In Password Vault
 
-- The broker authenticates entry into CT-Passwd but does not unlock the user's
-  vault.
-- CT Ops must never receive or issue CT-Passwd unlock passwords, derived keys,
-  private keys, vault keys, entry data encryption keys, plaintext secrets, or
-  decrypted password-entry fields.
-- CT-Passwd keeps its own plugin-local session and then requires a separate
-  unlock step inside the browser before vault secrets become accessible.
+- CTOps Password Vault is now built in to CT Ops and does not use this external
+  plugin broker model.
+- Browser-side unlock, key handling, and vault-secret isolation are documented
+  in the Password Vault implementation and threat-model work instead of plugin
+  launch contracts.
 
 ## Failure Handling
 
@@ -332,5 +327,4 @@ Next phases remain separate:
 
 - Plugin entitlement storage and CT Portal contract.
 - CT-CVE integration with real CT Ops launch/session status.
-- CT-Passwd launch assertion verification, plugin-local sessions, and unlock
-  flows.
+- Future plugin-specific launch/session constraints beyond CT-CVE.

--- a/docs/password-vault-implementation-plan.md
+++ b/docs/password-vault-implementation-plan.md
@@ -99,7 +99,7 @@ implementation decision.
 
 | ID | Task | Dependencies | Status | Owner | PR | Expected session output |
 | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Remove obsolete external password-manager plugin references | none | Not started |  |  | Rewrite or delete stale docs and progress entries for the removed external plugin/repo direction. Leave real `/etc/passwd` host-scanner references intact. |
+| 1 | Remove obsolete external password-manager plugin references | none | Complete | automation/work-on-password-manager |  | Rewrote CT-Passwd/external password-manager references into generic external-plugin guidance or explicit superseded-history notes; old repo slug removed from active docs. |
 | 2 | Add built-in Password Vault architecture and threat model | 1 | Not started |  |  | Add a docs file covering first-party boundaries, zero-knowledge limits, recovery posture, browser/server trust, key hierarchy, and standards alignment. |
 | 3 | Add public docs shell and navigation | 2 | Not started |  |  | Add `apps/docs/docs/features/password-vault.md`, wire it into the docs sidebar, and describe MVP behavior without promising deferred features. |
 | 4 | Add schema test expectations first | 2 | Not started |  |  | Add failing or validation-focused tests/checks for the vault tables, organisation scoping, membership constraints, key epochs, and audit relationships. |
@@ -224,3 +224,4 @@ the built-in Password Vault.
 
 | Date | Agent | Task | Status | PR | Validation | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-04 | automation/work-on-password-manager | 1 | Complete |  | `rg -n "CT-Passwd|ct-passwd|git@github.com:simonjcarr/ct-passwd.git" docs PROGRESS.md`; `git diff --check`; Markdown fence/tab sanity check | Removed active external password-manager direction from shared docs, kept only an explicit superseded historical note in `PROGRESS.md`, and preserved generic CT-CVE/plugin broker guidance. |


### PR DESCRIPTION
## Summary
- remove the active CT-Passwd external-plugin direction from shared CT Ops docs
- rewrite shared plugin docs around CT-CVE plus generic future external plugins
- record the old password-manager direction only as an explicit superseded historical note

## Validation
- rg -n "CT-Passwd|ct-passwd|git@github.com:simonjcarr/ct-passwd.git" docs PROGRESS.md
- git diff --check
- targeted Markdown fence/tab sanity check