### PR TITLE
fix(web): verify agent enrolment TLS by default

### DIFF
--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -129,7 +129,7 @@ export function AgentsSettingsClient({
     defaultValues: {
       label: '',
       autoApprove: false,
-      skipVerify: true,
+      skipVerify: false,
       maxUses: String(DEFAULT_ENROLMENT_TOKEN_MAX_USES),
       expiresInDays: String(DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS),
     },
@@ -426,10 +426,10 @@ export function AgentsSettingsClient({
                 />
                 <div>
                   <Label htmlFor="skipVerify" className="font-normal cursor-pointer">
-                    Accept self-signed certificates
+                    Skip TLS certificate verification
                   </Label>
                   <p className="text-xs text-muted-foreground">
-                    Enable if your ingest service uses a self-signed or private CA certificate.
+                    Insecure. Only enable for controlled development or break-glass installs.
                   </p>
                 </div>
               </div>
@@ -520,7 +520,7 @@ function BundleDialog({ open, onOpenChange, activeTokens, orgId }: BundleDialogP
   const [tokenLabel, setTokenLabel] = useState('Install bundle')
   const [expiresInDays, setExpiresInDays] = useState('7')
   const [autoApprove, setAutoApprove] = useState(false)
-  const [skipVerify, setSkipVerify] = useState(true)
+  const [skipVerify, setSkipVerify] = useState(false)
   const [ingestAddress, setIngestAddress] = useState('')
   const [existingTokenId, setExistingTokenId] = useState<string>(activeTokens[0]?.id ?? '')
   const [bundleTags, setBundleTags] = useState<EditorTag[]>([])
@@ -767,9 +767,14 @@ function BundleDialog({ open, onOpenChange, activeTokens, orgId }: BundleDialogP
                   checked={skipVerify}
                   onChange={(e) => setSkipVerify(e.target.checked)}
                 />
-                <Label htmlFor="bundle-skipverify" className="font-normal cursor-pointer">
-                  Accept self-signed TLS certificates
-                </Label>
+                <div>
+                  <Label htmlFor="bundle-skipverify" className="font-normal cursor-pointer">
+                    Skip TLS certificate verification
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Insecure. Only enable for controlled development or break-glass installs.
+                  </p>
+                </div>
               </div>
             </div>
           )}
@@ -802,7 +807,7 @@ function BundleDialog({ open, onOpenChange, activeTokens, orgId }: BundleDialogP
                 onChange={(e) => setSkipVerify(e.target.checked)}
               />
               <Label htmlFor="bundle-skipverify-none" className="font-normal cursor-pointer">
-                Write <code>tls_skip_verify = true</code> in the config
+                Write insecure <code>tls_skip_verify = true</code> in the config
               </Label>
             </div>
           )}

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -28,7 +28,6 @@ test('admin can create and revoke an enrolment token from agent settings', async
   await page.getByTestId('agent-enrolment-create-open').click()
 
   await page.getByTestId('agent-enrolment-label').fill('Datacenter Linux')
-  await page.getByTestId('agent-enrolment-skip-verify').click()
   await page.getByTestId('agent-enrolment-max-uses').fill('3')
   await page.getByTestId('agent-enrolment-expires-days').fill('14')
   await page.getByTestId('agent-enrolment-create-submit').click()
@@ -108,7 +107,7 @@ test('admin can create and revoke an enrolment token from agent settings', async
     .toBeTruthy()
 })
 
-test('admin can create an auto-approved token that skips TLS verification', async ({ authenticatedPage: page }) => {
+test('admin cannot create an auto-approved token without super admin privileges', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const { orgId } = await getOrgAndUserIds(sql)
 
@@ -210,4 +209,41 @@ test('admin can generate an install bundle with an existing token and bundle tag
     })
 
   await expect(page.getByRole('dialog')).toHaveCount(0)
+})
+
+test('admin can generate an install bundle that verifies TLS by default', async ({ authenticatedPage: page }) => {
+  let capturedBody: Record<string, unknown> | null = null
+
+  await page.route('**/api/agent/bundle', async (route) => {
+    capturedBody = route.request().postDataJSON() as Record<string, unknown>
+
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'application/zip',
+        'content-disposition': 'attachment; filename=\"ct-ops-agent-linux-amd64.zip\"',
+      },
+      body: 'bundle-zip-placeholder',
+    })
+  })
+
+  await page.goto('/settings/agents')
+
+  await expect(page.getByTestId('agent-enrolment-heading')).toBeVisible()
+  await page.getByRole('button', { name: 'Download Install Bundle' }).click()
+
+  const downloadButton = page.getByRole('dialog').getByRole('button', { name: 'Download' })
+  await downloadButton.scrollIntoViewIfNeeded()
+  await downloadButton.evaluate((button: HTMLButtonElement) => button.click())
+
+  await expect
+    .poll(() => capturedBody)
+    .toMatchObject({
+      os: 'linux',
+      arch: 'amd64',
+      createToken: {
+        label: 'Install bundle',
+        skipVerify: false,
+      },
+    })
 })


### PR DESCRIPTION
## Summary
- default agent enrolment token creation to TLS verification instead of skip-verify
- default install bundle generation to `skipVerify: false`
- update the TLS bypass checkbox copy to make the insecure opt-in explicit

Closes #951

## Tests
- `pnpm --dir apps/web test:e2e tests/e2e/settings/agent-enrolment.spec.ts`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint` (passes with existing warnings)
