### PR TITLE
fix(web): tighten production script csp

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { QueryProvider } from '@/components/shared/query-provider'
 import '@mdxeditor/editor/style.css'
@@ -34,6 +34,7 @@ export default async function RootLayout({
   children: React.ReactNode
 }>) {
   const cookieStore = await cookies()
+  const nonce = (await headers()).get('x-nonce') ?? undefined
   const theme = cookieStore.get('theme')?.value ?? 'system'
   const isDark = theme === 'dark'
 
@@ -44,7 +45,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className="min-h-full antialiased">
         <QueryProvider>

--- a/apps/web/lib/security/csp-headers.test.mjs
+++ b/apps/web/lib/security/csp-headers.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildContentSecurityPolicy } from './csp.ts'
+
+test('production CSP does not allow unsafe script execution', async () => {
+  process.env.BETTER_AUTH_URL = 'https://ct-ops.example.com'
+
+  const { default: nextConfig } = await import('../../next.config.ts')
+  const headerGroups = await nextConfig.headers()
+  const staticCspHeader = headerGroups
+    .flatMap((group) => group.headers)
+    .find((header) => header.key.toLowerCase() === 'content-security-policy')
+
+  assert.equal(staticCspHeader, undefined)
+
+  const directives = new Map(
+    buildContentSecurityPolicy('test-nonce')
+      .split(';')
+      .map((directive) => directive.trim().split(/\s+/))
+      .map(([name, ...values]) => [name, values]),
+  )
+
+  const scriptSrc = directives.get('script-src')
+
+  assert.deepEqual(scriptSrc, ["'self'", "'nonce-test-nonce'", "'strict-dynamic'"])
+  assert.ok(!scriptSrc.includes("'unsafe-eval'"))
+  assert.ok(!scriptSrc.includes("'unsafe-inline'"))
+})

--- a/apps/web/lib/security/csp.ts
+++ b/apps/web/lib/security/csp.ts
@@ -1,0 +1,21 @@
+export function buildContentSecurityPolicy(nonce: string, isDevelopment = false): string {
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    ...(isDevelopment ? ["'unsafe-eval'"] : []),
+  ].join(' ')
+
+  return [
+    "default-src 'self'",
+    `script-src ${scriptSrc}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    "connect-src 'self' ws: wss:",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join('; ')
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,5 @@
 import type { NextConfig } from 'next'
-import { getTrustedOriginHosts } from './lib/security/trusted-origins'
+import { getTrustedOriginHosts } from './lib/security/trusted-origins.ts'
 
 const securityHeaders = [
   // Prevent clickjacking
@@ -10,22 +10,6 @@ const securityHeaders = [
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   // Restrict powerful browser APIs — expand as needed
   { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), payment=()' },
-  // Basic CSP — upgrade to nonce-based strict-dynamic before GA
-  {
-    key: 'Content-Security-Policy',
-    value: [
-      "default-src 'self'",
-      // TODO: tighten to 'unsafe-inline' removal + nonce once all inline scripts use nonces
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob:",
-      "font-src 'self'",
-      "connect-src 'self' ws: wss:",
-      "frame-ancestors 'none'",
-      "base-uri 'self'",
-      "form-action 'self'",
-    ].join('; '),
-  },
 ]
 
 const nextConfig: NextConfig = {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { hasBetterAuthSessionCookie } from '@/lib/auth/session-cookie-names'
 import { getClientIpFromHeaders } from '@/lib/client-ip'
+import { buildContentSecurityPolicy } from '@/lib/security/csp'
 
 const AUTH_ROUTES = ['/login', '/register']
 
@@ -28,6 +29,12 @@ const BETTER_AUTH_SENSITIVE_PATHS = [
 ]
 const authRateLimitHits = new Map<string, number[]>()
 
+function generateNonce(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return btoa(String.fromCharCode(...bytes))
+}
+
 function checkAuthRateLimit(ip: string, now = Date.now()): boolean {
   const cutoff = now - 60_000
   const hits = (authRateLimitHits.get(ip) ?? []).filter((timestamp) => timestamp > cutoff)
@@ -48,8 +55,12 @@ export function proxy(request: NextRequest) {
 
   // Honour an upstream-supplied request ID (load balancer, proxy) or generate one.
   const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID()
+  const nonce = generateNonce()
+  const csp = buildContentSecurityPolicy(nonce, process.env.NODE_ENV === 'development')
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('x-request-id', requestId)
+  requestHeaders.set('x-nonce', nonce)
+  requestHeaders.set('Content-Security-Policy', csp)
 
   const ip = getClientIpFromHeaders(request.headers)
 
@@ -64,6 +75,7 @@ export function proxy(request: NextRequest) {
         { status: 429 },
       )
       limitResponse.headers.set('X-Request-Id', requestId)
+      limitResponse.headers.set('Content-Security-Policy', csp)
       return limitResponse
     }
   }
@@ -71,6 +83,7 @@ export function proxy(request: NextRequest) {
   if (!isAuthenticated && isProtectedRoute) {
     const redirectResponse = NextResponse.redirect(new URL('/login', request.url))
     redirectResponse.headers.set('X-Request-Id', requestId)
+    redirectResponse.headers.set('Content-Security-Policy', csp)
     return redirectResponse
   }
 
@@ -79,6 +92,7 @@ export function proxy(request: NextRequest) {
   const response = NextResponse.next({ request: { headers: requestHeaders } })
   // Echo the ID back to the client so it appears in browser DevTools / client logs.
   response.headers.set('X-Request-Id', requestId)
+  response.headers.set('Content-Security-Policy', csp)
   return response
 }
 


### PR DESCRIPTION
## Summary\n- move script CSP to per-request proxy headers with a fresh nonce\n- remove unsafe inline/eval script allowances from production CSP\n- nonce the root theme init script and add a CSP regression test\n\nFixes #950\n\n## Tests\n- node --experimental-strip-types --test lib/security/csp-headers.test.mjs\n- pnpm --dir apps/web type-check\n- pnpm --dir apps/web test:unit\n- pnpm --dir apps/web lint (passes with existing warnings)\n- BETTER_AUTH_URL=https://ct-ops.example.com BETTER_AUTH_SECRET=abcdefghijklmnopqrstuvwxyz123456 DATABASE_URL=postgres://ctops:ctops@localhost:5432/ctops pnpm --dir apps/web build (passes with existing Turbopack NFT warning)