### PR TITLE
feat(web): add password manager client and browser crypto

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,31 @@
 
 ## What Has Been Built
 
+### Session 111 — Password Manager portable client and browser crypto
+
+**Reusable Password Manager product layer** (`apps/web/lib/password-manager/client.ts`, `apps/web/lib/password-manager/browser-crypto.ts`, `apps/web/lib/password-manager/client.test.mjs`, `apps/web/lib/password-manager/browser-crypto.test.mjs`)
+- Added a configurable Password Manager client abstraction that treats the API
+  base URL and CT-Ops launch path as configuration, covers launch, session
+  refresh/logout, setup, user-key, vault, entry, member, key-rotation, and
+  audit routes, and sends `credentials: include` on every Password Manager
+  request.
+- Added request payload helpers that serialize the Password Manager API’s
+  expected JSON field names while rejecting plaintext-shaped fields such as
+  `plaintext`, `password`, `secret`, `private_key`, `vault_key`, and
+  `entry_key` before anything is sent over the wire.
+- Added a browser-only crypto module for unlock-profile creation, PBKDF2-based
+  key derivation, encrypted private-key envelopes, RSA-OAEP vault-key wrapping,
+  AES-GCM entry payload encryption/decryption, and member public-key export.
+- Added route-coverage tests against the pinned Password Manager OpenAPI
+  contract so client route drift is caught locally when the API contract or
+  client surface changes.
+
+**Validation**
+- `pnpm install --frozen-lockfile`
+- `pnpm --dir apps/web type-check`
+- `node --experimental-strip-types --test apps/web/lib/password-manager/client.test.mjs apps/web/lib/password-manager/browser-crypto.test.mjs`
+- `git diff --check`
+
 ### Session 110 — Release bundle digest verification fix
 
 **Release workflow Password Manager digest scope** (`.github/workflows/agent-release.yml`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-agent-release-password-manager-image-ref.sh`)

--- a/apps/web/lib/password-manager/browser-crypto.test.mjs
+++ b/apps/web/lib/password-manager/browser-crypto.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createEncryptedEntryPayload,
+  createUnlockProfile,
+  decryptEntryPayload,
+  decryptUserPrivateKeyEnvelope,
+  exportPublicKeyEnvelope,
+  generateVaultKey,
+  unwrapVaultKeyEnvelope,
+  wrapVaultKeyForMember,
+} from './browser-crypto.ts'
+
+test('unlock profile generation and decrypt round-trip stays browser-only', async () => {
+  const profile = await createUnlockProfile('correct horse battery staple')
+  const decrypted = await decryptUserPrivateKeyEnvelope({
+    unlockPassword: 'correct horse battery staple',
+    encryptedPrivateKeyEnvelope: profile.encryptedPrivateKeyEnvelope,
+    kdfMetadata: profile.kdfMetadata,
+  })
+
+  assert.equal(profile.kdfMetadata.algorithm, 'pbkdf2-sha256')
+  assert.equal(profile.kdfMetadata.derived_key_length, 32)
+  assert.equal(profile.publicKey.algorithm.name, 'RSA-OAEP')
+  assert.equal(decrypted.privateKey.algorithm.name, 'RSA-OAEP')
+})
+
+test('vault key wrapping and entry encryption round-trip', async () => {
+  const owner = await createUnlockProfile('owner password')
+  const ownerKeys = await decryptUserPrivateKeyEnvelope({
+    unlockPassword: 'owner password',
+    encryptedPrivateKeyEnvelope: owner.encryptedPrivateKeyEnvelope,
+    kdfMetadata: owner.kdfMetadata,
+  })
+
+  const vaultKey = await generateVaultKey()
+  const wrappedVaultKeyEnvelope = await wrapVaultKeyForMember(vaultKey, owner.publicKey)
+  const unwrappedVaultKey = await unwrapVaultKeyEnvelope(
+    wrappedVaultKeyEnvelope,
+    ownerKeys.privateKey,
+  )
+  const encryptedPayload = await createEncryptedEntryPayload(
+    {
+      title: 'Database root password',
+      username: 'postgres',
+      password: 'super-secret',
+    },
+    unwrappedVaultKey,
+  )
+  const decryptedPayload = await decryptEntryPayload(encryptedPayload, unwrappedVaultKey)
+
+  assert.equal(wrappedVaultKeyEnvelope.algorithm, 'rsa-oaep-256')
+  assert.equal(encryptedPayload.algorithm, 'aes-256-gcm')
+  assert.deepEqual(decryptedPayload, {
+    title: 'Database root password',
+    username: 'postgres',
+    password: 'super-secret',
+  })
+})
+
+test('exportPublicKeyEnvelope returns a portable encrypted member key target', async () => {
+  const profile = await createUnlockProfile('member password')
+  const publicKeyEnvelope = await exportPublicKeyEnvelope(profile.publicKey)
+
+  assert.equal(publicKeyEnvelope.version, 1)
+  assert.equal(publicKeyEnvelope.algorithm, 'rsa-oaep-256')
+  assert.equal(typeof publicKeyEnvelope.public_key_spki_b64, 'string')
+  assert.equal(publicKeyEnvelope.public_key_spki_b64.length > 0, true)
+})

--- a/apps/web/lib/password-manager/browser-crypto.ts
+++ b/apps/web/lib/password-manager/browser-crypto.ts
@@ -1,0 +1,288 @@
+const PBKDF2_ITERATIONS = 600_000
+const DERIVED_KEY_LENGTH = 32
+const AES_GCM_IV_BYTES = 12
+const PBKDF2_SALT_BYTES = 16
+
+export interface PasswordManagerKdfMetadata {
+  algorithm: 'pbkdf2-sha256'
+  iterations: number
+  salt_b64: string
+  derived_key_length: number
+}
+
+export interface PasswordManagerPublicKeyEnvelope {
+  version: 1
+  algorithm: 'rsa-oaep-256'
+  public_key_spki_b64: string
+}
+
+export interface PasswordManagerEncryptedPrivateKeyEnvelope
+  extends PasswordManagerPublicKeyEnvelope {
+  iv_b64: string
+  ciphertext_b64: string
+}
+
+export interface PasswordManagerWrappedVaultKeyEnvelope {
+  version: 1
+  algorithm: 'rsa-oaep-256'
+  wrapped_key_b64: string
+}
+
+export interface PasswordManagerEncryptedPayloadEnvelope {
+  version: 1
+  algorithm: 'aes-256-gcm'
+  iv_b64: string
+  ciphertext_b64: string
+}
+
+function getWebCrypto(): Crypto {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto API is required')
+  }
+  return globalThis.crypto
+}
+
+function toBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)
+  return Buffer.from(bytes).toString('base64')
+}
+
+function fromBase64(value: string): ArrayBuffer {
+  const bytes = Buffer.from(value, 'base64')
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(new ArrayBuffer(length))
+  getWebCrypto().getRandomValues(bytes)
+  return bytes
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const arrayBuffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(arrayBuffer).set(bytes)
+  return arrayBuffer
+}
+
+async function deriveAesKey(
+  unlockPassword: string,
+  metadata: PasswordManagerKdfMetadata,
+): Promise<CryptoKey> {
+  const crypto = getWebCrypto()
+  const passwordMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(unlockPassword),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  )
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt: fromBase64(metadata.salt_b64),
+      iterations: metadata.iterations,
+    },
+    passwordMaterial,
+    {
+      name: 'AES-GCM',
+      length: metadata.derived_key_length * 8,
+    },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+export async function createUnlockProfile(unlockPassword: string): Promise<{
+  encryptedPrivateKeyEnvelope: PasswordManagerEncryptedPrivateKeyEnvelope
+  kdfMetadata: PasswordManagerKdfMetadata
+  publicKey: CryptoKey
+}> {
+  const crypto = getWebCrypto()
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: 'RSA-OAEP',
+      hash: 'SHA-256',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    },
+    true,
+    ['wrapKey', 'unwrapKey'],
+  )
+  const privateKeyBytes = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey)
+  const publicKeyBytes = await crypto.subtle.exportKey('spki', keyPair.publicKey)
+  const kdfMetadata: PasswordManagerKdfMetadata = {
+    algorithm: 'pbkdf2-sha256',
+    iterations: PBKDF2_ITERATIONS,
+    salt_b64: toBase64(randomBytes(PBKDF2_SALT_BYTES)),
+    derived_key_length: DERIVED_KEY_LENGTH,
+  }
+  const aesKey = await deriveAesKey(unlockPassword, kdfMetadata)
+  const iv = randomBytes(AES_GCM_IV_BYTES)
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(iv),
+    },
+    aesKey,
+    privateKeyBytes,
+  )
+
+  return {
+    encryptedPrivateKeyEnvelope: {
+      version: 1,
+      algorithm: 'rsa-oaep-256',
+      public_key_spki_b64: toBase64(publicKeyBytes),
+      iv_b64: toBase64(iv),
+      ciphertext_b64: toBase64(ciphertext),
+    },
+    kdfMetadata,
+    publicKey: keyPair.publicKey,
+  }
+}
+
+export async function decryptUserPrivateKeyEnvelope(input: {
+  unlockPassword: string
+  encryptedPrivateKeyEnvelope: PasswordManagerEncryptedPrivateKeyEnvelope
+  kdfMetadata: PasswordManagerKdfMetadata
+}): Promise<{
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+}> {
+  const crypto = getWebCrypto()
+  const aesKey = await deriveAesKey(input.unlockPassword, input.kdfMetadata)
+  const privateKeyBytes = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: fromBase64(input.encryptedPrivateKeyEnvelope.iv_b64),
+    },
+    aesKey,
+    fromBase64(input.encryptedPrivateKeyEnvelope.ciphertext_b64),
+  )
+
+  const [privateKey, publicKey] = await Promise.all([
+    crypto.subtle.importKey(
+      'pkcs8',
+      privateKeyBytes,
+      {
+        name: 'RSA-OAEP',
+        hash: 'SHA-256',
+      },
+      true,
+      ['unwrapKey'],
+    ),
+    crypto.subtle.importKey(
+      'spki',
+      fromBase64(input.encryptedPrivateKeyEnvelope.public_key_spki_b64),
+      {
+        name: 'RSA-OAEP',
+        hash: 'SHA-256',
+      },
+      true,
+      ['wrapKey'],
+    ),
+  ])
+
+  return { privateKey, publicKey }
+}
+
+export async function exportPublicKeyEnvelope(
+  publicKey: CryptoKey,
+): Promise<PasswordManagerPublicKeyEnvelope> {
+  const publicKeyBytes = await getWebCrypto().subtle.exportKey('spki', publicKey)
+  return {
+    version: 1,
+    algorithm: 'rsa-oaep-256',
+    public_key_spki_b64: toBase64(publicKeyBytes),
+  }
+}
+
+export async function generateVaultKey(): Promise<CryptoKey> {
+  return getWebCrypto().subtle.generateKey(
+    {
+      name: 'AES-GCM',
+      length: 256,
+    },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+export async function wrapVaultKeyForMember(
+  vaultKey: CryptoKey,
+  memberPublicKey: CryptoKey,
+): Promise<PasswordManagerWrappedVaultKeyEnvelope> {
+  const wrappedKey = await getWebCrypto().subtle.wrapKey(
+    'raw',
+    vaultKey,
+    memberPublicKey,
+    {
+      name: 'RSA-OAEP',
+    },
+  )
+
+  return {
+    version: 1,
+    algorithm: 'rsa-oaep-256',
+    wrapped_key_b64: toBase64(wrappedKey),
+  }
+}
+
+export async function unwrapVaultKeyEnvelope(
+  wrappedVaultKeyEnvelope: PasswordManagerWrappedVaultKeyEnvelope,
+  memberPrivateKey: CryptoKey,
+): Promise<CryptoKey> {
+  return getWebCrypto().subtle.unwrapKey(
+    'raw',
+    fromBase64(wrappedVaultKeyEnvelope.wrapped_key_b64),
+    memberPrivateKey,
+    {
+      name: 'RSA-OAEP',
+    },
+    {
+      name: 'AES-GCM',
+      length: 256,
+    },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+export async function createEncryptedEntryPayload(
+  value: unknown,
+  vaultKey: CryptoKey,
+): Promise<PasswordManagerEncryptedPayloadEnvelope> {
+  const iv = randomBytes(AES_GCM_IV_BYTES)
+  const ciphertext = await getWebCrypto().subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(iv),
+    },
+    vaultKey,
+    new TextEncoder().encode(JSON.stringify(value)),
+  )
+
+  return {
+    version: 1,
+    algorithm: 'aes-256-gcm',
+    iv_b64: toBase64(iv),
+    ciphertext_b64: toBase64(ciphertext),
+  }
+}
+
+export async function decryptEntryPayload<T>(
+  envelope: PasswordManagerEncryptedPayloadEnvelope,
+  vaultKey: CryptoKey,
+): Promise<T> {
+  const plaintext = await getWebCrypto().subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: fromBase64(envelope.iv_b64),
+    },
+    vaultKey,
+    fromBase64(envelope.ciphertext_b64),
+  )
+
+  return JSON.parse(new TextDecoder().decode(plaintext)) as T
+}

--- a/apps/web/lib/password-manager/client.test.mjs
+++ b/apps/web/lib/password-manager/client.test.mjs
@@ -1,0 +1,265 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import {
+  PASSWORD_MANAGER_CLIENT_ROUTE_SPECS,
+  PasswordManagerApiError,
+  createPasswordManagerClient,
+  createEntryPayload,
+  createMemberPayload,
+  createPasswordManagerLaunchPayload,
+  createRotateVaultKeysPayload,
+  createUserKeyPayload,
+  createVaultPayload,
+  updateEntryPayload,
+  updateMemberPayload,
+  updateVaultPayload,
+} from './client.ts'
+
+function loadPinnedContract() {
+  const filePath = fileURLToPath(
+    new URL('../../../../../ct-password-manager/docs/api-contract/openapi.json', import.meta.url),
+  )
+  return JSON.parse(readFileSync(filePath, 'utf8'))
+}
+
+function createJsonResponse(status, payload) {
+  return new Response(payload === undefined ? null : JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+test('PASSWORD_MANAGER_CLIENT_ROUTE_SPECS matches the pinned Password Manager contract', () => {
+  const contract = loadPinnedContract()
+  const actual = new Set(
+    Object.values(PASSWORD_MANAGER_CLIENT_ROUTE_SPECS).map(
+      ({ method, path }) => `${method.toUpperCase()} ${path}`,
+    ),
+  )
+  const expected = new Set(
+    Object.entries(contract.paths).flatMap(([path, methods]) =>
+      Object.keys(methods).map((method) => `${method.toUpperCase()} ${path}`),
+    ),
+  )
+  expected.delete('GET /healthz')
+
+  assert.deepEqual([...actual].sort(), [...expected].sort())
+})
+
+test('launch fetches a fresh assertion and exchanges it with Password Manager using credentials', async () => {
+  const calls = []
+  const client = createPasswordManagerClient({
+    apiBaseUrl: 'https://ops.example.test/password-manager-api/',
+    launchPath: '/api/password-manager/launch-assertion',
+    fetch: async (input, init = {}) => {
+      calls.push({
+        url: input instanceof Request ? input.url : String(input),
+        init,
+      })
+
+      if (calls.length === 1) {
+        return createJsonResponse(200, { assertion: 'signed-launch-assertion' })
+      }
+
+      return new Response(null, { status: 204 })
+    },
+  })
+
+  await client.launch()
+
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0].url, 'http://localhost/api/password-manager/launch-assertion')
+  assert.equal(calls[0].init.method, 'POST')
+  assert.equal(calls[0].init.credentials, 'include')
+
+  assert.equal(calls[1].url, 'https://ops.example.test/password-manager-api/launch/ct-ops')
+  assert.equal(calls[1].init.method, 'POST')
+  assert.equal(calls[1].init.credentials, 'include')
+  assert.match(String(calls[1].init.body), /signed-launch-assertion/)
+})
+
+test('createVault and rotateVaultKeys preserve the supplied Idempotency-Key header', async () => {
+  const calls = []
+  const client = createPasswordManagerClient({
+    apiBaseUrl: 'https://ops.example.test/password-manager-api',
+    fetch: async (input, init = {}) => {
+      calls.push({
+        url: input instanceof Request ? input.url : String(input),
+        init,
+      })
+      return createJsonResponse(201, {
+        id: 'vault-1',
+        encrypted_metadata: { ciphertext_b64: 'meta' },
+        wrapped_vault_key_envelope: { wrapped_key_b64: 'wrapped' },
+        role: 'owner',
+        current_key_epoch: 1,
+        created_at: '2026-05-05T18:00:00Z',
+        updated_at: '2026-05-05T18:00:00Z',
+      })
+    },
+  })
+
+  await client.createVault({
+    idempotencyKey: 'vault-create-key',
+    encryptedMetadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+  })
+
+  await client.rotateVaultKeys({
+    vaultId: 'vault-1',
+    idempotencyKey: 'rotate-key',
+    rotationReason: 'membership_revoked',
+    members: [{ userId: 'user-1', wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'ZA==' } }],
+  })
+
+  assert.equal(calls[0].init.headers['Idempotency-Key'], 'vault-create-key')
+  assert.equal(calls[1].init.headers['Idempotency-Key'], 'rotate-key')
+})
+
+test('audit routes send empty bodies only', async () => {
+  const calls = []
+  const client = createPasswordManagerClient({
+    apiBaseUrl: 'https://ops.example.test/password-manager-api',
+    fetch: async (input, init = {}) => {
+      calls.push({
+        url: input instanceof Request ? input.url : String(input),
+        init,
+      })
+      return new Response(null, { status: 204 })
+    },
+  })
+
+  await client.auditReveal({ vaultId: 'vault-1', entryId: 'entry-1' })
+  await client.auditCopy({ vaultId: 'vault-1', entryId: 'entry-1' })
+  await client.auditExport({ vaultId: 'vault-1' })
+
+  for (const call of calls) {
+    assert.equal(call.init.method, 'POST')
+    assert.equal(call.init.credentials, 'include')
+    assert.equal('body' in call.init, false)
+  }
+})
+
+test('request payload helpers reject plaintext-shaped fields', () => {
+  assert.throws(
+    () =>
+      createUserKeyPayload({
+        encryptedPrivateKeyEnvelope: { ciphertext_b64: 'abc', private_key: 'plaintext' },
+        kdfMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
+      }),
+    /plaintext-shaped field/i,
+  )
+
+  assert.throws(
+    () =>
+      createVaultPayload({
+        encryptedMetadata: { ciphertext_b64: 'abc', plaintext: 'secret' },
+        wrappedVaultKeyEnvelope: { wrapped_key_b64: 'wrapped' },
+      }),
+    /plaintext-shaped field/i,
+  )
+
+  assert.throws(
+    () =>
+      createEntryPayload({
+        encryptedPayload: { ciphertext_b64: 'abc', secret: 'plaintext' },
+        keyEpoch: 1,
+      }),
+    /plaintext-shaped field/i,
+  )
+
+  assert.throws(
+    () =>
+      createMemberPayload({
+        userId: 'user-1',
+        role: 'viewer',
+        wrappedVaultKeyEnvelope: { wrapped_key_b64: 'abc', vault_key: 'plaintext' },
+        keyEpoch: 1,
+      }),
+    /plaintext-shaped field/i,
+  )
+})
+
+test('request payload helpers serialize supported encrypted shapes', () => {
+  assert.deepEqual(createPasswordManagerLaunchPayload('assertion-token'), { assertion: 'assertion-token' })
+  assert.deepEqual(createVaultPayload({
+    encryptedMetadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+  }), {
+    encrypted_metadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    wrapped_vault_key_envelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+  })
+  assert.deepEqual(updateVaultPayload({
+    encryptedMetadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+  }), {
+    encrypted_metadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+  })
+  assert.deepEqual(createEntryPayload({
+    encryptedPayload: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    keyEpoch: 3,
+  }), {
+    encrypted_payload: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    key_epoch: 3,
+  })
+  assert.deepEqual(updateEntryPayload({
+    encryptedPayload: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    keyEpoch: 4,
+  }), {
+    encrypted_payload: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+    key_epoch: 4,
+  })
+  assert.deepEqual(createMemberPayload({
+    userId: 'user-1',
+    role: 'viewer',
+    wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+    keyEpoch: 1,
+  }), {
+    user_id: 'user-1',
+    role: 'viewer',
+    wrapped_vault_key_envelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+    key_epoch: 1,
+  })
+  assert.deepEqual(updateMemberPayload({
+    role: 'manager',
+    wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+    keyEpoch: 2,
+  }), {
+    role: 'manager',
+    wrapped_vault_key_envelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+    key_epoch: 2,
+  })
+  assert.deepEqual(createRotateVaultKeysPayload({
+    rotationReason: 'membership_revoked',
+    members: [
+      { userId: 'user-1', wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' } },
+    ],
+  }), {
+    rotation_reason: 'membership_revoked',
+    members: [
+      { user_id: 'user-1', wrapped_vault_key_envelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' } },
+    ],
+  })
+})
+
+test('non-success responses surface a normalized PasswordManagerApiError', async () => {
+  const client = createPasswordManagerClient({
+    apiBaseUrl: 'https://ops.example.test/password-manager-api',
+    fetch: async () => createJsonResponse(409, { error: 'idempotency_conflict' }),
+  })
+
+  await assert.rejects(
+    () =>
+      client.createVault({
+        idempotencyKey: 'vault-create-key',
+        encryptedMetadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+        wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+      }),
+    (error) =>
+      error instanceof PasswordManagerApiError &&
+      error.status === 409 &&
+      error.code === 'idempotency_conflict',
+  )
+})

--- a/apps/web/lib/password-manager/client.ts
+++ b/apps/web/lib/password-manager/client.ts
@@ -1,0 +1,602 @@
+import { randomUUID } from 'node:crypto'
+
+type JsonPrimitive = string | number | boolean | null
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue }
+type JsonObject = { [key: string]: JsonValue }
+
+type FetchLike = typeof fetch
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+const PLAINTEXT_SHAPED_FIELD_NAMES = new Set([
+  'plaintext',
+  'private_key',
+  'password',
+  'secret',
+  'unlock_key',
+  'derived_key',
+  'vault_key',
+  'entry_key',
+])
+
+export interface PasswordManagerClientRouteSpec {
+  method: HttpMethod
+  path: string
+}
+
+export const PASSWORD_MANAGER_CLIENT_ROUTE_SPECS = {
+  launch: { method: 'POST', path: '/launch/ct-ops' },
+  refreshSession: { method: 'POST', path: '/sessions/refresh' },
+  logout: { method: 'POST', path: '/sessions/logout' },
+  getSetupStatus: { method: 'GET', path: '/setup-status' },
+  getUnlockMetadata: { method: 'GET', path: '/unlock-metadata' },
+  getUserKey: { method: 'GET', path: '/user-key' },
+  putUserKey: { method: 'PUT', path: '/user-key' },
+  listVaults: { method: 'GET', path: '/vaults' },
+  createVault: { method: 'POST', path: '/vaults' },
+  getVault: { method: 'GET', path: '/vaults/{vaultID}' },
+  updateVault: { method: 'PATCH', path: '/vaults/{vaultID}' },
+  deleteVault: { method: 'DELETE', path: '/vaults/{vaultID}' },
+  listEntries: { method: 'GET', path: '/vaults/{vaultID}/entries' },
+  createEntry: { method: 'POST', path: '/vaults/{vaultID}/entries' },
+  getEntry: { method: 'GET', path: '/vaults/{vaultID}/entries/{entryID}' },
+  updateEntry: { method: 'PATCH', path: '/vaults/{vaultID}/entries/{entryID}' },
+  deleteEntry: { method: 'DELETE', path: '/vaults/{vaultID}/entries/{entryID}' },
+  auditCopy: { method: 'POST', path: '/vaults/{vaultID}/entries/{entryID}/copy-audit' },
+  auditReveal: { method: 'POST', path: '/vaults/{vaultID}/entries/{entryID}/reveal-audit' },
+  auditExport: { method: 'POST', path: '/vaults/{vaultID}/export-audit' },
+  listMembers: { method: 'GET', path: '/vaults/{vaultID}/members' },
+  addMember: { method: 'POST', path: '/vaults/{vaultID}/members' },
+  updateMember: { method: 'PATCH', path: '/vaults/{vaultID}/members/{userID}' },
+  removeMember: { method: 'DELETE', path: '/vaults/{vaultID}/members/{userID}' },
+  rotateVaultKeys: { method: 'POST', path: '/vaults/{vaultID}/key-epochs' },
+} satisfies Record<string, PasswordManagerClientRouteSpec>
+
+export class PasswordManagerApiError extends Error {
+  status: number
+  code: string
+
+  constructor(status: number, code: string) {
+    super(`Password Manager API error ${status}: ${code}`)
+    this.name = 'PasswordManagerApiError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export interface PasswordManagerClientOptions {
+  apiBaseUrl: string
+  launchPath?: string
+  launchAssertionSupplier?: () => Promise<string | { assertion: string }>
+  fetch?: FetchLike
+}
+
+export interface SetupStatusResponse {
+  configured: boolean
+}
+
+export interface UserKeyResponse {
+  encrypted_private_key_envelope: JsonObject
+  kdf_metadata: JsonObject
+}
+
+export interface UnlockMetadataResponse {
+  kdf_metadata: JsonObject
+}
+
+export interface VaultRecord {
+  id: string
+  encrypted_metadata: JsonObject
+  wrapped_vault_key_envelope: JsonObject
+  role: string
+  current_key_epoch: number
+  created_at: string
+  updated_at: string
+}
+
+export interface EntryRecord {
+  id: string
+  vault_id: string
+  encrypted_payload: JsonObject
+  key_epoch: number
+  created_at: string
+  updated_at: string
+}
+
+export interface MemberRecord {
+  user_id: string
+  role: string
+  wrapped_vault_key_envelope: JsonObject
+  key_epoch: number
+  created_at: string
+  updated_at: string
+}
+
+export interface KeyEpochRecord {
+  id: string
+  vault_id: string
+  epoch: number
+  rotation_reason: string
+  created_at: string
+}
+
+function normalizeApiBaseUrl(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error('apiBaseUrl must be set')
+  }
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`
+}
+
+function resolvePath(template: string, params: Record<string, string> = {}): string {
+  let resolved = template
+  for (const [key, value] of Object.entries(params)) {
+    resolved = resolved.replace(`{${key}}`, encodeURIComponent(value))
+  }
+  return resolved
+}
+
+function assertNoPlaintextLikeKeys(value: JsonValue, path = '$'): void {
+  if (Array.isArray(value)) {
+    for (const [index, nested] of value.entries()) {
+      assertNoPlaintextLikeKeys(nested, `${path}[${index}]`)
+    }
+    return
+  }
+
+  if (!value || typeof value !== 'object') {
+    return
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (PLAINTEXT_SHAPED_FIELD_NAMES.has(key.toLowerCase())) {
+      throw new Error(`plaintext-shaped field "${key}" is not allowed in Password Manager payload helpers`)
+    }
+    assertNoPlaintextLikeKeys(nested, `${path}.${key}`)
+  }
+}
+
+function cloneJsonObject(value: JsonObject): JsonObject {
+  return JSON.parse(JSON.stringify(value)) as JsonObject
+}
+
+function requireNonEmptyString(value: string, field: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new Error(`${field} must be set`)
+  }
+  return trimmed
+}
+
+async function parseResponse(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return undefined
+  }
+
+  const text = await response.text()
+  if (!text) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+async function throwIfNotOk(response: Response): Promise<void> {
+  if (response.ok) {
+    return
+  }
+
+  const payload = await parseResponse(response)
+  const code =
+    payload && typeof payload === 'object' && 'error' in payload && typeof payload.error === 'string'
+      ? payload.error
+      : 'unknown_error'
+  throw new PasswordManagerApiError(response.status, code)
+}
+
+async function extractAssertion(
+  fetchImpl: FetchLike,
+  launchPath: string | undefined,
+  launchAssertionSupplier: PasswordManagerClientOptions['launchAssertionSupplier'],
+): Promise<string> {
+  if (launchAssertionSupplier) {
+    const supplied = await launchAssertionSupplier()
+    if (typeof supplied === 'string') {
+      return requireNonEmptyString(supplied, 'assertion')
+    }
+    return requireNonEmptyString(supplied.assertion, 'assertion')
+  }
+
+  if (!launchPath) {
+    throw new Error('Either launchPath or launchAssertionSupplier must be configured')
+  }
+
+  const response = await fetchImpl(new URL(launchPath, 'http://localhost').toString(), {
+    method: 'POST',
+    credentials: 'include',
+  })
+  await throwIfNotOk(response)
+  const payload = (await parseResponse(response)) as { assertion?: string } | undefined
+  return requireNonEmptyString(payload?.assertion ?? '', 'assertion')
+}
+
+async function requestJson<TResponse>(
+  fetchImpl: FetchLike,
+  apiBaseUrl: string,
+  route: PasswordManagerClientRouteSpec,
+  options: {
+    pathParams?: Record<string, string>
+    headers?: Record<string, string>
+    body?: JsonObject
+  } = {},
+): Promise<TResponse> {
+  const url = `${apiBaseUrl.replace(/\/$/, '')}${resolvePath(route.path, options.pathParams)}`
+  const headers: Record<string, string> = {
+    ...(options.headers ?? {}),
+  }
+  const init: RequestInit & { headers: Record<string, string> } = {
+    method: route.method,
+    credentials: 'include',
+    headers,
+  }
+
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+    init.body = JSON.stringify(options.body)
+  }
+
+  const response = await fetchImpl(url, init)
+  await throwIfNotOk(response)
+  return (await parseResponse(response)) as TResponse
+}
+
+export function createPasswordManagerLaunchPayload(assertion: string): JsonObject {
+  return {
+    assertion: requireNonEmptyString(assertion, 'assertion'),
+  }
+}
+
+export function createUserKeyPayload(input: {
+  encryptedPrivateKeyEnvelope: JsonObject
+  kdfMetadata: JsonObject
+}): JsonObject {
+  const encryptedPrivateKeyEnvelope = cloneJsonObject(input.encryptedPrivateKeyEnvelope)
+  const kdfMetadata = cloneJsonObject(input.kdfMetadata)
+  assertNoPlaintextLikeKeys(encryptedPrivateKeyEnvelope)
+  assertNoPlaintextLikeKeys(kdfMetadata)
+
+  return {
+    encrypted_private_key_envelope: encryptedPrivateKeyEnvelope,
+    kdf_metadata: kdfMetadata,
+  }
+}
+
+export function createVaultPayload(input: {
+  encryptedMetadata: JsonObject
+  wrappedVaultKeyEnvelope: JsonObject
+}): JsonObject {
+  const encryptedMetadata = cloneJsonObject(input.encryptedMetadata)
+  const wrappedVaultKeyEnvelope = cloneJsonObject(input.wrappedVaultKeyEnvelope)
+  assertNoPlaintextLikeKeys(encryptedMetadata)
+  assertNoPlaintextLikeKeys(wrappedVaultKeyEnvelope)
+
+  return {
+    encrypted_metadata: encryptedMetadata,
+    wrapped_vault_key_envelope: wrappedVaultKeyEnvelope,
+  }
+}
+
+export function updateVaultPayload(input: {
+  encryptedMetadata: JsonObject
+}): JsonObject {
+  const encryptedMetadata = cloneJsonObject(input.encryptedMetadata)
+  assertNoPlaintextLikeKeys(encryptedMetadata)
+
+  return {
+    encrypted_metadata: encryptedMetadata,
+  }
+}
+
+export function createEntryPayload(input: {
+  encryptedPayload: JsonObject
+  keyEpoch: number
+}): JsonObject {
+  const encryptedPayload = cloneJsonObject(input.encryptedPayload)
+  assertNoPlaintextLikeKeys(encryptedPayload)
+
+  return {
+    encrypted_payload: encryptedPayload,
+    key_epoch: input.keyEpoch,
+  }
+}
+
+export function updateEntryPayload(input: {
+  encryptedPayload: JsonObject
+  keyEpoch: number
+}): JsonObject {
+  return createEntryPayload(input)
+}
+
+export function createMemberPayload(input: {
+  userId: string
+  role: string
+  wrappedVaultKeyEnvelope: JsonObject
+  keyEpoch: number
+}): JsonObject {
+  const wrappedVaultKeyEnvelope = cloneJsonObject(input.wrappedVaultKeyEnvelope)
+  assertNoPlaintextLikeKeys(wrappedVaultKeyEnvelope)
+
+  return {
+    user_id: requireNonEmptyString(input.userId, 'userId'),
+    role: requireNonEmptyString(input.role, 'role'),
+    wrapped_vault_key_envelope: wrappedVaultKeyEnvelope,
+    key_epoch: input.keyEpoch,
+  }
+}
+
+export function updateMemberPayload(input: {
+  role: string
+  wrappedVaultKeyEnvelope: JsonObject
+  keyEpoch: number
+}): JsonObject {
+  const wrappedVaultKeyEnvelope = cloneJsonObject(input.wrappedVaultKeyEnvelope)
+  assertNoPlaintextLikeKeys(wrappedVaultKeyEnvelope)
+
+  return {
+    role: requireNonEmptyString(input.role, 'role'),
+    wrapped_vault_key_envelope: wrappedVaultKeyEnvelope,
+    key_epoch: input.keyEpoch,
+  }
+}
+
+export function createRotateVaultKeysPayload(input: {
+  rotationReason: string
+  members: Array<{
+    userId: string
+    wrappedVaultKeyEnvelope: JsonObject
+  }>
+}): JsonObject {
+  return {
+    rotation_reason: requireNonEmptyString(input.rotationReason, 'rotationReason'),
+    members: input.members.map((member) => {
+      const wrappedVaultKeyEnvelope = cloneJsonObject(member.wrappedVaultKeyEnvelope)
+      assertNoPlaintextLikeKeys(wrappedVaultKeyEnvelope)
+      return {
+        user_id: requireNonEmptyString(member.userId, 'userId'),
+        wrapped_vault_key_envelope: wrappedVaultKeyEnvelope,
+      }
+    }),
+  }
+}
+
+export function createPasswordManagerClient(options: PasswordManagerClientOptions) {
+  const fetchImpl = options.fetch ?? fetch
+  const apiBaseUrl = normalizeApiBaseUrl(options.apiBaseUrl)
+
+  return {
+    async launch(): Promise<void> {
+      const assertion = await extractAssertion(fetchImpl, options.launchPath, options.launchAssertionSupplier)
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.launch, {
+        body: createPasswordManagerLaunchPayload(assertion),
+      })
+    },
+
+    async refreshSession(): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.refreshSession)
+    },
+
+    async logout(): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.logout)
+    },
+
+    async getSetupStatus(): Promise<SetupStatusResponse> {
+      return requestJson<SetupStatusResponse>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.getSetupStatus)
+    },
+
+    async getUnlockMetadata(): Promise<UnlockMetadataResponse> {
+      return requestJson<UnlockMetadataResponse>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.getUnlockMetadata)
+    },
+
+    async getUserKey(): Promise<UserKeyResponse> {
+      return requestJson<UserKeyResponse>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.getUserKey)
+    },
+
+    async putUserKey(input: {
+      encryptedPrivateKeyEnvelope: JsonObject
+      kdfMetadata: JsonObject
+    }): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.putUserKey, {
+        body: createUserKeyPayload(input),
+      })
+    },
+
+    async listVaults(): Promise<{ vaults: VaultRecord[] }> {
+      return requestJson<{ vaults: VaultRecord[] }>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.listVaults)
+    },
+
+    async createVault(input: {
+      encryptedMetadata: JsonObject
+      wrappedVaultKeyEnvelope: JsonObject
+      idempotencyKey?: string
+    }): Promise<VaultRecord> {
+      return requestJson<VaultRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.createVault, {
+        headers: {
+          'Idempotency-Key': input.idempotencyKey ?? randomUUID(),
+        },
+        body: createVaultPayload(input),
+      })
+    },
+
+    async getVault(vaultId: string): Promise<VaultRecord> {
+      return requestJson<VaultRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.getVault, {
+        pathParams: { vaultID: requireNonEmptyString(vaultId, 'vaultId') },
+      })
+    },
+
+    async updateVault(input: {
+      vaultId: string
+      encryptedMetadata: JsonObject
+    }): Promise<VaultRecord> {
+      return requestJson<VaultRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.updateVault, {
+        pathParams: { vaultID: requireNonEmptyString(input.vaultId, 'vaultId') },
+        body: updateVaultPayload(input),
+      })
+    },
+
+    async deleteVault(vaultId: string): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.deleteVault, {
+        pathParams: { vaultID: requireNonEmptyString(vaultId, 'vaultId') },
+      })
+    },
+
+    async listEntries(vaultId: string): Promise<{ entries: EntryRecord[] }> {
+      return requestJson<{ entries: EntryRecord[] }>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.listEntries, {
+        pathParams: { vaultID: requireNonEmptyString(vaultId, 'vaultId') },
+      })
+    },
+
+    async createEntry(input: {
+      vaultId: string
+      encryptedPayload: JsonObject
+      keyEpoch: number
+    }): Promise<EntryRecord> {
+      return requestJson<EntryRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.createEntry, {
+        pathParams: { vaultID: requireNonEmptyString(input.vaultId, 'vaultId') },
+        body: createEntryPayload(input),
+      })
+    },
+
+    async getEntry(input: {
+      vaultId: string
+      entryId: string
+    }): Promise<EntryRecord> {
+      return requestJson<EntryRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.getEntry, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          entryID: requireNonEmptyString(input.entryId, 'entryId'),
+        },
+      })
+    },
+
+    async updateEntry(input: {
+      vaultId: string
+      entryId: string
+      encryptedPayload: JsonObject
+      keyEpoch: number
+    }): Promise<EntryRecord> {
+      return requestJson<EntryRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.updateEntry, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          entryID: requireNonEmptyString(input.entryId, 'entryId'),
+        },
+        body: updateEntryPayload(input),
+      })
+    },
+
+    async deleteEntry(input: {
+      vaultId: string
+      entryId: string
+    }): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.deleteEntry, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          entryID: requireNonEmptyString(input.entryId, 'entryId'),
+        },
+      })
+    },
+
+    async listMembers(vaultId: string): Promise<{ members: MemberRecord[] }> {
+      return requestJson<{ members: MemberRecord[] }>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.listMembers, {
+        pathParams: { vaultID: requireNonEmptyString(vaultId, 'vaultId') },
+      })
+    },
+
+    async addMember(input: {
+      vaultId: string
+      userId: string
+      role: string
+      wrappedVaultKeyEnvelope: JsonObject
+      keyEpoch: number
+    }): Promise<MemberRecord> {
+      return requestJson<MemberRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.addMember, {
+        pathParams: { vaultID: requireNonEmptyString(input.vaultId, 'vaultId') },
+        body: createMemberPayload(input),
+      })
+    },
+
+    async updateMember(input: {
+      vaultId: string
+      userId: string
+      role: string
+      wrappedVaultKeyEnvelope: JsonObject
+      keyEpoch: number
+    }): Promise<MemberRecord> {
+      return requestJson<MemberRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.updateMember, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          userID: requireNonEmptyString(input.userId, 'userId'),
+        },
+        body: updateMemberPayload(input),
+      })
+    },
+
+    async removeMember(input: {
+      vaultId: string
+      userId: string
+    }): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.removeMember, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          userID: requireNonEmptyString(input.userId, 'userId'),
+        },
+      })
+    },
+
+    async rotateVaultKeys(input: {
+      vaultId: string
+      rotationReason: string
+      members: Array<{
+        userId: string
+        wrappedVaultKeyEnvelope: JsonObject
+      }>
+      idempotencyKey?: string
+    }): Promise<KeyEpochRecord> {
+      return requestJson<KeyEpochRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.rotateVaultKeys, {
+        pathParams: { vaultID: requireNonEmptyString(input.vaultId, 'vaultId') },
+        headers: {
+          'Idempotency-Key': input.idempotencyKey ?? randomUUID(),
+        },
+        body: createRotateVaultKeysPayload(input),
+      })
+    },
+
+    async auditReveal(input: { vaultId: string; entryId: string }): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.auditReveal, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          entryID: requireNonEmptyString(input.entryId, 'entryId'),
+        },
+      })
+    },
+
+    async auditCopy(input: { vaultId: string; entryId: string }): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.auditCopy, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+          entryID: requireNonEmptyString(input.entryId, 'entryId'),
+        },
+      })
+    },
+
+    async auditExport(input: { vaultId: string }): Promise<void> {
+      await requestJson<void>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.auditExport, {
+        pathParams: {
+          vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
+        },
+      })
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add a portable Password Manager client abstraction covering launch, sessions, setup, vault, entry, member, key-rotation, and audit routes
- add browser-only crypto helpers for unlock-profile creation, encrypted private-key envelopes, vault-key wrapping, and AES-GCM payload encryption
- add route-coverage and plaintext-guard tests against the pinned Password Manager API contract

## Validation
- pnpm install --frozen-lockfile
- pnpm --dir apps/web type-check
- node --experimental-strip-types --test apps/web/lib/password-manager/client.test.mjs apps/web/lib/password-manager/browser-crypto.test.mjs
- git diff --check
