### PR TITLE
fix(setup): run migrations before startup

### DIFF
--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -559,6 +559,23 @@ start_stack() {
 
   docker compose down --remove-orphans >/dev/null 2>&1 || true
 
+  echo "Running database migrations..."
+  if ! docker compose up --force-recreate --abort-on-container-exit --exit-code-from migrate migrate; then
+    echo "" >&2
+    echo "ERROR: CT-Ops database migrations failed." >&2
+    echo "Recent migration logs:" >&2
+    docker compose logs --tail 50 migrate db || true
+    exit 1
+  fi
+
+  if ! docker compose up --force-recreate --abort-on-container-exit --exit-code-from password-manager-migrate password-manager-migrate; then
+    echo "" >&2
+    echo "ERROR: Password Manager database migrations failed." >&2
+    echo "Recent migration logs:" >&2
+    docker compose logs --tail 50 password-manager-migrate password-manager-db || true
+    exit 1
+  fi
+
   echo "Starting CT-Ops..."
   if ! docker compose up -d; then
     echo "" >&2

--- a/deploy/scripts/test-password-manager-startup.sh
+++ b/deploy/scripts/test-password-manager-startup.sh
@@ -18,6 +18,9 @@ if [ "$#" -ge 2 ] && [ "$1" = "compose" ] && [ "$2" = "version" ]; then
 fi
 
 if [ "$#" -ge 1 ] && [ "$1" = "compose" ]; then
+  if [ -n "${MOCK_DOCKER_LOG:-}" ]; then
+    printf 'docker %s\n' "$*" >> "$MOCK_DOCKER_LOG"
+  fi
   exit 0
 fi
 
@@ -121,12 +124,13 @@ assert_password_manager_bootstrap() {
 }
 
 run_root_start_bootstrap_test() {
-  local tmpdir mockbin repo_dir
+  local tmpdir mockbin repo_dir docker_log
 
   tmpdir="$(mktemp -d)"
   trap 'chmod -R u+w "'"$tmpdir"'" 2>/dev/null || true; rm -rf "'"$tmpdir"'"' RETURN
   mockbin="${tmpdir}/mockbin"
   repo_dir="${tmpdir}/ct-ops"
+  docker_log="${tmpdir}/docker.log"
   mkdir -p "$mockbin" "$repo_dir/deploy/dev-tls"
   make_mock_docker "$mockbin"
 
@@ -149,8 +153,11 @@ EOF
 
   (
     cd "$repo_dir" &&
-      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" ./start.sh >/dev/null 2>&1
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" MOCK_DOCKER_LOG="$docker_log" ./start.sh >/dev/null 2>&1
   )
+
+  grep -q 'docker compose -f docker-compose.single.yml up --force-recreate --abort-on-container-exit --exit-code-from migrate migrate' "$docker_log"
+  grep -q 'docker compose -f docker-compose.single.yml up --force-recreate --abort-on-container-exit --exit-code-from password-manager-migrate password-manager-migrate' "$docker_log"
 
   assert_password_manager_bootstrap \
     "$repo_dir/.env" \
@@ -160,12 +167,13 @@ EOF
 }
 
 run_bundle_start_bootstrap_test() {
-  local tmpdir mockbin bundle_dir
+  local tmpdir mockbin bundle_dir docker_log
 
   tmpdir="$(mktemp -d)"
   trap 'chmod -R u+w "'"$tmpdir"'" 2>/dev/null || true; rm -rf "'"$tmpdir"'"' RETURN
   mockbin="${tmpdir}/mockbin"
   bundle_dir="${tmpdir}/bundle"
+  docker_log="${tmpdir}/docker.log"
   mkdir -p "$mockbin" "$bundle_dir/deploy/nginx" "$bundle_dir/deploy/dev-tls" "$bundle_dir/deploy/tls"
   make_mock_docker "$mockbin"
 
@@ -190,8 +198,11 @@ EOF
 
   (
     cd "$bundle_dir" &&
-      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" ./start.sh >/dev/null 2>&1
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" MOCK_DOCKER_LOG="$docker_log" ./start.sh >/dev/null 2>&1
   )
+
+  grep -q 'docker compose up --force-recreate --abort-on-container-exit --exit-code-from migrate migrate' "$docker_log"
+  grep -q 'docker compose up --force-recreate --abort-on-container-exit --exit-code-from password-manager-migrate password-manager-migrate' "$docker_log"
 
   assert_password_manager_bootstrap \
     "$bundle_dir/.env" \

--- a/start.sh
+++ b/start.sh
@@ -339,14 +339,15 @@ if ! $LOCAL; then
   # checkout to build from. To run a locally-built image instead, set
   # WEB_IMAGE / INGEST_IMAGE in your environment (or .env) before invoking this
   # script, or run `docker compose -f docker-compose.single.yml build` manually.
-  docker compose -f docker-compose.single.yml pull db web ingest
+  docker compose -f docker-compose.single.yml pull db password-manager-db password-manager-migrate password-manager-api web migrate ingest nginx tls-init
   docker compose -f docker-compose.single.yml down
+  echo "Running database migrations..."
+  docker compose -f docker-compose.single.yml up --force-recreate --abort-on-container-exit --exit-code-from migrate migrate
+  docker compose -f docker-compose.single.yml up --force-recreate --abort-on-container-exit --exit-code-from password-manager-migrate password-manager-migrate
   docker compose -f docker-compose.single.yml up -d --pull always
 
-  # Database migrations are applied automatically by the web container on
-  # startup (its CMD runs `node migrate.js && node server.js`), and the
-  # release-please manifest is baked into both web and ingest images at build
-  # time. Nothing else for this script to do.
+  # The release-please manifest is baked into both web and ingest images at
+  # build time. Nothing else for this script to do.
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- run CT-Ops migrations explicitly before starting services in production start.sh
- run CT-Ops and Password Manager migrations explicitly before customer-bundle startup
- assert the startup scripts invoke both migration services every run

## Validation
- bash deploy/scripts/test-password-manager-startup.sh
- bash deploy/scripts/test-upgrade.sh
- bash -n start.sh && bash -n deploy/customer-bundle/start.sh && git diff --check
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder docker compose -f docker-compose.single.yml config >/tmp/ct-ops-compose-config-migrations.out