### PR TITLE
fix(notifications): bind inbox actions to session user

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -932,7 +932,6 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
 
               <HostNotificationCharts
                 orgId={orgId}
-                userId={currentUserId}
                 hostId={initialHost.id}
               />
             </>

--- a/apps/web/app/(dashboard)/hosts/[id]/host-notification-charts.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-notification-charts.tsx
@@ -56,22 +56,21 @@ function formatTrendDate(raw: string, range: TrendRange): string {
 
 interface HostNotificationChartsProps {
   orgId: string
-  userId: string
   hostId: string
 }
 
-export function HostNotificationCharts({ orgId, userId, hostId }: HostNotificationChartsProps) {
+export function HostNotificationCharts({ orgId, hostId }: HostNotificationChartsProps) {
   const [trendRange, setTrendRange] = useState<TrendRange>('30d')
 
   const { data: stats } = useQuery({
-    queryKey: ['notifications-stats', orgId, userId, hostId],
-    queryFn: () => getNotificationStats(orgId, userId, hostId),
+    queryKey: ['notifications-stats', orgId, hostId],
+    queryFn: () => getNotificationStats(orgId, hostId),
     refetchInterval: 60_000,
   })
 
   const { data: timeSeries } = useQuery({
-    queryKey: ['notifications-time-series', orgId, userId, hostId, trendRange],
-    queryFn: () => getNotificationsOverTime(orgId, userId, trendRange, hostId),
+    queryKey: ['notifications-time-series', orgId, hostId, trendRange],
+    queryFn: () => getNotificationsOverTime(orgId, trendRange, hostId),
     refetchInterval: 60_000,
   })
 

--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -74,7 +74,6 @@ const SEVERITY_COLORS: Record<string, string> = {
 
 interface NotificationsClientProps {
   orgId: string
-  userId: string
   initialNotifications: Notification[]
   initialUnread: number
 }
@@ -102,18 +101,18 @@ function SeverityDot({ severity }: { severity: string }) {
   return <span className={`inline-block size-2.5 rounded-full shrink-0 mt-1 ${cls}`} />
 }
 
-function NotificationCharts({ orgId, userId }: { orgId: string; userId: string }) {
+function NotificationCharts({ orgId }: { orgId: string }) {
   const [trendRange, setTrendRange] = useState<TrendRange>('30d')
 
   const { data: stats } = useQuery({
-    queryKey: ['notifications-stats', orgId, userId],
-    queryFn: () => getNotificationStats(orgId, userId),
+    queryKey: ['notifications-stats', orgId],
+    queryFn: () => getNotificationStats(orgId),
     refetchInterval: 60_000,
   })
 
   const { data: timeSeries } = useQuery({
-    queryKey: ['notifications-time-series', orgId, userId, trendRange],
-    queryFn: () => getNotificationsOverTime(orgId, userId, trendRange),
+    queryKey: ['notifications-time-series', orgId, trendRange],
+    queryFn: () => getNotificationsOverTime(orgId, trendRange),
     refetchInterval: 60_000,
   })
 
@@ -250,7 +249,6 @@ function NotificationCharts({ orgId, userId }: { orgId: string; userId: string }
 
 export function NotificationsClient({
   orgId,
-  userId,
   initialNotifications,
   initialUnread,
 }: NotificationsClientProps) {
@@ -262,64 +260,64 @@ export function NotificationsClient({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
   const { data: unread = initialUnread } = useQuery({
-    queryKey: ['notifications-unread', orgId, userId],
-    queryFn: () => getUnreadCount(orgId, userId),
+    queryKey: ['notifications-unread', orgId],
+    queryFn: () => getUnreadCount(orgId),
     initialData: initialUnread,
     refetchInterval: 20_000,
   })
 
   const { data: notifications = initialNotifications } = useQuery({
-    queryKey: ['notifications', orgId, userId, offset],
-    queryFn: () => getNotifications(orgId, userId, PAGE_SIZE, offset),
+    queryKey: ['notifications', orgId, offset],
+    queryFn: () => getNotifications(orgId, PAGE_SIZE, offset),
     initialData: offset === 0 ? initialNotifications : undefined,
     refetchInterval: 30_000,
   })
 
   const markReadMutation = useMutation({
-    mutationFn: (id: string) => markAsRead(orgId, userId, id),
+    mutationFn: (id: string) => markAsRead(orgId, id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
     },
   })
 
   const markAllMutation = useMutation({
-    mutationFn: () => markAllAsRead(orgId, userId),
+    mutationFn: () => markAllAsRead(orgId),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
     },
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteNotification(orgId, userId, id),
+    mutationFn: (id: string) => deleteNotification(orgId, id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
     },
   })
 
   const bulkDeleteMutation = useMutation({
-    mutationFn: (ids: string[]) => deleteNotifications(orgId, userId, ids),
+    mutationFn: (ids: string[]) => deleteNotifications(orgId, ids),
     onSuccess: () => {
       setSelectedIds(new Set())
-      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-stats', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-stats', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId] })
     },
   })
 
   const bulkMarkReadMutation = useMutation({
     mutationFn: ({ ids, read }: { ids: string[]; read: boolean }) =>
-      markBatchReadStatus(orgId, userId, ids, read),
+      markBatchReadStatus(orgId, ids, read),
     onSuccess: () => {
       setSelectedIds(new Set())
-      qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
     },
   })
 
@@ -374,7 +372,7 @@ export function NotificationsClient({
         </div>
       </div>
 
-      <NotificationCharts orgId={orgId} userId={userId} />
+      <NotificationCharts orgId={orgId} />
 
       {/* Filter tabs */}
       <div className="flex items-center gap-1 border-b">
@@ -560,10 +558,10 @@ export function NotificationsClient({
                         <Button
                           size="sm"
                           variant="ghost"
-                          onClick={() => markBatchReadStatus(orgId, userId, [n.id], false).then(() => {
-                            qc.invalidateQueries({ queryKey: ['notifications', orgId, userId] })
-                            qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-                            qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+                          onClick={() => markBatchReadStatus(orgId, [n.id], false).then(() => {
+                            qc.invalidateQueries({ queryKey: ['notifications', orgId] })
+                            qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+                            qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
                           })}
                           data-testid={`notification-mark-unread-${n.id}`}
                         >

--- a/apps/web/app/(dashboard)/notifications/page.tsx
+++ b/apps/web/app/(dashboard)/notifications/page.tsx
@@ -10,17 +10,15 @@ export const metadata: Metadata = {
 export default async function NotificationsPage() {
   const session = await getRequiredSession()
   const orgId = session.user.organisationId ?? ''
-  const userId = session.user.id
 
   const [initialNotifications, initialUnread] = await Promise.all([
-    getNotifications(orgId, userId, 25),
-    getUnreadCount(orgId, userId),
+    getNotifications(orgId, 25),
+    getUnreadCount(orgId),
   ])
 
   return (
     <NotificationsClient
       orgId={orgId}
-      userId={userId}
       initialNotifications={initialNotifications}
       initialUnread={initialUnread}
     />

--- a/apps/web/components/shared/notification-bell.tsx
+++ b/apps/web/components/shared/notification-bell.tsx
@@ -17,7 +17,6 @@ import type { Notification } from '@/lib/db/schema'
 
 interface NotificationBellProps {
   orgId: string
-  userId: string
 }
 
 function getResourceUrl(resourceType: string, resourceId: string): string {
@@ -37,36 +36,36 @@ function severityDot(severity: string) {
   return <span className={`inline-block size-2 rounded-full shrink-0 mt-1.5 ${cls}`} />
 }
 
-export function NotificationBell({ orgId, userId }: NotificationBellProps) {
+export function NotificationBell({ orgId }: NotificationBellProps) {
   const qc = useQueryClient()
 
   const { data: unreadCount = 0 } = useQuery({
-    queryKey: ['notifications-unread', orgId, userId],
-    queryFn: () => getUnreadCount(orgId, userId),
+    queryKey: ['notifications-unread', orgId],
+    queryFn: () => getUnreadCount(orgId),
     refetchInterval: 20_000,
     staleTime: 10_000,
   })
 
   const { data: notifications = [] } = useQuery({
-    queryKey: ['notifications-recent', orgId, userId],
-    queryFn: () => getNotifications(orgId, userId, 10),
+    queryKey: ['notifications-recent', orgId],
+    queryFn: () => getNotifications(orgId, 10),
     refetchInterval: 20_000,
     staleTime: 10_000,
   })
 
   const markReadMutation = useMutation({
-    mutationFn: (id: string) => markAsRead(orgId, userId, id),
+    mutationFn: (id: string) => markAsRead(orgId, id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
     },
   })
 
   const markAllMutation = useMutation({
-    mutationFn: () => markAllAsRead(orgId, userId),
+    mutationFn: () => markAllAsRead(orgId),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId, userId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId, userId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
     },
   })
 

--- a/apps/web/components/shared/topbar.tsx
+++ b/apps/web/components/shared/topbar.tsx
@@ -40,15 +40,13 @@ export function Topbar({ orgId }: TopbarProps) {
 
   const userName = session?.user?.name ?? 'User'
   const userEmail = session?.user?.email ?? ''
-  const userId = session?.user?.id
-
   return (
     <header className="flex h-14 items-center gap-3 border-b bg-background px-4">
       <SidebarTrigger />
       <div className="flex-1" />
       <CommandPaletteTrigger />
-      {userId && orgId && (
-        <NotificationBell orgId={orgId} userId={userId} />
+      {session?.user?.id && orgId && (
+        <NotificationBell orgId={orgId} />
       )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/web/lib/actions/notifications-authz.test.mjs
+++ b/apps/web/lib/actions/notifications-authz.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const notificationsSource = readFileSync(path.join(here, 'notifications.ts'), 'utf8')
+
+const userScopedActions = [
+  'getNotifications',
+  'getUnreadCount',
+  'markAsRead',
+  'markAllAsRead',
+  'deleteNotification',
+  'deleteNotifications',
+  'markBatchReadStatus',
+  'getNotificationStats',
+  'getNotificationsOverTime',
+]
+
+function getActionSegment(action) {
+  const start = notificationsSource.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist in notifications.ts`)
+  const next = notificationsSource.indexOf('\nexport ', start + 1)
+  return notificationsSource.slice(start, next === -1 ? undefined : next)
+}
+
+test('notification actions derive the user scope from the authenticated session', () => {
+  for (const action of userScopedActions) {
+    const segment = getActionSegment(action)
+
+    assert.doesNotMatch(
+      segment,
+      /\buserId\s*:/,
+      `${action} must not accept a caller-controlled userId`,
+    )
+    assert.match(
+      segment,
+      /const session = await requireOrgAccess\(orgId\)/,
+      `${action} must load the authenticated session before querying notifications`,
+    )
+    assert.match(
+      segment,
+      /eq\(notifications\.userId, session\.user\.id\)/,
+      `${action} must scope notification access to session.user.id`,
+    )
+  }
+})

--- a/apps/web/lib/actions/notifications.ts
+++ b/apps/web/lib/actions/notifications.ts
@@ -9,15 +9,14 @@ import type { Notification } from '@/lib/db/schema'
 
 export async function getNotifications(
   orgId: string,
-  userId: string,
   limit = 20,
   offset = 0,
 ): Promise<Notification[]> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   return db.query.notifications.findMany({
     where: and(
       eq(notifications.organisationId, orgId),
-      eq(notifications.userId, userId),
+      eq(notifications.userId, session.user.id),
       isNull(notifications.deletedAt),
     ),
     orderBy: desc(notifications.createdAt),
@@ -26,15 +25,15 @@ export async function getNotifications(
   })
 }
 
-export async function getUnreadCount(orgId: string, userId: string): Promise<number> {
-  await requireOrgAccess(orgId)
+export async function getUnreadCount(orgId: string): Promise<number> {
+  const session = await requireOrgAccess(orgId)
   const [result] = await db
     .select({ value: count() })
     .from(notifications)
     .where(
       and(
         eq(notifications.organisationId, orgId),
-        eq(notifications.userId, userId),
+        eq(notifications.userId, session.user.id),
         eq(notifications.read, false),
         isNull(notifications.deletedAt),
       ),
@@ -44,10 +43,9 @@ export async function getUnreadCount(orgId: string, userId: string): Promise<num
 
 export async function markAsRead(
   orgId: string,
-  userId: string,
   notificationId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   try {
     await db
       .update(notifications)
@@ -56,7 +54,7 @@ export async function markAsRead(
         and(
           eq(notifications.id, notificationId),
           eq(notifications.organisationId, orgId),
-          eq(notifications.userId, userId),
+          eq(notifications.userId, session.user.id),
           isNull(notifications.deletedAt),
         ),
       )
@@ -68,9 +66,8 @@ export async function markAsRead(
 
 export async function markAllAsRead(
   orgId: string,
-  userId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   try {
     await db
       .update(notifications)
@@ -78,7 +75,7 @@ export async function markAllAsRead(
       .where(
         and(
           eq(notifications.organisationId, orgId),
-          eq(notifications.userId, userId),
+          eq(notifications.userId, session.user.id),
           eq(notifications.read, false),
           isNull(notifications.deletedAt),
         ),
@@ -91,10 +88,9 @@ export async function markAllAsRead(
 
 export async function deleteNotification(
   orgId: string,
-  userId: string,
   notificationId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   try {
     await db
       .update(notifications)
@@ -103,7 +99,7 @@ export async function deleteNotification(
         and(
           eq(notifications.id, notificationId),
           eq(notifications.organisationId, orgId),
-          eq(notifications.userId, userId),
+          eq(notifications.userId, session.user.id),
           isNull(notifications.deletedAt),
         ),
       )
@@ -115,10 +111,9 @@ export async function deleteNotification(
 
 export async function deleteNotifications(
   orgId: string,
-  userId: string,
   ids: string[],
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   if (ids.length === 0) return { success: true }
   try {
     await db
@@ -128,7 +123,7 @@ export async function deleteNotifications(
         and(
           inArray(notifications.id, ids),
           eq(notifications.organisationId, orgId),
-          eq(notifications.userId, userId),
+          eq(notifications.userId, session.user.id),
           isNull(notifications.deletedAt),
         ),
       )
@@ -140,11 +135,10 @@ export async function deleteNotifications(
 
 export async function markBatchReadStatus(
   orgId: string,
-  userId: string,
   ids: string[],
   read: boolean,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   if (ids.length === 0) return { success: true }
   try {
     await db
@@ -154,7 +148,7 @@ export async function markBatchReadStatus(
         and(
           inArray(notifications.id, ids),
           eq(notifications.organisationId, orgId),
-          eq(notifications.userId, userId),
+          eq(notifications.userId, session.user.id),
           isNull(notifications.deletedAt),
         ),
       )
@@ -171,10 +165,9 @@ export type NotificationSeverityStat = {
 
 export async function getNotificationStats(
   orgId: string,
-  userId: string,
   hostId?: string,
 ): Promise<NotificationSeverityStat[]> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   const results = await db
     .select({
       severity: notifications.severity,
@@ -184,7 +177,7 @@ export async function getNotificationStats(
     .where(
       and(
         eq(notifications.organisationId, orgId),
-        eq(notifications.userId, userId),
+        eq(notifications.userId, session.user.id),
         isNull(notifications.deletedAt),
         hostId ? eq(notifications.resourceType, 'host') : undefined,
         hostId ? eq(notifications.resourceId, hostId) : undefined,
@@ -215,11 +208,10 @@ export type NotificationTimeSeriesPoint = {
 
 export async function getNotificationsOverTime(
   orgId: string,
-  userId: string,
   range: TrendRange = '30d',
   hostId?: string,
 ): Promise<NotificationTimeSeriesPoint[]> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   // Intentionally does NOT filter on deletedAt so that deleting notifications
   // from the inbox does not affect the historical trend.
   const config = TREND_RANGE_CONFIG[range]
@@ -243,7 +235,7 @@ export async function getNotificationsOverTime(
     .where(
       and(
         eq(notifications.organisationId, orgId),
-        eq(notifications.userId, userId),
+        eq(notifications.userId, session.user.id),
         gte(notifications.createdAt, cutoff),
         hostId ? eq(notifications.resourceType, 'host') : undefined,
         hostId ? eq(notifications.resourceId, hostId) : undefined,


### PR DESCRIPTION
## Summary
- bind notification inbox server actions to the authenticated session user instead of a caller-supplied `userId`
- remove `userId` from notification action callers in the bell, inbox, and host charts
- add a regression test that enforces session-bound notification scoping

## Testing
- `node --experimental-strip-types --test lib/actions/notifications-authz.test.mjs`
- `pnpm exec tsc --noEmit`
- `pnpm test:e2e tests/e2e/notifications/inbox.spec.ts tests/e2e/notifications/bell.spec.ts`

Closes #888
