### PR TITLE
fix(security): restrict agent ca rotation

### DIFF
--- a/apps/web/lib/actions/security-auth.test.mjs
+++ b/apps/web/lib/actions/security-auth.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { assertAgentCAManagementAccess } from './security-auth.ts'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const securitySource = readFileSync(path.join(here, 'security.ts'), 'utf8')
+
+const baseUser = {
+  role: 'org_admin',
+  roles: ['org_admin'],
+}
+
+test('Agent CA management rejects org admins', () => {
+  assert.throws(
+    () => assertAgentCAManagementAccess(baseUser),
+    /forbidden: super_admin role required/,
+  )
+})
+
+test('Agent CA management allows super admins', () => {
+  assert.doesNotThrow(
+    () => assertAgentCAManagementAccess({
+      ...baseUser,
+      role: 'super_admin',
+      roles: ['super_admin'],
+    }),
+  )
+})
+
+test('uploadAgentCA requires Agent CA management access before rotating the global CA', () => {
+  const start = securitySource.indexOf('export async function uploadAgentCA')
+  assert.notEqual(start, -1, 'expected uploadAgentCA to exist')
+  const segment = securitySource.slice(start)
+
+  const guardIndex = segment.indexOf('await requireAgentCAManager()')
+  const transactionIndex = segment.indexOf('await db.transaction')
+  assert.ok(guardIndex >= 0, 'uploadAgentCA must require Agent CA management access')
+  assert.ok(transactionIndex >= 0, 'uploadAgentCA should still rotate the CA in a transaction')
+  assert.ok(guardIndex < transactionIndex, 'Agent CA access must be checked before CA rotation')
+})

--- a/apps/web/lib/actions/security-auth.ts
+++ b/apps/web/lib/actions/security-auth.ts
@@ -1,0 +1,6 @@
+import { requireRole } from '../auth/guards.ts'
+import type { SessionUser } from '../auth/session.ts'
+
+export function assertAgentCAManagementAccess(user: Pick<SessionUser, 'role'> & Partial<Pick<SessionUser, 'roles'>>): void {
+  requireRole(user, 'super_admin', 'forbidden: super_admin role required')
+}

--- a/apps/web/lib/actions/security.ts
+++ b/apps/web/lib/actions/security.ts
@@ -11,11 +11,17 @@ import { encrypt } from '@/lib/crypto/encrypt'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
 import { requireRole } from '@/lib/auth/guards'
+import { assertAgentCAManagementAccess } from './security-auth'
 import type { SecurityOverview } from './security-types'
 
 async function requireAdmin(): Promise<void> {
   const session = await getRequiredSession()
   requireRole(session.user, ADMIN_ROLES)
+}
+
+async function requireAgentCAManager(): Promise<void> {
+  const session = await getRequiredSession()
+  assertAgentCAManagementAccess(session.user)
 }
 
 const SERVER_TLS_CERT_PATH = process.env['INGEST_TLS_CERT'] ?? '/etc/ct-ops/tls/server.crt'
@@ -79,7 +85,7 @@ export async function uploadAgentCA(
   input: z.infer<typeof uploadSchema>,
 ): Promise<{ success: true; fingerprint: string } | { error: string }> {
   try {
-    await requireAdmin()
+    await requireAgentCAManager()
     const parsed = uploadSchema.parse(input)
 
     // Validate cert: parses, is a CA, still valid.


### PR DESCRIPTION
## Summary

- require `super_admin` access before rotating the install-wide Agent CA
- keep the read-only security overview available to existing admin roles
- add focused regression coverage proving org admins cannot pass Agent CA management authorization and that `uploadAgentCA` checks the stricter guard before rotation

Closes #981

## Validation

- `node --experimental-strip-types --test lib/actions/security-auth.test.mjs`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint` (passes with existing warnings)
- `pnpm --dir apps/web test:unit`
