### PR TITLE
feat(deploy): pin password manager bundle image

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -180,7 +180,8 @@ jobs:
             INGEST_IMAGE_REF="$(docker buildx imagetools inspect ghcr.io/carrtech-dev/ct-ops/ingest:latest --format '{{json .Manifest.Digest}}' | tr -d '"')"
             INGEST_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/ingest@${INGEST_IMAGE_REF}"
           fi
-          export WEB_IMAGE_REF INGEST_IMAGE_REF
+          PASSWORD_MANAGER_API_IMAGE_REF="$(python3 -c 'import json; print(json.load(open("deploy/password-manager-release.json", encoding="utf-8"))["digest_reference"])')"
+          export WEB_IMAGE_REF INGEST_IMAGE_REF PASSWORD_MANAGER_API_IMAGE_REF
           mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example
@@ -195,7 +196,7 @@ jobs:
           echo "$VERSION" > dist/ct-ops/VERSION
 
           perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml
-          perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m' dist/ct-ops/.env.example
+          perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m; s/^# PASSWORD_MANAGER_API_IMAGE=.*$/PASSWORD_MANAGER_API_IMAGE=$ENV{PASSWORD_MANAGER_API_IMAGE_REF}/m' dist/ct-ops/.env.example
 
           # The customer start.sh is generated here rather than checked into
           # the repo so the only source of truth lives next to the workflow
@@ -595,6 +596,8 @@ jobs:
           export POSTGRES_PASSWORD=verify-placeholder
           refs="$(docker compose -f dist/ct-ops/docker-compose.yml --env-file dist/ct-ops/.env.example config --images)"
           echo "$refs"
+          grep -Fxq "${PASSWORD_MANAGER_API_IMAGE_REF}" <<< "$refs"
+          grep -Eq '^postgres:17-alpine@sha256:[0-9a-f]{64}$' <<< "$refs"
           while IFS= read -r ref; do
             case "$ref" in
               *@sha256:*) ;;

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -34,8 +34,9 @@ jobs:
           set -euo pipefail
           WEB_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/web@sha256:1111111111111111111111111111111111111111111111111111111111111111"
           INGEST_IMAGE_REF="ghcr.io/carrtech-dev/ct-ops/ingest@sha256:2222222222222222222222222222222222222222222222222222222222222222"
-          export WEB_IMAGE_REF INGEST_IMAGE_REF
           python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
+          PASSWORD_MANAGER_API_IMAGE_REF="$(python3 -c 'import json; print(json.load(open("deploy/password-manager-release.json", encoding="utf-8"))["digest_reference"])')"
+          export WEB_IMAGE_REF INGEST_IMAGE_REF PASSWORD_MANAGER_API_IMAGE_REF
           mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml dist/ct-ops/docker-compose.yml
           cp .env.example dist/ct-ops/.env.example
@@ -51,7 +52,7 @@ jobs:
           cp deploy/nginx/nginx.conf dist/ct-ops/deploy/nginx/nginx.conf
           echo "test" > dist/ct-ops/VERSION
           perl -0pi -e 's/\$\{WEB_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/web:latest\}/$ENV{WEB_IMAGE_REF}/g; s/\$\{INGEST_IMAGE:-ghcr\.io\/carrtech-dev\/ct-ops\/ingest:latest\}/$ENV{INGEST_IMAGE_REF}/g' dist/ct-ops/docker-compose.yml
-          perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m' dist/ct-ops/.env.example
+          perl -0pi -e 's/^# WEB_IMAGE=.*$/WEB_IMAGE=$ENV{WEB_IMAGE_REF}/m; s/^# INGEST_IMAGE=.*$/INGEST_IMAGE=$ENV{INGEST_IMAGE_REF}/m; s/^# PASSWORD_MANAGER_API_IMAGE=.*$/PASSWORD_MANAGER_API_IMAGE=$ENV{PASSWORD_MANAGER_API_IMAGE_REF}/m' dist/ct-ops/.env.example
           chmod +x dist/ct-ops/start.sh dist/ct-ops/backup.sh dist/ct-ops/build-offline-installer.sh dist/ct-ops/refresh_licence_key dist/ct-ops/upgrade.sh dist/ct-ops/generate_support_data
 
       - name: Validate scripts and required files
@@ -63,6 +64,7 @@ jobs:
           test -f .env.example
           test -f password-manager-release.json
           test -f licence-keys/current.pem
+          grep -q '^PASSWORD_MANAGER_API_IMAGE=ghcr.io/carrtech-dev/ct-password-manager/api@sha256:' .env.example
           test -x backup.sh
           test -x refresh_licence_key
           test -x upgrade.sh
@@ -97,6 +99,8 @@ jobs:
           set -euo pipefail
           refs="$(docker compose config --images)"
           echo "$refs"
+          grep -Eq '^ghcr\.io/carrtech-dev/ct-password-manager/api@sha256:[0-9a-f]{64}$' <<< "$refs"
+          grep -Eq '^postgres:17-alpine@sha256:[0-9a-f]{64}$' <<< "$refs"
           while IFS= read -r ref; do
             case "$ref" in
               *@sha256:*) ;;

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,27 @@
 
 ## What Has Been Built
 
+### Session 108 — Password Manager release bundle pinning
+
+**Customer bundle Password Manager pinning** (`deploy/customer-bundle/upgrade.sh`, `deploy/customer-bundle/README.md`, `.github/workflows/customer-bundle-check.yml`, `.github/workflows/agent-release.yml`, `deploy/scripts/test-upgrade.sh`)
+- Stamped `PASSWORD_MANAGER_API_IMAGE` into staged customer bundles from
+  `deploy/password-manager-release.json` so online and air-gapped installs both
+  render against the reviewed Password Manager API digest instead of relying on
+  a floating operator edit.
+- Extended `upgrade.sh` so existing installs refresh the release-pinned
+  Password Manager API image reference alongside `WEB_IMAGE` and `INGEST_IMAGE`
+  while still preserving explicit custom overrides in `.env`.
+- Tightened bundle documentation to call out that Password Manager starts by
+  default, that its API image pin is refreshed during upgrades, and that
+  operators must include `password_manager_db_data`, `.env`, and
+  `password-manager-release.json` in backup/restore procedures.
+
+**Validation**
+- `bash deploy/scripts/test-upgrade.sh` (still fails on the current base with `tar: Write error`, tracked in [carrtech-dev/ct-ops#1033](https://github.com/carrtech-dev/ct-ops/issues/1033))
+- `python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json`
+- `bash -n deploy/customer-bundle/upgrade.sh`
+- `git diff --check`
+
 ### Session 107 — Password Manager startup bootstrap
 
 **First-run Password Manager config** (`start.sh`, `deploy/customer-bundle/start.sh`, `docker-compose.single.yml`, `.env.example`, `deploy/customer-bundle/generate_support_data`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-password-manager-startup.sh`, `deploy/scripts/test-support-data.sh`)

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -44,9 +44,11 @@ This will:
 1. Generate `BETTER_AUTH_SECRET` if it is still blank
 2. Generate dev TLS certificates under `./deploy/dev-tls/` for the ingest
    service
-3. Pull the release-pinned `web`, `ingest`, and `db` images from GHCR
+3. Pull the release-pinned `web`, `ingest`, `db`, and bundled Password Manager
+   images from GHCR
    (or load `images.tar.gz` if it is present — see *Air-gap installs* below)
-4. Start the stack
+4. Start the CT-Ops stack, including the bundled Password Manager services by
+   default
 5. A one-shot migration container applies database migrations before web and ingest start
 
 Open `https://localhost` (or whatever you set as `BETTER_AUTH_URL`) and
@@ -115,6 +117,10 @@ edit: update the digest, source commit, contract version, and contract checksum
 together only after compatibility validation against the selected Password
 Manager release.
 
+Customer bundles also stamp `PASSWORD_MANAGER_API_IMAGE` to that digest-pinned
+API image by default, and `upgrade.sh` refreshes it automatically unless you
+intentionally override it in `.env`.
+
 ## Backups
 
 ```sh
@@ -126,6 +132,11 @@ the local bundle files, `.env`, TLS material, `licence-keys/current.pem`, and a
 database dump when the `db` container is running. The archive contains secrets;
 store it securely. `upgrade.sh` calls this script automatically before replacing
 release files.
+
+The bundled Password Manager state lives in the dedicated
+`password_manager_db_data` Docker volume, and its deployment pin/configuration
+also live in the backed-up `.env` plus `password-manager-release.json`, so keep
+those together in any host-level backup or restore procedure.
 
 ## Licence verifier key
 
@@ -161,10 +172,11 @@ machine:
 ```
 
 This pulls every image referenced by `docker-compose.yml`, saves them to
-`images.tar.gz`, and writes `ct-ops-single-<version>-airgap.zip` next to
-the bundle directory. Transfer that zip to the air-gapped host, unzip,
-and run `./start.sh` — it detects `images.tar.gz` and loads the images
-locally instead of attempting a GHCR pull.
+`images.tar.gz`, including the bundled Password Manager API and database
+images, and writes `ct-ops-single-<version>-airgap.zip` next to the bundle
+directory. Transfer that zip to the air-gapped host, unzip, and run
+`./start.sh` — it detects `images.tar.gz` and loads the images locally
+instead of attempting a GHCR pull.
 
 To update an air-gapped host, repeat the process: produce a new airgap
 zip on the connected machine and ship it across.
@@ -189,7 +201,8 @@ logs, host information, file metadata, and TLS certificate fingerprints. It
 does not include raw `.env` files, private keys, or database dumps. Review the
 archive before attaching it to a ticket.
 
-Data lives in named Docker volumes (`db_data`, `ingest_data`, `agent_dist`).
+Data lives in named Docker volumes (`db_data`, `password_manager_db_data`,
+`ingest_data`, `agent_dist`).
 
 ## Uninstall
 

--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -334,7 +334,7 @@ install_new_bundle_files() {
 refresh_release_image_env_refs() {
   local var new_value current_value
 
-  for var in WEB_IMAGE INGEST_IMAGE; do
+  for var in WEB_IMAGE INGEST_IMAGE PASSWORD_MANAGER_API_IMAGE; do
     new_value="$(sed -n "s/^${var}=//p" .env.example | head -n1)"
     if [ -z "$new_value" ] || ! grep -q "^${var}=" .env; then
       continue
@@ -342,7 +342,7 @@ refresh_release_image_env_refs() {
 
     current_value="$(sed -n "s/^${var}=//p" .env | head -n1)"
     case "$current_value" in
-      ghcr.io/carrtech-dev/ct-ops/web@sha256:*|ghcr.io/carrtech-dev/ct-ops/ingest@sha256:*)
+      ghcr.io/carrtech-dev/ct-ops/web@sha256:*|ghcr.io/carrtech-dev/ct-ops/ingest@sha256:*|ghcr.io/carrtech-dev/ct-password-manager/api@sha256:*)
         awk -v key="$var" -v value="$new_value" '
           $0 ~ "^" key "=" { print key "=" value; next }
           { print }
@@ -352,7 +352,11 @@ refresh_release_image_env_refs() {
         ;;
       *)
         echo "WARN: preserving custom ${var} override in .env." >&2
-        echo "      Ensure WEB_IMAGE and INGEST_IMAGE come from the same CT-Ops release." >&2
+        if [ "$var" = "PASSWORD_MANAGER_API_IMAGE" ]; then
+          echo "      Ensure PASSWORD_MANAGER_API_IMAGE stays aligned with password-manager-release.json." >&2
+        else
+          echo "      Ensure WEB_IMAGE and INGEST_IMAGE come from the same CT-Ops release." >&2
+        fi
         ;;
     esac
   done

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -6,6 +6,27 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 UPGRADE_SCRIPT="${REPO_ROOT}/deploy/customer-bundle/upgrade.sh"
 BACKUP_SCRIPT="${REPO_ROOT}/deploy/customer-bundle/backup.sh"
 
+assert_env_value() {
+  local env_file="$1"
+  local key="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(sed -n "s/^${key}=//p" "$env_file" | head -n1)"
+  if [ "$actual" != "$expected" ]; then
+    echo "expected ${key}=${expected}, got ${actual:-<missing>}" >&2
+    sed -n '1,200p' "$env_file" >&2
+    exit 1
+  fi
+}
+
+read_env_value() {
+  local env_file="$1"
+  local key="$2"
+
+  sed -n "s/^${key}=//p" "$env_file" | head -n1
+}
+
 make_mock_bin() {
   local dir="$1"
 
@@ -87,6 +108,7 @@ write_bundle() {
     printf 'BETTER_AUTH_URL=https://example.test\n'
     printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' "${version//[^0-9]/}"
     printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' "${version//[^0-9]/}"
+    printf 'PASSWORD_MANAGER_API_IMAGE=ghcr.io/carrtech-dev/ct-password-manager/api@sha256:%064d\n' "${version//[^0-9]/}"
   } > "${dir}/ct-ops/.env.example"
   cat > "${dir}/ct-ops/password-manager-release.json" <<EOF
 {"schema_version":1,"repository":"carrtech-dev/ct-password-manager","git_tag":"api/${version}","source_commit_sha":"53ecd8f3cacbb8617cc05f4847ad506b1988fd99","image_repository":"ghcr.io/carrtech-dev/ct-password-manager/api","image_digest":"sha256:$(printf '%064d' "${version//[^0-9]/}")","digest_reference":"ghcr.io/carrtech-dev/ct-password-manager/api@sha256:$(printf '%064d' "${version//[^0-9]/}")","api_contract_version":"1.0.0","api_contract_checksum_sha256":"a07ffa6c4c8a6f0b57611a1a7c380a8b8ea1a889f4449c4f2ce02f914c05cf95"}
@@ -128,6 +150,7 @@ main() {
     printf 'customer-secret=true\n'
     printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' 100
     printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' 100
+    printf 'PASSWORD_MANAGER_API_IMAGE=ghcr.io/carrtech-dev/ct-password-manager/api@sha256:%064d\n' 100
   } > "${old_install}/.env"
   mkdir -p "${old_install}/deploy/tls" "${old_install}/deploy/dev-tls"
   printf 'tls-cert\n' > "${old_install}/deploy/tls/server.crt"
@@ -151,6 +174,7 @@ main() {
   grep -q 'customer-secret=true' "${old_install}/.env"
   grep -q 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:.*999' "${old_install}/.env"
   grep -q 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:.*999' "${old_install}/.env"
+  assert_env_value "${old_install}/.env" PASSWORD_MANAGER_API_IMAGE "$(read_env_value "${new_src}/ct-ops/.env.example" PASSWORD_MANAGER_API_IMAGE)"
   grep -q '"git_tag":"api/v9.9.9"' "${old_install}/password-manager-release.json"
   grep -q 'tls-cert' "${old_install}/deploy/tls/server.crt"
   grep -q 'dev-cert' "${old_install}/deploy/dev-tls/server.crt"
@@ -175,6 +199,7 @@ main() {
     printf 'customer-secret=true\n'
     printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' 100
     printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' 100
+    printf 'PASSWORD_MANAGER_API_IMAGE=ghcr.io/carrtech-dev/ct-password-manager/api@sha256:%064d\n' 100
   } > "${old_install}/.env"
 
   write_bundle "$new_src" "v9.9.9"
@@ -208,6 +233,7 @@ main() {
     printf 'customer-secret=true\n'
     printf 'WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:%064d\n' 100
     printf 'INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:%064d\n' 100
+    printf 'PASSWORD_MANAGER_API_IMAGE=ghcr.io/carrtech-dev/ct-password-manager/api@sha256:%064d\n' 100
   } > "${old_install}/.env"
 
   write_bundle "$new_src" "v0.100.0"
@@ -238,6 +264,7 @@ main() {
   grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v0.100.0/ct-ops-single.zip" "$MOCK_CURL_LOG"
   grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v0.100.0/ct-ops-single.zip.sha256" "$MOCK_CURL_LOG"
   grep -q 'example/web:v0.100.0' "${old_install}/docker-compose.yml"
+  assert_env_value "${old_install}/.env" PASSWORD_MANAGER_API_IMAGE "$(read_env_value "${new_src}/ct-ops/.env.example" PASSWORD_MANAGER_API_IMAGE)"
   grep -q '"git_tag":"api/v0.100.0"' "${old_install}/password-manager-release.json"
   unset MOCK_CURL_LOG MOCK_RELEASES_JSON_PAGE_2
 


### PR DESCRIPTION
## Summary
- stamp customer bundles with the reviewed Password Manager API digest from deploy/password-manager-release.json
- refresh PASSWORD_MANAGER_API_IMAGE during bundle upgrades while preserving explicit operator overrides
- extend bundle docs and CI checks to cover Password Manager images in connected and air-gapped installs

## Validation
- git diff --check
- python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
- bash -n deploy/customer-bundle/upgrade.sh
- bash deploy/scripts/test-upgrade.sh *(currently fails on the base branch with , already tracked in #1033)*