### PR TITLE
fix(web): stabilize e2e isolation and db pooling

### DIFF
--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -67,6 +67,8 @@ import type { AlertInstanceWithRule, NotificationChannelSafe, AlertSilenceWithHo
 import type { AlertSeverity, AlertInstanceStatus } from '@/lib/db/schema'
 import type { HostWithAgent } from '@/lib/actions/agents'
 
+type SuccessHandler = () => void | Promise<void>
+
 // ─── Severity Badge ────────────────────────────────────────────────────────────
 
 function SeverityBadge({ severity }: { severity: AlertSeverity }) {
@@ -149,7 +151,7 @@ function AddWebhookDialog({
   orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -168,7 +170,7 @@ function AddWebhookDialog({
       return
     }
     reset()
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -244,7 +246,7 @@ function AddSmtpDialog({
   orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -268,7 +270,7 @@ function AddSmtpDialog({
     })
     if ('error' in result) return
     reset()
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -396,7 +398,7 @@ function EditWebhookDialog({
   channel: NotificationChannelSafe & { type: 'webhook' }
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -416,7 +418,7 @@ function EditWebhookDialog({
       secret: values.secret || undefined,
     })
     if ('error' in result) return
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -485,7 +487,7 @@ function EditSmtpDialog({
   channel: NotificationChannelSafe & { type: 'smtp' }
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -510,7 +512,7 @@ function EditSmtpDialog({
       toAddresses,
     })
     if ('error' in result) return
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -576,7 +578,7 @@ function AddSlackDialog({
   orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -593,7 +595,7 @@ function AddSlackDialog({
     })
     if ('error' in result) return
     reset()
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -647,7 +649,7 @@ function EditSlackDialog({
   channel: NotificationChannelSafe & { type: 'slack' }
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -666,7 +668,7 @@ function EditSlackDialog({
       webhookUrl: values.webhookUrl,
     })
     if ('error' in result) return
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -725,7 +727,7 @@ function AddTelegramDialog({
   orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -742,7 +744,7 @@ function AddTelegramDialog({
     })
     if ('error' in result) return
     reset()
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -816,7 +818,7 @@ function EditTelegramDialog({
   channel: NotificationChannelSafe & { type: 'telegram' }
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
 }) {
   const {
     register,
@@ -836,7 +838,7 @@ function EditTelegramDialog({
       chatId: values.chatId,
     })
     if ('error' in result) return
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 
@@ -914,7 +916,7 @@ function AddSilenceDialog({
   hosts: HostWithAgent[]
   open: boolean
   onOpenChange: (v: boolean) => void
-  onSuccess: () => void
+  onSuccess: SuccessHandler
   prefilledHostId?: string
 }) {
   const now = new Date()
@@ -943,7 +945,7 @@ function AddSilenceDialog({
     })
     if ('error' in result) return
     reset()
-    onSuccess()
+    await onSuccess()
     onOpenChange(false)
   }
 

--- a/apps/web/app/(dashboard)/hosts/hosts-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/hosts-client.tsx
@@ -222,7 +222,9 @@ export function HostsClient({
   // event callback path rather than from inside an effect — the lint rule
   // `react-hooks/set-state-in-effect` blocks the effect variant.
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
+    rootRef.current?.setAttribute('data-hydrated', 'true')
     return () => {
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
     }
@@ -361,7 +363,7 @@ export function HostsClient({
     .reduce((acc, row) => acc + row.count, 0)
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-testid="hosts-client-root" ref={rootRef}>
       <div>
         <h1 className="text-2xl font-semibold text-foreground" data-testid="hosts-heading">Hosts</h1>
         <p className="text-muted-foreground mt-1">

--- a/apps/web/lib/db/index.ts
+++ b/apps/web/lib/db/index.ts
@@ -1,5 +1,5 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
-import postgres from 'postgres'
+import postgres, { type Sql } from 'postgres'
 import * as schema from './schema/index.ts'
 import { runWithOrgDatabaseScope } from './rls.ts'
 import { getDatabaseUrl } from './connection-string.ts'
@@ -8,7 +8,7 @@ const connectionString = getDatabaseUrl()
 const maxConnections = getMaxConnections()
 
 // Disable prefetch as it is not supported for "transaction" pool mode
-export const client = postgres(connectionString, { prepare: false, max: maxConnections })
+export const client = getPostgresClient()
 
 const rootDb = drizzle(client, { schema })
 
@@ -33,4 +33,47 @@ function getMaxConnections(): number {
   }
 
   return max
+}
+
+function getPostgresClient(): Sql {
+  if (!shouldCacheClient()) return createPostgresClient()
+
+  const globalForDb = globalThis as typeof globalThis & {
+    __ctOpsPostgresClient?: Sql
+  }
+  globalForDb.__ctOpsPostgresClient ??= createPostgresClient()
+  return globalForDb.__ctOpsPostgresClient
+}
+
+function createPostgresClient(): Sql {
+  return postgres(connectionString, {
+    prepare: false,
+    max: maxConnections,
+    ...getConnectionLifecycleOptions(),
+  })
+}
+
+function shouldCacheClient(): boolean {
+  return process.env['NODE_ENV'] !== 'production' || process.env['E2E'] === '1'
+}
+
+function getConnectionLifecycleOptions(): { idle_timeout?: number; max_lifetime?: number } {
+  if (process.env['E2E'] !== '1') return {}
+
+  return {
+    idle_timeout: getPositiveIntegerEnv('POSTGRES_IDLE_TIMEOUT', 1),
+    max_lifetime: getPositiveIntegerEnv('POSTGRES_MAX_LIFETIME', 30),
+  }
+}
+
+function getPositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+
+  return value
 }

--- a/apps/web/tests/e2e/alerts/alerts.spec.ts
+++ b/apps/web/tests/e2e/alerts/alerts.spec.ts
@@ -281,12 +281,12 @@ test('admin can create a silence, email channel, and webhook channel from the al
 
   await page.getByTestId('alerts-add-webhook').click()
   await page.getByTestId('alert-webhook-name').fill('PagerDuty Webhook')
-  await page.getByTestId('alert-webhook-url').fill('https://alerts.example.com/hooks/pagerduty')
+  await page.getByTestId('alert-webhook-url').fill('https://example.com/hooks/pagerduty')
   await page.getByTestId('alert-webhook-secret').fill('super-secret-token')
   await page.getByTestId('alert-webhook-submit').click()
 
   const webhookRow = page.getByRole('row').filter({ hasText: 'PagerDuty Webhook' })
-  await expect(webhookRow).toContainText('https://alerts.example.com/hooks/pagerduty')
+  await expect(webhookRow).toContainText('https://example.com/hooks/pagerduty')
 
   const createdRows = await sql<Array<{
     silence_reason: string | null
@@ -323,7 +323,7 @@ test('admin can create a silence, email channel, and webhook channel from the al
       recipients: ['alerts2@example.com', 'team@example.com'],
       webhook_name: 'PagerDuty Webhook',
       webhook_type: 'webhook',
-      webhook_url: 'https://alerts.example.com/hooks/pagerduty',
+      webhook_url: 'https://example.com/hooks/pagerduty',
       webhook_secret: 'super-secret-token',
     },
   ])

--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -1,6 +1,6 @@
 import { test as setup } from '@playwright/test'
 import { seedOrgAndUser } from './fixtures/seed'
 
-setup('seed test organisation and user', async ({ request }) => {
-  await seedOrgAndUser(request)
+setup('seed test organisation and user', async () => {
+  await seedOrgAndUser()
 })

--- a/apps/web/tests/e2e/auth/stale-sessions.spec.ts
+++ b/apps/web/tests/e2e/auth/stale-sessions.spec.ts
@@ -91,7 +91,7 @@ test('deactivating a user revokes existing sessions and blocks stale dashboard/a
     expect(response.status()).toBe(401)
 
     await stalePage.goto('/dashboard')
-    await expect(stalePage).toHaveURL(/\/login$/)
+    await expect(stalePage).toHaveURL(/\/login(?:\?session=expired)?$/)
   } finally {
     await staleContext.close()
   }

--- a/apps/web/tests/e2e/fixtures/db.ts
+++ b/apps/web/tests/e2e/fixtures/db.ts
@@ -27,11 +27,21 @@ const APP_TABLES = [
   'alert_instances',
   'alert_rules',
   'alert_silences',
+  'audit_events',
+  'build_doc_asset_storage_settings',
+  'build_doc_assets',
+  'build_doc_revisions',
+  'build_doc_sections',
+  'build_doc_snippets',
+  'build_doc_template_versions',
+  'build_doc_templates',
+  'build_docs',
   'certificate_authorities',
   'certificate_events',
   'certificates',
   'check_results',
   'checks',
+  'ct_cve_service_nonces',
   'domain_accounts',
   'host_group_members',
   'host_groups',
@@ -52,13 +62,16 @@ const APP_TABLES = [
   'notes',
   'notification_channels',
   'notifications',
+  'pending_cert_signings',
   'resource_tags',
+  'revoked_certificates',
   'security_throttles',
   'saved_software_reports',
   'service_accounts',
   'software_packages',
   'software_scans',
   'ssh_keys',
+  'system_config',
   'tag_rules',
   'tags',
   'task_run_hosts',
@@ -68,9 +81,17 @@ const APP_TABLES = [
   'vulnerability_cves',
 ]
 
+const AUTH_AND_ORG_TABLES = [
+  'totp_credential',
+  'session',
+  'account',
+  'verification',
+  'user',
+  'organisations',
+]
+
 export async function truncateAppTables(): Promise<void> {
   const sql = getTestDb()
-  const list = APP_TABLES.map((t) => `"${t}"`).join(', ')
+  const list = [...APP_TABLES, ...AUTH_AND_ORG_TABLES].map((t) => `"${t}"`).join(', ')
   await sql.unsafe(`TRUNCATE TABLE ${list} RESTART IDENTITY CASCADE`)
-  await sql.unsafe('DELETE FROM "session"')
 }

--- a/apps/web/tests/e2e/fixtures/seed.ts
+++ b/apps/web/tests/e2e/fixtures/seed.ts
@@ -1,4 +1,4 @@
-import { type APIRequestContext } from '@playwright/test'
+import { hashPassword } from 'better-auth/crypto'
 import { createId } from '@paralleldrive/cuid2'
 import { getTestDb } from './db'
 
@@ -13,46 +13,99 @@ export const TEST_ORG = {
   slug: 'e2e-test-org',
 } as const
 
-// Idempotent. Calls Better Auth's public sign-up HTTP endpoint (which hashes
-// the password correctly and creates the matching `account` row), then
-// attaches the user to an organisation and promotes them to admin so the
-// dashboard layout guards pass.
-export async function seedOrgAndUser(request: APIRequestContext): Promise<void> {
-  const sql = getTestDb()
+let testUserPasswordHash: string | null = null
 
-  const existing = await sql<Array<{ id: string }>>`
-    SELECT id FROM "user" WHERE email = ${TEST_USER.email} LIMIT 1
-  `
-  if (existing.length === 0) {
-    const res = await request.post('/api/auth/sign-up/email', {
-      data: {
-        email: TEST_USER.email,
-        password: TEST_USER.password,
-        name: TEST_USER.name,
-      },
-    })
-    if (!res.ok()) {
-      const body = await res.text()
-      throw new Error(`sign-up failed: ${res.status()} ${body}`)
-    }
-  }
+async function getTestUserPasswordHash(): Promise<string> {
+  testUserPasswordHash ??= await hashPassword(TEST_USER.password)
+  return testUserPasswordHash
+}
+
+// Idempotent deterministic baseline for E2E tests. It writes Better Auth's
+// required user/account rows directly so per-test isolation does not have to
+// round-trip through the app server before each spec.
+export async function seedOrgAndUser(): Promise<void> {
+  const sql = getTestDb()
+  const orgId = createId()
+  const userId = createId()
+  const passwordHash = await getTestUserPasswordHash()
 
   await sql`
     INSERT INTO organisations (id, name, slug)
-    VALUES (${createId()}, ${TEST_ORG.name}, ${TEST_ORG.slug})
-    ON CONFLICT (slug) DO NOTHING
+    VALUES (${orgId}, ${TEST_ORG.name}, ${TEST_ORG.slug})
+    ON CONFLICT (slug) DO UPDATE
+    SET name = EXCLUDED.name
   `
 
   await sql`
-    UPDATE "user"
-    SET organisation_id = (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
-        email_verified = true,
-        role = 'org_admin',
-        is_active = true
-    WHERE email = ${TEST_USER.email}
+    INSERT INTO "user" (
+      id,
+      name,
+      email,
+      email_verified,
+      created_at,
+      updated_at,
+      organisation_id,
+      role,
+      roles,
+      is_active
+    )
+    VALUES (
+      ${userId},
+      ${TEST_USER.name},
+      ${TEST_USER.email},
+      true,
+      NOW(),
+      NOW(),
+      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      'org_admin',
+      '[]'::jsonb,
+      true
+    )
+    ON CONFLICT (email) DO UPDATE
+    SET name = EXCLUDED.name,
+        email_verified = EXCLUDED.email_verified,
+        updated_at = NOW(),
+        organisation_id = EXCLUDED.organisation_id,
+        role = EXCLUDED.role,
+        roles = EXCLUDED.roles,
+        is_active = EXCLUDED.is_active
   `
 
-  // Sign-up auto-creates a session — drop it so the login test exercises a
-  // fresh form submission.
+  await sql`
+    INSERT INTO account (
+      id,
+      account_id,
+      provider_id,
+      user_id,
+      password,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      ${createId()},
+      (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+      'credential',
+      (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+      ${passwordHash},
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (id) DO NOTHING
+  `
+
+  await sql`
+    DELETE FROM account
+    WHERE user_id = (SELECT id FROM "user" WHERE email = ${TEST_USER.email})
+      AND provider_id = 'credential'
+      AND id NOT IN (
+        SELECT id
+        FROM account
+        WHERE user_id = (SELECT id FROM "user" WHERE email = ${TEST_USER.email})
+          AND provider_id = 'credential'
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      )
+  `
+
   await sql`DELETE FROM "session" WHERE user_id = (SELECT id FROM "user" WHERE email = ${TEST_USER.email})`
 }

--- a/apps/web/tests/e2e/fixtures/test.ts
+++ b/apps/web/tests/e2e/fixtures/test.ts
@@ -12,14 +12,14 @@ export const test = base.extend<Fixtures>({
   autoTruncate: [
     async ({}, use) => {
       await truncateAppTables()
+      await seedOrgAndUser()
       await use()
     },
     { auto: true },
   ],
 
-  authenticatedPage: async ({ browser, baseURL, request }, use) => {
+  authenticatedPage: async ({ browser, baseURL }, use) => {
     if (!baseURL) throw new Error('baseURL must be configured')
-    await seedOrgAndUser(request)
     const storageState = await getStorageStatePath(baseURL)
     const context = await browser.newContext({ storageState })
     const page = await context.newPage()

--- a/apps/web/tests/e2e/hosts/inventory.spec.ts
+++ b/apps/web/tests/e2e/hosts/inventory.spec.ts
@@ -70,6 +70,7 @@ test('authenticated user can search and filter the host inventory', async ({ aut
 
   await page.goto('/hosts')
 
+  await expect(page.getByTestId('hosts-client-root')).toHaveAttribute('data-hydrated', 'true')
   await expect(page.getByTestId('hosts-heading')).toBeVisible()
   await expect(page.getByText('2 hosts registered')).toBeVisible()
   await expect(page.getByRole('link', { name: 'Alpha Node' })).toBeVisible()
@@ -135,6 +136,7 @@ test('authenticated user can paginate through the host inventory', async ({ auth
 
   await page.goto('/hosts')
 
+  await expect(page.getByTestId('hosts-client-root')).toHaveAttribute('data-hydrated', 'true')
   await expect(page.getByTestId('hosts-heading')).toBeVisible()
   await expect(page.getByTestId('hosts-pagination-summary')).toContainText('Showing 1–50 of 55')
   await expect(page.getByTestId('hosts-page-indicator')).toContainText('Page 1 of 2')
@@ -374,6 +376,7 @@ test('authenticated user can sort and paginate the host inventory', async ({ aut
 
   await page.goto('/hosts')
 
+  await expect(page.getByTestId('hosts-client-root')).toHaveAttribute('data-hydrated', 'true')
   await expect(page.getByTestId('hosts-pagination-summary')).toContainText('Showing 1–50 of 55')
   await expect(page.getByTestId('hosts-page-indicator')).toContainText('Page 1 of 2')
   await expect(page.getByRole('link', { name: 'Host 001' })).toBeVisible()

--- a/apps/web/tests/e2e/runner.mjs
+++ b/apps/web/tests/e2e/runner.mjs
@@ -54,6 +54,7 @@ async function main() {
     process.env.BETTER_AUTH_TRUSTED_ORIGINS = appUrl
     process.env.E2E_PORT = String(port)
     process.env.AUTH_EMAIL_CAPTURE_FILE = authEmailCaptureFile
+    process.env.E2E = '1'
     process.env.E2E_DISABLE_AGENT_CACHE_PREWARM = '1'
     process.env.POSTGRES_POOL_MAX = process.env.POSTGRES_POOL_MAX ?? '2'
     process.env.LICENCE_PUBLIC_KEY = e2eLicencePublicKey


### PR DESCRIPTION
## Summary\n- reset auth/user/org state between E2E tests and reseed a deterministic Better Auth baseline directly in the test DB\n- cache the postgres-js client on globalThis in dev/E2E and add short E2E connection lifecycle defaults\n- fix the alerts webhook E2E fixture URL, await alert settings refreshes before closing dialogs, and wait for host inventory hydration before pagination clicks\n\n## Validation\n- `pnpm --dir apps/web exec tsc --noEmit --pretty false`\n- `pnpm --dir apps/web test:e2e -- tests/e2e/auth/stale-sessions.spec.ts tests/e2e/alerts/alerts.spec.ts` -> `5 passed (32.2s)`\n- `pnpm --dir apps/web test:e2e -- tests/e2e/dashboard/overview.spec.ts tests/e2e/hosts/inventory.spec.ts tests/e2e/hosts/access-control.spec.ts tests/e2e/hosts/compare.spec.ts` -> `10 passed (53.0s)`\n\nFull `pnpm --dir apps/web test:e2e` was attempted after these fixes. The original auth seat leak and Postgres connection exhaustion did not recur, but the run was stopped after it degraded into unrelated cold Next dev route compilation timeouts across many pages. Tracked separately in #977.