### PR TITLE
fix(upgrade): select latest web release by semver

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -382,7 +382,7 @@ jobs:
               fi
               return 0
             fi
-            echo "Pulling latest images from GHCR..."
+            echo "Pulling release-pinned images from GHCR..."
             if ! docker compose pull db web ingest; then
               echo "" >&2
               echo "ERROR: failed to pull one or more images from GHCR." >&2

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -362,7 +362,7 @@ start_stack() {
       exit 1
     fi
   else
-    echo "Pulling latest images from GHCR..."
+    echo "Pulling release-pinned images from GHCR..."
     if ! docker compose pull db web migrate ingest nginx tls-init; then
       echo "" >&2
       echo "ERROR: failed to pull one or more images from GHCR." >&2

--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -104,19 +104,51 @@ require_docker() {
 }
 
 latest_web_tag() {
-  local releases_tmp
-  releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
+  local page releases_tmp tags_tmp tag
+  tags_tmp="$(mktemp -t ct-ops.XXXXXX.release-tags)"
+  page=1
 
-  if ! curl -fsSL \
-    -o "$releases_tmp" \
-    "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100"; then
+  while :; do
+    releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
+    if ! curl -fsSL \
+      -o "$releases_tmp" \
+      "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100&page=${page}"; then
+      rm -f "$releases_tmp" "$tags_tmp"
+      return 1
+    fi
+
+    awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9]+[.][0-9]+[.][0-9]+"/ { print $4 }' "$releases_tmp" >> "$tags_tmp"
+    if ! grep -q '"tag_name":[[:space:]]*"' "$releases_tmp"; then
+      rm -f "$releases_tmp"
+      break
+    fi
+
     rm -f "$releases_tmp"
-    return 1
-  fi
+    page=$((page + 1))
+  done
 
-  local tag
-  tag="$(awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9][^"]*"/ { print $4; exit }' "$releases_tmp")"
-  rm -f "$releases_tmp"
+  tag="$(awk -F '"' '
+    {
+      tag = $0
+      version = tag
+      sub(/^web\/v/, "", version)
+      if (version !~ /^[0-9]+[.][0-9]+[.][0-9]+$/) {
+        next
+      }
+      split(version, parts, ".")
+      key = sprintf("%010d.%010d.%010d", parts[1], parts[2], parts[3])
+      if (key > best_key) {
+        best_key = key
+        best_tag = tag
+      }
+    }
+    END {
+      if (best_tag != "") {
+        print best_tag
+      }
+    }
+  ' "$tags_tmp")"
+  rm -f "$tags_tmp"
 
   if [ -z "$tag" ]; then
     echo "ERROR: could not find a published web release for ${REPO_OWNER}/${REPO_NAME}." >&2

--- a/deploy/scripts/test-install.sh
+++ b/deploy/scripts/test-install.sh
@@ -44,8 +44,13 @@ if [[ -n "${MOCK_CURL_LOG:-}" ]]; then
   printf '%s\n' "$url" >> "$MOCK_CURL_LOG"
 fi
 
-if [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100" ]]; then
+if [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100" \
+  || "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=1" ]]; then
   printf '%s' "${MOCK_RELEASES_JSON}" > "$out"
+elif [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=2" ]]; then
+  printf '%s' "${MOCK_RELEASES_JSON_PAGE_2:-[]}" > "$out"
+elif [[ "$url" == https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100\&page=* ]]; then
+  printf '[]' > "$out"
 elif [[ "$url" == *.sha256 ]]; then
   printf '%s  ct-ops-single.zip\n' "${MOCK_CHECKSUM}" > "$out"
 else
@@ -78,7 +83,11 @@ run_match_case() {
   export MOCK_PAYLOAD="verified bundle payload"
   export MOCK_RELEASES_JSON='[
     { "tag_name": "ingest/v9.9.9" },
-    { "tag_name": "web/v1.2.3" }
+    { "tag_name": "web/v0.99.0" },
+    { "tag_name": "web/v0.98.0" }
+  ]'
+  export MOCK_RELEASES_JSON_PAGE_2='[
+    { "tag_name": "web/v0.100.0" }
   ]'
   export MOCK_CURL_LOG="${workspace}/curl.log"
   export MOCK_CHECKSUM
@@ -90,13 +99,14 @@ run_match_case() {
   )
 
   test -d "${workspace}/ct-ops"
-  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v1.2.3/ct-ops-single.zip" "$MOCK_CURL_LOG"
-  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v1.2.3/ct-ops-single.zip.sha256" "$MOCK_CURL_LOG"
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v0.100.0/ct-ops-single.zip" "$MOCK_CURL_LOG"
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v0.100.0/ct-ops-single.zip.sha256" "$MOCK_CURL_LOG"
   if grep -Fq "/releases/latest/" "$MOCK_CURL_LOG"; then
     echo "installer should not use GitHub's repo-wide latest release URL" >&2
     exit 1
   fi
   unset MOCK_CURL_LOG
+  unset MOCK_RELEASES_JSON_PAGE_2
 }
 
 run_mismatch_case() {

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -29,7 +29,52 @@ fi
 exit 0
 EOF
 
-  chmod +x "${dir}/docker"
+  cat > "${dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$out" || -z "$url" ]]; then
+  echo "mock curl expected -o <file> <url>" >&2
+  exit 2
+fi
+
+if [[ -n "${MOCK_CURL_LOG:-}" ]]; then
+  printf '%s\n' "$url" >> "$MOCK_CURL_LOG"
+fi
+
+if [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100" \
+  || "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=1" ]]; then
+  printf '%s' "${MOCK_RELEASES_JSON}" > "$out"
+elif [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=2" ]]; then
+  printf '%s' "${MOCK_RELEASES_JSON_PAGE_2:-[]}" > "$out"
+elif [[ "$url" == https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100\&page=* ]]; then
+  printf '[]' > "$out"
+elif [[ "$url" == *.sha256 ]]; then
+  printf '%s  ct-ops-single.zip\n' "${MOCK_CHECKSUM}" > "$out"
+else
+  cp "${MOCK_BUNDLE_ZIP}" "$out"
+fi
+EOF
+
+  chmod +x "${dir}/docker" "${dir}/curl"
 }
 
 write_bundle() {
@@ -149,6 +194,46 @@ main() {
     echo "expected one backup tarball for legacy install, found $backups" >&2
     exit 1
   fi
+
+  rm -rf "$old_install" "$new_src" "$backup_dir"
+  mkdir -p "${tmpdir}/current" "$backup_dir"
+
+  write_bundle "${tmpdir}/current" "v1.0.0"
+  {
+    printf 'customer-secret=true\n'
+    printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' 100
+    printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' 100
+  } > "${old_install}/.env"
+
+  write_bundle "$new_src" "v0.100.0"
+  rm -f "$bundle_zip"
+  (cd "$new_src" && zip -qr "$bundle_zip" ct-ops)
+
+  export MOCK_RELEASES_JSON='[
+    { "tag_name": "ingest/v9.9.9" },
+    { "tag_name": "web/v0.99.0" },
+    { "tag_name": "web/v0.98.0" }
+  ]'
+  export MOCK_RELEASES_JSON_PAGE_2='[
+    { "tag_name": "web/v0.100.0" }
+  ]'
+  export MOCK_BUNDLE_ZIP="$bundle_zip"
+  export MOCK_CURL_LOG="${tmpdir}/curl.log"
+  export MOCK_CHECKSUM
+  MOCK_CHECKSUM="$(openssl dgst -sha256 "$bundle_zip" | awk '{print $NF}')"
+
+  (
+    cd "$old_install"
+    PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" \
+      MOCK_DOCKER_LOG="$docker_log" \
+      CT_OPS_BACKUP_DIR="$backup_dir" \
+      ./upgrade.sh --no-start
+  )
+
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v0.100.0/ct-ops-single.zip" "$MOCK_CURL_LOG"
+  grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v0.100.0/ct-ops-single.zip.sha256" "$MOCK_CURL_LOG"
+  grep -q 'example/web:v0.100.0' "${old_install}/docker-compose.yml"
+  unset MOCK_CURL_LOG MOCK_RELEASES_JSON_PAGE_2
 
   echo "upgrade.sh local bundle tests passed"
 }

--- a/install.sh
+++ b/install.sh
@@ -17,19 +17,51 @@ REPO_OWNER="carrtech-dev"
 REPO_NAME="ct-ops"
 
 latest_web_tag() {
-  local releases_tmp
-  releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
+  local page releases_tmp tags_tmp tag
+  tags_tmp="$(mktemp -t ct-ops.XXXXXX.release-tags)"
+  page=1
 
-  if ! curl -fsSL \
-    -o "$releases_tmp" \
-    "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100"; then
+  while :; do
+    releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
+    if ! curl -fsSL \
+      -o "$releases_tmp" \
+      "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100&page=${page}"; then
+      rm -f "$releases_tmp" "$tags_tmp"
+      return 1
+    fi
+
+    awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9]+[.][0-9]+[.][0-9]+"/ { print $4 }' "$releases_tmp" >> "$tags_tmp"
+    if ! grep -q '"tag_name":[[:space:]]*"' "$releases_tmp"; then
+      rm -f "$releases_tmp"
+      break
+    fi
+
     rm -f "$releases_tmp"
-    return 1
-  fi
+    page=$((page + 1))
+  done
 
-  local tag
-  tag="$(awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9][^"]*"/ { print $4; exit }' "$releases_tmp")"
-  rm -f "$releases_tmp"
+  tag="$(awk -F '"' '
+    {
+      tag = $0
+      version = tag
+      sub(/^web\/v/, "", version)
+      if (version !~ /^[0-9]+[.][0-9]+[.][0-9]+$/) {
+        next
+      }
+      split(version, parts, ".")
+      key = sprintf("%010d.%010d.%010d", parts[1], parts[2], parts[3])
+      if (key > best_key) {
+        best_key = key
+        best_tag = tag
+      }
+    }
+    END {
+      if (best_tag != "") {
+        print best_tag
+      }
+    }
+  ' "$tags_tmp")"
+  rm -f "$tags_tmp"
 
   if [ -z "$tag" ]; then
     echo "ERROR: could not find a published web release for ${REPO_OWNER}/${REPO_NAME}." >&2


### PR DESCRIPTION
## Summary
- make install.sh and customer upgrade.sh select the highest stable web/vX.Y.Z release by SemVer instead of the first release returned by GitHub
- page through GitHub releases so selection is not limited to the first 100 releases
- update customer-bundle tests to reproduce shuffled/paginated release ordering
- clarify start.sh output to say release-pinned images are being pulled

## Root cause
GitHub's releases list is not a reliable source of latest-by-version ordering for this repository. The old parser selected the first matching web release in the list, which allowed web/v0.99.0 to win even when web/v0.100.0 was published and marked latest.

## Validation
- bash -n install.sh deploy/customer-bundle/upgrade.sh deploy/customer-bundle/start.sh
- bash deploy/scripts/test-install.sh
- bash deploy/scripts/test-start.sh
- bash deploy/scripts/test-upgrade.sh
- bash deploy/scripts/test-web-entrypoint.sh
- bash deploy/scripts/test-support-data.sh
- live GitHub release-selection check returned the newest web tag from paginated release data
