### PR TITLE
fix(auth): enforce LDAP 2FA challenge

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -28,6 +28,7 @@ const domainLoginSchema = z.object({
 
 type LocalLoginValues = z.infer<typeof localLoginSchema>
 type DomainLoginValues = z.infer<typeof domainLoginSchema>
+type DomainTwoFactorMethod = 'totp' | 'backup_code'
 
 interface LoginFormProps {
   ldapLoginEnabled?: boolean
@@ -46,6 +47,9 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
   const [canResendVerification, setCanResendVerification] = useState(false)
   const [verificationEmail, setVerificationEmail] = useState<string | null>(null)
   const [loginMode, setLoginMode] = useState<'local' | 'domain'>('local')
+  const [ldapTwoFactorRequired, setLdapTwoFactorRequired] = useState(false)
+  const [ldapTwoFactorCode, setLdapTwoFactorCode] = useState('')
+  const [ldapTwoFactorMethod, setLdapTwoFactorMethod] = useState<DomainTwoFactorMethod>('totp')
 
   const localForm = useForm<LocalLoginValues>({
     resolver: zodResolver(localLoginSchema),
@@ -84,9 +88,48 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
       const res = await fetch('/api/auth/ldap', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(ldapTwoFactorRequired
+          ? {
+              twoFactorCode: ldapTwoFactorCode,
+              twoFactorMethod: ldapTwoFactorMethod,
+            }
+          : {
+              username: values.username,
+              password: values.password,
+            }),
+      })
+
+      const data = await res.json()
+
+      if (data.twoFactorRequired) {
+        setLdapTwoFactorRequired(true)
+        setLdapTwoFactorMethod('totp')
+        setLdapTwoFactorCode('')
+        return
+      }
+
+      if (!res.ok) {
+        setServerError(data.error ?? 'Domain sign in failed.')
+        return
+      }
+
+      router.push('/dashboard')
+    } catch {
+      setServerError('An unexpected error occurred.')
+    }
+  }
+
+  async function onDomainTwoFactorSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setServerError(null)
+
+    try {
+      const res = await fetch('/api/auth/ldap', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          username: values.username,
-          password: values.password,
+          twoFactorCode: ldapTwoFactorCode,
+          twoFactorMethod: ldapTwoFactorMethod,
         }),
       })
 
@@ -101,6 +144,12 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
     } catch {
       setServerError('An unexpected error occurred.')
     }
+  }
+
+  function resetDomainTwoFactor() {
+    setLdapTwoFactorRequired(false)
+    setLdapTwoFactorCode('')
+    setLdapTwoFactorMethod('totp')
   }
 
   return (
@@ -130,6 +179,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
                 setServerError(null)
                 setCanResendVerification(false)
                 setVerificationEmail(null)
+                resetDomainTwoFactor()
               }}
             >
               Local Account
@@ -146,6 +196,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
                 setServerError(null)
                 setCanResendVerification(false)
                 setVerificationEmail(null)
+                resetDomainTwoFactor()
               }}
             >
               Domain Account
@@ -244,41 +295,113 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
           </CardFooter>
         </form>
       ) : (
-        <form onSubmit={domainForm.handleSubmit(onDomainSubmit)}>
+        <form onSubmit={ldapTwoFactorRequired ? onDomainTwoFactorSubmit : domainForm.handleSubmit(onDomainSubmit)}>
           <CardContent className="space-y-4">
             {serverError && (
               <p className="text-sm text-destructive">{serverError}</p>
             )}
-            <div className="space-y-1.5">
-              <Label htmlFor="domain-username">Username</Label>
-              <Input
-                id="domain-username"
-                type="text"
-                autoComplete="username"
-                placeholder="jsmith"
-                {...domainForm.register('username')}
-              />
-              {domainForm.formState.errors.username && (
-                <p className="text-xs text-destructive">{domainForm.formState.errors.username.message}</p>
-              )}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="domain-password">Password</Label>
-              <Input
-                id="domain-password"
-                type="password"
-                autoComplete="current-password"
-                {...domainForm.register('password')}
-              />
-              {domainForm.formState.errors.password && (
-                <p className="text-xs text-destructive">{domainForm.formState.errors.password.message}</p>
-              )}
-            </div>
+            {ldapTwoFactorRequired ? (
+              <>
+                <div className="space-y-2 rounded-md border bg-muted/40 p-3 text-sm">
+                  <p className="font-medium text-foreground">Second factor required</p>
+                  <p className="text-muted-foreground">
+                    Enter the code from your authenticator app or use one of your backup codes to finish signing in.
+                  </p>
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Verification method</Label>
+                  <div className="flex rounded-md border p-1 gap-1">
+                    <button
+                      type="button"
+                      className={`flex-1 px-3 py-1.5 text-sm rounded transition-colors ${
+                        ldapTwoFactorMethod === 'totp'
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                      onClick={() => setLdapTwoFactorMethod('totp')}
+                      data-testid="domain-2fa-method-totp"
+                    >
+                      Authenticator
+                    </button>
+                    <button
+                      type="button"
+                      className={`flex-1 px-3 py-1.5 text-sm rounded transition-colors ${
+                        ldapTwoFactorMethod === 'backup_code'
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                      onClick={() => setLdapTwoFactorMethod('backup_code')}
+                      data-testid="domain-2fa-method-backup"
+                    >
+                      Backup Code
+                    </button>
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="domain-two-factor-code">
+                    {ldapTwoFactorMethod === 'totp' ? 'Authenticator code' : 'Backup code'}
+                  </Label>
+                  <Input
+                    id="domain-two-factor-code"
+                    type="text"
+                    autoComplete="one-time-code"
+                    value={ldapTwoFactorCode}
+                    onChange={(event) => setLdapTwoFactorCode(event.target.value)}
+                    data-testid="domain-2fa-code"
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="domain-username">Username</Label>
+                  <Input
+                    id="domain-username"
+                    type="text"
+                    autoComplete="username"
+                    placeholder="jsmith"
+                    {...domainForm.register('username')}
+                    data-testid="domain-login-username"
+                  />
+                  {domainForm.formState.errors.username && (
+                    <p className="text-xs text-destructive">{domainForm.formState.errors.username.message}</p>
+                  )}
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="domain-password">Password</Label>
+                  <Input
+                    id="domain-password"
+                    type="password"
+                    autoComplete="current-password"
+                    {...domainForm.register('password')}
+                    data-testid="domain-login-password"
+                  />
+                  {domainForm.formState.errors.password && (
+                    <p className="text-xs text-destructive">{domainForm.formState.errors.password.message}</p>
+                  )}
+                </div>
+              </>
+            )}
           </CardContent>
           <CardFooter className="flex flex-col gap-3">
-            <Button type="submit" className="w-full" disabled={domainForm.formState.isSubmitting}>
-              {domainForm.formState.isSubmitting ? 'Signing in...' : 'Sign in with Domain Account'}
+            <Button type="submit" className="w-full" disabled={domainForm.formState.isSubmitting || (ldapTwoFactorRequired && !ldapTwoFactorCode.trim())}>
+              {domainForm.formState.isSubmitting
+                ? (ldapTwoFactorRequired ? 'Verifying...' : 'Signing in...')
+                : (ldapTwoFactorRequired ? 'Verify code' : 'Sign in with Domain Account')}
             </Button>
+            {ldapTwoFactorRequired && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => {
+                  setServerError(null)
+                  resetDomainTwoFactor()
+                }}
+              >
+                Start over
+              </Button>
+            )}
           </CardFooter>
         </form>
       )}

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -1,7 +1,7 @@
 import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { users, accounts, sessions, ldapConfigurations } from '@/lib/db/schema'
+import { users, accounts, sessions, ldapConfigurations, totpCredentials, verifications } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
@@ -12,6 +12,17 @@ import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
 import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
 import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
 import { SeatAdmissionError, assertUserCanAccessSeat } from '@/lib/seat-admission'
+import {
+  createSignedLdapTwoFactorCookieValue,
+  encryptLdapBackupCodes,
+  LDAP_TWO_FACTOR_CHALLENGE_TTL_MS,
+  LDAP_TWO_FACTOR_COOKIE_NAME,
+  parseLdapTwoFactorChallenge,
+  readSignedLdapTwoFactorCookieValue,
+  serialiseLdapTwoFactorChallenge,
+  verifyLdapTwoFactorCode,
+  type LdapTwoFactorMethod,
+} from '@/lib/auth/ldap-two-factor'
 
 // 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
 const ldapRateLimit = createRateLimiter({
@@ -46,7 +57,151 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { username, password } = body as { username?: string; password?: string }
+    const {
+      username,
+      password,
+      twoFactorCode,
+      twoFactorMethod,
+    } = body as {
+      username?: string
+      password?: string
+      twoFactorCode?: string
+      twoFactorMethod?: LdapTwoFactorMethod
+    }
+
+    const authSecret = getBetterAuthSecret()
+
+    if (twoFactorCode) {
+      const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value
+      const challengeId = await readSignedLdapTwoFactorCookieValue(signedChallengeCookie, authSecret)
+
+      if (!challengeId) {
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Two-factor verification session expired. Please sign in again.' }, { status: 401 }),
+        )
+      }
+
+      const challengeRecord = await db.query.verifications.findFirst({
+        where: eq(verifications.identifier, challengeId),
+      })
+
+      if (!challengeRecord || challengeRecord.expiresAt <= new Date()) {
+        if (challengeRecord) {
+          await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+        }
+
+        const expiredResponse = NextResponse.json(
+          { error: 'Two-factor verification session expired. Please sign in again.' },
+          { status: 401 },
+        )
+        expiredResponse.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
+          path: '/',
+          httpOnly: true,
+          sameSite: 'lax',
+          secure: process.env.NODE_ENV === 'production',
+          expires: new Date(0),
+        })
+        return withAuthDelay(requestStart, expiredResponse)
+      }
+
+      const challenge = parseLdapTwoFactorChallenge(challengeRecord.value)
+      if (!challenge) {
+        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Two-factor verification session expired. Please sign in again.' }, { status: 401 }),
+        )
+      }
+
+      const user = await db.query.users.findFirst({
+        where: eq(users.id, challenge.userId),
+      })
+      if (!user || !user.isActive || user.deletedAt || !user.twoFactorEnabled) {
+        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
+        )
+      }
+
+      await assertUserCanAccessSeat(user.organisationId!, user.id)
+
+      const credential = await db.query.totpCredentials.findFirst({
+        where: eq(totpCredentials.userId, user.id),
+      })
+      if (!credential) {
+        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Two-factor authentication is not configured for this account.' }, { status: 403 }),
+        )
+      }
+
+      const verification = await verifyLdapTwoFactorCode({
+        credential,
+        method: twoFactorMethod === 'backup_code' ? 'backup_code' : 'totp',
+        code: twoFactorCode,
+        secret: authSecret,
+        digits: 6,
+        period: 30,
+      })
+
+      if (!verification.ok) {
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Invalid two-factor code' }, { status: 401 }),
+        )
+      }
+
+      if (verification.backupCode) {
+        await db
+          .update(totpCredentials)
+          .set({
+            backupCodes: await encryptLdapBackupCodes(verification.backupCode.remainingCodes, authSecret),
+            updatedAt: new Date(),
+          })
+          .where(eq(totpCredentials.id, credential.id))
+      }
+
+      const sessionToken = randomBytes(32).toString('hex')
+      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+
+      await db.insert(sessions).values({
+        token: sessionToken,
+        userId: user.id,
+        expiresAt,
+        ipAddress: request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? null,
+        userAgent: request.headers.get('user-agent') ?? null,
+      })
+
+      const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
+      await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+      await passwordLoginAttemptGuard.reset(challenge.username)
+
+      const response = NextResponse.json({
+        success: true,
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+        },
+      })
+
+      response.headers.append(
+        'Set-Cookie',
+        `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
+      )
+      response.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        expires: new Date(0),
+      })
+
+      return withAuthDelay(requestStart, response)
+    }
 
     if (!username || !password) {
       return NextResponse.json({ error: 'Username and password are required' }, { status: 400 })
@@ -170,9 +325,37 @@ export async function POST(request: NextRequest) {
 
       await assertUserCanAccessSeat(user.organisationId!, user.id)
 
-      // Create session
+      if (user.twoFactorEnabled) {
+        const challengeId = `ldap-2fa-${createId()}`
+        const expiresAt = new Date(Date.now() + LDAP_TWO_FACTOR_CHALLENGE_TTL_MS)
+        const signedChallenge = await createSignedLdapTwoFactorCookieValue(challengeId, authSecret)
+
+        await db.insert(verifications).values({
+          identifier: challengeId,
+          value: serialiseLdapTwoFactorChallenge({
+            userId: user.id,
+            username,
+          }),
+          expiresAt,
+        })
+
+        const challengeResponse = NextResponse.json({
+          twoFactorRequired: true,
+          methods: ['totp', 'backup_code'],
+        })
+        challengeResponse.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, signedChallenge, {
+          path: '/',
+          httpOnly: true,
+          sameSite: 'lax',
+          secure: process.env.NODE_ENV === 'production',
+          expires: expiresAt,
+        })
+
+        return withAuthDelay(requestStart, challengeResponse)
+      }
+
       const sessionToken = randomBytes(32).toString('hex')
-      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) // 30 days
+      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
 
       await db.insert(sessions).values({
         token: sessionToken,
@@ -182,7 +365,6 @@ export async function POST(request: NextRequest) {
         userAgent: request.headers.get('user-agent') ?? null,
       })
 
-      const authSecret = getBetterAuthSecret()
       const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
 
       const response = NextResponse.json({

--- a/apps/web/lib/auth/ldap-two-factor.test.mjs
+++ b/apps/web/lib/auth/ldap-two-factor.test.mjs
@@ -1,0 +1,114 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { symmetricEncrypt } from 'better-auth/crypto'
+
+import {
+  createSignedLdapTwoFactorCookieValue,
+  generateTotpCode,
+  parseLdapTwoFactorChallenge,
+  readSignedLdapTwoFactorCookieValue,
+  serialiseLdapTwoFactorChallenge,
+  verifyLdapTwoFactorCode,
+} from './ldap-two-factor.ts'
+
+const secret = 'ldap-2fa-test-secret'
+
+test('signed LDAP 2FA cookie values round-trip and reject tampering', async () => {
+  const signed = await createSignedLdapTwoFactorCookieValue('ldap-2fa-123', secret)
+
+  assert.equal(await readSignedLdapTwoFactorCookieValue(signed, secret), 'ldap-2fa-123')
+  assert.equal(await readSignedLdapTwoFactorCookieValue(`${signed}tamper`, secret), null)
+})
+
+test('LDAP 2FA challenge payload round-trips and rejects malformed values', () => {
+  const encoded = serialiseLdapTwoFactorChallenge({
+    userId: 'user-123',
+    username: 'jsmith',
+  })
+
+  assert.deepEqual(parseLdapTwoFactorChallenge(encoded), {
+    userId: 'user-123',
+    username: 'jsmith',
+  })
+  assert.equal(parseLdapTwoFactorChallenge('{"userId":1}'), null)
+  assert.equal(parseLdapTwoFactorChallenge('not-json'), null)
+})
+
+test('LDAP TOTP verification accepts a valid authenticator code', async () => {
+  const totpSecret = 'TOTP_SHARED_SECRET_1234567890'
+  const encryptedSecret = await symmetricEncrypt({
+    key: secret,
+    data: totpSecret,
+  })
+  const code = generateTotpCode({
+    secret: totpSecret,
+    digits: 6,
+    period: 30,
+  })
+
+  assert.deepEqual(
+    await verifyLdapTwoFactorCode({
+      credential: {
+        secret: encryptedSecret,
+        backupCodes: null,
+      },
+      method: 'totp',
+      code,
+      secret,
+    }),
+    { ok: true },
+  )
+
+  assert.deepEqual(
+    await verifyLdapTwoFactorCode({
+      credential: {
+        secret: encryptedSecret,
+        backupCodes: null,
+      },
+      method: 'totp',
+      code: '000000',
+      secret,
+    }),
+    { ok: false },
+  )
+})
+
+test('LDAP backup-code verification consumes a matching code', async () => {
+  const backupCodes = ['ABCDE-12345', 'FGHIJ-67890']
+  const encryptedBackupCodes = await symmetricEncrypt({
+    key: secret,
+    data: JSON.stringify(backupCodes),
+  })
+
+  assert.deepEqual(
+    await verifyLdapTwoFactorCode({
+      credential: {
+        secret: await symmetricEncrypt({ key: secret, data: 'unused' }),
+        backupCodes: encryptedBackupCodes,
+      },
+      method: 'backup_code',
+      code: 'ABCDE-12345',
+      secret,
+    }),
+    {
+      ok: true,
+      backupCode: {
+        remainingCodes: ['FGHIJ-67890'],
+      },
+    },
+  )
+
+  assert.deepEqual(
+    await verifyLdapTwoFactorCode({
+      credential: {
+        secret: await symmetricEncrypt({ key: secret, data: 'unused' }),
+        backupCodes: encryptedBackupCodes,
+      },
+      method: 'backup_code',
+      code: 'WRONG-00000',
+      secret,
+    }),
+    { ok: false },
+  )
+})

--- a/apps/web/lib/auth/ldap-two-factor.ts
+++ b/apps/web/lib/auth/ldap-two-factor.ts
@@ -1,0 +1,175 @@
+import { makeSignature, symmetricDecrypt, symmetricEncrypt } from 'better-auth/crypto'
+import { createHmac } from 'node:crypto'
+
+export const LDAP_TWO_FACTOR_COOKIE_NAME = 'ct-ops.ldap_2fa'
+export const LDAP_TWO_FACTOR_CHALLENGE_TTL_MS = 10 * 60 * 1000
+
+export type LdapTwoFactorMethod = 'totp' | 'backup_code'
+
+export interface LdapTwoFactorChallenge {
+  userId: string
+  username: string
+}
+
+export interface LdapTwoFactorCredential {
+  secret: string
+  backupCodes: string | null
+}
+
+export interface VerifiedBackupCode {
+  remainingCodes: string[]
+}
+
+export async function createSignedLdapTwoFactorCookieValue(identifier: string, secret: string): Promise<string> {
+  const signature = await makeSignature(identifier, secret)
+  return `${identifier}.${signature}`
+}
+
+export async function readSignedLdapTwoFactorCookieValue(
+  value: string | undefined,
+  secret: string,
+): Promise<string | null> {
+  if (!value) return null
+
+  const separatorIndex = value.lastIndexOf('.')
+  if (separatorIndex <= 0) return null
+
+  const identifier = value.slice(0, separatorIndex)
+  const signature = value.slice(separatorIndex + 1)
+  const expectedSignature = await makeSignature(identifier, secret)
+
+  return signature === expectedSignature ? identifier : null
+}
+
+export async function verifyLdapTwoFactorCode(params: {
+  credential: LdapTwoFactorCredential
+  method: LdapTwoFactorMethod
+  code: string
+  secret: string
+  digits?: number
+  period?: number
+}): Promise<{ ok: true; backupCode?: VerifiedBackupCode } | { ok: false }> {
+  const code = params.code.trim()
+  if (!code) return { ok: false }
+
+  if (params.method === 'totp') {
+    const sharedSecret = await symmetricDecrypt({
+      key: params.secret,
+      data: params.credential.secret,
+    })
+
+    const isValid = verifyTotpCode({
+      secret: sharedSecret,
+      code,
+      digits: params.digits ?? 6,
+      period: params.period ?? 30,
+    })
+
+    return isValid ? { ok: true } : { ok: false }
+  }
+
+  const backupCodes = await readBackupCodes(params.credential.backupCodes, params.secret)
+  if (!backupCodes.includes(code)) {
+    return { ok: false }
+  }
+
+  return {
+    ok: true,
+    backupCode: {
+      remainingCodes: backupCodes.filter((backupCode) => backupCode !== code),
+    },
+  }
+}
+
+export function generateTotpCode(params: {
+  secret: string
+  digits?: number
+  period?: number
+  timestampMs?: number
+}): string {
+  const digits = params.digits ?? 6
+  const period = params.period ?? 30
+  const counter = Math.floor((params.timestampMs ?? Date.now()) / 1000 / period)
+
+  return hotp(params.secret, counter, digits)
+}
+
+export async function encryptLdapBackupCodes(codes: string[], secret: string): Promise<string> {
+  return symmetricEncrypt({
+    key: secret,
+    data: JSON.stringify(codes),
+  })
+}
+
+export function serialiseLdapTwoFactorChallenge(challenge: LdapTwoFactorChallenge): string {
+  return JSON.stringify(challenge)
+}
+
+export function parseLdapTwoFactorChallenge(value: string): LdapTwoFactorChallenge | null {
+  try {
+    const parsed = JSON.parse(value) as Partial<LdapTwoFactorChallenge>
+    if (typeof parsed.userId !== 'string' || typeof parsed.username !== 'string') {
+      return null
+    }
+    return {
+      userId: parsed.userId,
+      username: parsed.username,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function readBackupCodes(value: string | null, secret: string): Promise<string[]> {
+  if (!value) return []
+
+  let decrypted = value
+  try {
+    decrypted = await symmetricDecrypt({
+      key: secret,
+      data: value,
+    })
+  } catch {
+    decrypted = value
+  }
+
+  const parsed = JSON.parse(decrypted) as unknown
+  return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === 'string') : []
+}
+
+function verifyTotpCode(params: {
+  secret: string
+  code: string
+  digits: number
+  period: number
+  timestampMs?: number
+}): boolean {
+  const timestampMs = params.timestampMs ?? Date.now()
+  const currentCounter = Math.floor(timestampMs / 1000 / params.period)
+
+  for (let offset = -1; offset <= 1; offset += 1) {
+    if (hotp(params.secret, currentCounter + offset, params.digits) === params.code) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function hotp(secret: string, counter: number, digits: number): string {
+  const counterBuffer = Buffer.alloc(8)
+  counterBuffer.writeBigUInt64BE(BigInt(counter))
+
+  const digest = createHmac('sha1', Buffer.from(secret, 'utf8'))
+    .update(counterBuffer)
+    .digest()
+  const offset = (digest.at(-1) ?? 0) & 0x0f
+  const binary = (
+    (((digest[offset] ?? 0) & 0x7f) << 24)
+    | (((digest[offset + 1] ?? 0) & 0xff) << 16)
+    | (((digest[offset + 2] ?? 0) & 0xff) << 8)
+    | ((digest[offset + 3] ?? 0) & 0xff)
+  )
+
+  return String(binary % (10 ** digits)).padStart(digits, '0')
+}


### PR DESCRIPTION
## Summary
- stop LDAP sign-in from issuing a full session when the CT-Ops user has 2FA enabled
- issue a short-lived signed LDAP 2FA challenge and require a TOTP or backup code before session creation
- add focused helper tests for challenge signing, TOTP verification, and backup-code consumption

## Testing
- node --experimental-strip-types --test lib/auth/ldap-two-factor.test.mjs
- pnpm type-check
- pnpm exec eslint app/api/auth/ldap/route.ts app/(auth)/login/login-form.tsx lib/auth/ldap-two-factor.ts lib/auth/ldap-two-factor.test.mjs

Closes #908