### PR TITLE
fix(web): require tooling auth for agent lifecycle actions

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -75,6 +75,7 @@ import { checkTerminalAccess } from '@/lib/actions/terminal'
 import { getAlertInstances } from '@/lib/actions/alerts'
 import { getHostVulnerabilityAssessment } from '@/lib/actions/vulnerabilities'
 import type { HostVulnerabilityAssessmentStatus } from '@/lib/vulnerabilities/assessment'
+import { canAccessTooling } from '@/lib/auth/tooling'
 import { getHostCollectionSettings } from '@/lib/actions/host-settings'
 import { getServiceAccounts } from '@/lib/actions/service-accounts'
 import { listGroupsForHost, listGroups, addHostToGroup, removeHostFromGroup } from '@/lib/actions/host-groups'
@@ -255,6 +256,7 @@ function TabButton({
 }
 
 export function HostDetailClient({ host: initialHost, orgId, currentUserId, userRole, latestAgentVersion }: Props) {
+  const canManageHost = canAccessTooling({ role: userRole })
   const [activeParentTab, setActiveParentTab] = useState<ParentTabId>('overview')
   const [activeTab, setActiveTab] = useState<Tab>('overview')
   const [metricsRange, setMetricsRange] = useState<MetricsPreset>('24h')
@@ -506,23 +508,25 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
             </h1>
             <StatusBadge status={host.status} />
           </div>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => {
-              setDeleteError(null)
-              setUninstallAgent(false)
-              setDeleteOpen(true)
-            }}
-            disabled={isDeleting}
-          >
-            {isDeleting ? (
-              <Loader2 className="size-4 mr-1 animate-spin" />
-            ) : (
-              <Trash2 className="size-4 mr-1" />
-            )}
-            Delete Host
-          </Button>
+          {canManageHost ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => {
+                setDeleteError(null)
+                setUninstallAgent(false)
+                setDeleteOpen(true)
+              }}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <Loader2 className="size-4 mr-1 animate-spin" />
+              ) : (
+                <Trash2 className="size-4 mr-1" />
+              )}
+              Delete Host
+            </Button>
+          ) : null}
         </div>
         <p className="text-sm text-muted-foreground mt-1">
           Last seen {formatLastSeen(host.lastSeenAt)}
@@ -1310,27 +1314,28 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
         />
       )}
 
-      <AlertDialog
-        open={deleteOpen}
-        onOpenChange={(open) => {
-          if (isDeleting) return
-          setDeleteOpen(open)
-          if (!open) {
-            setDeleteError(null)
-            setUninstallAgent(false)
-          }
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete host</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to permanently delete{' '}
-              <strong>{host.displayName ?? host.hostname}</strong>? This will
-              remove all associated data including metrics, checks, alerts,
-              certificates, users, and SSH keys. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+      {canManageHost ? (
+        <AlertDialog
+          open={deleteOpen}
+          onOpenChange={(open) => {
+            if (isDeleting) return
+            setDeleteOpen(open)
+            if (!open) {
+              setDeleteError(null)
+              setUninstallAgent(false)
+            }
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete host</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to permanently delete{' '}
+                <strong>{host.displayName ?? host.hostname}</strong>? This will
+                remove all associated data including metrics, checks, alerts,
+                certificates, users, and SSH keys. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
           {/* Remote uninstall option */}
           <div className="rounded-md border border-border bg-muted/30 p-3">
@@ -1394,33 +1399,34 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
             </div>
           )}
 
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-red-600 hover:bg-red-700 text-white"
-              disabled={isDeleting}
-              onClick={(e) => {
-                // Prevent the dialog from closing automatically on click so we
-                // can keep it open to show the error on failure.
-                e.preventDefault()
-                setDeleteError(null)
-                removeHost({ uninstall: uninstallAgent })
-              }}
-            >
-              {isDeleting ? (
-                <>
-                  <Loader2 className="size-4 mr-1 animate-spin" />
-                  {uninstallAgent ? 'Uninstalling & deleting…' : 'Deleting…'}
-                </>
-              ) : uninstallAgent ? (
-                'Uninstall agent & delete'
-              ) : (
-                'Delete permanently'
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-red-600 hover:bg-red-700 text-white"
+                disabled={isDeleting}
+                onClick={(e) => {
+                  // Prevent the dialog from closing automatically on click so we
+                  // can keep it open to show the error on failure.
+                  e.preventDefault()
+                  setDeleteError(null)
+                  removeHost({ uninstall: uninstallAgent })
+                }}
+              >
+                {isDeleting ? (
+                  <>
+                    <Loader2 className="size-4 mr-1 animate-spin" />
+                    {uninstallAgent ? 'Uninstalling & deleting…' : 'Deleting…'}
+                  </>
+                ) : uninstallAgent ? (
+                  'Uninstall agent & delete'
+                ) : (
+                  'Delete permanently'
+                )}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/lib/actions/agents-authz.test.mjs
+++ b/apps/web/lib/actions/agents-authz.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const agentsSource = readFileSync(path.join(here, 'agents.ts'), 'utf8')
+
+const privilegedActions = [
+  'approveAgent',
+  'rejectAgent',
+  'createEnrolmentToken',
+  'revokeEnrolmentToken',
+  'deleteHost',
+  'uninstallAndDeleteHost',
+]
+
+test('privileged agent and host mutations require tooling access', () => {
+  for (const action of privilegedActions) {
+    const start = agentsSource.indexOf(`export async function ${action}`)
+    assert.notEqual(start, -1, `expected ${action} to exist in agents.ts`)
+    const next = agentsSource.indexOf('\nexport async function ', start + 1)
+    const segment = agentsSource.slice(start, next === -1 ? undefined : next)
+
+    assert.match(
+      segment,
+      /requireOrgToolingAccess\(orgId\)/,
+      `${action} must require tooling access before mutating fleet state`,
+    )
+  }
+})

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError, logWarn } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -98,7 +98,7 @@ export async function approveAgent(
   agentId: string,
   actorId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   try {
     const agent = await db.query.agents.findFirst({
       where: and(eq(agents.id, agentId), eq(agents.organisationId, orgId)),
@@ -228,7 +228,7 @@ export async function rejectAgent(
   agentId: string,
   actorId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   try {
     const agent = await db.query.agents.findFirst({
       where: and(eq(agents.id, agentId), eq(agents.organisationId, orgId)),
@@ -501,7 +501,7 @@ export async function createEnrolmentToken(
     tags?: Array<{ key: string; value: string }>
   },
 ): Promise<{ token: string; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   if (!await createEnrolmentTokenLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before creating another enrolment token.' }
   }
@@ -590,7 +590,7 @@ export async function revokeEnrolmentToken(
   orgId: string,
   tokenId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   try {
     await db
       .update(agentEnrolmentTokens)
@@ -962,7 +962,7 @@ export async function deleteHost(
   orgId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   try {
     const session = await getRequiredSession()
     // Capture the result of the "not found" check that happens inside the
@@ -1231,7 +1231,7 @@ export async function uninstallAndDeleteHost(
   | { success: true }
   | { error: string; taskRunId?: string; agentOffline?: boolean }
 > {
-  await requireOrgAccess(orgId)
+  await requireOrgToolingAccess(orgId)
   try {
     const host = await db.query.hosts.findFirst({
       where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)),

--- a/apps/web/tests/e2e/hosts/access-control.spec.ts
+++ b/apps/web/tests/e2e/hosts/access-control.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
+  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
+    SELECT organisations.id AS org_id, "user".id AS user_id
+    FROM organisations
+    JOIN "user" ON "user".organisation_id = organisations.id
+    WHERE organisations.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    orgId: rows[0]!.org_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('read-only users cannot delete hosts from the host detail page', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      organisation_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'read-only-host-1',
+      ${orgId},
+      'readonly-node',
+      'Read Only Node',
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.80.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await sql`UPDATE "user" SET role = 'read_only', updated_at = NOW() WHERE id = ${userId}`
+
+  try {
+    await page.goto('/hosts/read-only-host-1')
+    await expect(page.getByText('Read Only Node')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Delete Host' })).toHaveCount(0)
+
+    await expect
+      .poll(async () => {
+        const rows = await sql<Array<{ deleted_at: string | null }>>`
+          SELECT deleted_at
+          FROM hosts
+          WHERE id = 'read-only-host-1'
+            AND organisation_id = ${orgId}
+          LIMIT 1
+        `
+        return rows[0]?.deleted_at ?? 'present'
+      })
+      .toBe('present')
+  } finally {
+    await sql`UPDATE "user" SET role = 'org_admin', updated_at = NOW() WHERE id = ${userId}`
+  }
+})


### PR DESCRIPTION
## Summary
- require tooling access for agent approval, rejection, enrolment token create/revoke, host delete, and uninstall-delete server actions
- hide the host delete affordance for read-only users on the host detail page
- add a regression test that pins privileged agent/host actions to `requireOrgToolingAccess()` and an E2E spec for the read-only host detail path

## Testing
- `node --experimental-strip-types --test lib/actions/agents-authz.test.mjs`
- `pnpm --dir apps/web exec eslint 'lib/actions/agents.ts' 'lib/actions/agents-authz.test.mjs' 'tests/e2e/hosts/access-control.spec.ts' 'app/(dashboard)/hosts/[id]/host-detail-client.tsx'` (passes with one pre-existing warning in `lib/actions/agents.ts:583`)
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web test:e2e tests/e2e/hosts/access-control.spec.ts` currently blocked by an existing migration failure: `ALTER TABLE "password_vault_key_epochs" ALTER COLUMN "epoch_number" SET DATA TYPE integer;` cannot auto-cast on a fresh database

Closes #889.
