### PR TITLE
fix(alerts): block stored private notification targets

### DIFF
--- a/apps/ingest/internal/handlers/notify.go
+++ b/apps/ingest/internal/handlers/notify.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/smtp"
 	"net/url"
@@ -21,6 +22,64 @@ import (
 	ctcrypto "github.com/carrtech-dev/ct-ops/ingest/internal/crypto"
 	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
 )
+
+var cgnatIPv4Range = mustParseCIDR("100.64.0.0/10")
+
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return network
+}
+
+func isPrivateOrReservedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ipv4 := ip.To4(); ipv4 != nil {
+		return ipv4[0] == 0 || cgnatIPv4Range.Contains(ipv4) || ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified()
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified()
+}
+
+func assertPublicHost(host string) error {
+	normalizedHost := strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	if ip := net.ParseIP(normalizedHost); ip != nil {
+		if isPrivateOrReservedIP(ip) {
+			return fmt.Errorf("blocked private or reserved address: %s", ip.String())
+		}
+		return nil
+	}
+
+	ips, err := net.LookupIP(normalizedHost)
+	if err != nil {
+		return fmt.Errorf("resolve host %q: %w", normalizedHost, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("resolve host %q: no addresses returned", normalizedHost)
+	}
+	for _, ip := range ips {
+		if isPrivateOrReservedIP(ip) {
+			return fmt.Errorf("blocked private or reserved address: %s", ip.String())
+		}
+	}
+	return nil
+}
+
+func assertPublicHTTPURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported outbound scheme: %s", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("missing outbound host")
+	}
+	return assertPublicHost(parsed.Hostname())
+}
 
 // AlertEvent is the payload sent to webhook notification channels.
 type AlertEvent struct {
@@ -36,6 +95,11 @@ type AlertEvent struct {
 // HMAC-SHA256 signature is added as X-CT-Ops-Signature. Failures are logged
 // and discarded — webhook delivery is best-effort.
 func postWebhook(ctx context.Context, url, secret string, event AlertEvent) {
+	if err := assertPublicHTTPURL(url); err != nil {
+		slog.Warn("webhook: blocked outbound target", "url", url, "err", err)
+		return
+	}
+
 	body, err := json.Marshal(event)
 	if err != nil {
 		slog.Warn("webhook: marshalling event", "url", url, "err", err)
@@ -249,6 +313,10 @@ func dispatchSmtp(smtpChannels []queries.SmtpChannelRow, event AlertEvent) {
 			slog.Warn("dispatchSmtp: incomplete smtp configuration", "channel_id", ch.ID)
 			continue
 		}
+		if err := assertPublicHost(cfg.Host); err != nil {
+			slog.Warn("dispatchSmtp: blocked outbound target", "channel_id", ch.ID, "host", cfg.Host, "err", err)
+			continue
+		}
 		go func(c smtpChannelConfig) {
 			if err := sendSmtpEmail(c, event); err != nil {
 				slog.Warn("smtp: delivery failed", "host", c.Host, "err", err)
@@ -278,6 +346,11 @@ func severityEmoji(severity string) string {
 // postSlack POSTs an AlertEvent to a Slack incoming webhook URL.
 // Failures are logged and discarded — delivery is best-effort.
 func postSlack(ctx context.Context, webhookURL string, event AlertEvent) {
+	if err := assertPublicHTTPURL(webhookURL); err != nil {
+		slog.Warn("slack: blocked outbound target", "url", webhookURL, "err", err)
+		return
+	}
+
 	emoji := severityEmoji(event.Severity)
 	eventLabel := map[string]string{
 		"alert.fired":    "FIRING",

--- a/apps/ingest/internal/handlers/notify_ssrf_test.go
+++ b/apps/ingest/internal/handlers/notify_ssrf_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import "testing"
+
+func TestAssertPublicHTTPURLRejectsPrivateTargets(t *testing.T) {
+	if err := assertPublicHTTPURL("https://127.0.0.1/webhook"); err == nil {
+		t.Fatal("expected private IPv4 webhook target to be rejected")
+	}
+	if err := assertPublicHTTPURL("https://[::1]/webhook"); err == nil {
+		t.Fatal("expected private IPv6 webhook target to be rejected")
+	}
+}
+
+func TestAssertPublicHTTPURLAllowsPublicTargets(t *testing.T) {
+	if err := assertPublicHTTPURL("https://8.8.8.8/webhook"); err != nil {
+		t.Fatalf("expected public webhook target to be allowed: %v", err)
+	}
+}
+
+func TestAssertPublicHostRejectsPrivateTargets(t *testing.T) {
+	if err := assertPublicHost("127.0.0.1"); err == nil {
+		t.Fatal("expected private smtp host to be rejected")
+	}
+	if err := assertPublicHost("::1"); err == nil {
+		t.Fatal("expected private IPv6 smtp host to be rejected")
+	}
+}
+
+func TestAssertPublicHostAllowsPublicTargets(t *testing.T) {
+	if err := assertPublicHost("8.8.8.8"); err != nil {
+		t.Fatalf("expected public smtp host to be allowed: %v", err)
+	}
+}

--- a/apps/web/lib/actions/alerts-notification-security.test.mjs
+++ b/apps/web/lib/actions/alerts-notification-security.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { validateStoredNotificationChannelConfig } from './alerts-notification-security.ts'
+
+test('validateStoredNotificationChannelConfig rejects private webhook targets', async () => {
+  await assert.rejects(
+    () => validateStoredNotificationChannelConfig('webhook', { url: 'https://127.0.0.1/hooks' }),
+    /private or reserved address/,
+  )
+})
+
+test('validateStoredNotificationChannelConfig rejects private Slack webhook targets', async () => {
+  await assert.rejects(
+    () => validateStoredNotificationChannelConfig('slack', { webhookUrl: 'https://[::1]/slack' }),
+    /private or reserved address/,
+  )
+})
+
+test('validateStoredNotificationChannelConfig allows public webhook and slack targets', async () => {
+  await assert.doesNotReject(() =>
+    validateStoredNotificationChannelConfig('webhook', { url: 'https://8.8.8.8/hooks' }),
+  )
+  await assert.doesNotReject(() =>
+    validateStoredNotificationChannelConfig('slack', { webhookUrl: 'https://8.8.8.8/slack' }),
+  )
+})
+
+test('validateStoredNotificationChannelConfig ignores smtp and telegram configs', async () => {
+  await assert.doesNotReject(() =>
+    validateStoredNotificationChannelConfig('smtp', { toAddresses: ['ops@example.com'] }),
+  )
+  await assert.doesNotReject(() =>
+    validateStoredNotificationChannelConfig('telegram', { botToken: 'bot-token', chatId: '123' }),
+  )
+})

--- a/apps/web/lib/actions/alerts-notification-security.ts
+++ b/apps/web/lib/actions/alerts-notification-security.ts
@@ -5,7 +5,7 @@ import type {
   SmtpChannelConfig,
   TelegramChannelConfig,
   WebhookChannelConfig,
-} from '../db/schema.ts'
+} from '../db/schema'
 
 type StoredNotificationChannelType = 'webhook' | 'smtp' | 'slack' | 'telegram'
 

--- a/apps/web/lib/actions/alerts-notification-security.ts
+++ b/apps/web/lib/actions/alerts-notification-security.ts
@@ -1,0 +1,37 @@
+import { assertPublicHost, assertPublicUrl } from '../net/ssrf-guard.ts'
+
+import type {
+  SlackChannelConfig,
+  SmtpChannelConfig,
+  TelegramChannelConfig,
+  WebhookChannelConfig,
+} from '../db/schema.ts'
+
+type StoredNotificationChannelType = 'webhook' | 'smtp' | 'slack' | 'telegram'
+
+type StoredNotificationChannelConfig =
+  | WebhookChannelConfig
+  | SmtpChannelConfig
+  | SlackChannelConfig
+  | TelegramChannelConfig
+
+export async function validateStoredNotificationChannelConfig(
+  type: StoredNotificationChannelType,
+  config: StoredNotificationChannelConfig,
+): Promise<void> {
+  switch (type) {
+    case 'webhook':
+      await assertPublicUrl((config as WebhookChannelConfig).url)
+      return
+    case 'slack':
+      await assertPublicUrl((config as SlackChannelConfig).webhookUrl)
+      return
+    case 'smtp':
+      if ('host' in config && typeof config.host === 'string' && config.host.length > 0) {
+        await assertPublicHost(config.host)
+      }
+      return
+    case 'telegram':
+      return
+  }
+}

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { createHmac } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { assertPublicHost, assertPublicUrl } from '@/lib/net/ssrf-guard'
+import { validateStoredNotificationChannelConfig } from '@/lib/actions/alerts-notification-security'
 import { getRequiredSession } from '@/lib/auth/session'
 import { writeAuditEvent } from '@/lib/audit/events'
 import { decrypt } from '@/lib/crypto/encrypt'
@@ -570,6 +571,8 @@ export async function createNotificationChannel(
   const data = parsed.data
 
   try {
+    await validateStoredNotificationChannelConfig(data.type, data.config)
+
     const [row] = await db
       .insert(notificationChannels)
       .values({
@@ -688,6 +691,7 @@ export async function updateNotificationChannel(
         url,
         secret: secret || existingConfig.secret,
       }
+      await validateStoredNotificationChannelConfig(existing.type, newConfig)
       await db
         .update(notificationChannels)
         .set({ name, config: newConfig, updatedAt: new Date() })
@@ -700,6 +704,7 @@ export async function updateNotificationChannel(
       const newConfig: SmtpChannelConfig = {
         toAddresses,
       }
+      await validateStoredNotificationChannelConfig(existing.type, newConfig)
       await db
         .update(notificationChannels)
         .set({ name, config: newConfig, updatedAt: new Date() })
@@ -710,6 +715,7 @@ export async function updateNotificationChannel(
       const { name, webhookUrl } = parsed.data
       nextName = name
       const newConfig: SlackChannelConfig = { webhookUrl }
+      await validateStoredNotificationChannelConfig(existing.type, newConfig)
       await db
         .update(notificationChannels)
         .set({ name, config: newConfig, updatedAt: new Date() })
@@ -724,6 +730,7 @@ export async function updateNotificationChannel(
         botToken: botToken || existingConfig.botToken,
         chatId,
       }
+      await validateStoredNotificationChannelConfig(existing.type, newConfig)
       await db
         .update(notificationChannels)
         .set({ name, config: newConfig, updatedAt: new Date() })


### PR DESCRIPTION
## Summary
- validate stored webhook and Slack notification channel destinations before persistence
- re-validate webhook, Slack, and SMTP destinations in ingest before outbound delivery
- add regression tests for the new SSRF guards in web and ingest

## Testing
- `node --experimental-strip-types --test lib/actions/alerts-notification-security.test.mjs`
- `node --experimental-strip-types --test lib/net/ssrf-guard.test.mjs`
- `go test ./internal/handlers`

Fixes #890.
