### PR TITLE
fix(ingest): prevent host identity takeover on registration

### DIFF
--- a/apps/ingest/internal/db/queries/hosts.sql.go
+++ b/apps/ingest/internal/db/queries/hosts.sql.go
@@ -12,8 +12,7 @@ import (
 )
 
 // HostCollision describes an existing host whose identity (hostname or IP) overlaps
-// with a newly registering agent. Used to reject online duplicates and adopt offline
-// ones rather than creating a second row for the same physical machine.
+// with a newly registering agent.
 type HostCollision struct {
 	HostID      string
 	AgentID     string
@@ -26,10 +25,9 @@ type HostCollision struct {
 // matches or whose ip_addresses jsonb array overlaps any of the provided ips.
 // Returns nil, nil when no collision exists.
 //
-// An "online" match means the physical machine is still heartbeating under a
-// different keypair — the new registration must be rejected. An "offline" or
-// "unknown" match is treated as a re-registration of the same machine and the
-// caller will rotate the keypair onto the existing row.
+// An "online" match means the physical machine may still be heartbeating under
+// a different keypair. Offline and unknown matches are weak identity signals
+// and callers must not mutate the existing row based only on this result.
 func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname string, ips []string) (*HostCollision, error) {
 	const q = `
 		SELECT h.id, COALESCE(h.agent_id, ''), h.hostname, h.status, COALESCE(a.status, '')
@@ -58,29 +56,6 @@ func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname 
 		return nil, err
 	}
 	return &c, nil
-}
-
-// RotateAgentPublicKey replaces the public key on an existing agent row. Used
-// during re-registration adoption: the physical machine is the same (hostname
-// or IP match) but the agent has generated a fresh keypair (e.g. data dir wiped).
-func RotateAgentPublicKey(ctx context.Context, pool *pgxpool.Pool, agentID, publicKey string) error {
-	const q = `UPDATE agents SET public_key = $1, updated_at = NOW() WHERE id = $2`
-	_, err := pool.Exec(ctx, q, publicKey, agentID)
-	return err
-}
-
-// ReattachHostToAgent ensures a host row is linked to the given agent id. Used
-// when adopting an existing host during re-registration.
-func ReattachHostToAgent(ctx context.Context, pool *pgxpool.Pool, hostID, agentID, hostname string) error {
-	const q = `
-		UPDATE hosts
-		SET agent_id   = $2,
-		    hostname   = $3,
-		    updated_at = NOW()
-		WHERE id = $1
-	`
-	_, err := pool.Exec(ctx, q, hostID, agentID, hostname)
-	return err
 }
 
 // InsertHost inserts a new host row linked to an agent and returns the host ID.

--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -34,8 +34,8 @@ func NewRegisterHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, ca *pki.Agen
 //  1. Validate org_token → UNAUTHENTICATED if invalid/expired
 //  2. Check if public_key already registered → return existing state (idempotent)
 //  3. Check for a colliding host (same hostname or overlapping IP) in the org:
-//     - Online match → reject with ALREADY_EXISTS (two live hosts can't share identity)
-//     - Offline/unknown match → adopt: rotate public key onto the existing agent row
+//     - Online/active/revoked match → reject with ALREADY_EXISTS
+//     - Offline/unknown match → create a separate pending registration
 //  4. Insert agent (status=pending) + host row
 //  5. If auto_approve on token → set active, issue JWT
 //  6. Return RegisterResponse
@@ -123,19 +123,18 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	mergedTags := queries.MergeTagLayers(token.Metadata.Tags, reqTagPairs)
 
 	// Step 3: Check for identity collision with an existing host in the org.
-	// Hostname or IP overlap indicates the same physical machine — either
-	// actively duplicating (reject) or re-registering after a data-dir wipe
-	// (adopt the existing row to avoid stale duplicate records).
+	// Hostname or IP overlap is not a strong identity signal. Online/active
+	// matches are rejected, and offline/unknown matches continue as separate
+	// pending registrations instead of mutating an existing trusted identity.
+	forcePendingApproval := false
 	collision, err := queries.FindHostCollision(ctx, h.pool, orgID, hostname, reportedIPs)
 	if err != nil {
 		slog.Error("checking host collision", "err", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
 	if collision != nil {
-		// An active/online match means a live agent is still heartbeating under
-		// a different keypair. The network can't hold two machines with the same
-		// hostname/IP, so this is an error — delete the existing host first.
-		if collision.HostStatus == "online" || collision.AgentStatus == "active" || collision.AgentStatus == "revoked" {
+		switch classifyHostCollision(collision) {
+		case collisionActionReject:
 			reason := "online duplicate"
 			if collision.AgentStatus == "revoked" {
 				reason = "existing agent revoked"
@@ -152,47 +151,15 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 				"a host matching this hostname or IP is already registered in this organisation (%s) — delete the existing host before re-registering",
 				reason,
 			)
-		}
-
-		// Offline or unknown: treat as a re-registration of the same machine.
-		// Rotate the public key onto the existing agent row and reuse the host.
-		if collision.AgentID == "" {
-			slog.Warn("host collision has no linked agent; falling through to fresh insert",
-				"host_id", collision.HostID)
-		} else {
-			if err := queries.RotateAgentPublicKey(ctx, h.pool, collision.AgentID, req.PublicKey); err != nil {
-				slog.Error("rotating public key on adopted agent", "err", err)
-				return nil, status.Error(codes.Internal, "failed to adopt existing registration")
-			}
-			if err := queries.ReattachHostToAgent(ctx, h.pool, collision.HostID, collision.AgentID, hostname); err != nil {
-				slog.Warn("reattaching host during adoption", "err", err)
-			}
-			// A keypair change is a new identity claim — always require re-approval
-			// regardless of the prior agent status. Resuming "active" without
-			// re-approval would let anyone who learns the enrolment token silently
-			// hijack an already-trusted agent identity (H-11).
-			if err := queries.SetAgentStatus(ctx, h.pool, collision.AgentID, "pending"); err != nil {
-				slog.Error("resetting agent status to pending after keypair rotation", "err", err)
-				return nil, status.Error(codes.Internal, "internal error")
-			}
-			if err := queries.InsertAgentStatusHistory(ctx, h.pool, collision.AgentID, orgID, "pending", nil,
-				"keypair rotated on re-registration; requires admin re-approval"); err != nil {
-				slog.Warn("inserting adoption history", "err", err)
-			}
-			if err := queries.IncrementUsageCount(ctx, h.pool, token.ID); err != nil {
-				slog.Warn("incrementing enrolment token usage", "err", err)
-			}
-			slog.Info("adopted existing host for re-registering agent",
-				"agent_id", collision.AgentID,
+		case collisionActionFreshInsert:
+			forcePendingApproval = true
+			slog.Warn("continuing suspicious host collision as separate pending registration",
+				"existing_agent_id", collision.AgentID,
 				"host_id", collision.HostID,
 				"hostname", hostname,
-				"prior_status", collision.AgentStatus,
+				"existing_host_status", collision.HostStatus,
+				"existing_agent_status", collision.AgentStatus,
 			)
-			return &agentv1.RegisterResponse{
-				AgentId: collision.AgentID,
-				Status:  "pending",
-				Message: "re-registration adopted existing host; keypair rotated — awaiting admin approval",
-			}, nil
 		}
 	}
 
@@ -220,7 +187,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	// tags into metadata.pendingTags so approveAgent (TS) can drain them. On
 	// auto-approve we apply tags directly below and pass nil here.
 	var pendingForInsert []queries.TagPair
-	if !token.AutoApprove {
+	if !token.AutoApprove || forcePendingApproval {
 		pendingForInsert = mergedTags
 	}
 	hostID, err := queries.InsertHost(ctx, h.pool, orgID, agentID, hostname, agentOS, agentArch, pendingForInsert)
@@ -236,7 +203,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	slog.Info("agent registered", "agent_id", agentID, "hostname", hostname, "auto_approve", token.AutoApprove)
 
 	// Step 5: Auto-approve if configured
-	if token.AutoApprove {
+	if token.AutoApprove && !forcePendingApproval {
 		if err := queries.ApproveAgent(ctx, h.pool, agentID); err != nil {
 			slog.Error("auto-approving agent", "err", err)
 			return nil, status.Error(codes.Internal, "internal error")
@@ -288,11 +255,32 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 
 	// Step 6: Pending — waiting for admin approval
+	message := "agent registered and awaiting admin approval"
+	if forcePendingApproval {
+		message = "agent registered with a hostname or IP collision and requires explicit admin approval"
+	}
 	return &agentv1.RegisterResponse{
 		AgentId: agentID,
 		Status:  "pending",
-		Message: "agent registered and awaiting admin approval",
+		Message: message,
 	}, nil
+}
+
+type collisionAction int
+
+const (
+	collisionActionFreshInsert collisionAction = iota
+	collisionActionReject
+)
+
+func classifyHostCollision(collision *queries.HostCollision) collisionAction {
+	if collision == nil {
+		return collisionActionFreshInsert
+	}
+	if collision.HostStatus == "online" || collision.AgentStatus == "active" || collision.AgentStatus == "revoked" {
+		return collisionActionReject
+	}
+	return collisionActionFreshInsert
 }
 
 // signAndAttach signs a CSR immediately, persists the leaf onto the agents

--- a/apps/ingest/internal/handlers/register_test.go
+++ b/apps/ingest/internal/handlers/register_test.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
+)
+
+func TestClassifyHostCollisionCreatesFreshPendingRegistrationForOfflineExistingAgent(t *testing.T) {
+	t.Parallel()
+
+	collision := &queries.HostCollision{
+		HostID:      "host_123",
+		AgentID:     "agent_123",
+		Hostname:    "db-01",
+		HostStatus:  "offline",
+		AgentStatus: "pending",
+	}
+
+	action := classifyHostCollision(collision)
+	if action != collisionActionFreshInsert {
+		t.Fatalf("classifyHostCollision() = %v, want %v", action, collisionActionFreshInsert)
+	}
+}
+
+func TestClassifyHostCollisionRejectsOnlineExistingAgent(t *testing.T) {
+	t.Parallel()
+
+	collision := &queries.HostCollision{
+		HostID:      "host_123",
+		AgentID:     "agent_123",
+		Hostname:    "db-01",
+		HostStatus:  "online",
+		AgentStatus: "active",
+	}
+
+	action := classifyHostCollision(collision)
+	if action != collisionActionReject {
+		t.Fatalf("classifyHostCollision() = %v, want %v", action, collisionActionReject)
+	}
+}
+
+func TestClassifyHostCollisionAllowsUnlinkedHostInsert(t *testing.T) {
+	t.Parallel()
+
+	collision := &queries.HostCollision{
+		HostID:     "host_123",
+		Hostname:   "db-01",
+		HostStatus: "unknown",
+	}
+
+	action := classifyHostCollision(collision)
+	if action != collisionActionFreshInsert {
+		t.Fatalf("classifyHostCollision() = %v, want %v", action, collisionActionFreshInsert)
+	}
+}


### PR DESCRIPTION
## Summary
- stop agent registration from rotating an existing agent public key on hostname/IP collisions
- continue offline/unknown collisions as separate pending registrations that require explicit admin approval
- keep online, active, or revoked collisions rejected and remove unused adoption query helpers

## Tests
- `go test ./apps/ingest/internal/handlers -run 'TestClassifyHostCollision'`
- `go test ./apps/ingest/...`

Closes #909
