### PR TITLE
fix(alerts): redact Slack webhook URLs

### DIFF
--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -558,6 +558,15 @@ const slackFormSchema = z.object({
 
 type SlackFormValues = z.infer<typeof slackFormSchema>
 
+const editSlackFormSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  webhookUrl: z.string().trim().refine((value) => value === '' || z.string().url().safeParse(value).success, {
+    message: 'Must be a valid URL',
+  }),
+})
+
+type EditSlackFormValues = z.infer<typeof editSlackFormSchema>
+
 function AddSlackDialog({
   orgId,
   open,
@@ -645,13 +654,13 @@ function EditSlackDialog({
     handleSubmit,
     reset,
     formState: { errors, isSubmitting },
-  } = useForm<SlackFormValues>({ resolver: zodResolver(slackFormSchema) })
+  } = useForm<EditSlackFormValues>({ resolver: zodResolver(editSlackFormSchema) })
 
   useEffect(() => {
-    if (open) reset({ name: channel.name, webhookUrl: channel.config.webhookUrl })
+    if (open) reset({ name: channel.name, webhookUrl: '' })
   }, [open, channel, reset])
 
-  async function onSubmit(values: SlackFormValues) {
+  async function onSubmit(values: EditSlackFormValues) {
     const result = await updateNotificationChannel(orgId, channel.id, {
       name: values.name,
       webhookUrl: values.webhookUrl,
@@ -675,7 +684,12 @@ function EditSlackDialog({
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="edit-slack-url">Incoming Webhook URL</Label>
-            <Input id="edit-slack-url" type="url" {...register('webhookUrl')} />
+            <Input
+              id="edit-slack-url"
+              type="url"
+              placeholder={channel.config.hasWebhookUrl ? 'Leave blank to keep existing URL' : 'https://hooks.slack.com/services/...'}
+              {...register('webhookUrl')}
+            />
             {errors.webhookUrl && <p className="text-sm text-red-600">{errors.webhookUrl.message}</p>}
           </div>
           <DialogFooter>
@@ -1549,7 +1563,7 @@ export function AlertsClient({
                           {ch.config.toAddresses.join(', ')}
                         </span>
                       ) : ch.type === 'slack' ? (
-                        <span className="font-mono truncate block max-w-xs">{ch.config.webhookUrl}</span>
+                        <span>{ch.config.hasWebhookUrl ? 'Webhook URL configured' : 'Webhook URL missing'}</span>
                       ) : ch.type === 'telegram' ? (
                         <span>Chat ID: {ch.config.chatId}</span>
                       ) : (

--- a/apps/web/lib/actions/alerts-notification-redaction.test.mjs
+++ b/apps/web/lib/actions/alerts-notification-redaction.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const alertsSource = readFileSync(path.join(here, 'alerts.ts'), 'utf8')
+
+function getActionSegment(action) {
+  const start = alertsSource.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist in alerts.ts`)
+  const next = alertsSource.indexOf('\nexport ', start + 1)
+  return alertsSource.slice(start, next === -1 ? undefined : next)
+}
+
+test('getNotificationChannels redacts Slack webhook URLs from client payloads', () => {
+  const segment = getActionSegment('getNotificationChannels')
+  const slackBranchStart = segment.indexOf("if (ch.type === 'slack')")
+  assert.notEqual(slackBranchStart, -1, 'expected Slack notification branch to exist')
+  const nextBranch = segment.indexOf("if (ch.type === 'telegram')", slackBranchStart)
+  assert.notEqual(nextBranch, -1, 'expected Slack branch to be followed by Telegram branch')
+  const slackBranch = segment.slice(slackBranchStart, nextBranch)
+
+  assert.match(slackBranch, /hasWebhookUrl:\s*!!\(?cfg\.webhookUrl\)?/)
+  assert.doesNotMatch(slackBranch, /config:\s*\{\s*webhookUrl:\s*cfg\.webhookUrl\s*\}/)
+})
+
+test('notification channel management actions require org admin access', () => {
+  for (const action of [
+    'createNotificationChannel',
+    'deleteNotificationChannel',
+    'updateNotificationChannel',
+    'sendTestNotification',
+  ]) {
+    const segment = getActionSegment(action)
+
+    assert.match(
+      segment,
+      /(?:const session = )?await requireOrgAdminAccess\(orgId\)/,
+      `${action} must require org admin access before managing notification channels`,
+    )
+  }
+})

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { createHmac } from 'crypto'
@@ -493,7 +493,7 @@ export type NotificationChannelSafe = Omit<NotificationChannel, 'config' | 'type
         toAddresses: string[]
       }
     }
-  | { type: 'slack'; config: { webhookUrl: string } }
+  | { type: 'slack'; config: { hasWebhookUrl: boolean } }
   | { type: 'telegram'; config: { chatId: string; hasBotToken: boolean } }
 )
 
@@ -534,7 +534,7 @@ export async function getNotificationChannels(orgId: string): Promise<Notificati
       return {
         ...ch,
         type: 'slack' as const,
-        config: { webhookUrl: cfg.webhookUrl },
+        config: { hasWebhookUrl: !!(cfg.webhookUrl) },
       }
     }
     if (ch.type === 'telegram') {
@@ -561,8 +561,7 @@ export async function createNotificationChannel(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
+  const session = await requireOrgAdminAccess(orgId)
   const parsed = createNotificationChannelSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -605,8 +604,7 @@ export async function deleteNotificationChannel(
   orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
+  const session = await requireOrgAdminAccess(orgId)
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
       eq(notificationChannels.id, channelId),
@@ -652,7 +650,10 @@ const updateSmtpChannelSchema = z.object({
 
 const updateSlackChannelSchema = z.object({
   name: z.string().min(1).max(100),
-  webhookUrl: httpsUrl,
+  webhookUrl: z.preprocess(
+    (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+    httpsUrl.optional(),
+  ),
 })
 
 const updateTelegramChannelSchema = z.object({
@@ -666,8 +667,7 @@ export async function updateNotificationChannel(
   channelId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
+  const session = await requireOrgAdminAccess(orgId)
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
       eq(notificationChannels.id, channelId),
@@ -713,7 +713,8 @@ export async function updateNotificationChannel(
       if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
       const { name, webhookUrl } = parsed.data
       nextName = name
-      const newConfig: SlackChannelConfig = { webhookUrl }
+      const existingConfig = existing.config as SlackChannelConfig
+      const newConfig: SlackChannelConfig = { webhookUrl: webhookUrl || existingConfig.webhookUrl }
       await validateStoredNotificationChannelConfig(existing.type, newConfig)
       await db
         .update(notificationChannels)
@@ -760,7 +761,7 @@ export async function sendTestNotification(
   orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   if (!await testNotificationLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before sending another test notification.' }
   }


### PR DESCRIPTION
## Summary\n- redact Slack incoming webhook URLs from notification-channel read payloads\n- preserve existing Slack webhook URLs when editing a channel without entering a replacement\n- require org admin access for notification channel create/update/delete/test-send actions\n\nCloses #892\n\n## Tests\n- node --experimental-strip-types --test apps/web/lib/actions/alerts-notification-redaction.test.mjs apps/web/lib/actions/alerts-notification-security.test.mjs\n- pnpm --filter web type-check\n- pnpm --filter web test:unit\n- pnpm --filter web lint (passes with existing warnings)