### PR TITLE
fix(agent): verify downloaded agent binaries

### DIFF
--- a/apps/web/lib/agent/binary-integrity.test.mjs
+++ b/apps/web/lib/agent/binary-integrity.test.mjs
@@ -1,0 +1,124 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+const realFetch = globalThis.fetch
+
+test.afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+test('resolveAgentBinary rejects GitHub assets that do not match release checksums', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ct-ops-agent-binary-'))
+  process.env.AGENT_DIST_DIR = tempDir
+
+  const trusted = Buffer.from('trusted-agent-binary')
+  const tampered = Buffer.from('tampered-agent-binary')
+  const trustedSha256 = sha256(trusted)
+  const tamperedSha256 = sha256(tampered)
+  const sidecar = `${trustedSha256}  ct-ops-agent-linux-amd64\n`
+
+  globalThis.fetch = async (url) => {
+    const href = String(url)
+    if (href.includes('/releases/tags/')) {
+      return jsonResponse({
+        tag_name: 'agent/v0.33.0',
+        assets: [
+          {
+            name: 'ct-ops-agent-linux-amd64',
+            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64',
+            digest: `sha256:${trustedSha256}`,
+            size: trusted.byteLength,
+          },
+          {
+            name: 'ct-ops-agent-linux-amd64.sha256',
+            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64.sha256',
+            digest: `sha256:${sha256(Buffer.from(sidecar))}`,
+            size: Buffer.byteLength(sidecar),
+          },
+        ],
+      })
+    }
+    if (href.endsWith('.sha256')) {
+      return textResponse(sidecar)
+    }
+    return new Response(tampered, {
+      status: 200,
+      headers: { 'content-length': String(tampered.byteLength) },
+    })
+  }
+
+  const { resolveAgentBinary } = await import(`./binary.ts?tampered=${Date.now()}`)
+
+  assert.equal(await resolveAgentBinary('linux', 'amd64'), null)
+  assert.notEqual(trustedSha256, tamperedSha256)
+})
+
+test('resolveAgentBinary revalidates cached bytes before serving them', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ct-ops-agent-binary-'))
+  process.env.AGENT_DIST_DIR = tempDir
+
+  const stale = Buffer.from('stale-cached-agent')
+  const trusted = Buffer.from('trusted-agent-binary')
+  const trustedSha256 = sha256(trusted)
+  const sidecar = `${trustedSha256}  ct-ops-agent-linux-amd64\n`
+
+  await fs.writeFile(path.join(tempDir, 'ct-ops-agent-linux-amd64-v0.33.0'), stale)
+
+  globalThis.fetch = async (url) => {
+    const href = String(url)
+    if (href.includes('/releases/tags/')) {
+      return jsonResponse({
+        tag_name: 'agent/v0.33.0',
+        assets: [
+          {
+            name: 'ct-ops-agent-linux-amd64',
+            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64',
+            digest: `sha256:${trustedSha256}`,
+            size: trusted.byteLength,
+          },
+          {
+            name: 'ct-ops-agent-linux-amd64.sha256',
+            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64.sha256',
+            digest: `sha256:${sha256(Buffer.from(sidecar))}`,
+            size: Buffer.byteLength(sidecar),
+          },
+        ],
+      })
+    }
+    if (href.endsWith('.sha256')) {
+      return textResponse(sidecar)
+    }
+    return new Response(trusted, {
+      status: 200,
+      headers: { 'content-length': String(trusted.byteLength) },
+    })
+  }
+
+  const { resolveAgentBinary } = await import(`./binary.ts?cache=${Date.now()}`)
+
+  const binary = await resolveAgentBinary('linux', 'amd64')
+
+  assert.equal(binary?.bytes.toString(), 'trusted-agent-binary')
+})
+
+function sha256(data) {
+  return crypto.createHash('sha256').update(data).digest('hex')
+}
+
+function jsonResponse(data) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function textResponse(body) {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+  })
+}

--- a/apps/web/lib/agent/binary.ts
+++ b/apps/web/lib/agent/binary.ts
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
-import { REQUIRED_AGENT_VERSION } from './version'
-import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from './repo'
+import crypto from 'crypto'
+import { REQUIRED_AGENT_VERSION } from './version.ts'
+import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from './repo.ts'
 
 const AGENT_DIST_DIR = process.env.AGENT_DIST_DIR ?? './data/agent-dist'
 
@@ -15,6 +16,7 @@ interface GitHubAsset {
   name: string
   browser_download_url: string
   size: number
+  digest?: string
 }
 
 interface GitHubRelease {
@@ -43,33 +45,37 @@ export async function resolveAgentBinary(
   const versionedName = `ct-ops-agent-${os}-${arch}-${REQUIRED_AGENT_VERSION}${suffix}`
   const versionedPath = path.join(AGENT_DIST_DIR, versionedName)
 
-  if (fs.existsSync(versionedPath)) {
-    return { bytes: await fs.promises.readFile(versionedPath), fileName: baseName }
+  const cachedVersioned = await readVerifiedLocalBinary(versionedPath, baseName)
+  if (cachedVersioned) {
+    return { bytes: cachedVersioned, fileName: baseName }
   }
 
   const tag = `agent/${REQUIRED_AGENT_VERSION}`
   const release = await fetchRelease(tag)
-  if (release) {
+  if (release?.tag_name === tag) {
     const asset = release.assets.find((a) => a.name === baseName)
-    if (asset) {
-      const binary = await fetchBinaryFromGitHub(asset.browser_download_url)
-      if (binary) {
-        await cacheLocally(versionedPath, binary)
-        return { bytes: Buffer.from(binary), fileName: baseName }
+    const checksumAsset = release.assets.find((a) => a.name === `${baseName}.sha256`)
+    if (asset && checksumAsset) {
+      const verified = await fetchVerifiedBinaryFromGitHub(asset, checksumAsset, baseName)
+      if (verified) {
+        await cacheLocally(versionedPath, verified.bytes, verified.checksumLine)
+        return { bytes: Buffer.from(verified.bytes), fileName: baseName }
       }
     }
   }
 
   const unversionedPath = path.join(AGENT_DIST_DIR, baseName)
-  if (fs.existsSync(unversionedPath)) {
-    return { bytes: await fs.promises.readFile(unversionedPath), fileName: baseName }
+  const cachedUnversioned = await readVerifiedLocalBinary(unversionedPath, baseName)
+  if (cachedUnversioned) {
+    return { bytes: cachedUnversioned, fileName: baseName }
   }
 
   const bakedDistDir = path.join(process.cwd(), 'data/agent-dist')
   if (path.resolve(bakedDistDir) !== path.resolve(AGENT_DIST_DIR)) {
     const bakedPath = path.join(bakedDistDir, baseName)
-    if (fs.existsSync(bakedPath)) {
-      return { bytes: await fs.promises.readFile(bakedPath), fileName: baseName }
+    const baked = await readVerifiedLocalBinary(bakedPath, baseName)
+    if (baked) {
+      return { bytes: baked, fileName: baseName }
     }
   }
 
@@ -79,8 +85,9 @@ export async function resolveAgentBinary(
 export function binaryUnavailableMessage(os: AgentOS, arch: AgentArch): string {
   return (
     `No binary available for ${os}/${arch} (required version: ${REQUIRED_AGENT_VERSION}). ` +
-    `Either place a binary in AGENT_DIST_DIR (${AGENT_DIST_DIR}) or ensure a GitHub release ` +
-    `exists for tag "agent/${REQUIRED_AGENT_VERSION}" in ${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}.`
+    `Either place a binary plus matching .sha256 sidecar in AGENT_DIST_DIR (${AGENT_DIST_DIR}) ` +
+    `or ensure a GitHub release exists for tag "agent/${REQUIRED_AGENT_VERSION}" in ` +
+    `${AGENT_REPO_OWNER}/${AGENT_REPO_NAME} with verified binary and checksum assets.`
   )
 }
 
@@ -105,7 +112,44 @@ async function fetchRelease(tag: string): Promise<GitHubRelease | null> {
   }
 }
 
-async function fetchBinaryFromGitHub(url: string): Promise<ArrayBuffer | null> {
+async function fetchVerifiedBinaryFromGitHub(
+  asset: GitHubAsset,
+  checksumAsset: GitHubAsset,
+  baseName: string,
+): Promise<{ bytes: ArrayBuffer; checksumLine: string } | null> {
+  const assetDigest = parseSha256Digest(asset.digest)
+  const checksumAssetDigest = parseSha256Digest(checksumAsset.digest)
+  if (!assetDigest || !checksumAssetDigest || asset.size <= 0 || checksumAsset.size <= 0) {
+    return null
+  }
+
+  const checksumBytes = await fetchBytesFromGitHub(checksumAsset.browser_download_url)
+  if (!checksumBytes) return null
+
+  const checksumBuffer = Buffer.from(checksumBytes)
+  if (
+    checksumBuffer.byteLength !== checksumAsset.size ||
+    sha256Hex(checksumBuffer) !== checksumAssetDigest
+  ) {
+    return null
+  }
+
+  const checksumText = checksumBuffer.toString('utf8')
+  const expectedDigest = parseSha256Sidecar(checksumText, baseName)
+  if (!expectedDigest || expectedDigest !== assetDigest) return null
+
+  const binary = await fetchBytesFromGitHub(asset.browser_download_url)
+  if (!binary) return null
+
+  const binaryBuffer = Buffer.from(binary)
+  if (binaryBuffer.byteLength !== asset.size || sha256Hex(binaryBuffer) !== expectedDigest) {
+    return null
+  }
+
+  return { bytes: binary, checksumLine: `${expectedDigest}  ${baseName}\n` }
+}
+
+async function fetchBytesFromGitHub(url: string): Promise<ArrayBuffer | null> {
   try {
     const res = await fetch(url, { headers: ghHeaders })
     if (!res.ok || !res.body) return null
@@ -115,10 +159,46 @@ async function fetchBinaryFromGitHub(url: string): Promise<ArrayBuffer | null> {
   }
 }
 
-async function cacheLocally(filePath: string, data: ArrayBuffer): Promise<void> {
+async function readVerifiedLocalBinary(filePath: string, baseName: string): Promise<Buffer | null> {
+  try {
+    const [binary, checksumText] = await Promise.all([
+      fs.promises.readFile(filePath),
+      fs.promises.readFile(`${filePath}.sha256`, 'utf8'),
+    ])
+    const expectedDigest = parseSha256Sidecar(checksumText, baseName)
+    if (!expectedDigest || sha256Hex(binary) !== expectedDigest) return null
+    return binary
+  } catch {
+    return null
+  }
+}
+
+function parseSha256Digest(digest: string | undefined): string | null {
+  const match = digest?.match(/^sha256:([a-f0-9]{64})$/i)
+  const value = match?.[1]
+  return value ? value.toLowerCase() : null
+}
+
+function parseSha256Sidecar(contents: string, baseName: string): string | null {
+  for (const line of contents.split(/\r?\n/)) {
+    const match = line.trim().match(/^([a-f0-9]{64})\s+\*?(.+)$/i)
+    const value = match?.[1]
+    if (value && match?.[2] === baseName) {
+      return value.toLowerCase()
+    }
+  }
+  return null
+}
+
+function sha256Hex(data: Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex')
+}
+
+async function cacheLocally(filePath: string, data: ArrayBuffer, checksumLine: string): Promise<void> {
   try {
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
     await fs.promises.writeFile(filePath, Buffer.from(data), { mode: 0o755 })
+    await fs.promises.writeFile(`${filePath}.sha256`, checksumLine, { mode: 0o644 })
   } catch {
     // Cache failure is non-fatal
   }

--- a/apps/web/lib/agent/cache-prewarm.ts
+++ b/apps/web/lib/agent/cache-prewarm.ts
@@ -1,8 +1,9 @@
 import { logWarn } from '@/lib/logging'
+import crypto from 'crypto'
 import fs from 'fs'
 import path from 'path'
-import { REQUIRED_AGENT_VERSION } from './version'
-import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from './repo'
+import { REQUIRED_AGENT_VERSION } from './version.ts'
+import { AGENT_REPO_OWNER, AGENT_REPO_NAME } from './repo.ts'
 
 const AGENT_DIST_DIR = process.env.AGENT_DIST_DIR ?? './data/agent-dist'
 const BAKED_AGENT_DIST_DIR = path.join(process.cwd(), 'data/agent-dist')
@@ -19,6 +20,8 @@ const PLATFORMS = [
 interface GitHubAsset {
   name: string
   browser_download_url: string
+  size: number
+  digest?: string
 }
 
 interface GitHubRelease {
@@ -35,9 +38,14 @@ interface GitHubRelease {
  * prewarm failure must never prevent the server from starting.
  */
 export async function prewarmAgentCache(): Promise<void> {
-  const missingBaked = PLATFORMS.filter(
-    ({ os, arch }) => !fs.existsSync(path.join(BAKED_AGENT_DIST_DIR, binaryBaseName(os, arch)))
+  const bakedAvailability = await Promise.all(
+    PLATFORMS.map(async ({ os, arch }) => {
+      const baseName = binaryBaseName(os, arch)
+      const isAvailable = await hasVerifiedLocalBinary(path.join(BAKED_AGENT_DIST_DIR, baseName), baseName)
+      return { os, arch, isAvailable }
+    })
   )
+  const missingBaked = bakedAvailability.filter(({ isAvailable }) => !isAvailable)
   if (missingBaked.length === 0) {
     console.log(`[agent-cache] Baked agent ${REQUIRED_AGENT_VERSION} binaries are available`)
     return
@@ -100,38 +108,116 @@ async function downloadIfMissing(
   const versionedName = `ct-ops-agent-${os}-${arch}-${version}${suffix}`
   const versionedPath = path.join(AGENT_DIST_DIR, versionedName)
 
-  if (fs.existsSync(versionedPath)) {
+  if (await hasVerifiedLocalBinary(versionedPath, baseName)) {
     console.log(`[agent-cache] ${versionedName} already cached`)
     return
   }
 
   const asset = release.assets.find((a) => a.name === baseName)
-  if (!asset) {
+  const checksumAsset = release.assets.find((a) => a.name === `${baseName}.sha256`)
+  if (!asset || !checksumAsset) {
     // Platform binary not in this release — skip silently
     return
   }
 
   console.log(`[agent-cache] Downloading ${versionedName}...`)
   try {
-    const res = await fetch(asset.browser_download_url, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-        ...(process.env.GITHUB_TOKEN
-          ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
-          : {}),
-      },
-    })
-    if (!res.ok) {
-      console.warn(`[agent-cache] Failed to download ${baseName}: HTTP ${res.status}`)
+    const verified = await fetchVerifiedBinary(asset, checksumAsset, baseName)
+    if (!verified) {
+      console.warn(`[agent-cache] Failed to verify ${baseName} — skipping cache`)
       return
     }
-    const buffer = Buffer.from(await res.arrayBuffer())
+    const buffer = Buffer.from(verified.bytes)
     await fs.promises.writeFile(versionedPath, buffer, { mode: 0o755 })
+    await fs.promises.writeFile(`${versionedPath}.sha256`, verified.checksumLine, { mode: 0o644 })
     console.log(
       `[agent-cache] Cached ${versionedName} (${(buffer.byteLength / 1024 / 1024).toFixed(1)} MB)`
     )
   } catch (err) {
     logWarn(`[agent-cache] Error downloading ${baseName}:`, err)
   }
+}
+
+async function fetchVerifiedBinary(
+  asset: GitHubAsset,
+  checksumAsset: GitHubAsset,
+  baseName: string
+): Promise<{ bytes: ArrayBuffer; checksumLine: string } | null> {
+  const assetDigest = parseSha256Digest(asset.digest)
+  const checksumAssetDigest = parseSha256Digest(checksumAsset.digest)
+  if (!assetDigest || !checksumAssetDigest || asset.size <= 0 || checksumAsset.size <= 0) {
+    return null
+  }
+
+  const checksumBytes = await fetchBytes(checksumAsset.browser_download_url)
+  if (!checksumBytes) return null
+
+  const checksumBuffer = Buffer.from(checksumBytes)
+  if (
+    checksumBuffer.byteLength !== checksumAsset.size ||
+    sha256Hex(checksumBuffer) !== checksumAssetDigest
+  ) {
+    return null
+  }
+
+  const expectedDigest = parseSha256Sidecar(checksumBuffer.toString('utf8'), baseName)
+  if (!expectedDigest || expectedDigest !== assetDigest) return null
+
+  const binary = await fetchBytes(asset.browser_download_url)
+  if (!binary) return null
+
+  const binaryBuffer = Buffer.from(binary)
+  if (binaryBuffer.byteLength !== asset.size || sha256Hex(binaryBuffer) !== expectedDigest) {
+    return null
+  }
+
+  return { bytes: binary, checksumLine: `${expectedDigest}  ${baseName}\n` }
+}
+
+async function fetchBytes(url: string): Promise<ArrayBuffer | null> {
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(process.env.GITHUB_TOKEN
+        ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+        : {}),
+    },
+  })
+  if (!res.ok || !res.body) return null
+  return res.arrayBuffer()
+}
+
+async function hasVerifiedLocalBinary(filePath: string, baseName: string): Promise<boolean> {
+  try {
+    const [binary, checksumText] = await Promise.all([
+      fs.promises.readFile(filePath),
+      fs.promises.readFile(`${filePath}.sha256`, 'utf8'),
+    ])
+    const expectedDigest = parseSha256Sidecar(checksumText, baseName)
+    return Boolean(expectedDigest && sha256Hex(binary) === expectedDigest)
+  } catch {
+    return false
+  }
+}
+
+function parseSha256Digest(digest: string | undefined): string | null {
+  const match = digest?.match(/^sha256:([a-f0-9]{64})$/i)
+  const value = match?.[1]
+  return value ? value.toLowerCase() : null
+}
+
+function parseSha256Sidecar(contents: string, baseName: string): string | null {
+  for (const line of contents.split(/\r?\n/)) {
+    const match = line.trim().match(/^([a-f0-9]{64})\s+\*?(.+)$/i)
+    const value = match?.[1]
+    if (value && match?.[2] === baseName) {
+      return value.toLowerCase()
+    }
+  }
+  return null
+}
+
+function sha256Hex(data: Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex')
 }

--- a/apps/web/lib/agent/repo.ts
+++ b/apps/web/lib/agent/repo.ts
@@ -6,5 +6,5 @@
  * before public release, it's a one-time grep/replace per CLAUDE.md, not a
  * customer-facing toggle.
  */
-export const AGENT_REPO_OWNER = 'simonjcarr'
+export const AGENT_REPO_OWNER = 'carrtech-dev'
 export const AGENT_REPO_NAME = 'ct-ops'


### PR DESCRIPTION
## Summary
- verify GitHub release agent binaries against GitHub asset digests and published .sha256 sidecars before caching or serving
- require matching .sha256 sidecars for cached, unversioned, and baked local agent binaries
- update the official agent release repository owner to carrtech-dev

Fixes #959

## Tests
- node --experimental-strip-types --test lib/agent/binary-integrity.test.mjs
- pnpm --filter web type-check
- pnpm --filter web test:unit
- pnpm --filter web lint (passes with existing warnings)