### PR TITLE
fix(auth): scope LDAP login to organisation slug

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -22,6 +22,9 @@ const localLoginSchema = z.object({
 })
 
 const domainLoginSchema = z.object({
+  organisationSlug: z.string().trim().min(2, 'Organisation slug is required').regex(/^[a-z0-9-]+$/, {
+    message: 'Use lowercase letters, numbers, and hyphens',
+  }),
   username: z.string().min(1, 'Username is required'),
   password: z.string().min(1, 'Password is required'),
 })
@@ -94,6 +97,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
               twoFactorMethod: ldapTwoFactorMethod,
             }
           : {
+              organisationSlug: values.organisationSlug,
               username: values.username,
               password: values.password,
             }),
@@ -353,6 +357,20 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
               </>
             ) : (
               <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="domain-organisation">Organisation slug</Label>
+                  <Input
+                    id="domain-organisation"
+                    type="text"
+                    autoComplete="organization"
+                    placeholder="acme"
+                    {...domainForm.register('organisationSlug')}
+                    data-testid="domain-login-organisation"
+                  />
+                  {domainForm.formState.errors.organisationSlug && (
+                    <p className="text-xs text-destructive">{domainForm.formState.errors.organisationSlug.message}</p>
+                  )}
+                </div>
                 <div className="space-y-1.5">
                   <Label htmlFor="domain-username">Username</Label>
                   <Input

--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -1,7 +1,7 @@
 import { logError } from '@/lib/logging'
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { users, accounts, sessions, ldapConfigurations, verifications } from '@/lib/db/schema'
+import { users, accounts, sessions, ldapConfigurations, verifications, organisations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
@@ -10,6 +10,7 @@ import { createRateLimiter } from '@/lib/rate-limit'
 import { getBetterAuthSecret } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
 import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
+import { normalizeLdapTenantSlug } from '@/lib/auth/ldap-tenant'
 import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
 import { SeatAdmissionError, assertUserCanAccessSeat } from '@/lib/seat-admission'
 import {
@@ -52,7 +53,12 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { username, password } = body as { username?: string; password?: string }
+    const { username, password, organisationSlug } = body as {
+      username?: string
+      password?: string
+      organisationSlug?: string
+    }
+    const tenantSlug = normalizeLdapTenantSlug(organisationSlug)
 
     const authSecret = getBetterAuthSecret()
 
@@ -60,7 +66,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Username and password are required' }, { status: 400 })
     }
 
-    const accountStatus = await passwordLoginAttemptGuard.check(username)
+    if (!tenantSlug) {
+      return NextResponse.json({ error: 'Organisation slug is required' }, { status: 400 })
+    }
+
+    const accountKey = `${tenantSlug}:${username}`
+    const accountStatus = await passwordLoginAttemptGuard.check(accountKey)
     if (!accountStatus.allowed) {
       return NextResponse.json(
         { error: 'Too many login attempts — please wait before trying again.' },
@@ -68,9 +79,21 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Find all enabled LDAP configs that allow login
+    const organisation = await db.query.organisations.findFirst({
+      where: and(
+        eq(organisations.slug, tenantSlug),
+        isNull(organisations.deletedAt),
+      ),
+      columns: { id: true },
+    })
+    if (!organisation) {
+      return NextResponse.json({ error: 'LDAP login is not configured for this organisation' }, { status: 400 })
+    }
+
+    // Authenticate only against the tenant explicitly selected by the caller.
     const configs = await db.query.ldapConfigurations.findMany({
       where: and(
+        eq(ldapConfigurations.organisationId, organisation.id),
         eq(ldapConfigurations.enabled, true),
         eq(ldapConfigurations.allowLogin, true),
         isNull(ldapConfigurations.deletedAt),
@@ -78,10 +101,9 @@ export async function POST(request: NextRequest) {
     })
 
     if (configs.length === 0) {
-      return NextResponse.json({ error: 'LDAP login is not configured' }, { status: 400 })
+      return NextResponse.json({ error: 'LDAP login is not configured for this organisation' }, { status: 400 })
     }
 
-    // Try each config until one succeeds
     const errors: string[] = []
     for (const config of configs) {
       const result = await authenticateUser(config, username, password)
@@ -169,7 +191,7 @@ export async function POST(request: NextRequest) {
       if (!user || !user.isActive || user.deletedAt) {
         // Log internally but return the same generic error to avoid leaking account existence.
         console.warn(`[LDAP] Login rejected — account inactive or deleted: userId=${userId}`)
-        await passwordLoginAttemptGuard.recordFailure(username)
+        await passwordLoginAttemptGuard.recordFailure(accountKey)
         return withAuthDelay(
           requestStart,
           NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),
@@ -235,12 +257,12 @@ export async function POST(request: NextRequest) {
         `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
       )
 
-      await passwordLoginAttemptGuard.reset(username)
+      await passwordLoginAttemptGuard.reset(accountKey)
       return withAuthDelay(requestStart, response)
     }
 
     logError(`[LDAP] All configs failed for user "${username}":`, errors)
-    await passwordLoginAttemptGuard.recordFailure(username)
+    await passwordLoginAttemptGuard.recordFailure(accountKey)
     return withAuthDelay(
       requestStart,
       NextResponse.json({ error: 'Invalid credentials' }, { status: 401 }),

--- a/apps/web/lib/auth/ldap-tenant.test.mjs
+++ b/apps/web/lib/auth/ldap-tenant.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  filterLdapConfigsForTenant,
+  normalizeLdapTenantSlug,
+} from './ldap-tenant.ts'
+
+test('normalizeLdapTenantSlug accepts only organisation slugs', () => {
+  assert.equal(normalizeLdapTenantSlug(' Acme-Operations '), 'acme-operations')
+  assert.equal(normalizeLdapTenantSlug('acme_ldap'), null)
+  assert.equal(normalizeLdapTenantSlug('../acme'), null)
+  assert.equal(normalizeLdapTenantSlug(''), null)
+  assert.equal(normalizeLdapTenantSlug(null), null)
+})
+
+test('filterLdapConfigsForTenant only returns login configs for the requested organisation slug', () => {
+  const configs = [
+    {
+      id: 'ldap_acme',
+      organisationId: 'org_acme',
+      organisationSlug: 'acme',
+      enabled: true,
+      allowLogin: true,
+      deletedAt: null,
+    },
+    {
+      id: 'ldap_beta',
+      organisationId: 'org_beta',
+      organisationSlug: 'beta',
+      enabled: true,
+      allowLogin: true,
+      deletedAt: null,
+    },
+    {
+      id: 'ldap_acme_disabled',
+      organisationId: 'org_acme',
+      organisationSlug: 'acme',
+      enabled: false,
+      allowLogin: true,
+      deletedAt: null,
+    },
+    {
+      id: 'ldap_acme_no_login',
+      organisationId: 'org_acme',
+      organisationSlug: 'acme',
+      enabled: true,
+      allowLogin: false,
+      deletedAt: null,
+    },
+    {
+      id: 'ldap_acme_deleted',
+      organisationId: 'org_acme',
+      organisationSlug: 'acme',
+      enabled: true,
+      allowLogin: true,
+      deletedAt: new Date('2026-05-05T00:00:00Z'),
+    },
+  ]
+
+  assert.deepEqual(
+    filterLdapConfigsForTenant(configs, 'ACME').map((config) => config.id),
+    ['ldap_acme'],
+  )
+})

--- a/apps/web/lib/auth/ldap-tenant.ts
+++ b/apps/web/lib/auth/ldap-tenant.ts
@@ -1,0 +1,30 @@
+const LDAP_TENANT_SLUG_PATTERN = /^[a-z0-9-]{2,50}$/
+
+export function normalizeLdapTenantSlug(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const slug = value.trim().toLowerCase()
+  if (!LDAP_TENANT_SLUG_PATTERN.test(slug)) return null
+  return slug
+}
+
+export interface TenantScopedLdapConfig {
+  organisationSlug: string
+  enabled: boolean
+  allowLogin: boolean
+  deletedAt: Date | null
+}
+
+export function filterLdapConfigsForTenant<T extends TenantScopedLdapConfig>(
+  configs: readonly T[],
+  tenantSlug: unknown,
+): T[] {
+  const slug = normalizeLdapTenantSlug(tenantSlug)
+  if (!slug) return []
+
+  return configs.filter((config) => (
+    config.organisationSlug === slug
+    && config.enabled
+    && config.allowLogin
+    && config.deletedAt === null
+  ))
+}


### PR DESCRIPTION
## Summary
- require an organisation slug for domain/LDAP login
- resolve that slug before LDAP authentication and only load configs for that organisation
- add LDAP tenant helper coverage for slug validation and config filtering

Fixes #912

## Tests
- node --experimental-strip-types --test apps/web/lib/auth/ldap-tenant.test.mjs
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing warnings)
- pnpm --dir apps/web test:unit