### PR TITLE
fix(db): cast password vault key epoch number migration

### DIFF
--- a/apps/web/lib/db/migrations/0057_wet_taskmaster.sql
+++ b/apps/web/lib/db/migrations/0057_wet_taskmaster.sql
@@ -1,1 +1,2 @@
-ALTER TABLE "password_vault_key_epochs" ALTER COLUMN "epoch_number" SET DATA TYPE integer;
+ALTER TABLE "password_vault_key_epochs"
+ALTER COLUMN "epoch_number" SET DATA TYPE integer USING "epoch_number"::integer;


### PR DESCRIPTION
## Summary
- cast `password_vault_key_epochs.epoch_number` with an explicit `USING` clause in migration `0057`
- restore clean-database migration success for the web RLS regression test
- fix issue #897

## Root cause
The password vault follow-up migration changed `epoch_number` from `text` to `integer` without a `USING` cast. PostgreSQL rejects that type change during clean migration setup, which caused `apps/web/lib/db/rls.test.mjs` to fail on `main`.

## Testing
- `node --experimental-strip-types --test lib/db/rls.test.mjs`
- `node --experimental-strip-types --test lib/db/schema/password-vault.contract.test.mjs`
- `pnpm --dir apps/web run db:validate`
