### PR TITLE
fix(ingest): prevent agent identity takeover on re-registration

### DIFF
--- a/apps/ingest/internal/db/queries/hosts.sql.go
+++ b/apps/ingest/internal/db/queries/hosts.sql.go
@@ -12,8 +12,8 @@ import (
 )
 
 // HostCollision describes an existing host whose identity (hostname or IP) overlaps
-// with a newly registering agent. Used to reject online duplicates and adopt offline
-// ones rather than creating a second row for the same physical machine.
+// with a newly registering agent. The registration handler uses this to reject
+// live duplicates and require explicit review for offline/unknown collisions.
 type HostCollision struct {
 	HostID      string
 	AgentID     string
@@ -26,10 +26,9 @@ type HostCollision struct {
 // matches or whose ip_addresses jsonb array overlaps any of the provided ips.
 // Returns nil, nil when no collision exists.
 //
-// An "online" match means the physical machine is still heartbeating under a
-// different keypair — the new registration must be rejected. An "offline" or
-// "unknown" match is treated as a re-registration of the same machine and the
-// caller will rotate the keypair onto the existing row.
+// An "online" match means a host is still heartbeating under a different
+// keypair, so the new registration must be rejected. An "offline" or "unknown"
+// match is a suspicious identity claim and must not mutate the existing row.
 func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname string, ips []string) (*HostCollision, error) {
 	const q = `
 		SELECT h.id, COALESCE(h.agent_id, ''), h.hostname, h.status, COALESCE(a.status, '')
@@ -60,17 +59,14 @@ func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname 
 	return &c, nil
 }
 
-// RotateAgentPublicKey replaces the public key on an existing agent row. Used
-// during re-registration adoption: the physical machine is the same (hostname
-// or IP match) but the agent has generated a fresh keypair (e.g. data dir wiped).
+// RotateAgentPublicKey replaces the public key on an existing agent row.
 func RotateAgentPublicKey(ctx context.Context, pool *pgxpool.Pool, agentID, publicKey string) error {
 	const q = `UPDATE agents SET public_key = $1, updated_at = NOW() WHERE id = $2`
 	_, err := pool.Exec(ctx, q, publicKey, agentID)
 	return err
 }
 
-// ReattachHostToAgent ensures a host row is linked to the given agent id. Used
-// when adopting an existing host during re-registration.
+// ReattachHostToAgent ensures a host row is linked to the given agent id.
 func ReattachHostToAgent(ctx context.Context, pool *pgxpool.Pool, hostID, agentID, hostname string) error {
 	const q = `
 		UPDATE hosts

--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -28,6 +28,27 @@ func NewRegisterHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, ca *pki.Agen
 	return &RegisterHandler{pool: pool, issuer: issuer, ca: ca}
 }
 
+type hostCollisionDecision int
+
+const (
+	hostCollisionNone hostCollisionDecision = iota
+	hostCollisionReject
+	hostCollisionCreateSeparatePending
+)
+
+func decideHostCollision(collision *queries.HostCollision) (hostCollisionDecision, string) {
+	if collision == nil || collision.AgentID == "" {
+		return hostCollisionNone, ""
+	}
+	if collision.AgentStatus == "revoked" {
+		return hostCollisionReject, "existing agent revoked"
+	}
+	if collision.HostStatus == "online" || collision.AgentStatus == "active" {
+		return hostCollisionReject, "online duplicate"
+	}
+	return hostCollisionCreateSeparatePending, "existing offline or unknown host identity"
+}
+
 // Register handles agent registration.
 //
 // Flow:
@@ -35,7 +56,7 @@ func NewRegisterHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, ca *pki.Agen
 //  2. Check if public_key already registered → return existing state (idempotent)
 //  3. Check for a colliding host (same hostname or overlapping IP) in the org:
 //     - Online match → reject with ALREADY_EXISTS (two live hosts can't share identity)
-//     - Offline/unknown match → adopt: rotate public key onto the existing agent row
+//     - Offline/unknown linked match → create a separate pending registration
 //  4. Insert agent (status=pending) + host row
 //  5. If auto_approve on token → set active, issue JWT
 //  6. Return RegisterResponse
@@ -123,23 +144,20 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	mergedTags := queries.MergeTagLayers(token.Metadata.Tags, reqTagPairs)
 
 	// Step 3: Check for identity collision with an existing host in the org.
-	// Hostname or IP overlap indicates the same physical machine — either
-	// actively duplicating (reject) or re-registering after a data-dir wipe
-	// (adopt the existing row to avoid stale duplicate records).
+	// Hostname or IP overlap is not sufficient proof that this is the same
+	// physical machine. Existing live identities are rejected; offline/unknown
+	// linked matches become separate pending registrations so an administrator
+	// can review the claim without mutating the existing agent's key material.
+	var collisionRequiringManualApproval *queries.HostCollision
 	collision, err := queries.FindHostCollision(ctx, h.pool, orgID, hostname, reportedIPs)
 	if err != nil {
 		slog.Error("checking host collision", "err", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 	if collision != nil {
-		// An active/online match means a live agent is still heartbeating under
-		// a different keypair. The network can't hold two machines with the same
-		// hostname/IP, so this is an error — delete the existing host first.
-		if collision.HostStatus == "online" || collision.AgentStatus == "active" || collision.AgentStatus == "revoked" {
-			reason := "online duplicate"
-			if collision.AgentStatus == "revoked" {
-				reason = "existing agent revoked"
-			}
+		decision, reason := decideHostCollision(collision)
+		switch decision {
+		case hostCollisionReject:
 			slog.Warn("rejecting registration due to host collision",
 				"hostname", hostname,
 				"existing_host_id", collision.HostID,
@@ -152,47 +170,19 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 				"a host matching this hostname or IP is already registered in this organisation (%s) — delete the existing host before re-registering",
 				reason,
 			)
-		}
-
-		// Offline or unknown: treat as a re-registration of the same machine.
-		// Rotate the public key onto the existing agent row and reuse the host.
-		if collision.AgentID == "" {
+		case hostCollisionCreateSeparatePending:
+			collisionRequiringManualApproval = collision
+			slog.Warn("creating separate pending registration for host collision",
+				"hostname", hostname,
+				"existing_host_id", collision.HostID,
+				"existing_agent_id", collision.AgentID,
+				"existing_host_status", collision.HostStatus,
+				"existing_agent_status", collision.AgentStatus,
+				"reason", reason,
+			)
+		case hostCollisionNone:
 			slog.Warn("host collision has no linked agent; falling through to fresh insert",
 				"host_id", collision.HostID)
-		} else {
-			if err := queries.RotateAgentPublicKey(ctx, h.pool, collision.AgentID, req.PublicKey); err != nil {
-				slog.Error("rotating public key on adopted agent", "err", err)
-				return nil, status.Error(codes.Internal, "failed to adopt existing registration")
-			}
-			if err := queries.ReattachHostToAgent(ctx, h.pool, collision.HostID, collision.AgentID, hostname); err != nil {
-				slog.Warn("reattaching host during adoption", "err", err)
-			}
-			// A keypair change is a new identity claim — always require re-approval
-			// regardless of the prior agent status. Resuming "active" without
-			// re-approval would let anyone who learns the enrolment token silently
-			// hijack an already-trusted agent identity (H-11).
-			if err := queries.SetAgentStatus(ctx, h.pool, collision.AgentID, "pending"); err != nil {
-				slog.Error("resetting agent status to pending after keypair rotation", "err", err)
-				return nil, status.Error(codes.Internal, "internal error")
-			}
-			if err := queries.InsertAgentStatusHistory(ctx, h.pool, collision.AgentID, orgID, "pending", nil,
-				"keypair rotated on re-registration; requires admin re-approval"); err != nil {
-				slog.Warn("inserting adoption history", "err", err)
-			}
-			if err := queries.IncrementUsageCount(ctx, h.pool, token.ID); err != nil {
-				slog.Warn("incrementing enrolment token usage", "err", err)
-			}
-			slog.Info("adopted existing host for re-registering agent",
-				"agent_id", collision.AgentID,
-				"host_id", collision.HostID,
-				"hostname", hostname,
-				"prior_status", collision.AgentStatus,
-			)
-			return &agentv1.RegisterResponse{
-				AgentId: collision.AgentID,
-				Status:  "pending",
-				Message: "re-registration adopted existing host; keypair rotated — awaiting admin approval",
-			}, nil
 		}
 	}
 
@@ -220,7 +210,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	// tags into metadata.pendingTags so approveAgent (TS) can drain them. On
 	// auto-approve we apply tags directly below and pass nil here.
 	var pendingForInsert []queries.TagPair
-	if !token.AutoApprove {
+	if !token.AutoApprove || collisionRequiringManualApproval != nil {
 		pendingForInsert = mergedTags
 	}
 	hostID, err := queries.InsertHost(ctx, h.pool, orgID, agentID, hostname, agentOS, agentArch, pendingForInsert)
@@ -229,14 +219,18 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 
 	// Append status history
-	if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, orgID, "pending", nil, "initial registration"); err != nil {
+	statusReason := "initial registration"
+	if collisionRequiringManualApproval != nil {
+		statusReason = "registration matched an existing host identity; requires explicit admin review before merge or rebind"
+	}
+	if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, orgID, "pending", nil, statusReason); err != nil {
 		slog.Warn("inserting status history", "err", err)
 	}
 
 	slog.Info("agent registered", "agent_id", agentID, "hostname", hostname, "auto_approve", token.AutoApprove)
 
 	// Step 5: Auto-approve if configured
-	if token.AutoApprove {
+	if token.AutoApprove && collisionRequiringManualApproval == nil {
 		if err := queries.ApproveAgent(ctx, h.pool, agentID); err != nil {
 			slog.Error("auto-approving agent", "err", err)
 			return nil, status.Error(codes.Internal, "internal error")
@@ -288,10 +282,14 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 
 	// Step 6: Pending — waiting for admin approval
+	message := "agent registered and awaiting admin approval"
+	if collisionRequiringManualApproval != nil {
+		message = "agent registered as separate pending host because hostname or IP matches an existing host; admin review required"
+	}
 	return &agentv1.RegisterResponse{
 		AgentId: agentID,
 		Status:  "pending",
-		Message: "agent registered and awaiting admin approval",
+		Message: message,
 	}, nil
 }
 

--- a/apps/ingest/internal/handlers/register_test.go
+++ b/apps/ingest/internal/handlers/register_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
+)
+
+func TestDecideHostCollisionCreatesSeparatePendingForOfflineLinkedHost(t *testing.T) {
+	t.Parallel()
+
+	decision, reason := decideHostCollision(&queries.HostCollision{
+		HostID:      "host_existing",
+		AgentID:     "agent_existing",
+		Hostname:    "server-01",
+		HostStatus:  "offline",
+		AgentStatus: "offline",
+	})
+
+	if decision != hostCollisionCreateSeparatePending {
+		t.Fatalf("decision = %v, want %v", decision, hostCollisionCreateSeparatePending)
+	}
+	if reason == "" {
+		t.Fatal("reason is empty")
+	}
+}
+
+func TestDecideHostCollisionRejectsOnlineOrActiveHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		collision queries.HostCollision
+	}{
+		{
+			name: "online host",
+			collision: queries.HostCollision{
+				HostID:      "host_existing",
+				AgentID:     "agent_existing",
+				Hostname:    "server-01",
+				HostStatus:  "online",
+				AgentStatus: "offline",
+			},
+		},
+		{
+			name: "active agent",
+			collision: queries.HostCollision{
+				HostID:      "host_existing",
+				AgentID:     "agent_existing",
+				Hostname:    "server-01",
+				HostStatus:  "offline",
+				AgentStatus: "active",
+			},
+		},
+		{
+			name: "revoked agent",
+			collision: queries.HostCollision{
+				HostID:      "host_existing",
+				AgentID:     "agent_existing",
+				Hostname:    "server-01",
+				HostStatus:  "offline",
+				AgentStatus: "revoked",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			decision, reason := decideHostCollision(&tt.collision)
+			if decision != hostCollisionReject {
+				t.Fatalf("decision = %v, want %v", decision, hostCollisionReject)
+			}
+			if reason == "" {
+				t.Fatal("reason is empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- stop offline/unknown host collisions from rotating an existing agent public key
- create a separate pending registration for suspicious hostname/IP reuse
- force admin review for collided registrations even when the enrolment token auto-approves

## Tests
- `go test ./internal/handlers -run 'TestDecideHostCollision'`
- `go test ./...` from `apps/ingest`

Closes #909
