### PR TITLE
fix(authz): restrict host task execution

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -257,6 +257,7 @@ function TabButton({
 
 export function HostDetailClient({ host: initialHost, orgId, currentUserId, userRole, latestAgentVersion }: Props) {
   const canManageHost = canAccessTooling({ role: userRole })
+  const canRunHostTasks = userRole === 'org_admin' || userRole === 'super_admin'
   const [activeParentTab, setActiveParentTab] = useState<ParentTabId>('overview')
   const [activeTab, setActiveTab] = useState<Tab>('overview')
   const [metricsRange, setMetricsRange] = useState<MetricsPreset>('24h')
@@ -1291,7 +1292,7 @@ export function HostDetailClient({ host: initialHost, orgId, currentUserId, user
 
       {/* Tasks Tab */}
       {activeTab === 'tasks' && (
-        <TasksTab orgId={orgId} host={host} userId={currentUserId} />
+        <TasksTab orgId={orgId} host={host} canRunTasks={canRunHostTasks} />
       )}
 
       {/* Logs Tab */}

--- a/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
@@ -64,7 +64,7 @@ import { useRouter } from 'next/navigation'
 interface Props {
   orgId: string
   host: HostWithAgent
-  userId: string
+  canRunTasks: boolean
 }
 
 type AgentQueryPollResponse = {
@@ -173,7 +173,7 @@ function TaskDetailsCell({ run, hostId }: { run: TaskRunWithHosts; hostId: strin
   return <span className="text-sm text-muted-foreground">—</span>
 }
 
-export function TasksTab({ orgId, host, userId }: Props) {
+export function TasksTab({ orgId, host, canRunTasks }: Props) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const isLinux = host.os?.toLowerCase() === 'linux'
@@ -237,7 +237,7 @@ export function TasksTab({ orgId, host, userId }: Props) {
   }
 
   const { mutate: doPatchRun, isPending: isPatching } = useMutation({
-    mutationFn: () => triggerPatchRun(orgId, userId, host.id, patchMode),
+    mutationFn: () => triggerPatchRun(orgId, host.id, patchMode),
     onSuccess: (result) => {
       setPatchOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -245,7 +245,7 @@ export function TasksTab({ orgId, host, userId }: Props) {
   })
 
   const { mutate: doScriptRun, isPending: isScripting } = useMutation({
-    mutationFn: () => triggerCustomScriptRun(orgId, userId, host.id, scriptBody, interpreter),
+    mutationFn: () => triggerCustomScriptRun(orgId, host.id, scriptBody, interpreter),
     onSuccess: (result) => {
       setScriptOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -253,7 +253,7 @@ export function TasksTab({ orgId, host, userId }: Props) {
   })
 
   const { mutate: doServiceAction, isPending: isServicing } = useMutation({
-    mutationFn: () => triggerServiceAction(orgId, userId, host.id, serviceName, serviceAction),
+    mutationFn: () => triggerServiceAction(orgId, host.id, serviceName, serviceAction),
     onSuccess: (result) => {
       setServiceOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -295,24 +295,26 @@ export function TasksTab({ orgId, host, userId }: Props) {
             Run operations against this host.
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setScriptOpen(true)}>
-            <Terminal className="size-4 mr-1.5" />
-            Run Script
-          </Button>
-          {isLinux && (
-            <>
-              <Button variant="outline" size="sm" onClick={() => setServiceOpen(true)}>
-                <Power className="size-4 mr-1.5" />
-                Service
-              </Button>
-              <Button size="sm" onClick={() => setPatchOpen(true)}>
-                <Shield className="size-4 mr-1.5" />
-                Run Patch
-              </Button>
-            </>
-          )}
-        </div>
+        {canRunTasks && (
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={() => setScriptOpen(true)}>
+              <Terminal className="size-4 mr-1.5" />
+              Run Script
+            </Button>
+            {isLinux && (
+              <>
+                <Button variant="outline" size="sm" onClick={() => setServiceOpen(true)}>
+                  <Power className="size-4 mr-1.5" />
+                  Service
+                </Button>
+                <Button size="sm" onClick={() => setPatchOpen(true)}>
+                  <Shield className="size-4 mr-1.5" />
+                  Run Patch
+                </Button>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Selection toolbar */}

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -72,7 +72,6 @@ import {
 } from '@/lib/actions/task-runs'
 import type { HostGroupWithMembers } from '@/lib/actions/host-groups'
 import type { HostWithAgent } from '@/lib/actions/agents'
-import type { TaskRunWithHosts } from '@/lib/actions/task-runs'
 import type {
   Host,
   PatchTaskConfig,
@@ -97,7 +96,7 @@ function isRunActive(status: string) {
 
 interface Props {
   orgId: string
-  userId: string
+  userRole: string
   initialGroup: HostGroupWithMembers
   initialAllHosts: HostWithAgent[]
 }
@@ -168,9 +167,10 @@ function RunStatusBadge({ status }: { status: string }) {
   }
 }
 
-export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts }: Props) {
+export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHosts }: Props) {
   const queryClient = useQueryClient()
   const router = useRouter()
+  const canRunTasks = userRole === 'org_admin' || userRole === 'super_admin'
   const [addOpen, setAddOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [removeTarget, setRemoveTarget] = useState<Host | null>(null)
@@ -237,7 +237,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
 
   const { mutate: doPatchGroup, isPending: isPatching } = useMutation({
     mutationFn: () =>
-      triggerGroupPatchRun(orgId, userId, initialGroup.id, patchMode, maxParallel),
+      triggerGroupPatchRun(orgId, initialGroup.id, patchMode, maxParallel),
     onSuccess: (result) => {
       setPatchOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -246,7 +246,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
 
   const { mutate: doGroupScript, isPending: isScripting } = useMutation({
     mutationFn: () =>
-      triggerGroupCustomScriptRun(orgId, userId, initialGroup.id, scriptBody, interpreter, scriptMaxParallel),
+      triggerGroupCustomScriptRun(orgId, initialGroup.id, scriptBody, interpreter, scriptMaxParallel),
     onSuccess: (result) => {
       setScriptOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -255,7 +255,7 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
 
   const { mutate: doGroupService, isPending: isServicing } = useMutation({
     mutationFn: () =>
-      triggerGroupServiceAction(orgId, userId, initialGroup.id, serviceName, serviceAction, serviceMaxParallel),
+      triggerGroupServiceAction(orgId, initialGroup.id, serviceName, serviceAction, serviceMaxParallel),
     onSuccess: (result) => {
       setServiceOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -306,18 +306,22 @@ export function GroupDetailClient({ orgId, userId, initialGroup, initialAllHosts
             )}
           </div>
           <div className="flex items-center gap-2">
-            <Button variant="outline" onClick={() => setScriptOpen(true)}>
-              <Terminal className="size-4 mr-1" />
-              Run Script
-            </Button>
-            <Button variant="outline" onClick={() => setServiceOpen(true)}>
-              <Power className="size-4 mr-1" />
-              Service Action
-            </Button>
-            <Button variant="outline" onClick={() => setPatchOpen(true)}>
-              <Shield className="size-4 mr-1" />
-              Patch Group
-            </Button>
+            {canRunTasks && (
+              <>
+                <Button variant="outline" onClick={() => setScriptOpen(true)}>
+                  <Terminal className="size-4 mr-1" />
+                  Run Script
+                </Button>
+                <Button variant="outline" onClick={() => setServiceOpen(true)}>
+                  <Power className="size-4 mr-1" />
+                  Service Action
+                </Button>
+                <Button variant="outline" onClick={() => setPatchOpen(true)}>
+                  <Shield className="size-4 mr-1" />
+                  Patch Group
+                </Button>
+              </>
+            )}
             <Button onClick={() => setAddOpen(true)} data-testid="host-group-add-open">
               <Plus className="size-4 mr-1" />
               Add Hosts

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function GroupDetailPage({ params }: Props) {
   return (
     <GroupDetailClient
       orgId={orgId}
-      userId={session.user.id}
+      userRole={session.user.role}
       initialGroup={group}
       initialAllHosts={allHosts}
     />

--- a/apps/web/app/(dashboard)/tasks/schedules-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules-client.tsx
@@ -62,7 +62,7 @@ export function SchedulesClient({
   const [deleteTarget, setDeleteTarget] = useState<ScheduleWithTargetName | null>(null)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
-  const canEdit = userRole !== 'read_only'
+  const canEdit = userRole === 'org_admin' || userRole === 'super_admin'
 
   const { data: schedules = initialSchedules } = useQuery({
     queryKey: ['task-schedules', orgId],

--- a/apps/web/app/(dashboard)/tasks/schedules/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
-import { canAccessTooling } from '@/lib/auth/tooling'
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { db } from '@/lib/db'
 import { hosts, hostGroups } from '@/lib/db/schema'
 import { and, eq, isNull, asc } from 'drizzle-orm'
@@ -19,7 +19,7 @@ interface Props {
 export default async function SchedulePage({ params }: Props) {
   const { id } = await params
   const session = await getRequiredSession()
-  if (!canAccessTooling(session.user)) redirect('/dashboard')
+  if (!ADMIN_ROLES.includes(session.user.role)) redirect('/tasks')
   const orgId = session.user.organisationId!
 
   const result = await getSchedule(orgId, id)

--- a/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
-import { canAccessTooling } from '@/lib/auth/tooling'
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { db } from '@/lib/db'
 import { hosts, hostGroups } from '@/lib/db/schema'
 import { and, eq, isNull, asc } from 'drizzle-orm'
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function NewSchedulePage() {
   const session = await getRequiredSession()
-  if (!canAccessTooling(session.user)) redirect('/dashboard')
+  if (!ADMIN_ROLES.includes(session.user.role)) redirect('/tasks')
   const orgId = session.user.organisationId!
 
   const [hostRows, groupRows] = await Promise.all([

--- a/apps/web/lib/actions/agents-authz.test.mjs
+++ b/apps/web/lib/actions/agents-authz.test.mjs
@@ -25,8 +25,8 @@ test('privileged agent and host mutations require tooling access', () => {
 
     assert.match(
       segment,
-      /requireOrgToolingAccess\(orgId\)/,
-      `${action} must require tooling access before mutating fleet state`,
+      /requireOrg(?:Admin|Tooling)Access\(orgId\)/,
+      `${action} must require an org-scoped privileged guard before mutating fleet state`,
     )
   }
 })

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError, logWarn } from '@/lib/logging'
-import { requireOrgAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -1230,8 +1230,7 @@ export async function uninstallAndDeleteHost(
   | { success: true }
   | { error: string; taskRunId?: string; agentOffline?: boolean }
 > {
-  const session = await requireOrgToolingAccess(orgId)
-  const userId = session.user.id
+  await requireOrgAdminAccess(orgId)
   try {
     const host = await db.query.hosts.findFirst({
       where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)),
@@ -1250,7 +1249,7 @@ export async function uninstallAndDeleteHost(
       }
     }
 
-    const trigger = await triggerAgentUninstall(orgId, userId, hostId)
+    const trigger = await triggerAgentUninstall(orgId, hostId)
     if ('error' in trigger) return { error: trigger.error }
 
     // Poll until the agent reports the uninstall as scheduled, or we hit

--- a/apps/web/lib/actions/session-actor.test.mjs
+++ b/apps/web/lib/actions/session-actor.test.mjs
@@ -16,7 +16,7 @@ function getActionSegment(source, action) {
 }
 
 test('privileged agent actions derive audit actors from the authenticated session', () => {
-  for (const action of ['approveAgent', 'rejectAgent', 'createEnrolmentToken', 'uninstallAndDeleteHost']) {
+  for (const action of ['approveAgent', 'rejectAgent', 'createEnrolmentToken']) {
     const segment = getActionSegment(agentsSource, action)
 
     assert.doesNotMatch(

--- a/apps/web/lib/actions/task-runs-authz.test.mjs
+++ b/apps/web/lib/actions/task-runs-authz.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const taskRunsSource = readFileSync(path.join(here, 'task-runs.ts'), 'utf8')
+const taskSchedulesSource = readFileSync(path.join(here, 'task-schedules.ts'), 'utf8')
+
+function getActionSegment(source, action) {
+  const start = source.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist`)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? undefined : next)
+}
+
+const privilegedTaskRunActions = [
+  'triggerCustomScriptRun',
+  'triggerGroupCustomScriptRun',
+  'triggerServiceAction',
+  'triggerGroupServiceAction',
+  'triggerAgentUninstall',
+  'triggerPatchRun',
+  'triggerGroupPatchRun',
+]
+
+test('privileged host task actions require org admin access and derive actors from session', () => {
+  for (const action of privilegedTaskRunActions) {
+    const segment = getActionSegment(taskRunsSource, action)
+
+    assert.doesNotMatch(
+      segment.slice(0, segment.indexOf('): Promise')),
+      /\buserId\s*:/,
+      `${action} must not accept caller-controlled userId`,
+    )
+    assert.match(
+      segment,
+      /const session = await requireOrgAdminAccess\(orgId\)/,
+      `${action} must capture an org-admin-authorized session`,
+    )
+    assert.match(
+      segment,
+      /session\.user\.id/,
+      `${action} must write task actor fields from session.user.id`,
+    )
+  }
+})
+
+test('privileged task schedule mutations require org admin access', () => {
+  for (const action of ['createSchedule', 'updateSchedule', 'runScheduleNow']) {
+    const segment = getActionSegment(taskSchedulesSource, action)
+
+    assert.match(
+      segment,
+      /(?:const session = )?await requireOrgAdminAccess\(orgId\)/,
+      `${action} must require org admin access before mutating privileged schedules`,
+    )
+  }
+})

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgToolingAccess } from '@/lib/actions/action-auth'
+import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import {
@@ -10,7 +10,7 @@ import {
   hosts,
   hostGroupMembers,
 } from '@/lib/db/schema'
-import { eq, and, isNull, isNotNull, desc, inArray, or } from 'drizzle-orm'
+import { eq, and, isNull, isNotNull, desc, inArray } from 'drizzle-orm'
 import type {
   TaskRun,
   TaskRunHost,
@@ -340,13 +340,12 @@ const MAX_SCRIPT_LENGTH: Record<'sh' | 'bash' | 'python3', number> = {
  */
 export async function triggerCustomScriptRun(
   orgId: string,
-  userId: string,
   hostId: string,
   script: string,
   interpreter: 'sh' | 'bash' | 'python3',
   timeoutSeconds?: number,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
     return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
   }
@@ -357,7 +356,7 @@ export async function triggerCustomScriptRun(
   if (!host) return { error: 'Host not found' }
 
   const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
-  return createTaskRun(orgId, userId, 'host', hostId, 'custom_script', config, 1, [hostId], [])
+  return createTaskRun(orgId, session.user.id, 'host', hostId, 'custom_script', config, 1, [hostId], [])
 }
 
 /**
@@ -366,14 +365,13 @@ export async function triggerCustomScriptRun(
  */
 export async function triggerGroupCustomScriptRun(
   orgId: string,
-  userId: string,
   groupId: string,
   script: string,
   interpreter: 'sh' | 'bash' | 'python3',
   maxParallel: number,
   timeoutSeconds?: number,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
     return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
   }
@@ -389,7 +387,7 @@ export async function triggerGroupCustomScriptRun(
 
   const hostIds = members.map((m) => m.hostId)
   const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
-  return createTaskRun(orgId, userId, 'group', groupId, 'custom_script', config, maxParallel, hostIds, [])
+  return createTaskRun(orgId, session.user.id, 'group', groupId, 'custom_script', config, maxParallel, hostIds, [])
 }
 
 // ── Service management actions ────────────────────────────────────────────────
@@ -400,12 +398,11 @@ export async function triggerGroupCustomScriptRun(
  */
 export async function triggerServiceAction(
   orgId: string,
-  userId: string,
   hostId: string,
   serviceName: string,
   action: 'start' | 'stop' | 'restart' | 'status',
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })
@@ -415,7 +412,7 @@ export async function triggerServiceAction(
   }
 
   const config: ServiceTaskConfig = { service_name: serviceName, action }
-  return createTaskRun(orgId, userId, 'host', hostId, 'service', config, 1, [hostId], [])
+  return createTaskRun(orgId, session.user.id, 'host', hostId, 'service', config, 1, [hostId], [])
 }
 
 /**
@@ -424,7 +421,6 @@ export async function triggerServiceAction(
  */
 export async function triggerGroupServiceAction(
   orgId: string,
-  userId: string,
   groupId: string,
   serviceName: string,
   action: 'start' | 'stop' | 'restart' | 'status',
@@ -432,7 +428,7 @@ export async function triggerGroupServiceAction(
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   const members = await db.query.hostGroupMembers.findMany({
     where: and(
       eq(hostGroupMembers.groupId, groupId),
@@ -472,7 +468,7 @@ export async function triggerGroupServiceAction(
 
   const config: ServiceTaskConfig = { service_name: serviceName, action }
   const result = await createTaskRun(
-    orgId, userId, 'group', groupId, 'service', config, maxParallel, pendingHostIds, skipHosts,
+    orgId, session.user.id, 'group', groupId, 'service', config, maxParallel, pendingHostIds, skipHosts,
   )
 
   if ('error' in result) return result
@@ -500,17 +496,16 @@ export async function triggerGroupServiceAction(
  */
 export async function triggerAgentUninstall(
   orgId: string,
-  userId: string,
   hostId: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })
   if (!host) return { error: 'Host not found' }
 
   const config: AgentUninstallTaskConfig = {}
-  return createTaskRun(orgId, userId, 'host', hostId, 'agent_uninstall', config, 1, [hostId], [])
+  return createTaskRun(orgId, session.user.id, 'host', hostId, 'agent_uninstall', config, 1, [hostId], [])
 }
 
 // ── Deletion ──────────────────────────────────────────────────────────────────
@@ -565,11 +560,10 @@ export async function deleteTaskRuns(
  */
 export async function triggerPatchRun(
   orgId: string,
-  userId: string,
   hostId: string,
   mode: 'security' | 'all',
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(
       eq(hosts.id, hostId),
@@ -583,7 +577,7 @@ export async function triggerPatchRun(
   }
 
   const config: PatchTaskConfig = { mode }
-  return createTaskRun(orgId, userId, 'host', hostId, 'patch', config, 1, [hostId], [])
+  return createTaskRun(orgId, session.user.id, 'host', hostId, 'patch', config, 1, [hostId], [])
 }
 
 /**
@@ -593,14 +587,13 @@ export async function triggerPatchRun(
  */
 export async function triggerGroupPatchRun(
   orgId: string,
-  userId: string,
   groupId: string,
   mode: 'security' | 'all',
   maxParallel: number,
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
   // Fetch all members of the group
   const members = await db.query.hostGroupMembers.findMany({
     where: and(
@@ -645,7 +638,7 @@ export async function triggerGroupPatchRun(
   const config: PatchTaskConfig = { mode }
   const result = await createTaskRun(
     orgId,
-    userId,
+    session.user.id,
     'group',
     groupId,
     'patch',

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgToolingAccess } from '@/lib/actions/action-auth'
+import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import { taskSchedules, taskRuns, hostGroups, hosts } from '@/lib/db/schema'
@@ -190,7 +190,7 @@ export async function createSchedule(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  const session = await requireOrgToolingAccess(orgId)
+  const session = await requireOrgAdminAccess(orgId)
 
   const parsed = scheduleInputSchema.safeParse(input)
   if (!parsed.success) {
@@ -241,7 +241,7 @@ export async function updateSchedule(
   id: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgToolingAccess(orgId)
+  await requireOrgAdminAccess(orgId)
 
   const existing = await db.query.taskSchedules.findFirst({
     where: and(
@@ -301,7 +301,7 @@ export async function setScheduleEnabled(
   id: string,
   enabled: boolean,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgToolingAccess(orgId)
+  await requireOrgAdminAccess(orgId)
 
   const existing = await db.query.taskSchedules.findFirst({
     where: and(
@@ -338,7 +338,7 @@ export async function deleteSchedule(
   orgId: string,
   id: string,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgToolingAccess(orgId)
+  await requireOrgAdminAccess(orgId)
 
   try {
     await db
@@ -367,7 +367,7 @@ export async function runScheduleNow(
   orgId: string,
   id: string,
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgToolingAccess(orgId)
+  await requireOrgAdminAccess(orgId)
 
   const schedule = await db.query.taskSchedules.findFirst({
     where: and(
@@ -378,15 +378,14 @@ export async function runScheduleNow(
   })
   if (!schedule) return { error: 'Schedule not found' }
 
-  const userId = session.user.id
   const { taskType, targetType, targetId, maxParallel, config } = schedule
 
   if (taskType === 'patch') {
     const mode = (config as { mode: 'security' | 'all' }).mode
     return targetType === 'host'
-      ? triggerPatchRun(orgId, userId, targetId, mode)
+      ? triggerPatchRun(orgId, targetId, mode)
       : (async () => {
-          const r = await triggerGroupPatchRun(orgId, userId, targetId, mode, maxParallel)
+          const r = await triggerGroupPatchRun(orgId, targetId, mode, maxParallel)
           if ('error' in r) return r
           return { success: true as const, taskRunId: r.taskRunId }
         })()
@@ -394,15 +393,15 @@ export async function runScheduleNow(
   if (taskType === 'custom_script') {
     const c = config as { script: string; interpreter: 'sh' | 'bash' | 'python3'; timeout_seconds?: number }
     return targetType === 'host'
-      ? triggerCustomScriptRun(orgId, userId, targetId, c.script, c.interpreter, c.timeout_seconds)
-      : triggerGroupCustomScriptRun(orgId, userId, targetId, c.script, c.interpreter, maxParallel, c.timeout_seconds)
+      ? triggerCustomScriptRun(orgId, targetId, c.script, c.interpreter, c.timeout_seconds)
+      : triggerGroupCustomScriptRun(orgId, targetId, c.script, c.interpreter, maxParallel, c.timeout_seconds)
   }
   if (taskType === 'service') {
     const c = config as { service_name: string; action: 'start' | 'stop' | 'restart' | 'status' }
     return targetType === 'host'
-      ? triggerServiceAction(orgId, userId, targetId, c.service_name, c.action)
+      ? triggerServiceAction(orgId, targetId, c.service_name, c.action)
       : (async () => {
-          const r = await triggerGroupServiceAction(orgId, userId, targetId, c.service_name, c.action, maxParallel)
+          const r = await triggerGroupServiceAction(orgId, targetId, c.service_name, c.action, maxParallel)
           if ('error' in r) return r
           return { success: true as const, taskRunId: r.taskRunId }
         })()


### PR DESCRIPTION
## Summary
- require org admin access for privileged host task execution, remote agent uninstall, and task schedule mutations
- derive task-run actors from the authenticated session instead of caller-supplied user IDs
- hide host/group execution and schedule mutation UI from non-admin tooling users while preserving read access
- add regression coverage for host task authorization and actor derivation

Fixes #949

## Tests
- node --experimental-strip-types --test apps/web/lib/actions/task-runs-authz.test.mjs apps/web/lib/actions/agents-authz.test.mjs apps/web/lib/actions/session-actor.test.mjs
- pnpm --dir apps/web test:unit
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing warnings)