### PR TITLE
fix(auth): gate LDAP 2FA on issued challenge

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -124,7 +124,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
     setServerError(null)
 
     try {
-      const res = await fetch('/api/auth/ldap', {
+      const res = await fetch('/api/auth/ldap/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -70,9 +70,16 @@ export async function POST(request: NextRequest) {
     }
 
     const authSecret = getBetterAuthSecret()
+    const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value
 
-    if (twoFactorCode) {
-      const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value
+    if (signedChallengeCookie) {
+      if (!twoFactorCode) {
+        return withAuthDelay(
+          requestStart,
+          NextResponse.json({ error: 'Two-factor code is required' }, { status: 400 }),
+        )
+      }
+
       const challengeId = await readSignedLdapTwoFactorCookieValue(signedChallengeCookie, authSecret)
 
       if (!challengeId) {

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -1,7 +1,7 @@
 import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { users, accounts, sessions, ldapConfigurations, totpCredentials, verifications } from '@/lib/db/schema'
+import { users, accounts, sessions, ldapConfigurations, verifications } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
@@ -14,14 +14,9 @@ import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions
 import { SeatAdmissionError, assertUserCanAccessSeat } from '@/lib/seat-admission'
 import {
   createSignedLdapTwoFactorCookieValue,
-  encryptLdapBackupCodes,
   LDAP_TWO_FACTOR_CHALLENGE_TTL_MS,
   LDAP_TWO_FACTOR_COOKIE_NAME,
-  parseLdapTwoFactorChallenge,
-  readSignedLdapTwoFactorCookieValue,
   serialiseLdapTwoFactorChallenge,
-  verifyLdapTwoFactorCode,
-  type LdapTwoFactorMethod,
 } from '@/lib/auth/ldap-two-factor'
 
 // 5 attempts per IP per 60 seconds — prevents brute-force and user enumeration
@@ -57,158 +52,9 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const {
-      username,
-      password,
-      twoFactorCode,
-      twoFactorMethod,
-    } = body as {
-      username?: string
-      password?: string
-      twoFactorCode?: string
-      twoFactorMethod?: LdapTwoFactorMethod
-    }
+    const { username, password } = body as { username?: string; password?: string }
 
     const authSecret = getBetterAuthSecret()
-    const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value
-
-    if (signedChallengeCookie) {
-      if (!twoFactorCode) {
-        return withAuthDelay(
-          requestStart,
-          NextResponse.json({ error: 'Two-factor code is required' }, { status: 400 }),
-        )
-      }
-
-      const challengeId = await readSignedLdapTwoFactorCookieValue(signedChallengeCookie, authSecret)
-
-      if (!challengeId) {
-        return withAuthDelay(
-          requestStart,
-          NextResponse.json({ error: 'Two-factor verification session expired. Please sign in again.' }, { status: 401 }),
-        )
-      }
-
-      const challengeRecord = await db.query.verifications.findFirst({
-        where: eq(verifications.identifier, challengeId),
-      })
-
-      if (!challengeRecord || challengeRecord.expiresAt <= new Date()) {
-        if (challengeRecord) {
-          await db.delete(verifications).where(eq(verifications.identifier, challengeId))
-        }
-
-        const expiredResponse = NextResponse.json(
-          { error: 'Two-factor verification session expired. Please sign in again.' },
-          { status: 401 },
-        )
-        expiredResponse.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
-          path: '/',
-          httpOnly: true,
-          sameSite: 'lax',
-          secure: process.env.NODE_ENV === 'production',
-          expires: new Date(0),
-        })
-        return withAuthDelay(requestStart, expiredResponse)
-      }
-
-      const challenge = parseLdapTwoFactorChallenge(challengeRecord.value)
-      if (!challenge) {
-        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
-        return withAuthDelay(
-          requestStart,
-          NextResponse.json({ error: 'Two-factor verification session expired. Please sign in again.' }, { status: 401 }),
-        )
-      }
-
-      const user = await db.query.users.findFirst({
-        where: eq(users.id, challenge.userId),
-      })
-      if (!user || !user.isActive || user.deletedAt || !user.twoFactorEnabled) {
-        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
-        return withAuthDelay(
-          requestStart,
-          NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
-        )
-      }
-
-      await assertUserCanAccessSeat(user.organisationId!, user.id)
-
-      const credential = await db.query.totpCredentials.findFirst({
-        where: eq(totpCredentials.userId, user.id),
-      })
-      if (!credential) {
-        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
-        return withAuthDelay(
-          requestStart,
-          NextResponse.json({ error: 'Two-factor authentication is not configured for this account.' }, { status: 403 }),
-        )
-      }
-
-      const verification = await verifyLdapTwoFactorCode({
-        credential,
-        method: twoFactorMethod === 'backup_code' ? 'backup_code' : 'totp',
-        code: twoFactorCode,
-        secret: authSecret,
-        digits: 6,
-        period: 30,
-      })
-
-      if (!verification.ok) {
-        return withAuthDelay(
-          requestStart,
-          NextResponse.json({ error: 'Invalid two-factor code' }, { status: 401 }),
-        )
-      }
-
-      if (verification.backupCode) {
-        await db
-          .update(totpCredentials)
-          .set({
-            backupCodes: await encryptLdapBackupCodes(verification.backupCode.remainingCodes, authSecret),
-            updatedAt: new Date(),
-          })
-          .where(eq(totpCredentials.id, credential.id))
-      }
-
-      const sessionToken = randomBytes(32).toString('hex')
-      const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
-
-      await db.insert(sessions).values({
-        token: sessionToken,
-        userId: user.id,
-        expiresAt,
-        ipAddress: request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? null,
-        userAgent: request.headers.get('user-agent') ?? null,
-      })
-
-      const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
-      await db.delete(verifications).where(eq(verifications.identifier, challengeId))
-      await passwordLoginAttemptGuard.reset(challenge.username)
-
-      const response = NextResponse.json({
-        success: true,
-        user: {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-        },
-      })
-
-      response.headers.append(
-        'Set-Cookie',
-        `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
-      )
-      response.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
-        path: '/',
-        httpOnly: true,
-        sameSite: 'lax',
-        secure: process.env.NODE_ENV === 'production',
-        expires: new Date(0),
-      })
-
-      return withAuthDelay(requestStart, response)
-    }
 
     if (!username || !password) {
       return NextResponse.json({ error: 'Username and password are required' }, { status: 400 })

--- a/apps/web/app/api/auth/ldap/verify/route.ts
+++ b/apps/web/app/api/auth/ldap/verify/route.ts
@@ -1,0 +1,210 @@
+import { logError } from '@/lib/logging'
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+import { sessions, totpCredentials, users, verifications } from '@/lib/db/schema'
+import { eq } from 'drizzle-orm'
+import { randomBytes } from 'crypto'
+import { createRateLimiter } from '@/lib/rate-limit'
+import { getBetterAuthSecret } from '@/lib/auth/env'
+import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
+import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
+import { assertUserCanAccessSeat, SeatAdmissionError } from '@/lib/seat-admission'
+import {
+  encryptLdapBackupCodes,
+  LDAP_TWO_FACTOR_COOKIE_NAME,
+  parseLdapTwoFactorChallenge,
+  readSignedLdapTwoFactorCookieValue,
+  type LdapTwoFactorMethod,
+  verifyLdapTwoFactorCode,
+} from '@/lib/auth/ldap-two-factor'
+import { toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
+
+const ldapTwoFactorRateLimit = createRateLimiter({
+  scope: 'auth:ldap:2fa',
+  windowMs: 60_000,
+  max: 10,
+})
+
+async function withAuthDelay<T>(start: number, value: T): Promise<T> {
+  const minMs = 400 + Math.floor(Math.random() * 200)
+  const elapsed = Date.now() - start
+  if (elapsed < minMs) await new Promise((resolve) => setTimeout(resolve, minMs - elapsed))
+  return value
+}
+
+export async function POST(request: NextRequest) {
+  const requestStart = Date.now()
+
+  try {
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+      ?? request.headers.get('x-real-ip')
+      ?? 'unknown'
+
+    if (!await ldapTwoFactorRateLimit.check(ip)) {
+      return NextResponse.json(
+        { error: 'Too many login attempts — please wait before trying again.' },
+        { status: 429 },
+      )
+    }
+
+    const body = await request.json()
+    const { twoFactorCode, twoFactorMethod } = body as {
+      twoFactorCode?: string
+      twoFactorMethod?: LdapTwoFactorMethod
+    }
+
+    if (!twoFactorCode) {
+      return NextResponse.json({ error: 'Two-factor code is required' }, { status: 400 })
+    }
+
+    const authSecret = getBetterAuthSecret()
+    const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value
+    const challengeId = await readSignedLdapTwoFactorCookieValue(signedChallengeCookie, authSecret)
+
+    if (!challengeId) {
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'Two-factor verification session expired. Please sign in again.' }, { status: 401 }),
+      )
+    }
+
+    const challengeRecord = await db.query.verifications.findFirst({
+      where: eq(verifications.identifier, challengeId),
+    })
+
+    if (!challengeRecord || challengeRecord.expiresAt <= new Date()) {
+      if (challengeRecord) {
+        await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+      }
+
+      const expiredResponse = NextResponse.json(
+        { error: 'Two-factor verification session expired. Please sign in again.' },
+        { status: 401 },
+      )
+      expiredResponse.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        expires: new Date(0),
+      })
+      return withAuthDelay(requestStart, expiredResponse)
+    }
+
+    const challenge = parseLdapTwoFactorChallenge(challengeRecord.value)
+    if (!challenge) {
+      await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'Two-factor verification session expired. Please sign in again.' }, { status: 401 }),
+      )
+    }
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, challenge.userId),
+    })
+    if (!user || !user.isActive || user.deletedAt || !user.twoFactorEnabled) {
+      await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
+      )
+    }
+
+    await assertUserCanAccessSeat(user.organisationId!, user.id)
+
+    const credential = await db.query.totpCredentials.findFirst({
+      where: eq(totpCredentials.userId, user.id),
+    })
+    if (!credential) {
+      await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'Two-factor authentication is not configured for this account.' }, { status: 403 }),
+      )
+    }
+
+    const verification = await verifyLdapTwoFactorCode({
+      credential,
+      method: twoFactorMethod === 'backup_code' ? 'backup_code' : 'totp',
+      code: twoFactorCode,
+      secret: authSecret,
+      digits: 6,
+      period: 30,
+    })
+
+    if (!verification.ok) {
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'Invalid two-factor code' }, { status: 401 }),
+      )
+    }
+
+    if (verification.backupCode) {
+      await db
+        .update(totpCredentials)
+        .set({
+          backupCodes: await encryptLdapBackupCodes(verification.backupCode.remainingCodes, authSecret),
+          updatedAt: new Date(),
+        })
+        .where(eq(totpCredentials.id, credential.id))
+    }
+
+    const sessionToken = randomBytes(32).toString('hex')
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+
+    await db.insert(sessions).values({
+      token: sessionToken,
+      userId: user.id,
+      expiresAt,
+      ipAddress: request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? null,
+      userAgent: request.headers.get('user-agent') ?? null,
+    })
+
+    const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
+    await db.delete(verifications).where(eq(verifications.identifier, challengeId))
+    await passwordLoginAttemptGuard.reset(challenge.username)
+
+    const response = NextResponse.json({
+      success: true,
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+      },
+    })
+
+    response.headers.append(
+      'Set-Cookie',
+      `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
+    )
+    response.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      expires: new Date(0),
+    })
+
+    return withAuthDelay(requestStart, response)
+  } catch (err) {
+    if (err instanceof SeatAdmissionError) {
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: 'User seat limit exceeded' }, { status: 403 }),
+      )
+    }
+    const seatLimitMessage = toSeatLimitErrorMessage(err)
+    if (seatLimitMessage) {
+      return withAuthDelay(
+        requestStart,
+        NextResponse.json({ error: seatLimitMessage }, { status: 403 }),
+      )
+    }
+    logError('[LDAP] Unexpected error during two-factor verification:', err)
+    return withAuthDelay(
+      requestStart,
+      NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 }),
+    )
+  }
+}

--- a/apps/web/app/api/auth/ldap/verify/route.ts
+++ b/apps/web/app/api/auth/ldap/verify/route.ts
@@ -47,15 +47,12 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const body = await request.json()
-    const { twoFactorCode, twoFactorMethod } = body as {
+    const body = await request.json() as {
       twoFactorCode?: string
       twoFactorMethod?: LdapTwoFactorMethod
     }
-
-    if (!twoFactorCode) {
-      return NextResponse.json({ error: 'Two-factor code is required' }, { status: 400 })
-    }
+    const twoFactorCode = typeof body.twoFactorCode === 'string' ? body.twoFactorCode : ''
+    const twoFactorMethod = body.twoFactorMethod
 
     const authSecret = getBetterAuthSecret()
     const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value

--- a/apps/web/lib/auth/ldap-two-factor.ts
+++ b/apps/web/lib/auth/ldap-two-factor.ts
@@ -123,7 +123,7 @@ export function parseLdapTwoFactorChallenge(value: string): LdapTwoFactorChallen
 async function readBackupCodes(value: string | null, secret: string): Promise<string[]> {
   if (!value) return []
 
-  let decrypted = value
+  let decrypted: string
   try {
     decrypted = await symmetricDecrypt({
       key: secret,


### PR DESCRIPTION
## Summary
- gate the LDAP second-factor path on the server-issued challenge cookie instead of user-controlled request fields
- keep the previously merged LDAP 2FA flow intact while removing the CodeQL auth-flow finding from the follow-up path

## Testing
- node --experimental-strip-types --test lib/auth/ldap-two-factor.test.mjs
- pnpm type-check
- pnpm exec eslint app/api/auth/ldap/route.ts lib/auth/ldap-two-factor.ts

Follow-up to #931 for #908.