### PR TITLE
ci(security): isolate pull request workflows

### DIFF
--- a/.github/scripts/assert-pr-workflows-use-hosted-runners.sh
+++ b/.github/scripts/assert-pr-workflows-use-hosted-runners.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failures=()
+matches_file="$(mktemp)"
+trap 'rm -f "$matches_file"' EXIT
+
+while IFS= read -r workflow; do
+  if ! grep -qE '^  pull_request:' "$workflow"; then
+    continue
+  fi
+
+  if grep -nE '^[[:space:]]+runs-on:[[:space:]]*self-hosted[[:space:]]*$' "$workflow" >"$matches_file"; then
+    while IFS= read -r match; do
+      failures+=("${workflow}:${match}")
+    done <"$matches_file"
+  fi
+done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+if [ "${#failures[@]}" -gt 0 ]; then
+  printf 'pull_request workflows must not use literal self-hosted runners:\n' >&2
+  printf '  %s\n' "${failures[@]}" >&2
+  exit 1
+fi

--- a/.github/workflows/ci-policy.yml
+++ b/.github/workflows/ci-policy.yml
@@ -1,0 +1,26 @@
+name: CI Policy
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/**'
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-runner-policy:
+    name: Workflow runner policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Assert PR workflows use hosted runners
+        run: .github/scripts/assert-pr-workflows-use-hosted-runners.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   analyse:
     name: Analyse ${{ matrix.language }}
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-checks-go.yml
+++ b/.github/workflows/pr-checks-go.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   go:
     name: Go (test / build)
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Reset workspace ownership
         run: |

--- a/.github/workflows/pr-checks-web.yml
+++ b/.github/workflows/pr-checks-web.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   web:
     name: Web (lint / type-check / build)
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Reset workspace ownership
         run: |

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   gosec:
     name: gosec (${{ matrix.module }})
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +71,7 @@ jobs:
 
   semgrep:
     name: semgrep
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     container:
       image: semgrep/semgrep
     steps:
@@ -127,7 +127,7 @@ jobs:
 
   trivy-fs:
     name: trivy (filesystem)
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Reset workspace ownership
         run: |
@@ -171,7 +171,7 @@ jobs:
 
   crypto-lint:
     name: crypto-lint (no weak hashes / ciphers)
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Reset workspace ownership
         run: |
@@ -229,7 +229,7 @@ jobs:
 
   trivy-config:
     name: trivy (config / IaC)
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Reset workspace ownership
         run: |

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       - name: Reset workspace ownership
         run: |


### PR DESCRIPTION
## Summary
- route PR-triggered workflow jobs that execute checked-out code to GitHub-hosted runners
- keep trusted push/schedule runs on self-hosted runners for existing capacity
- add a CI policy check that rejects literal self-hosted runners in pull_request workflows

Fixes #983

## Tests
- .github/scripts/assert-pr-workflows-use-hosted-runners.sh
- ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f) }'
- actionlint not run locally: not installed