### PR TITLE
fix(agent): use configured installer origin

### DIFF
--- a/apps/web/app/api/agent/bundle/route.ts
+++ b/apps/web/app/api/agent/bundle/route.ts
@@ -12,6 +12,7 @@ import {
   type AgentArch,
 } from '@/lib/agent/binary'
 import { buildInstallBundle } from '@/lib/agent/bundle'
+import { getAgentPublicOrigin } from '@/lib/agent/public-origin'
 import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
 import { readFile } from 'node:fs/promises'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
@@ -183,11 +184,9 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const host = request.headers.get('host') ?? 'localhost'
-  const proto = request.headers.get('x-forwarded-proto') ?? 'http'
-  const serverUrl = `${proto}://${host}`
+  const serverUrl = getAgentPublicOrigin()
   const ingestAddress =
-    parsed.data.ingestAddress?.trim() || `${host.split(':')[0]}:9443`
+    parsed.data.ingestAddress?.trim() || `${new URL(serverUrl).hostname}:9443`
 
   const serverCaPem = await readPemFile(SERVER_TLS_CERT_PATH)
   const webServerCertPem = await readPemFile(WEB_TLS_CERT_PATH)

--- a/apps/web/app/api/agent/install/route.ts
+++ b/apps/web/app/api/agent/install/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { buildAgentInstallScript } from '@/lib/agent/install-script'
+import { getAgentPublicOrigin } from '@/lib/agent/public-origin'
 import { createRateLimiter } from '@/lib/rate-limit'
 
 // 30 requests per IP per 60 s — generous for CI/CD pipelines but throttles enumeration/DoS.
@@ -38,12 +39,10 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  const host = request.headers.get('host') ?? 'localhost'
-  const proto = request.headers.get('x-forwarded-proto') ?? 'http'
-  const serverURL = `${proto}://${host}`
+  const serverURL = getAgentPublicOrigin()
 
   const { searchParams } = new URL(request.url)
-  const bareHost = host.split(':')[0]
+  const bareHost = new URL(serverURL).hostname
   const ingestAddress = searchParams.get('ingest') ?? `${bareHost}:9443`
   const skipVerify = searchParams.get('skip_verify') === 'true'
   const script = buildAgentInstallScript(serverURL, ingestAddress, skipVerify)

--- a/apps/web/lib/agent/public-origin.test.mjs
+++ b/apps/web/lib/agent/public-origin.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getAgentPublicOrigin } from './public-origin.ts'
+
+test('getAgentPublicOrigin prefers AGENT_DOWNLOAD_BASE_URL over BETTER_AUTH_URL', () => {
+  assert.equal(
+    getAgentPublicOrigin({
+      AGENT_DOWNLOAD_BASE_URL: 'https://agents.ct-ops.example.com/downloads/',
+      BETTER_AUTH_URL: 'https://app.ct-ops.example.com/login',
+    }),
+    'https://agents.ct-ops.example.com',
+  )
+})
+
+test('getAgentPublicOrigin falls back to BETTER_AUTH_URL', () => {
+  assert.equal(
+    getAgentPublicOrigin({
+      BETTER_AUTH_URL: 'https://ct-ops.example.com/dashboard?tab=agents',
+    }),
+    'https://ct-ops.example.com',
+  )
+})
+
+test('getAgentPublicOrigin rejects missing canonical origin configuration', () => {
+  assert.throws(
+    () => getAgentPublicOrigin({}),
+    /AGENT_DOWNLOAD_BASE_URL or BETTER_AUTH_URL must be set/,
+  )
+})
+
+test('getAgentPublicOrigin rejects invalid canonical origin configuration', () => {
+  assert.throws(
+    () => getAgentPublicOrigin({ AGENT_DOWNLOAD_BASE_URL: 'not-a-url' }),
+    /AGENT_DOWNLOAD_BASE_URL must be a valid absolute URL/,
+  )
+})

--- a/apps/web/lib/agent/public-origin.ts
+++ b/apps/web/lib/agent/public-origin.ts
@@ -1,0 +1,23 @@
+type EnvLike = Record<string, string | undefined>
+
+function normaliseAbsoluteOrigin(name: string, value: string): string {
+  try {
+    return new URL(value).origin
+  } catch {
+    throw new Error(`${name} must be a valid absolute URL`)
+  }
+}
+
+export function getAgentPublicOrigin(env: EnvLike = process.env): string {
+  const downloadBaseUrl = env['AGENT_DOWNLOAD_BASE_URL']?.trim()
+  if (downloadBaseUrl) {
+    return normaliseAbsoluteOrigin('AGENT_DOWNLOAD_BASE_URL', downloadBaseUrl)
+  }
+
+  const betterAuthUrl = env['BETTER_AUTH_URL']?.trim()
+  if (betterAuthUrl) {
+    return normaliseAbsoluteOrigin('BETTER_AUTH_URL', betterAuthUrl)
+  }
+
+  throw new Error('AGENT_DOWNLOAD_BASE_URL or BETTER_AUTH_URL must be set')
+}


### PR DESCRIPTION
## Summary
- add a canonical agent public origin resolver using `AGENT_DOWNLOAD_BASE_URL` with `BETTER_AUTH_URL` fallback
- stop `/api/agent/install` and `/api/agent/bundle` from deriving generated origins or default ingest hosts from `Host` / `X-Forwarded-Proto` request headers
- cover origin selection, normalisation, and invalid/missing config with unit tests

Fixes #934

## Tests
- `pnpm --dir apps/web exec node --experimental-strip-types --test lib/agent/install-script.test.mjs lib/agent/public-origin.test.mjs`
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `pnpm --filter web test:unit`

## Follow-up
- Filed #944 for the separate bundle-transfer route origin issue found during the scan.
