### PR TITLE
fix(security): ignore spoofed bundle transfer origins

### DIFF
--- a/apps/web/app/api/tools/bundle-transfer/route.ts
+++ b/apps/web/app/api/tools/bundle-transfer/route.ts
@@ -18,6 +18,7 @@ import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
 import { getApiOrgSession } from '@/lib/auth/session'
 import { canAccessTooling } from '@/lib/auth/tooling'
 import { buildHostDownloadScript } from '@/lib/tools/bundle-transfer/host-download-script'
+import { getBundleTransferDownloadOrigin } from '@/lib/tools/bundle-transfer/download-origin'
 
 export const runtime = 'nodejs'
 export const maxDuration = 900
@@ -628,17 +629,6 @@ async function getAuthorisedUser(request: NextRequest) {
   }
 }
 
-function getRequestOrigin(request: NextRequest) {
-  const configuredBaseUrl = process.env.AGENT_DOWNLOAD_BASE_URL?.trim()
-  if (configuredBaseUrl) return configuredBaseUrl.replace(/\/+$/, '')
-  const origin = request.headers.get('origin')
-  if (origin) return origin
-  const forwardedProto = request.headers.get('x-forwarded-proto')
-  const forwardedHost = request.headers.get('x-forwarded-host') ?? request.headers.get('host')
-  if (forwardedProto && forwardedHost) return `${forwardedProto.split(',')[0]}://${forwardedHost.split(',')[0]}`
-  return request.nextUrl.origin
-}
-
 async function serveBundleDownload(request: NextRequest) {
   cleanupOldJobs()
   const user = await getAuthorisedUser(request)
@@ -739,7 +729,7 @@ export async function POST(request: NextRequest) {
     updatedAt: Date.now(),
   }
   transferJobs.set(job.id, job)
-  void runTransferJob(job, parsed.data, getRequestOrigin(request))
+  void runTransferJob(job, parsed.data, getBundleTransferDownloadOrigin(request))
 
   return NextResponse.json({
     ok: true,

--- a/apps/web/lib/tools/bundle-transfer/download-origin.test.mjs
+++ b/apps/web/lib/tools/bundle-transfer/download-origin.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getBundleTransferDownloadOrigin } from './download-origin.ts'
+
+function requestWithSpoofedOriginHeaders() {
+  return {
+    headers: new Headers({
+      origin: 'https://evil.example',
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'evil-forwarded.example',
+      host: 'evil-host.example',
+    }),
+  }
+}
+
+test('getBundleTransferDownloadOrigin ignores spoofed request origin headers', () => {
+  assert.equal(
+    getBundleTransferDownloadOrigin(
+      requestWithSpoofedOriginHeaders(),
+      { BETTER_AUTH_URL: 'https://ct-ops.example.com/dashboard' },
+    ),
+    'https://ct-ops.example.com',
+  )
+})
+
+test('getBundleTransferDownloadOrigin prefers configured agent download origin', () => {
+  assert.equal(
+    getBundleTransferDownloadOrigin(
+      requestWithSpoofedOriginHeaders(),
+      {
+        AGENT_DOWNLOAD_BASE_URL: 'https://downloads.ct-ops.example.com/bundles/',
+        BETTER_AUTH_URL: 'https://ct-ops.example.com',
+      },
+    ),
+    'https://downloads.ct-ops.example.com',
+  )
+})

--- a/apps/web/lib/tools/bundle-transfer/download-origin.ts
+++ b/apps/web/lib/tools/bundle-transfer/download-origin.ts
@@ -1,0 +1,11 @@
+import { getAgentPublicOrigin } from '../../agent/public-origin.ts'
+
+type HeaderLikeRequest = {
+  headers: Pick<Headers, 'get'>
+}
+
+type EnvLike = Record<string, string | undefined>
+
+export function getBundleTransferDownloadOrigin(_request: HeaderLikeRequest, env: EnvLike = process.env): string {
+  return getAgentPublicOrigin(env)
+}


### PR DESCRIPTION
## Summary
- route bundle transfer download URLs through the canonical agent public origin policy
- ignore request-controlled Origin, forwarded host, and Host headers when generating host transfer URLs
- add regression coverage for spoofed bundle-transfer origin headers

Fixes #944

## Tests
- node --experimental-strip-types --test lib/agent/public-origin.test.mjs lib/tools/bundle-transfer/download-origin.test.mjs lib/tools/bundle-transfer/host-download-script.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings)