### PR TITLE
fix(bundle-transfer): verify host bundle downloads

### DIFF
--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -10,14 +10,14 @@ import { createReadStream, createWriteStream } from 'node:fs'
 import { mkdtemp, rm, stat as fsStat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { randomBytes, randomUUID } from 'node:crypto'
-import { auth } from '@/lib/auth'
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { db } from '@/lib/db'
-import { hosts, taskRunHosts, taskRuns, users } from '@/lib/db/schema'
+import { hosts, taskRunHosts, taskRuns } from '@/lib/db/schema'
 import { resolveWarUrl } from '@/lib/jenkins/update-center'
 import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 import { getApiOrgSession } from '@/lib/auth/session'
 import { canAccessTooling } from '@/lib/auth/tooling'
+import { buildHostDownloadScript } from '@/lib/tools/bundle-transfer/host-download-script'
 
 export const runtime = 'nodejs'
 export const maxDuration = 900
@@ -412,52 +412,24 @@ async function writeLocalArchive(params: {
   })
 }
 
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`
+async function calculateFileSha256(filePath: string) {
+  const hash = createHash('sha256')
+  await pipeline(createReadStream(filePath), hash)
+  return hash.digest('hex')
 }
 
-function buildHostDownloadScript(params: {
-  downloadUrl: string
-  directory: string
-  fileName: string
-  owner: string
-}) {
-  const destination = path.posix.join(params.directory, params.fileName)
-  return [
-    'set -eu',
-    `DEST_DIR=${shellQuote(params.directory)}`,
-    `DEST_FILE=${shellQuote(params.fileName)}`,
-    `DEST_PATH=${shellQuote(destination)}`,
-    `DOWNLOAD_URL=${shellQuote(params.downloadUrl)}`,
-    `OWNER=${shellQuote(params.owner)}`,
-    'TMP_PATH="${DEST_DIR}/.${DEST_FILE}.ct-ops-transfer.$$"',
-    'cleanup() { rm -f "$TMP_PATH"; }',
-    'trap cleanup INT TERM EXIT',
-    'mkdir -p "$DEST_DIR"',
-    'echo "Downloading bundle to ${DEST_PATH}"',
-    'if command -v curl >/dev/null 2>&1; then',
-    '  curl -fLk --retry 3 --connect-timeout 20 --output "$TMP_PATH" "$DOWNLOAD_URL"',
-    'elif command -v wget >/dev/null 2>&1; then',
-    '  wget --no-check-certificate --tries=3 --timeout=20 -O "$TMP_PATH" "$DOWNLOAD_URL"',
-    'else',
-    '  echo "Neither curl nor wget is installed on this host" >&2',
-    '  exit 127',
-    'fi',
-    'mv -f "$TMP_PATH" "$DEST_PATH"',
-    'trap - INT TERM EXIT',
-    'if [ -n "$OWNER" ] && command -v chown >/dev/null 2>&1 && id "$OWNER" >/dev/null 2>&1; then',
-    '  chown "$OWNER" "$DEST_PATH" || true',
-    'fi',
-    'echo "Bundle transferred to ${DEST_PATH}"',
-  ].join('\n')
-}
-
-async function createBundleTransferTask(job: TransferJob, request: TransferRequest, downloadUrl: string) {
+async function createBundleTransferTask(
+  job: TransferJob,
+  request: TransferRequest,
+  downloadUrl: string,
+  expectedSha256: string,
+) {
   const script = buildHostDownloadScript({
     downloadUrl,
     directory: path.posix.normalize(request.directory),
     fileName: request.fileName,
     owner: request.username.trim(),
+    expectedSha256,
   })
 
   return db.transaction(async (tx) => {
@@ -609,6 +581,7 @@ async function runTransferJob(job: TransferJob, request: TransferRequest, baseUr
       readme: archive.readme,
       job,
     })
+    const archiveSha256 = await calculateFileSha256(archivePath)
 
     const downloadToken = randomBytes(32).toString('base64url')
     const downloadUrl = new URL('/api/tools/bundle-transfer', baseUrl)
@@ -624,7 +597,7 @@ async function runTransferJob(job: TransferJob, request: TransferRequest, baseUr
       currentTotal: null,
     })
 
-    const taskRunId = await createBundleTransferTask(job, request, downloadUrl.toString())
+    const taskRunId = await createBundleTransferTask(job, request, downloadUrl.toString(), archiveSha256)
     publishJob(job, { taskRunId })
 
     await refreshTransferTaskStatus(job)

--- a/apps/web/lib/tools/bundle-transfer/host-download-script.test.mjs
+++ b/apps/web/lib/tools/bundle-transfer/host-download-script.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildHostDownloadScript } from './host-download-script.ts'
+
+test('buildHostDownloadScript keeps TLS certificate validation enabled', () => {
+  const script = buildHostDownloadScript({
+    downloadUrl: 'https://ct-ops.example.com/api/tools/bundle-transfer?jobId=job-1&token=token-1',
+    directory: '/opt/ct-ops/bundles',
+    fileName: 'gitlab-18.0.0.zip',
+    owner: 'deploy',
+    expectedSha256: 'a'.repeat(64),
+  })
+
+  assert.match(script, /curl -fL --retry 3 --connect-timeout 20 --output "\$TMP_PATH" "\$DOWNLOAD_URL"/)
+  assert.match(script, /wget --tries=3 --timeout=20 -O "\$TMP_PATH" "\$DOWNLOAD_URL"/)
+  assert.equal(script.includes('curl -fLk'), false)
+  assert.equal(script.includes('--no-check-certificate'), false)
+})
+
+test('buildHostDownloadScript verifies the downloaded archive before moving it into place', () => {
+  const script = buildHostDownloadScript({
+    downloadUrl: 'https://ct-ops.example.com/api/tools/bundle-transfer?jobId=job-1&token=token-1',
+    directory: '/opt/ct-ops/bundles',
+    fileName: 'gitlab-18.0.0.zip',
+    owner: '',
+    expectedSha256: 'b'.repeat(64),
+  })
+
+  assert.match(script, /EXPECTED_SHA256='bbbb/)
+  assert.match(script, /sha256sum -c -/)
+  assert.match(script, /shasum -a 256 -c -/)
+  assert.match(script, /Neither sha256sum nor shasum is installed/)
+  assert.ok(script.indexOf('sha256sum -c -') < script.indexOf('mv -f "$TMP_PATH" "$DEST_PATH"'))
+})

--- a/apps/web/lib/tools/bundle-transfer/host-download-script.ts
+++ b/apps/web/lib/tools/bundle-transfer/host-download-script.ts
@@ -1,0 +1,51 @@
+import path from 'node:path'
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+export function buildHostDownloadScript(params: {
+  downloadUrl: string
+  directory: string
+  fileName: string
+  owner: string
+  expectedSha256: string
+}) {
+  const destination = path.posix.join(params.directory, params.fileName)
+  return [
+    'set -eu',
+    `DEST_DIR=${shellQuote(params.directory)}`,
+    `DEST_FILE=${shellQuote(params.fileName)}`,
+    `DEST_PATH=${shellQuote(destination)}`,
+    `DOWNLOAD_URL=${shellQuote(params.downloadUrl)}`,
+    `OWNER=${shellQuote(params.owner)}`,
+    `EXPECTED_SHA256=${shellQuote(params.expectedSha256)}`,
+    'TMP_PATH="${DEST_DIR}/.${DEST_FILE}.ct-ops-transfer.$$"',
+    'cleanup() { rm -f "$TMP_PATH"; }',
+    'trap cleanup INT TERM EXIT',
+    'mkdir -p "$DEST_DIR"',
+    'echo "Downloading bundle to ${DEST_PATH}"',
+    'if command -v curl >/dev/null 2>&1; then',
+    '  curl -fL --retry 3 --connect-timeout 20 --output "$TMP_PATH" "$DOWNLOAD_URL"',
+    'elif command -v wget >/dev/null 2>&1; then',
+    '  wget --tries=3 --timeout=20 -O "$TMP_PATH" "$DOWNLOAD_URL"',
+    'else',
+    '  echo "Neither curl nor wget is installed on this host" >&2',
+    '  exit 127',
+    'fi',
+    'if command -v sha256sum >/dev/null 2>&1; then',
+    '  printf "%s  %s\\n" "$EXPECTED_SHA256" "$TMP_PATH" | sha256sum -c -',
+    'elif command -v shasum >/dev/null 2>&1; then',
+    '  printf "%s  %s\\n" "$EXPECTED_SHA256" "$TMP_PATH" | shasum -a 256 -c -',
+    'else',
+    '  echo "Neither sha256sum nor shasum is installed on this host" >&2',
+    '  exit 127',
+    'fi',
+    'mv -f "$TMP_PATH" "$DEST_PATH"',
+    'trap - INT TERM EXIT',
+    'if [ -n "$OWNER" ] && command -v chown >/dev/null 2>&1 && id "$OWNER" >/dev/null 2>&1; then',
+    '  chown "$OWNER" "$DEST_PATH" || true',
+    'fi',
+    'echo "Bundle transferred to ${DEST_PATH}"',
+  ].join('\n')
+}


### PR DESCRIPTION
## Summary
- remove TLS certificate bypass flags from generated bundle-transfer host download commands
- compute the server archive SHA-256 and require host-side verification before moving the bundle into place
- extract the host download script builder and add regression tests

Fixes #935

## Tests
- node --experimental-strip-types --test apps/web/lib/tools/bundle-transfer/host-download-script.test.mjs
- pnpm --filter web lint -- app/api/tools/bundle-transfer/route.ts lib/tools/bundle-transfer/host-download-script.ts lib/tools/bundle-transfer/host-download-script.test.mjs
- pnpm --filter web type-check
- pnpm --filter web test:unit