### PR TITLE
feat(deploy): proxy password manager api

### DIFF
--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -9,6 +9,7 @@ on:
       - "deploy/password-manager-release.json"
       - "deploy/scripts/validate-password-manager-release.py"
       - "deploy/scripts/test-install.sh"
+      - "deploy/scripts/test-password-manager-nginx.sh"
       - "deploy/scripts/test-start.sh"
       - "deploy/scripts/test-web-entrypoint.sh"
       - "deploy/scripts/test-upgrade.sh"
@@ -79,6 +80,7 @@ jobs:
           bash -n install.sh
           bash deploy/scripts/test-install.sh
           bash deploy/scripts/test-password-manager-compose.sh
+          bash deploy/scripts/test-password-manager-nginx.sh
           bash deploy/scripts/test-start.sh
           bash deploy/scripts/test-web-entrypoint.sh
           bash deploy/scripts/test-upgrade.sh

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,29 @@
 
 ## What Has Been Built
 
+### Session 106 — Password Manager nginx routing
+
+**CT-Ops origin routing** (`deploy/nginx/nginx.conf`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-password-manager-nginx.sh`)
+- Added a dedicated `ct_password_manager_api` nginx upstream pointing at the
+  bundled `password-manager-api` service on the internal compose network.
+- Added `/password-manager-api/` reverse proxy routing that strips only the
+  CT-Ops prefix, preserves Password Manager-owned route suffixes, and clears
+  `Upgrade` and `Connection` headers so normal API traffic cannot smuggle h2c
+  upgrades to the backend.
+- Kept `/password-manager` on the existing CT-Ops web route by leaving the
+  broader `location /` proxy in place and handling only the more-specific API
+  prefix separately.
+- Added a dedicated nginx regression test and wired it into the customer-bundle
+  CI workflow so upstream target, prefix-stripping semantics, and header
+  clearing remain enforced.
+
+**Validation**
+- `bash deploy/scripts/test-password-manager-nginx.sh`
+- `bash deploy/scripts/test-password-manager-compose.sh`
+- `BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder docker compose -f docker-compose.single.yml config`
+- `bash deploy/scripts/test-start.sh`
+- `git diff --check`
+
 ### Session 105 — Password Manager compose wiring
 
 **Default single-host deployment** (`docker-compose.single.yml`, `deploy/customer-bundle/start.sh`, `.env.example`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-password-manager-compose.sh`)

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -43,6 +43,11 @@ http {
     keepalive 8;
   }
 
+  upstream ct_password_manager_api {
+    server password-manager-api:8080;
+    keepalive 8;
+  }
+
   # Plain HTTP — redirect to HTTPS (but keep /nginx-healthz plaintext so
   # external load balancers can probe without terminating TLS themselves).
   server {
@@ -138,6 +143,26 @@ http {
       proxy_cache off;
       proxy_read_timeout 3600s;
       chunked_transfer_encoding on;
+    }
+
+    # Password Manager API traffic is proxied through the CT-Ops origin, but
+    # the Password Manager service still owns the route suffixes. The trailing
+    # slash on proxy_pass strips only /password-manager-api/ and preserves the
+    # remaining path exactly.
+    location /password-manager-api/ {
+      proxy_pass http://ct_password_manager_api/;
+      proxy_http_version 1.1;
+      # Explicitly clear Upgrade/Connection so no upgrade (h2c or otherwise)
+      # can reach the Password Manager API.
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
+      proxy_set_header Upgrade    "";
+      # nosemgrep: generic.nginx.security.possible-h2c-smuggling.possible-nginx-h2c-smuggling
+      proxy_set_header Connection "";
+      # nosemgrep: generic.nginx.security.request-host-used.request-host-used
+      proxy_set_header Host              $host;
+      proxy_set_header X-Real-IP         $remote_addr;
+      proxy_set_header X-Forwarded-For   $remote_addr;
+      proxy_set_header X-Forwarded-Proto https;
     }
 
     # Everything else goes to the Next.js app. The Host header is forwarded

--- a/deploy/scripts/test-password-manager-nginx.sh
+++ b/deploy/scripts/test-password-manager-nginx.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+NGINX_CONF="${REPO_ROOT}/deploy/nginx/nginx.conf"
+
+require_line() {
+  local pattern="$1"
+
+  if command -v rg >/dev/null 2>&1; then
+    if rg -q "$pattern" "$NGINX_CONF"; then
+      return 0
+    fi
+  elif grep -Eq "$pattern" "$NGINX_CONF"; then
+    return 0
+  fi
+
+  echo "expected nginx config to match: $pattern" >&2
+  exit 1
+}
+
+location_block() {
+  local prefix="$1"
+
+  awk -v location="$prefix" '
+    $0 == "    location " location " {" {
+      in_block = 1
+      print
+      next
+    }
+    in_block && $0 ~ /^    location / {
+      exit
+    }
+    in_block && $0 == "  }" {
+      exit
+    }
+    in_block {
+      print
+    }
+  ' "$NGINX_CONF"
+}
+
+password_manager_api_block="$(location_block "/password-manager-api/")"
+
+require_line '^  upstream ct_password_manager_api \{$'
+require_line '^    server password-manager-api:8080;$'
+
+if [[ -z "$password_manager_api_block" ]]; then
+  echo "expected /password-manager-api/ location block" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_api_block" != *$'\n      proxy_pass http://ct_password_manager_api/;'* ]]; then
+  echo "password manager proxy must strip only the /password-manager-api/ prefix" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_api_block" != *$'\n      proxy_set_header Upgrade    "";'* ]]; then
+  echo "password manager proxy must clear Upgrade header" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_api_block" != *$'\n      proxy_set_header Connection "";'* ]]; then
+  echo "password manager proxy must clear Connection header" >&2
+  exit 1
+fi
+
+if [[ "$password_manager_api_block" != *$'\n      proxy_set_header Host              $host;'* ]]; then
+  echo "password manager proxy must forward Host header" >&2
+  exit 1
+fi
+
+echo "password manager nginx routing test passed"


### PR DESCRIPTION
## Summary
- add a dedicated nginx upstream and `/password-manager-api/` reverse proxy for the bundled Password Manager API
- strip only the CT-Ops prefix so Password Manager keeps owning its route suffixes
- clear `Upgrade` and `Connection` headers on normal API traffic and add CI coverage for the routing contract

## Validation
- `bash deploy/scripts/test-password-manager-nginx.sh`
- `bash deploy/scripts/test-password-manager-compose.sh`
- `BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder docker compose -f docker-compose.single.yml config`
- `bash deploy/scripts/test-start.sh`
- `git diff --check`

Test-first note: this task is an nginx/deployment routing change, so the focused regression script was added before the config change and used as the failing baseline.