### PR TITLE
feat(web): add password manager launch assertions

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,26 @@
 
 ## What Has Been Built
 
+### Session 109 — Password Manager launch assertions
+
+**CT-Ops Password Manager launch route** (`apps/web/app/api/password-manager/launch-assertion/route.ts`, `apps/web/lib/password-manager/launch-assertion.ts`, `apps/web/lib/password-manager/launch-assertion.test.mjs`)
+- Added `POST /api/password-manager/launch-assertion`, gated by trusted
+  mutation origins, an active organisation session, Tooling access, and a
+  per-user launch rate limit.
+- Added a shared Password Manager launch-assertion helper that reads the CT-Ops
+  launch config from runtime env, parses the configured Ed25519 PKCS#8 private
+  key, and signs short-lived `EdDSA` JWTs carrying the required Password
+  Manager claims including issuer, audience, product, CT-Ops instance,
+  organisation, user identity, `iat`, `exp`, and `jti`.
+- Included optional organisation display names in the assertion when CT-Ops can
+  resolve them from the organisations table, while keeping failure responses
+  generic and never proxying Password Manager API traffic or session cookies.
+
+**Validation**
+- `node --experimental-strip-types --test lib/password-manager/launch-assertion.test.mjs`
+- `pnpm type-check`
+- `git diff --check`
+
 ### Session 108 — Password Manager release bundle pinning
 
 **Customer bundle Password Manager pinning** (`deploy/customer-bundle/upgrade.sh`, `deploy/customer-bundle/README.md`, `.github/workflows/customer-bundle-check.yml`, `.github/workflows/agent-release.yml`, `deploy/scripts/test-upgrade.sh`)

--- a/apps/web/app/api/password-manager/launch-assertion/route.ts
+++ b/apps/web/app/api/password-manager/launch-assertion/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { eq } from 'drizzle-orm'
+import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { requireToolingAccess } from '@/lib/auth/tooling'
+import { db } from '@/lib/db'
+import { organisations } from '@/lib/db/schema'
+import { logError } from '@/lib/logging'
+import {
+  getPasswordManagerLaunchAssertionConfig,
+  signPasswordManagerLaunchAssertion,
+} from '@/lib/password-manager/launch-assertion'
+import { createRateLimiter } from '@/lib/rate-limit'
+import { assertTrustedMutationOrigin } from '@/lib/security/trusted-origins'
+
+const launchAssertionRateLimit = createRateLimiter({
+  scope: 'password-manager:launch-assertion',
+  windowMs: 60_000,
+  max: 30,
+})
+
+function isLaunchConfigError(error: Error): boolean {
+  return /^(PASSWORD_MANAGER_CT_OPS_|CT_OPS_INSTANCE_ID|BETTER_AUTH_URL)\b/.test(error.message)
+}
+
+async function findOrganisationName(organisationId: string): Promise<string | null> {
+  const organisation = await db.query.organisations.findFirst({
+    columns: { name: true },
+    where: eq(organisations.id, organisationId),
+  })
+
+  return organisation?.name ?? null
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    assertTrustedMutationOrigin(request.headers)
+  } catch {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let session
+  try {
+    session = await getApiOrgSession(request.headers)
+    requireToolingAccess(session.user)
+  } catch (error) {
+    if (error instanceof ApiAuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof Error && error.message === 'forbidden: tooling role required') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    throw error
+  }
+
+  const rateLimitKey = `${session.user.organisationId}:${session.user.id}`
+  if (!await launchAssertionRateLimit.check(rateLimitKey)) {
+    return NextResponse.json(
+      { error: 'Too many requests — please wait before trying again.' },
+      { status: 429 },
+    )
+  }
+
+  try {
+    const config = getPasswordManagerLaunchAssertionConfig()
+    const organisationName = await findOrganisationName(session.user.organisationId)
+    const assertion = await signPasswordManagerLaunchAssertion(
+      {
+        organisationId: session.user.organisationId,
+        organisationName,
+        userId: session.user.id,
+        email: session.user.email,
+        name: session.user.name,
+      },
+      { config },
+    )
+
+    return NextResponse.json(
+      { assertion },
+      {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    )
+  } catch (error) {
+    logError('[password-manager] failed to mint launch assertion', error, {
+      organisationId: session.user.organisationId,
+      userId: session.user.id,
+    })
+
+    if (error instanceof Error && isLaunchConfigError(error)) {
+      return NextResponse.json(
+        { error: 'Password Manager launch is not configured.' },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json(
+      { error: 'Unable to create a Password Manager launch assertion.' },
+      { status: 500 },
+    )
+  }
+}

--- a/apps/web/lib/password-manager/launch-assertion.test.mjs
+++ b/apps/web/lib/password-manager/launch-assertion.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPairSync } from 'node:crypto'
+import { exportSPKI, importSPKI, jwtVerify } from 'jose'
+
+import {
+  PASSWORD_MANAGER_LAUNCH_ASSERTION_TTL_SECONDS,
+  getPasswordManagerLaunchAssertionConfig,
+  signPasswordManagerLaunchAssertion,
+} from './launch-assertion.ts'
+
+function createLaunchKeyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519')
+  return {
+    privateKeyDerBase64: privateKey.export({ format: 'der', type: 'pkcs8' }).toString('base64'),
+    publicKey,
+  }
+}
+
+test('getPasswordManagerLaunchAssertionConfig falls back to auth URL and defaults', () => {
+  const { privateKeyDerBase64 } = createLaunchKeyPair()
+
+  const config = getPasswordManagerLaunchAssertionConfig({
+    BETTER_AUTH_URL: 'https://ct-ops.example.com/login?next=%2Fdashboard',
+    CT_OPS_INSTANCE_ID: 'ct-ops-prod-1',
+    PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY: privateKeyDerBase64,
+  })
+
+  assert.equal(config.issuer, 'https://ct-ops.example.com/login?next=%2Fdashboard')
+  assert.equal(config.audience, 'ct-password-manager')
+  assert.equal(config.product, 'ct-password-manager')
+  assert.equal(config.ctOpsInstanceId, 'ct-ops-prod-1')
+  assert.equal(config.ttlSeconds, PASSWORD_MANAGER_LAUNCH_ASSERTION_TTL_SECONDS)
+})
+
+test('getPasswordManagerLaunchAssertionConfig rejects missing required launch config', () => {
+  assert.throws(
+    () =>
+      getPasswordManagerLaunchAssertionConfig({
+        BETTER_AUTH_URL: 'https://ct-ops.example.com',
+      }),
+    /CT_OPS_INSTANCE_ID must be set/,
+  )
+})
+
+test('signPasswordManagerLaunchAssertion emits the required claims', async () => {
+  const { privateKeyDerBase64, publicKey } = createLaunchKeyPair()
+  const config = getPasswordManagerLaunchAssertionConfig({
+    BETTER_AUTH_URL: 'https://ct-ops.example.com',
+    CT_OPS_INSTANCE_ID: 'ct-ops-prod-1',
+    PASSWORD_MANAGER_CT_OPS_AUDIENCE: 'ct-password-manager',
+    PASSWORD_MANAGER_CT_OPS_PRODUCT: 'ct-password-manager',
+    PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY: privateKeyDerBase64,
+  })
+
+  const assertion = await signPasswordManagerLaunchAssertion(
+    {
+      organisationId: 'org-123',
+      organisationName: 'Example Org',
+      userId: 'user-456',
+      email: 'ops@example.com',
+      name: 'Example Operator',
+    },
+    { config, now: new Date('2026-05-05T17:45:00.000Z'), jti: 'nonce-123' },
+  )
+
+  const verifier = await importSPKI(await exportSPKI(publicKey), 'EdDSA')
+  const { payload, protectedHeader } = await jwtVerify(assertion, verifier, {
+    algorithms: ['EdDSA'],
+    issuer: config.issuer,
+    audience: config.audience,
+    currentDate: new Date('2026-05-05T17:45:30.000Z'),
+  })
+
+  assert.equal(protectedHeader.alg, 'EdDSA')
+  assert.equal(payload.product, 'ct-password-manager')
+  assert.equal(payload.ct_ops_instance_id, 'ct-ops-prod-1')
+  assert.equal(payload.ct_ops_organization_id, 'org-123')
+  assert.equal(payload.ct_ops_organization_name, 'Example Org')
+  assert.equal(payload.ct_ops_user_id, 'user-456')
+  assert.equal(payload.email, 'ops@example.com')
+  assert.equal(payload.name, 'Example Operator')
+  assert.equal(payload.jti, 'nonce-123')
+  assert.equal(payload.iat, 1778003100)
+  assert.equal(payload.exp, 1778003100 + PASSWORD_MANAGER_LAUNCH_ASSERTION_TTL_SECONDS)
+})
+
+test('signPasswordManagerLaunchAssertion omits the optional organisation name when absent', async () => {
+  const { privateKeyDerBase64, publicKey } = createLaunchKeyPair()
+  const config = getPasswordManagerLaunchAssertionConfig({
+    BETTER_AUTH_URL: 'https://ct-ops.example.com',
+    CT_OPS_INSTANCE_ID: 'ct-ops-prod-1',
+    PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY: privateKeyDerBase64,
+  })
+
+  const assertion = await signPasswordManagerLaunchAssertion(
+    {
+      organisationId: 'org-123',
+      userId: 'user-456',
+      email: 'ops@example.com',
+      name: 'Example Operator',
+    },
+    { config, now: new Date('2026-05-05T17:45:00.000Z'), jti: 'nonce-456' },
+  )
+
+  const verifier = await importSPKI(await exportSPKI(publicKey), 'EdDSA')
+  const { payload } = await jwtVerify(assertion, verifier, {
+    algorithms: ['EdDSA'],
+    issuer: config.issuer,
+    audience: config.audience,
+    currentDate: new Date('2026-05-05T17:45:30.000Z'),
+  })
+
+  assert.equal('ct_ops_organization_name' in payload, false)
+})

--- a/apps/web/lib/password-manager/launch-assertion.ts
+++ b/apps/web/lib/password-manager/launch-assertion.ts
@@ -1,0 +1,134 @@
+import { createPrivateKey, randomUUID, type KeyObject } from 'node:crypto'
+import { SignJWT } from 'jose'
+
+type EnvLike = Record<string, string | undefined>
+
+export const PASSWORD_MANAGER_LAUNCH_ASSERTION_TTL_SECONDS = 60
+
+const DEFAULT_PASSWORD_MANAGER_AUDIENCE = 'ct-password-manager'
+const DEFAULT_PASSWORD_MANAGER_PRODUCT = 'ct-password-manager'
+
+export interface PasswordManagerLaunchAssertionConfig {
+  issuer: string
+  audience: string
+  product: string
+  ctOpsInstanceId: string
+  ttlSeconds: number
+  privateKey: KeyObject
+}
+
+export interface PasswordManagerLaunchPrincipal {
+  organisationId: string
+  organisationName?: string | null
+  userId: string
+  email: string
+  name: string
+}
+
+function readRequiredString(
+  env: EnvLike,
+  primaryKey: string,
+  fallbackKey?: string,
+): string {
+  const primaryValue = env[primaryKey]?.trim()
+  if (primaryValue) {
+    return primaryValue
+  }
+
+  if (fallbackKey) {
+    const fallbackValue = env[fallbackKey]?.trim()
+    if (fallbackValue) {
+      return fallbackValue
+    }
+    throw new Error(`${primaryKey} or ${fallbackKey} must be set`)
+  }
+
+  throw new Error(`${primaryKey} must be set`)
+}
+
+function readOptionalString(env: EnvLike, key: string, fallback: string): string {
+  return env[key]?.trim() || fallback
+}
+
+function parsePrivateKey(base64Der: string): KeyObject {
+  let der: Buffer
+  try {
+    der = Buffer.from(base64Der, 'base64')
+  } catch {
+    throw new Error('PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY must be valid base64 DER')
+  }
+
+  if (der.length === 0) {
+    throw new Error('PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY must be set')
+  }
+
+  try {
+    return createPrivateKey({
+      key: der,
+      format: 'der',
+      type: 'pkcs8',
+    })
+  } catch {
+    throw new Error('PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY must be a valid Ed25519 PKCS#8 DER key')
+  }
+}
+
+function assertNonEmptyPrincipalField(value: string | null | undefined, field: string): string {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    throw new Error(`${field} must be set`)
+  }
+  return trimmed
+}
+
+export function getPasswordManagerLaunchAssertionConfig(
+  env: EnvLike = process.env,
+): PasswordManagerLaunchAssertionConfig {
+  return {
+    issuer: readRequiredString(env, 'PASSWORD_MANAGER_CT_OPS_ISSUER', 'BETTER_AUTH_URL'),
+    audience: readOptionalString(env, 'PASSWORD_MANAGER_CT_OPS_AUDIENCE', DEFAULT_PASSWORD_MANAGER_AUDIENCE),
+    product: readOptionalString(env, 'PASSWORD_MANAGER_CT_OPS_PRODUCT', DEFAULT_PASSWORD_MANAGER_PRODUCT),
+    ctOpsInstanceId: readRequiredString(env, 'CT_OPS_INSTANCE_ID'),
+    ttlSeconds: PASSWORD_MANAGER_LAUNCH_ASSERTION_TTL_SECONDS,
+    privateKey: parsePrivateKey(
+      readRequiredString(env, 'PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY'),
+    ),
+  }
+}
+
+export async function signPasswordManagerLaunchAssertion(
+  principal: PasswordManagerLaunchPrincipal,
+  options: {
+    config?: PasswordManagerLaunchAssertionConfig
+    now?: Date
+    jti?: string
+  } = {},
+): Promise<string> {
+  const config = options.config ?? getPasswordManagerLaunchAssertionConfig()
+  const now = options.now ?? new Date()
+  const issuedAt = Math.floor(now.getTime() / 1000)
+  const jti = options.jti ?? randomUUID()
+
+  const payload: Record<string, string> = {
+    product: config.product,
+    ct_ops_instance_id: config.ctOpsInstanceId,
+    ct_ops_organization_id: assertNonEmptyPrincipalField(principal.organisationId, 'organisationId'),
+    ct_ops_user_id: assertNonEmptyPrincipalField(principal.userId, 'userId'),
+    email: assertNonEmptyPrincipalField(principal.email, 'email'),
+    name: assertNonEmptyPrincipalField(principal.name, 'name'),
+  }
+
+  const organisationName = principal.organisationName?.trim()
+  if (organisationName) {
+    payload.ct_ops_organization_name = organisationName
+  }
+
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'EdDSA', typ: 'JWT' })
+    .setIssuer(config.issuer)
+    .setAudience(config.audience)
+    .setIssuedAt(issuedAt)
+    .setExpirationTime(issuedAt + config.ttlSeconds)
+    .setJti(jti)
+    .sign(config.privateKey)
+}


### PR DESCRIPTION
## Summary
- add a trusted-origin, org-session, tooling-gated Password Manager launch assertion route
- sign short-lived Ed25519 launch JWTs with the required CT-Ops and Password Manager claims
- add unit coverage for config parsing, claim shape, and optional organisation-name handling

## Validation
- node --experimental-strip-types --test lib/password-manager/launch-assertion.test.mjs
- pnpm type-check
- git diff --check