### PR TITLE
fix(audit): record privileged lifecycle mutations

### DIFF
--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -146,6 +146,22 @@ export async function approveAgent(
         actorId,
         reason: 'Approved by admin',
       })
+
+      await writeAuditEvent(tx, {
+        organisationId: orgId,
+        actorUserId: actorId,
+        action: 'agent.approved',
+        targetType: 'agent',
+        targetId: agent.id,
+        summary: `Approved agent ${agent.hostname}`,
+        metadata: {
+          hostname: agent.hostname,
+          previousStatus: agent.status,
+          nextStatus: 'active',
+          agentVersion: agent.version,
+          os: agent.os,
+        },
+      })
     })
 
     // Apply defaults to the associated host (best-effort, outside transaction)
@@ -259,6 +275,23 @@ export async function rejectAgent(
           reason: 'Rejected by admin',
         }).onConflictDoNothing()
       }
+
+      await writeAuditEvent(tx, {
+        organisationId: orgId,
+        actorUserId: actorId,
+        action: 'agent.rejected',
+        targetType: 'agent',
+        targetId: agent.id,
+        summary: `Rejected agent ${agent.hostname}`,
+        metadata: {
+          hostname: agent.hostname,
+          previousStatus: agent.status,
+          nextStatus: 'revoked',
+          agentVersion: agent.version,
+          os: agent.os,
+          revokedClientCertificate: Boolean(agent.clientCertSerial),
+        },
+      })
     })
 
     return { success: true }
@@ -590,14 +623,51 @@ export async function revokeEnrolmentToken(
   orgId: string,
   tokenId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
+  const session = await requireOrgToolingAccess(orgId)
   try {
-    await db
-      .update(agentEnrolmentTokens)
-      .set({ deletedAt: new Date(), updatedAt: new Date() })
-      .where(
-        and(eq(agentEnrolmentTokens.id, tokenId), eq(agentEnrolmentTokens.organisationId, orgId)),
-      )
+    const token = await db.query.agentEnrolmentTokens.findFirst({
+      where: and(
+        eq(agentEnrolmentTokens.id, tokenId),
+        eq(agentEnrolmentTokens.organisationId, orgId),
+        isNull(agentEnrolmentTokens.deletedAt),
+      ),
+      columns: {
+        id: true,
+        label: true,
+        autoApprove: true,
+        skipVerify: true,
+        maxUses: true,
+        usageCount: true,
+        expiresAt: true,
+      },
+    })
+    if (!token) return { error: 'Enrolment token not found' }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(agentEnrolmentTokens)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(
+          and(eq(agentEnrolmentTokens.id, tokenId), eq(agentEnrolmentTokens.organisationId, orgId)),
+        )
+
+      await writeAuditEvent(tx, {
+        organisationId: orgId,
+        actorUserId: session.user.id,
+        action: 'agent.enrolment_token.revoked',
+        targetType: 'agent_enrolment_token',
+        targetId: token.id,
+        summary: `Revoked enrolment token ${token.label}`,
+        metadata: {
+          label: token.label,
+          autoApprove: token.autoApprove,
+          skipVerify: token.skipVerify,
+          maxUses: token.maxUses,
+          usageCount: token.usageCount,
+          expiresAt: token.expiresAt,
+        },
+      })
+    })
 
     return { success: true }
   } catch (err) {

--- a/apps/web/lib/actions/lifecycle-audit.test.mjs
+++ b/apps/web/lib/actions/lifecycle-audit.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const agentsSource = readFileSync(path.join(here, 'agents.ts'), 'utf8')
+const usersSource = readFileSync(path.join(here, 'users.ts'), 'utf8')
+
+function getActionSegment(source, action) {
+  const start = source.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist`)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? undefined : next)
+}
+
+const auditedLifecycleActions = [
+  ['users.ts', usersSource, 'inviteUser', ['invitation.created', 'user.restored']],
+  ['users.ts', usersSource, 'deactivateUser', ['user.deactivated']],
+  ['users.ts', usersSource, 'reactivateUser', ['user.reactivated']],
+  ['users.ts', usersSource, 'cancelInvite', ['invitation.cancelled']],
+  ['agents.ts', agentsSource, 'approveAgent', ['agent.approved']],
+  ['agents.ts', agentsSource, 'rejectAgent', ['agent.rejected']],
+  ['agents.ts', agentsSource, 'revokeEnrolmentToken', ['agent.enrolment_token.revoked']],
+]
+
+test('privileged lifecycle mutations write central audit events', () => {
+  for (const [fileName, source, action, auditActions] of auditedLifecycleActions) {
+    const segment = getActionSegment(source, action)
+
+    assert.match(
+      segment,
+      /writeAuditEvent\(/,
+      `${fileName} ${action} must write a central audit event`,
+    )
+
+    for (const auditAction of auditActions) {
+      assert.match(
+        segment,
+        new RegExp(`action: '${auditAction.replaceAll('.', '\\.')}'`),
+        `${fileName} ${action} must emit ${auditAction}`,
+      )
+    }
+  }
+})

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -78,10 +78,28 @@ export async function inviteUser(
     })
     if (removedUser) {
       await assertCanReserveUserSeat(orgId)
-      await db
-        .update(users)
-        .set({ deletedAt: null, isActive: true, role: nextRole, roles: nextRoles, updatedAt: new Date() })
-        .where(eq(users.id, removedUser.id))
+      await db.transaction(async (tx) => {
+        await tx
+          .update(users)
+          .set({ deletedAt: null, isActive: true, role: nextRole, roles: nextRoles, updatedAt: new Date() })
+          .where(eq(users.id, removedUser.id))
+
+        await writeAuditEvent(tx, {
+          organisationId: orgId,
+          actorUserId: session.user.id,
+          action: 'user.restored',
+          targetType: 'user',
+          targetId: removedUser.id,
+          summary: `Restored ${removedUser.email} to the organisation`,
+          metadata: {
+            targetEmail: removedUser.email,
+            previousRole: removedUser.role,
+            previousRoles: normalizeAssignedRoles(removedUser.roles, removedUser.role),
+            nextRole,
+            nextRoles,
+          },
+        })
+      })
       return { restored: true }
     }
 
@@ -114,17 +132,38 @@ export async function inviteUser(
     const expiresAt = new Date()
     expiresAt.setDate(expiresAt.getDate() + 7)
 
-    const [invite] = await db
-      .insert(invitations)
-      .values({
-        email: parsed.data.email,
-        role: nextRole,
-        roles: nextRoles,
+    const invite = await db.transaction(async (tx) => {
+      const [createdInvite] = await tx
+        .insert(invitations)
+        .values({
+          email: parsed.data.email,
+          role: nextRole,
+          roles: nextRoles,
+          organisationId: orgId,
+          invitedById: session.user.id,
+          expiresAt,
+        })
+        .returning()
+
+      if (!createdInvite) return null
+
+      await writeAuditEvent(tx, {
         organisationId: orgId,
-        invitedById: session.user.id,
-        expiresAt,
+        actorUserId: session.user.id,
+        action: 'invitation.created',
+        targetType: 'invitation',
+        targetId: createdInvite.id,
+        summary: `Invited ${createdInvite.email} to the organisation`,
+        metadata: {
+          targetEmail: createdInvite.email,
+          role: createdInvite.role,
+          roles: normalizeAssignedRoles(createdInvite.roles, createdInvite.role),
+          expiresAt: createdInvite.expiresAt,
+        },
       })
-      .returning()
+
+      return createdInvite
+    })
 
     if (!invite) return { error: 'Failed to create invitation' }
 
@@ -219,6 +258,14 @@ export async function deactivateUser(
       return { error: 'You cannot deactivate your own account' }
     }
 
+    const targetUser = await db.query.users.findFirst({
+      where: and(eq(users.id, targetUserId), eq(users.organisationId, orgId), isNull(users.deletedAt)),
+      columns: { id: true, email: true, isActive: true, role: true, roles: true },
+    })
+    if (!targetUser) {
+      return { error: 'User not found' }
+    }
+
     const activeSuperAdmins = await db.query.users.findMany({
       where: and(
         eq(users.organisationId, orgId),
@@ -232,12 +279,30 @@ export async function deactivateUser(
       return { error: 'Cannot deactivate the last active super admin' }
     }
 
-    await db
-      .update(users)
-      .set({ isActive: false, updatedAt: new Date() })
-      .where(and(eq(users.id, targetUserId), eq(users.organisationId, orgId)))
+    await db.transaction(async (tx) => {
+      await tx
+        .update(users)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(and(eq(users.id, targetUserId), eq(users.organisationId, orgId)))
 
-    await db.delete(sessions).where(eq(sessions.userId, targetUserId))
+      await tx.delete(sessions).where(eq(sessions.userId, targetUserId))
+
+      await writeAuditEvent(tx, {
+        organisationId: orgId,
+        actorUserId: session.user.id,
+        action: 'user.deactivated',
+        targetType: 'user',
+        targetId: targetUser.id,
+        summary: `Deactivated ${targetUser.email}`,
+        metadata: {
+          targetEmail: targetUser.email,
+          previousActive: targetUser.isActive,
+          nextActive: false,
+          role: targetUser.role,
+          roles: normalizeAssignedRoles(targetUser.roles, targetUser.role),
+        },
+      })
+    })
 
     return { success: true }
   } catch (err) {
@@ -252,11 +317,11 @@ export async function reactivateUser(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   try {
-    await requireOrgAdminAccess(orgId)
+    const session = await requireOrgAdminAccess(orgId)
 
     const targetUser = await db.query.users.findFirst({
       where: and(eq(users.id, targetUserId), eq(users.organisationId, orgId), isNull(users.deletedAt)),
-      columns: { id: true, isActive: true },
+      columns: { id: true, email: true, isActive: true, role: true, roles: true },
     })
     if (!targetUser) {
       return { error: 'User not found' }
@@ -266,10 +331,28 @@ export async function reactivateUser(
       await assertCanReserveUserSeat(orgId)
     }
 
-    await db
-      .update(users)
-      .set({ isActive: true, updatedAt: new Date() })
-      .where(and(eq(users.id, targetUserId), eq(users.organisationId, orgId)))
+    await db.transaction(async (tx) => {
+      await tx
+        .update(users)
+        .set({ isActive: true, updatedAt: new Date() })
+        .where(and(eq(users.id, targetUserId), eq(users.organisationId, orgId)))
+
+      await writeAuditEvent(tx, {
+        organisationId: orgId,
+        actorUserId: session.user.id,
+        action: 'user.reactivated',
+        targetType: 'user',
+        targetId: targetUser.id,
+        summary: `Reactivated ${targetUser.email}`,
+        metadata: {
+          targetEmail: targetUser.email,
+          previousActive: targetUser.isActive,
+          nextActive: true,
+          role: targetUser.role,
+          roles: normalizeAssignedRoles(targetUser.roles, targetUser.role),
+        },
+      })
+    })
 
     return { success: true }
   } catch (err) {
@@ -351,12 +434,37 @@ export async function cancelInvite(
 ): Promise<{ success: true } | { error: string }> {
   await requireOrgAccess(orgId)
   try {
-    await requireOrgAdminAccess(orgId)
+    const session = await requireOrgAdminAccess(orgId)
 
-    await db
-      .update(invitations)
-      .set({ deletedAt: new Date(), updatedAt: new Date() })
-      .where(and(eq(invitations.id, inviteId), eq(invitations.organisationId, orgId)))
+    const invite = await db.query.invitations.findFirst({
+      where: and(eq(invitations.id, inviteId), eq(invitations.organisationId, orgId), isNull(invitations.deletedAt)),
+      columns: { id: true, email: true, role: true, roles: true, expiresAt: true },
+    })
+    if (!invite) {
+      return { error: 'Invitation not found' }
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(invitations)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(invitations.id, inviteId), eq(invitations.organisationId, orgId)))
+
+      await writeAuditEvent(tx, {
+        organisationId: orgId,
+        actorUserId: session.user.id,
+        action: 'invitation.cancelled',
+        targetType: 'invitation',
+        targetId: invite.id,
+        summary: `Cancelled invitation for ${invite.email}`,
+        metadata: {
+          targetEmail: invite.email,
+          role: invite.role,
+          roles: normalizeAssignedRoles(invite.roles, invite.role),
+          expiresAt: invite.expiresAt,
+        },
+      })
+    })
 
     return { success: true }
   } catch (err) {


### PR DESCRIPTION
## Summary
- add central audit events for user invitations, restoration, deactivation/reactivation, and invite cancellation
- add central audit events for agent approval/rejection and enrolment token revocation
- add lifecycle audit regression coverage for privileged mutations

Closes #960

## Tests
- pnpm --filter web exec node --experimental-strip-types --test lib/actions/lifecycle-audit.test.mjs lib/actions/session-actor.test.mjs lib/actions/agents-authz.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings)
- pnpm --filter web test:unit (started; new test passed, but broad run hung idle after test 98 and was stopped)