### PR TITLE
fix(release): persist password manager image ref

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -593,6 +593,7 @@ jobs:
       - name: Verify bundled compose pins image digests
         run: |
           set -euo pipefail
+          PASSWORD_MANAGER_API_IMAGE_REF="$(python3 -c 'import json; print(json.load(open("deploy/password-manager-release.json", encoding="utf-8"))["digest_reference"])')"
           export BETTER_AUTH_SECRET=verify-placeholder
           export POSTGRES_PASSWORD=verify-placeholder
           refs="$(docker compose -f dist/ct-ops/docker-compose.yml --env-file dist/ct-ops/.env.example config --images)"

--- a/.github/workflows/customer-bundle-check.yml
+++ b/.github/workflows/customer-bundle-check.yml
@@ -9,6 +9,7 @@ on:
       - "deploy/password-manager-release.json"
       - "deploy/scripts/validate-password-manager-release.py"
       - "deploy/scripts/test-install.sh"
+      - "deploy/scripts/test-agent-release-password-manager-image-ref.sh"
       - "deploy/scripts/test-password-manager-nginx.sh"
       - "deploy/scripts/test-password-manager-startup.sh"
       - "deploy/scripts/test-start.sh"
@@ -82,6 +83,7 @@ jobs:
           set -euo pipefail
           bash -n install.sh
           bash deploy/scripts/test-install.sh
+          bash deploy/scripts/test-agent-release-password-manager-image-ref.sh
           bash deploy/scripts/test-password-manager-compose.sh
           bash deploy/scripts/test-password-manager-nginx.sh
           bash deploy/scripts/test-password-manager-startup.sh

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,24 @@
 
 ## What Has Been Built
 
+### Session 110 — Release bundle digest verification fix
+
+**Release workflow Password Manager digest scope** (`.github/workflows/agent-release.yml`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-agent-release-password-manager-image-ref.sh`)
+- Fixed the post-merge release workflow so the `Verify bundled compose pins
+  image digests` step resolves `PASSWORD_MANAGER_API_IMAGE_REF` inside the same
+  shell step where it is consumed, instead of relying on a prior step-local
+  export that disappears between GitHub Actions steps.
+- Added a dedicated regression script that fails if the release workflow ever
+  stops resolving `PASSWORD_MANAGER_API_IMAGE_REF` before asserting the bundled
+  compose image pins.
+- Wired that regression into `Customer bundle check` so future PR CI catches the
+  variable-scope bug before another release run fails on `set -u`.
+
+**Validation**
+- `bash deploy/scripts/test-agent-release-password-manager-image-ref.sh`
+- `git diff --check`
+- `python3` workflow whitespace sanity check for `.github/workflows/agent-release.yml` and `.github/workflows/customer-bundle-check.yml`
+
 ### Session 109 — Password Manager launch assertions
 
 **CT-Ops Password Manager launch route** (`apps/web/app/api/password-manager/launch-assertion/route.ts`, `apps/web/lib/password-manager/launch-assertion.ts`, `apps/web/lib/password-manager/launch-assertion.test.mjs`)

--- a/deploy/scripts/test-agent-release-password-manager-image-ref.sh
+++ b/deploy/scripts/test-agent-release-password-manager-image-ref.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKFLOW_PATH="${REPO_ROOT}/.github/workflows/agent-release.yml"
+
+verify_step="$(
+  awk '
+    $0 ~ /^      - name: Verify bundled compose pins image digests$/ { capture = 1 }
+    capture { print }
+    capture && $0 ~ /^      - name: / && $0 !~ /Verify bundled compose pins image digests$/ {
+      exit
+    }
+  ' "$WORKFLOW_PATH"
+)"
+
+if [[ -z "$verify_step" ]]; then
+  echo "failed to locate verify step in agent-release.yml" >&2
+  exit 1
+fi
+
+if [[ "$verify_step" != *'PASSWORD_MANAGER_API_IMAGE_REF="$('* ]]; then
+  echo "verify step must resolve PASSWORD_MANAGER_API_IMAGE_REF before using it" >&2
+  exit 1
+fi
+
+if [[ "$verify_step" != *'grep -Fxq "${PASSWORD_MANAGER_API_IMAGE_REF}" <<< "$refs"'* ]]; then
+  echo "verify step no longer checks the Password Manager digest pin" >&2
+  exit 1
+fi
+
+echo "agent-release password manager image ref check passed"


### PR DESCRIPTION
## Summary
- resolve PASSWORD_MANAGER_API_IMAGE_REF inside the release verify step so set -u cannot see it as unbound
- add a dedicated regression script for the release workflow
- run that regression in Customer bundle check so PR CI catches the scope bug before another release run

## Validation
- bash deploy/scripts/test-agent-release-password-manager-image-ref.sh
- git diff --check
- python3 workflow whitespace sanity check for .github/workflows/agent-release.yml and .github/workflows/customer-bundle-check.yml