### PR TITLE
fix(authz): derive privileged action actors from session

### DIFF
--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -890,7 +890,6 @@ type SilenceFormValues = z.infer<typeof silenceFormSchema>
 
 function AddSilenceDialog({
   orgId,
-  userId,
   hosts,
   open,
   onOpenChange,
@@ -898,7 +897,6 @@ function AddSilenceDialog({
   prefilledHostId,
 }: {
   orgId: string
-  userId: string
   hosts: HostWithAgent[]
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -923,7 +921,7 @@ function AddSilenceDialog({
   })
 
   async function onSubmit(values: SilenceFormValues) {
-    const result = await createSilence(orgId, userId, {
+    const result = await createSilence(orgId, {
       hostId: values.hostId || null,
       reason: values.reason,
       startsAt: new Date(values.startsAt).toISOString(),
@@ -996,7 +994,6 @@ function AddSilenceDialog({
 
 interface AlertsClientProps {
   orgId: string
-  currentUserId: string
   initialActive: AlertInstanceWithRule[]
   initialChannels: NotificationChannelSafe[]
   initialSilences: AlertSilenceWithHost[]
@@ -1009,7 +1006,6 @@ const HISTORY_PAGE_SIZE = 25
 
 export function AlertsClient({
   orgId,
-  currentUserId,
   initialActive,
   initialChannels,
   initialSilences,
@@ -1076,7 +1072,7 @@ export function AlertsClient({
   })
 
   const acknowledgeMutation = useMutation({
-    mutationFn: (instanceId: string) => acknowledgeAlert(orgId, instanceId, currentUserId),
+    mutationFn: (instanceId: string) => acknowledgeAlert(orgId, instanceId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['alerts', orgId] })
     },
@@ -1608,7 +1604,6 @@ export function AlertsClient({
 
       <AddSilenceDialog
         orgId={orgId}
-        userId={currentUserId}
         hosts={hosts}
         open={addSilenceOpen}
         onOpenChange={setAddSilenceOpen}

--- a/apps/web/app/(dashboard)/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/alerts/page.tsx
@@ -22,7 +22,6 @@ export default async function AlertsPage() {
   return (
     <AlertsClient
       orgId={orgId}
-      currentUserId={session.user.id}
       initialActive={activeAlerts}
       initialChannels={channels}
       initialSilences={silences}

--- a/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
@@ -118,14 +118,12 @@ type SilenceFormValues = z.infer<typeof silenceFormSchema>
 function AddSilenceDialog({
   orgId,
   hostId,
-  userId,
   open,
   onOpenChange,
   onSuccess,
 }: {
   orgId: string
   hostId: string
-  userId: string
   open: boolean
   onOpenChange: (v: boolean) => void
   onSuccess: () => void
@@ -147,7 +145,7 @@ function AddSilenceDialog({
   })
 
   async function onSubmit(values: SilenceFormValues) {
-    const result = await createSilence(orgId, userId, {
+    const result = await createSilence(orgId, {
       hostId,
       reason: values.reason,
       startsAt: new Date(values.startsAt).toISOString(),
@@ -532,10 +530,9 @@ function AddRuleDialog({
 interface Props {
   orgId: string
   hostId: string
-  currentUserId: string
 }
 
-export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
+export function AlertsTab({ orgId, hostId }: Props) {
   const qc = useQueryClient()
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   const [addSilenceOpen, setAddSilenceOpen] = useState(false)
@@ -762,7 +759,6 @@ export function AlertsTab({ orgId, hostId, currentUserId }: Props) {
       <AddSilenceDialog
         orgId={orgId}
         hostId={hostId}
-        userId={currentUserId}
         open={addSilenceOpen}
         onOpenChange={setAddSilenceOpen}
         onSuccess={() => qc.invalidateQueries({ queryKey: ['silences-active', orgId, hostId] })}

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -300,7 +300,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
   const { mutate: removeHost, isPending: isDeleting } = useMutation({
     mutationFn: (opts: { uninstall: boolean }) =>
       opts.uninstall
-        ? uninstallAndDeleteHost(orgId, currentUserId, initialHost.id)
+        ? uninstallAndDeleteHost(orgId, initialHost.id)
         : deleteHost(orgId, initialHost.id),
     onSuccess: (result) => {
       if ('success' in result) {
@@ -946,7 +946,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
 
       {/* Alerts Tab */}
       {activeTab === 'alerts' && (
-        <AlertsTab orgId={orgId} hostId={initialHost.id} currentUserId={currentUserId} />
+        <AlertsTab orgId={orgId} hostId={initialHost.id} />
       )}
 
       {/* Users Tab */}

--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -63,7 +63,6 @@ type StatusFilter = 'all' | 'online' | 'offline' | 'unknown'
 
 interface HostsClientProps {
   orgId: string
-  currentUserId: string
   currentUserRole: string
   initialHostPage: HostListResult
   initialStats: HostInventoryStats
@@ -199,7 +198,6 @@ function SortableHeader({
 
 export function HostsClient({
   orgId,
-  currentUserId,
   currentUserRole,
   initialHostPage,
   initialStats,
@@ -313,7 +311,7 @@ export function HostsClient({
 
   const approveMutation = useMutation({
     mutationFn: ({ agentId }: { agentId: string }) =>
-      approveAgent(orgId, agentId, currentUserId),
+      approveAgent(orgId, agentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', 'pending', orgId] })
       queryClient.invalidateQueries({ queryKey: ['hosts', 'page', orgId] })
@@ -323,7 +321,7 @@ export function HostsClient({
 
   const rejectMutation = useMutation({
     mutationFn: ({ agentId }: { agentId: string }) =>
-      rejectAgent(orgId, agentId, currentUserId),
+      rejectAgent(orgId, agentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['agents', 'pending', orgId] })
       queryClient.invalidateQueries({ queryKey: ['hosts', 'stats', orgId] })

--- a/apps/web/app/(dashboard)/hosts/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/page.tsx
@@ -26,7 +26,6 @@ export default async function HostsPage() {
   return (
     <HostsClient
       orgId={orgId}
-      currentUserId={session.user.id}
       currentUserRole={session.user.role}
       initialHostPage={hostPage}
       initialStats={stats}

--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -61,7 +61,6 @@ type CreateTokenForm = z.infer<typeof createTokenSchema>
 
 interface AgentsSettingsClientProps {
   orgId: string
-  currentUserId: string
   initialTokens: EnrolmentTokenSafe[]
   appUrl: string
 }
@@ -101,7 +100,6 @@ function tokenStatus(token: EnrolmentTokenSafe): { label: string; className: str
 
 export function AgentsSettingsClient({
   orgId,
-  currentUserId,
   initialTokens,
   appUrl,
 }: AgentsSettingsClientProps) {
@@ -142,7 +140,7 @@ export function AgentsSettingsClient({
 
   const createMutation = useMutation({
     mutationFn: (data: CreateTokenForm) =>
-      createEnrolmentToken(orgId, currentUserId, {
+      createEnrolmentToken(orgId, {
         label: data.label,
         autoApprove: data.autoApprove,
         skipVerify: data.skipVerify,

--- a/apps/web/app/(dashboard)/settings/agents/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/page.tsx
@@ -33,7 +33,6 @@ export default async function AgentsSettingsPage() {
       />
       <AgentsSettingsClient
         orgId={orgId}
-        currentUserId={session.user.id}
         initialTokens={tokens}
         appUrl={appUrl}
       />

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -49,6 +49,7 @@ import type { HostMetadata, TagPair } from '@/lib/db/schema'
 import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getRequiredSession } from '@/lib/auth/session'
+import { hasRole } from '@/lib/auth/guards'
 import {
   calculateEnrolmentTokenExpiry,
   DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
@@ -96,9 +97,9 @@ export async function listPendingAgents(orgId: string): Promise<Agent[]> {
 export async function approveAgent(
   orgId: string,
   agentId: string,
-  actorId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgToolingAccess(orgId)
+  const actorId = session.user.id
   try {
     const agent = await db.query.agents.findFirst({
       where: and(eq(agents.id, agentId), eq(agents.organisationId, orgId)),
@@ -226,9 +227,9 @@ async function findOnlineHostCollision(
 export async function rejectAgent(
   orgId: string,
   agentId: string,
-  actorId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgToolingAccess(orgId)
+  const actorId = session.user.id
   try {
     const agent = await db.query.agents.findFirst({
       where: and(eq(agents.id, agentId), eq(agents.organisationId, orgId)),
@@ -491,7 +492,6 @@ export async function listDistinctHostOses(orgId: string): Promise<string[]> {
 
 export async function createEnrolmentToken(
   orgId: string,
-  userId: string,
   input: {
     label: string
     autoApprove: boolean
@@ -501,7 +501,8 @@ export async function createEnrolmentToken(
     tags?: Array<{ key: string; value: string }>
   },
 ): Promise<{ token: string; id: string } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgToolingAccess(orgId)
+  const userId = session.user.id
   if (!await createEnrolmentTokenLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before creating another enrolment token.' }
   }
@@ -513,8 +514,7 @@ export async function createEnrolmentToken(
   // autoApprove bypasses the registration approval queue — restrict to super_admin to limit
   // blast radius if an org_admin account is compromised (M-29).
   if (parsed.data.autoApprove) {
-    const { user } = await getRequiredSession()
-    if (user.role !== 'super_admin') {
+    if (!hasRole(session.user, 'super_admin')) {
       return { error: 'Only super_admin users may create auto-approve enrolment tokens.' }
     }
   }
@@ -1225,13 +1225,13 @@ export async function deleteHost(
  */
 export async function uninstallAndDeleteHost(
   orgId: string,
-  userId: string,
   hostId: string,
 ): Promise<
   | { success: true }
   | { error: string; taskRunId?: string; agentOffline?: boolean }
 > {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgToolingAccess(orgId)
+  const userId = session.user.id
   try {
     const host = await db.query.hosts.findFirst({
       where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)),

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -435,9 +435,8 @@ export async function getAlertInstanceCount(
 export async function acknowledgeAlert(
   orgId: string,
   instanceId: string,
-  userId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   const existing = await db.query.alertInstances.findFirst({
     where: and(
       eq(alertInstances.id, instanceId),
@@ -452,7 +451,7 @@ export async function acknowledgeAlert(
     .set({
       status: 'acknowledged',
       acknowledgedAt: new Date(),
-      acknowledgedBy: userId,
+      acknowledgedBy: session.user.id,
     })
     .where(and(eq(alertInstances.id, instanceId), eq(alertInstances.organisationId, orgId)))
 
@@ -967,10 +966,9 @@ export async function getActiveSilencesForHost(
 
 export async function createSilence(
   orgId: string,
-  userId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  const session = await requireOrgAccess(orgId)
   const parsed = createSilenceSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -987,14 +985,14 @@ export async function createSilence(
         reason: data.reason,
         startsAt: new Date(data.startsAt),
         endsAt: new Date(data.endsAt),
-        createdBy: userId,
+        createdBy: session.user.id,
       })
       .returning({ id: alertSilences.id })
 
     if (!row) return { error: 'Insert failed' }
     await writeAuditEvent(db, {
       organisationId: orgId,
-      actorUserId: userId,
+      actorUserId: session.user.id,
       action: 'alert_silence.created',
       targetType: 'alert_silence',
       targetId: row.id,

--- a/apps/web/lib/actions/session-actor.test.mjs
+++ b/apps/web/lib/actions/session-actor.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const agentsSource = readFileSync(path.join(here, 'agents.ts'), 'utf8')
+const alertsSource = readFileSync(path.join(here, 'alerts.ts'), 'utf8')
+
+function getActionSegment(source, action) {
+  const start = source.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist`)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? undefined : next)
+}
+
+test('privileged agent actions derive audit actors from the authenticated session', () => {
+  for (const action of ['approveAgent', 'rejectAgent', 'createEnrolmentToken', 'uninstallAndDeleteHost']) {
+    const segment = getActionSegment(agentsSource, action)
+
+    assert.doesNotMatch(
+      segment.slice(0, segment.indexOf('): Promise')),
+      /\b(?:actorId|userId)\s*:/,
+      `${action} must not accept caller-controlled actor or user identifiers`,
+    )
+    assert.match(
+      segment,
+      /const session = await requireOrgToolingAccess\(orgId\)/,
+      `${action} must capture the tooling-authorized session`,
+    )
+  }
+})
+
+test('alert mutations derive audit actors from the authenticated session', () => {
+  for (const action of ['acknowledgeAlert', 'createSilence']) {
+    const segment = getActionSegment(alertsSource, action)
+
+    assert.doesNotMatch(
+      segment.slice(0, segment.indexOf('): Promise')),
+      /\buserId\s*:/,
+      `${action} must not accept a caller-controlled userId`,
+    )
+    assert.match(
+      segment,
+      /const session = await requireOrgAccess\(orgId\)/,
+      `${action} must capture the authenticated session`,
+    )
+    assert.match(
+      segment,
+      /session\.user\.id/,
+      `${action} must write identity fields from session.user.id`,
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- Remove caller-controlled actor/user IDs from privileged agent and alert server actions
- Derive approved-by, status-history, enrolment-token, uninstall-task, alert-ack, silence, and audit actor identity from the authenticated session
- Drop now-unneeded user ID props from the affected client components
- Add regression coverage that rejects reintroducing identity-bearing action parameters

## Root Cause
Several client-callable server actions accepted `actorId` or `userId` arguments and persisted them directly into privileged state or audit fields. A tampered browser action payload could spoof another in-org user as the actor.

## Tests
- `node --experimental-strip-types --test apps/web/lib/actions/session-actor.test.mjs apps/web/lib/actions/agents-authz.test.mjs apps/web/lib/actions/notifications-authz.test.mjs`
- `node --experimental-strip-types --test apps/web/lib/actions/session-actor.test.mjs apps/web/lib/actions/agents-authz.test.mjs apps/web/lib/auth/guards.test.mjs`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web test:unit`
- `pnpm --dir apps/web lint` (passes with existing warnings)

Fixes #891
