### PR TITLE
ci(release): persist password manager image ref

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -182,6 +182,7 @@ jobs:
           fi
           PASSWORD_MANAGER_API_IMAGE_REF="$(python3 -c 'import json; print(json.load(open("deploy/password-manager-release.json", encoding="utf-8"))["digest_reference"])')"
           export WEB_IMAGE_REF INGEST_IMAGE_REF PASSWORD_MANAGER_API_IMAGE_REF
+          echo "PASSWORD_MANAGER_API_IMAGE_REF=${PASSWORD_MANAGER_API_IMAGE_REF}" >> "$GITHUB_ENV"
           mkdir -p dist/ct-ops/deploy/nginx
           cp docker-compose.single.yml        dist/ct-ops/docker-compose.yml
           cp .env.example                     dist/ct-ops/.env.example


### PR DESCRIPTION
## Summary
- persist the password manager API image digest from the bundle staging step into later release workflow steps
- fixes the customer bundle verifier failing under set -u after web/v0.104.0 image publication

## Validation
- git diff --check
- actionlint was not available locally; GitHub workflow checks will validate the workflow file

Follow-up for failed release run: https://github.com/carrtech-dev/ct-ops/actions/runs/25393657957