### PR TITLE
fix(terminal): require pinned SSH host keys

### DIFF
--- a/apps/ingest/internal/db/queries/terminal_sessions.sql.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions.sql.go
@@ -2,6 +2,7 @@ package queries
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -16,6 +17,11 @@ type TerminalSessionInfo struct {
 	Username       string
 	LoggingEnabled bool
 }
+
+var (
+	ErrSSHHostKeyNotTrusted = errors.New("SSH host key is not trusted")
+	ErrSSHHostKeyMismatch   = errors.New("SSH host key mismatch")
+)
 
 // ValidateAndActivateTerminalSession looks up a terminal session by session_id
 // and a one-time WebSocket token hash, verifies it is pending and unexpired,
@@ -54,7 +60,7 @@ func ValidateAndActivateTerminalSession(ctx context.Context, pool *pgxpool.Pool,
 	return &info, nil
 }
 
-func VerifyOrTrustSSHHostKey(ctx context.Context, pool *pgxpool.Pool, hostID string, fingerprint string) error {
+func VerifySSHHostKey(ctx context.Context, pool *pgxpool.Pool, hostID string, fingerprint string) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return err
@@ -75,28 +81,20 @@ func VerifyOrTrustSSHHostKey(ctx context.Context, pool *pgxpool.Pool, hostID str
 		}
 		return err
 	}
-	if current != nil && *current != "" {
-		if *current != fingerprint {
-			return fmt.Errorf("SSH host key mismatch")
-		}
-		return tx.Commit(ctx)
-	}
-
-	const updateQ = `
-		UPDATE hosts
-		SET metadata = jsonb_set(
-		      COALESCE(metadata, '{}'::jsonb),
-		      '{sshHostKeySha256}',
-		      to_jsonb($2::text),
-		      true
-		    ),
-		    updated_at = NOW()
-		WHERE id = $1
-	`
-	if _, err := tx.Exec(ctx, updateQ, hostID, fingerprint); err != nil {
+	if err := verifySSHHostKeyFingerprint(current, fingerprint); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+func verifySSHHostKeyFingerprint(current *string, fingerprint string) error {
+	if current == nil || *current == "" {
+		return ErrSSHHostKeyNotTrusted
+	}
+	if *current != fingerprint {
+		return ErrSSHHostKeyMismatch
+	}
+	return nil
 }
 
 // SetTerminalSessionEnded marks a terminal session as 'ended' with duration and

--- a/apps/ingest/internal/db/queries/terminal_sessions_test.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions_test.go
@@ -1,0 +1,42 @@
+package queries
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestVerifySSHHostKeyFingerprintRejectsUnpinnedHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		current *string
+	}{
+		{name: "missing fingerprint"},
+		{name: "empty fingerprint", current: ptr("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifySSHHostKeyFingerprint(tt.current, "SHA256:presented")
+			if !errors.Is(err, ErrSSHHostKeyNotTrusted) {
+				t.Fatalf("verifySSHHostKeyFingerprint() error = %v, want ErrSSHHostKeyNotTrusted", err)
+			}
+		})
+	}
+}
+
+func TestVerifySSHHostKeyFingerprintRejectsMismatch(t *testing.T) {
+	err := verifySSHHostKeyFingerprint(ptr("SHA256:pinned"), "SHA256:presented")
+	if !errors.Is(err, ErrSSHHostKeyMismatch) {
+		t.Fatalf("verifySSHHostKeyFingerprint() error = %v, want ErrSSHHostKeyMismatch", err)
+	}
+}
+
+func TestVerifySSHHostKeyFingerprintAllowsPinnedMatch(t *testing.T) {
+	if err := verifySSHHostKeyFingerprint(ptr("SHA256:pinned"), "SHA256:pinned"); err != nil {
+		t.Fatalf("verifySSHHostKeyFingerprint() error = %v, want nil", err)
+	}
+}
+
+func ptr(value string) *string {
+	return &value
+}

--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -104,8 +104,14 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	authMsg.Password = ""
 	if err != nil {
 		slog.Warn("terminal ws: SSH connection failed", "session_id", sessionID, "host_id", info.HostID, "username", info.Username, "err", err)
-		_ = queries.SetTerminalSessionError(context.Background(), h.pool, sessionID, "ssh authentication failed")
-		writeWS(ctx, conn, wsMessage{Type: "error", Msg: "SSH authentication failed"})
+		reason := "ssh authentication failed"
+		message := "SSH authentication failed"
+		if errors.Is(err, queries.ErrSSHHostKeyNotTrusted) || errors.Is(err, queries.ErrSSHHostKeyMismatch) {
+			reason = "ssh host key verification failed"
+			message = "SSH host key verification failed"
+		}
+		_ = queries.SetTerminalSessionError(context.Background(), h.pool, sessionID, reason)
+		writeWS(ctx, conn, wsMessage{Type: "error", Msg: message})
 		return
 	}
 	defer sshClient.Close()
@@ -246,7 +252,7 @@ func (h *TerminalWSHandler) openSSHSession(ctx context.Context, hostID, host, us
 			}),
 		},
 		HostKeyCallback: func(_ string, _ net.Addr, key ssh.PublicKey) error {
-			return queries.VerifyOrTrustSSHHostKey(ctx, h.pool, hostID, ssh.FingerprintSHA256(key))
+			return queries.VerifySSHHostKey(ctx, h.pool, hostID, ssh.FingerprintSHA256(key))
 		},
 		Timeout: 30 * time.Second,
 	}


### PR DESCRIPTION
## Summary
- stop trusting first-seen SSH host keys during terminal connections
- require an existing `sshHostKeySha256` metadata pin before password-backed SSH is attempted
- return a host-key verification failure for missing or mismatched pins

## Tests
- `go test ./internal/db/queries`
- `go test ./internal/handlers`
- `go test ./...` from `apps/ingest`

Closes #911