### PR TITLE
feat(deploy): wire password manager compose services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,3 +132,23 @@ POSTGRES_PASSWORD=
 # Override only when you intentionally want a different published image.
 # WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:...
 # INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:...
+# PASSWORD_MANAGER_API_IMAGE=ghcr.io/carrtech-dev/ct-password-manager/api@sha256:...
+
+# === Password Manager integration ===
+
+# Optional dedicated database password for the bundled Password Manager
+# services. If left blank, docker-compose.single.yml falls back to
+# POSTGRES_PASSWORD until the installer flow adds first-run generation.
+# PASSWORD_MANAGER_DB_PASSWORD=
+
+# Optional CT-Ops launch-assertion settings for the bundled Password Manager
+# API. These defaults exist so the compose stack can boot before the dedicated
+# installer wiring lands; customer bundles should eventually set explicit
+# values rather than relying on these fallbacks.
+# CT_OPS_INSTANCE_ID=ct-ops-prod-1
+# PASSWORD_MANAGER_CT_OPS_ISSUER=https://localhost
+# PASSWORD_MANAGER_CT_OPS_AUDIENCE=ct-password-manager
+# PASSWORD_MANAGER_CT_OPS_PRODUCT=ct-password-manager
+# PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY=MCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+# PASSWORD_MANAGER_TRUSTED_ORIGINS=https://localhost
+# PASSWORD_MANAGER_SESSION_COOKIE_SECURE=true

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -78,6 +78,7 @@ jobs:
           set -euo pipefail
           bash -n install.sh
           bash deploy/scripts/test-install.sh
+          bash deploy/scripts/test-password-manager-compose.sh
           bash deploy/scripts/test-start.sh
           bash deploy/scripts/test-web-entrypoint.sh
           bash deploy/scripts/test-upgrade.sh

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,30 @@
 
 ## What Has Been Built
 
+### Session 105 — Password Manager compose wiring
+
+**Default single-host deployment** (`docker-compose.single.yml`, `deploy/customer-bundle/start.sh`, `.env.example`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-password-manager-compose.sh`)
+- Added bundled `password-manager-db`, `password-manager-migrate`, and
+  `password-manager-api` services to the single-host compose profile.
+- Kept Password Manager off public host ports, added a dedicated
+  `password_manager_db_data` volume, and enforced migration ordering with
+  database health plus `service_completed_successfully` dependencies before
+  the API and web/nginx stack continue.
+- Wired the customer start path to pull the Password Manager services by
+  default and documented the temporary env fallbacks used until first-run
+  installer generation lands for the dedicated Password Manager secrets and
+  CT-Ops launch settings.
+- Added a rendered-compose regression test in CI that fails if the service set,
+  dependency ordering, dedicated volume, or no-host-port boundary drifts.
+
+**Validation**
+- `bash deploy/scripts/test-password-manager-compose.sh`
+- `python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json`
+- `BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder docker compose -f docker-compose.single.yml config`
+- `bash -n deploy/customer-bundle/start.sh`
+- `bash deploy/scripts/test-start.sh`
+- `git diff --check`
+
 ### Session 104 — Password Manager direction reset
 
 **Historical note**

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -30,7 +30,7 @@ REQUIRED_VARS=(BETTER_AUTH_URL BETTER_AUTH_TRUSTED_ORIGINS BETTER_AUTH_SECRET PO
 
 # Optional variables — missing values get a warning, not an error. Most have
 # safe localhost defaults baked into docker-compose.yml.
-OPTIONAL_VARS=(AGENT_DOWNLOAD_BASE_URL INGEST_WS_URL CT_OPS_TRUST_PROXY_HEADERS CT_OPS_LOADTEST_ADMIN_KEY WEB_IMAGE INGEST_IMAGE)
+OPTIONAL_VARS=(AGENT_DOWNLOAD_BASE_URL INGEST_WS_URL CT_OPS_TRUST_PROXY_HEADERS CT_OPS_LOADTEST_ADMIN_KEY WEB_IMAGE INGEST_IMAGE PASSWORD_MANAGER_API_IMAGE PASSWORD_MANAGER_DB_PASSWORD PASSWORD_MANAGER_CT_OPS_ISSUER PASSWORD_MANAGER_CT_OPS_AUDIENCE PASSWORD_MANAGER_CT_OPS_PRODUCT PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY PASSWORD_MANAGER_TRUSTED_ORIGINS PASSWORD_MANAGER_SESSION_COOKIE_SECURE CT_OPS_INSTANCE_ID)
 REQUIRED_FILES=(
   docker-compose.yml
   deploy/nginx/nginx.conf
@@ -363,7 +363,7 @@ start_stack() {
     fi
   else
     echo "Pulling release-pinned images from GHCR..."
-    if ! docker compose pull db web migrate ingest nginx tls-init; then
+    if ! docker compose pull db password-manager-db password-manager-migrate password-manager-api web migrate ingest nginx tls-init; then
       echo "" >&2
       echo "ERROR: failed to pull one or more images from GHCR." >&2
       echo "  - Check your network access to ghcr.io" >&2

--- a/deploy/scripts/test-password-manager-compose.sh
+++ b/deploy/scripts/test-password-manager-compose.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "'"$tmpdir"'"' EXIT
+
+rendered="${tmpdir}/compose.rendered.yml"
+
+(
+  cd "$REPO_ROOT"
+  BETTER_AUTH_SECRET=build-time-placeholder \
+    POSTGRES_PASSWORD=build-time-placeholder \
+    docker compose -f docker-compose.single.yml config >"$rendered"
+)
+
+require_line() {
+  local pattern="$1"
+
+  if command -v rg >/dev/null 2>&1; then
+    if rg -q "$pattern" "$rendered"; then
+      return 0
+    fi
+  elif grep -Eq "$pattern" "$rendered"; then
+    return 0
+  fi
+
+  echo "expected rendered compose to match: $pattern" >&2
+  exit 1
+}
+
+service_block() {
+  local service_name="$1"
+
+  awk -v name="$service_name" '
+    $0 == "  " name ":" {
+      in_block = 1
+      print
+      next
+    }
+    in_block && $0 ~ /^  [^ ]/ {
+      exit
+    }
+    in_block {
+      print
+    }
+  ' "$rendered"
+}
+
+password_manager_api_block="$(service_block "password-manager-api")"
+password_manager_db_block="$(service_block "password-manager-db")"
+password_manager_migrate_block="$(service_block "password-manager-migrate")"
+
+require_line '^  password-manager-db:$'
+require_line '^  password-manager-migrate:$'
+require_line '^  password-manager-api:$'
+require_line '^volumes:$'
+require_line '^  password_manager_db_data:$'
+
+if [[ -z "$password_manager_api_block" || -z "$password_manager_db_block" || -z "$password_manager_migrate_block" ]]; then
+  echo "expected rendered compose to include password manager service blocks" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_api_block" == *$'\n    ports:'* ]]; then
+  echo "password-manager-api must not expose host ports" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_db_block" == *$'\n    ports:'* ]]; then
+  echo "password-manager-db must not expose host ports" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_migrate_block" != *$'\n    entrypoint:\n      - /app/password-manager-migrate'* ]]; then
+  echo "password-manager-migrate must run /app/password-manager-migrate" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_migrate_block" != *$'\n    depends_on:\n      password-manager-db:\n        condition: service_healthy'* ]]; then
+  echo "password-manager-migrate must wait for password-manager-db health" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_api_block" != *$'\n    depends_on:\n      password-manager-db:\n        condition: service_healthy'* || "$password_manager_api_block" != *$'\n      password-manager-migrate:\n        condition: service_completed_successfully'* ]]; then
+  echo "password-manager-api must wait for db health and successful migration" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_db_block" != *$'\n    volumes:\n      - type: volume\n        source: password_manager_db_data\n        target: /var/lib/postgresql/data'* ]]; then
+  echo "password-manager-db must use the dedicated password_manager_db_data volume" >&2
+  exit 1
+fi
+
+echo "password manager compose wiring test passed"

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -17,6 +17,64 @@ services:
       timeout: 5s
       retries: 5
 
+  password-manager-db:
+    image: postgres:17-alpine@sha256:c7526c0f6c3f30260a563d7bcf8ad778effac59a44f8ffa86678c35418338609
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: password_manager
+      POSTGRES_USER: password_manager
+      POSTGRES_PASSWORD: ${PASSWORD_MANAGER_DB_PASSWORD:-${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}}
+    volumes:
+      - password_manager_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U password_manager -d password_manager"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  password-manager-migrate:
+    image: ${PASSWORD_MANAGER_API_IMAGE:-ghcr.io/carrtech-dev/ct-password-manager/api@sha256:ccd97b4fd8f48dc9c58d990f7ece10dd6611aaabd1efd92bb0177c5b96577520}
+    restart: "no"
+    depends_on:
+      password-manager-db:
+        condition: service_healthy
+    environment:
+      PM_DATABASE_URL: postgres://password_manager:${PASSWORD_MANAGER_DB_PASSWORD:-${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}}@password-manager-db:5432/password_manager?sslmode=disable
+      PM_CT_OPS_ISSUER: ${PASSWORD_MANAGER_CT_OPS_ISSUER:-${BETTER_AUTH_URL:-https://localhost}}
+      PM_CT_OPS_AUDIENCE: ${PASSWORD_MANAGER_CT_OPS_AUDIENCE:-ct-password-manager}
+      PM_CT_OPS_PRODUCT: ${PASSWORD_MANAGER_CT_OPS_PRODUCT:-ct-password-manager}
+      PM_CT_OPS_INSTANCE_ID: ${CT_OPS_INSTANCE_ID:-ct-ops-dev}
+      PM_CT_OPS_ED25519_PUBLIC_KEY: ${PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY:-MCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}
+      PM_TRUSTED_ORIGINS: ${PASSWORD_MANAGER_TRUSTED_ORIGINS:-${BETTER_AUTH_TRUSTED_ORIGINS:-https://localhost}}
+      PM_SESSION_COOKIE_SECURE: ${PASSWORD_MANAGER_SESSION_COOKIE_SECURE:-true}
+    entrypoint: ["/app/password-manager-migrate"]
+    command: ["-action", "up"]
+
+  password-manager-api:
+    image: ${PASSWORD_MANAGER_API_IMAGE:-ghcr.io/carrtech-dev/ct-password-manager/api@sha256:ccd97b4fd8f48dc9c58d990f7ece10dd6611aaabd1efd92bb0177c5b96577520}
+    restart: unless-stopped
+    depends_on:
+      password-manager-db:
+        condition: service_healthy
+      password-manager-migrate:
+        condition: service_completed_successfully
+    environment:
+      PM_DATABASE_URL: postgres://password_manager:${PASSWORD_MANAGER_DB_PASSWORD:-${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}}@password-manager-db:5432/password_manager?sslmode=disable
+      PM_CT_OPS_ISSUER: ${PASSWORD_MANAGER_CT_OPS_ISSUER:-${BETTER_AUTH_URL:-https://localhost}}
+      PM_CT_OPS_AUDIENCE: ${PASSWORD_MANAGER_CT_OPS_AUDIENCE:-ct-password-manager}
+      PM_CT_OPS_PRODUCT: ${PASSWORD_MANAGER_CT_OPS_PRODUCT:-ct-password-manager}
+      PM_CT_OPS_INSTANCE_ID: ${CT_OPS_INSTANCE_ID:-ct-ops-dev}
+      PM_CT_OPS_ED25519_PUBLIC_KEY: ${PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY:-MCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}
+      PM_TRUSTED_ORIGINS: ${PASSWORD_MANAGER_TRUSTED_ORIGINS:-${BETTER_AUTH_TRUSTED_ORIGINS:-https://localhost}}
+      PM_SESSION_COOKIE_SECURE: ${PASSWORD_MANAGER_SESSION_COOKIE_SECURE:-true}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
   web:
     image: ${WEB_IMAGE:-ghcr.io/carrtech-dev/ct-ops/web:latest}
     build:
@@ -28,6 +86,8 @@ services:
         condition: service_completed_successfully
       migrate:
         condition: service_completed_successfully
+      password-manager-api:
+        condition: service_healthy
     ports:
       # Loopback-only — browser traffic flows in via the nginx container on :443.
       # Keeping :3000 on 127.0.0.1 lets operators tunnel for debugging without
@@ -165,6 +225,8 @@ services:
         condition: service_started
       ingest:
         condition: service_healthy
+      password-manager-api:
+        condition: service_healthy
     ports:
       - "${NGINX_HTTPS_PORT:-443}:443"
       - "${NGINX_HTTP_PORT:-80}:80"
@@ -215,5 +277,6 @@ services:
 
 volumes:
   db_data:
+  password_manager_db_data:
   ingest_data:
   agent_dist:


### PR DESCRIPTION
## Summary
- add bundled Password Manager db, migrate, and api services to the single-host compose profile
- keep Password Manager off host ports while enforcing db health and migration ordering
- pull the new services from the customer start path and add compose regression coverage

## Validation
- bash deploy/scripts/test-password-manager-compose.sh
- python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder docker compose -f docker-compose.single.yml config
- bash -n deploy/customer-bundle/start.sh
- bash deploy/scripts/test-start.sh
- git diff --check