### PR TITLE
fix(ingest): reject cross-org agent re-registration

### DIFF
--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -49,6 +49,10 @@ func decideHostCollision(collision *queries.HostCollision) (hostCollisionDecisio
 	return hostCollisionCreateSeparatePending, "existing offline or unknown host identity"
 }
 
+func existingAgentBelongsToTokenOrg(existing *queries.AgentRow, tokenOrgID string) bool {
+	return existing != nil && existing.OrganisationID == tokenOrgID
+}
+
 // Register handles agent registration.
 //
 // Flow:
@@ -94,6 +98,14 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 
 	if existing != nil {
+		if !existingAgentBelongsToTokenOrg(existing, orgID) {
+			slog.Warn("rejecting registration for existing public key in different organisation",
+				"agent_id", existing.ID,
+				"agent_org_id", existing.OrganisationID,
+				"token_org_id", orgID,
+			)
+			return nil, status.Error(codes.Unauthenticated, "invalid or expired enrolment token")
+		}
 		slog.Info("agent already registered", "agent_id", existing.ID, "status", existing.Status)
 		// Update the queued CSR in case the agent has re-generated one (e.g.
 		// after a reinstall that preserved the keypair but lost the cert).
@@ -103,7 +115,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 			}
 		}
 		if existing.Status == "active" {
-			jwtToken, err := h.issuer.IssueAgentToken(existing.ID, orgID)
+			jwtToken, err := h.issuer.IssueAgentToken(existing.ID, existing.OrganisationID)
 			if err != nil {
 				slog.Error("issuing JWT for existing agent", "err", err)
 				return nil, status.Error(codes.Internal, "internal error")

--- a/apps/ingest/internal/handlers/register_test.go
+++ b/apps/ingest/internal/handlers/register_test.go
@@ -79,3 +79,17 @@ func TestDecideHostCollisionRejectsOnlineOrActiveHost(t *testing.T) {
 		})
 	}
 }
+
+func TestExistingAgentBelongsToTokenOrgRejectsOrgMismatch(t *testing.T) {
+	t.Parallel()
+
+	existing := &queries.AgentRow{
+		ID:             "agent_existing",
+		OrganisationID: "org_original",
+		Status:         "active",
+	}
+
+	if existingAgentBelongsToTokenOrg(existing, "org_attacker") {
+		t.Fatal("existing agent matched a different enrolment token organisation")
+	}
+}


### PR DESCRIPTION
## Summary
- rejects the idempotent existing-public-key registration path when the existing agent belongs to a different organisation than the presented enrolment token
- signs repeat-registration JWTs with the existing agent's stored organisation ID
- adds regression coverage for the organisation mismatch guard

## Evidence
- Recent commit `639fe925483f6bbb73bbf456116a25b641d26243` changed ingest re-registration handling to prevent agent identity takeover.
- In `apps/ingest/internal/handlers/register.go`, `Register` validates `req.OrgToken`, then `GetAgentByPublicKey` returns an existing agent by globally unique public key without scoping to the token organisation.
- Before this patch, an active existing-agent path called `IssueAgentToken(existing.ID, orgID)`, where `orgID` came from the newly presented enrolment token rather than the existing agent row.

## Approach
- Added an organisation equality guard before CSR updates or JWT issuance for existing public keys.
- Kept the rejection response generic to avoid leaking cross-organisation agent existence.
- Used `existing.OrganisationID` when issuing an idempotent active-agent token.

## Tests
- `go test ./apps/ingest/internal/handlers`
- `go test ./apps/ingest/...`
- `go test ./agent/... ./apps/ingest/...`