### PR TITLE
fix(security): scope host checks to tenant

### DIFF
--- a/apps/ingest/internal/db/queries/checks.sql.go
+++ b/apps/ingest/internal/db/queries/checks.sql.go
@@ -2,8 +2,11 @@ package queries
 
 import (
 	"context"
+	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -15,16 +18,29 @@ type CheckRow struct {
 	IntervalSeconds int
 }
 
-// GetChecksForHost returns all enabled, non-deleted checks for a given host ID.
-func GetChecksForHost(ctx context.Context, pool *pgxpool.Pool, hostID string) ([]CheckRow, error) {
-	const q = `
+type checkQueryer interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+type checkExecer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// GetChecksForHost returns all enabled, non-deleted checks for a given host and organisation.
+func GetChecksForHost(ctx context.Context, pool *pgxpool.Pool, hostID, orgID string) ([]CheckRow, error) {
+	return getChecksForHost(ctx, pool, hostID, orgID)
+}
+
+func getChecksForHost(ctx context.Context, queryer checkQueryer, hostID, orgID string) ([]CheckRow, error) {
+	const sql = `
 		SELECT id, check_type, config::text, interval_seconds
 		FROM checks
 		WHERE host_id = $1
+		  AND organisation_id = $2
 		  AND enabled = true
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, hostID)
+	rows, err := queryer.Query(ctx, sql, hostID, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -41,6 +57,8 @@ func GetChecksForHost(ctx context.Context, pool *pgxpool.Pool, hostID string) ([
 	return result, rows.Err()
 }
 
+var ErrCheckOwnershipMismatch = errors.New("check does not belong to host organisation")
+
 // InsertCheckResult persists a single check result row and prunes old rows beyond 100 per check.
 func InsertCheckResult(
 	ctx context.Context,
@@ -50,16 +68,42 @@ func InsertCheckResult(
 	durationMs int32,
 	ranAt time.Time,
 ) error {
-	const q = `
-		INSERT INTO check_results (id, check_id, host_id, organisation_id, ran_at, status, output, duration_ms)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	`
-	if _, err := pool.Exec(ctx, q,
-		newCUID(), checkID, hostID, orgID, ranAt, status, output, durationMs,
-	); err != nil {
+	if err := insertCheckResult(ctx, pool, checkID, hostID, orgID, status, output, durationMs, ranAt); err != nil {
 		return err
 	}
 	return pruneCheckResults(ctx, pool, checkID)
+}
+
+func insertCheckResult(
+	ctx context.Context,
+	exec checkExecer,
+	checkID, hostID, orgID string,
+	status, output string,
+	durationMs int32,
+	ranAt time.Time,
+) error {
+	const q = `
+		INSERT INTO check_results (id, check_id, host_id, organisation_id, ran_at, status, output, duration_ms)
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8
+		WHERE EXISTS (
+			SELECT 1
+			FROM checks
+			WHERE id = $2
+			  AND host_id = $3
+			  AND organisation_id = $4
+			  AND deleted_at IS NULL
+		)
+	`
+	tag, err := exec.Exec(ctx, q,
+		newCUID(), checkID, hostID, orgID, ranAt, status, output, durationMs,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrCheckOwnershipMismatch
+	}
+	return nil
 }
 
 // pruneCheckResults deletes rows beyond the 100 most recent results for a check.

--- a/apps/ingest/internal/db/queries/checks_test.go
+++ b/apps/ingest/internal/db/queries/checks_test.go
@@ -1,0 +1,84 @@
+package queries
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakeCheckQueryer struct {
+	sql  string
+	args []any
+	err  error
+}
+
+func (f *fakeCheckQueryer) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+	f.sql = sql
+	f.args = args
+	return nil, f.err
+}
+
+type fakeCheckExecer struct {
+	sql  string
+	args []any
+	tag  pgconn.CommandTag
+	err  error
+}
+
+func (f *fakeCheckExecer) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.sql = sql
+	f.args = args
+	return f.tag, f.err
+}
+
+func TestGetChecksForHostScopesByHostAndOrganisation(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("stop after query capture")
+	queryer := &fakeCheckQueryer{err: queryErr}
+
+	_, err := getChecksForHost(context.Background(), queryer, "host-victim", "org-victim")
+	if !errors.Is(err, queryErr) {
+		t.Fatalf("getChecksForHost error = %v, want sentinel query error", err)
+	}
+	if !strings.Contains(queryer.sql, "WHERE host_id = $1") {
+		t.Fatalf("query does not filter by host_id: %s", queryer.sql)
+	}
+	if !strings.Contains(queryer.sql, "AND organisation_id = $2") {
+		t.Fatalf("query does not filter by organisation_id: %s", queryer.sql)
+	}
+	if len(queryer.args) != 2 || queryer.args[0] != "host-victim" || queryer.args[1] != "org-victim" {
+		t.Fatalf("args = %#v, want host and organisation", queryer.args)
+	}
+}
+
+func TestInsertCheckResultRejectsCrossTenantCheckID(t *testing.T) {
+	t.Parallel()
+
+	execer := &fakeCheckExecer{tag: pgconn.NewCommandTag("INSERT 0 0")}
+
+	err := insertCheckResult(
+		context.Background(),
+		execer,
+		"check-attacker",
+		"host-victim",
+		"org-victim",
+		"pass",
+		"ok",
+		123,
+		time.Unix(100, 0),
+	)
+	if !errors.Is(err, ErrCheckOwnershipMismatch) {
+		t.Fatalf("insertCheckResult error = %v, want ErrCheckOwnershipMismatch", err)
+	}
+	if !strings.Contains(execer.sql, "WHERE id = $2") ||
+		!strings.Contains(execer.sql, "AND host_id = $3") ||
+		!strings.Contains(execer.sql, "AND organisation_id = $4") {
+		t.Fatalf("insert query does not enforce check ownership: %s", execer.sql)
+	}
+}

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -325,7 +325,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 	if hostID != "" {
 		// Build a checkID → checkType map once per heartbeat to route cert results.
 		checkTypeMap := make(map[string]string)
-		if hostChecks, err := queries.GetChecksForHost(ctx, h.pool, hostID); err == nil {
+		if hostChecks, err := queries.GetChecksForHost(ctx, h.pool, hostID, orgID); err == nil {
 			for _, c := range hostChecks {
 				checkTypeMap[c.ID] = c.CheckType
 			}
@@ -469,7 +469,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 
 	// Push active check definitions to the agent
 	if hostID != "" {
-		checkRows, err := queries.GetChecksForHost(ctx, h.pool, hostID)
+		checkRows, err := queries.GetChecksForHost(ctx, h.pool, hostID, orgID)
 		if err != nil {
 			slog.Warn("fetching checks for host", "host_id", hostID, "err", err)
 		} else {

--- a/apps/web/lib/actions/checks-authz.test.mjs
+++ b/apps/web/lib/actions/checks-authz.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const checksSource = readFileSync(path.join(here, 'checks.ts'), 'utf8')
+
+function getActionSegment(action) {
+  const start = checksSource.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist in checks.ts`)
+  const next = checksSource.indexOf('\nexport async function ', start + 1)
+  return checksSource.slice(start, next === -1 ? undefined : next)
+}
+
+test('createCheck validates the target host belongs to the organisation before insert', () => {
+  const segment = getActionSegment('createCheck')
+  const hostLookupIndex = segment.indexOf('db.query.hosts.findFirst')
+  const insertIndex = segment.indexOf('.insert(checks)')
+
+  assert.notEqual(hostLookupIndex, -1, 'createCheck must look up the host before inserting a check')
+  assert.notEqual(insertIndex, -1, 'createCheck must insert the validated check')
+  assert.ok(hostLookupIndex < insertIndex, 'host ownership must be validated before insert')
+  assert.match(segment, /eq\(hosts\.id, data\.hostId\)/, 'host lookup must use the requested host ID')
+  assert.match(segment, /eq\(hosts\.organisationId, orgId\)/, 'host lookup must be scoped to the caller organisation')
+  assert.match(segment, /isNull\(hosts\.deletedAt\)/, 'host lookup must reject soft-deleted hosts')
+  assert.match(segment, /if \(!host\) return \{ error: 'Host not found' \}/, 'missing or cross-tenant hosts must fail closed')
+})
+

--- a/apps/web/lib/actions/checks.ts
+++ b/apps/web/lib/actions/checks.ts
@@ -4,7 +4,7 @@ import { requireOrgAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
-import { checks, checkResults } from '@/lib/db/schema'
+import { checks, checkResults, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, desc } from 'drizzle-orm'
 import type { Check, CheckConfig, CheckType, CheckResultRow } from '@/lib/db/schema'
 
@@ -111,6 +111,14 @@ export async function createCheck(
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
   }
   const data = parsed.data
+  const host = await db.query.hosts.findFirst({
+    where: and(
+      eq(hosts.id, data.hostId),
+      eq(hosts.organisationId, orgId),
+      isNull(hosts.deletedAt),
+    ),
+  })
+  if (!host) return { error: 'Host not found' }
 
   try {
     const [row] = await db


### PR DESCRIPTION
## Summary
- validate check creation host IDs against the caller organisation before insert
- scope ingest check dispatch by host and organisation
- reject check results whose check ID does not belong to the connected agent host/org

Fixes #1043

## Tests
- `go test ./internal/db/queries -run 'Test(GetChecksForHostScopesByHostAndOrganisation|InsertCheckResultRejectsCrossTenantCheckID)'`\n- `go test ./internal/db/queries`\n- `go test ./internal/handlers`\n- `go test ./...` from `apps/ingest`\n- `node --experimental-strip-types --test lib/actions/checks-authz.test.mjs` from `apps/web`\n\nNote: `pnpm --filter web test:unit -- lib/actions/checks-authz.test.mjs` invokes the package-wide glob in this repo and failed in this fresh worktree because `node_modules` is not installed; the direct targeted Node test passed.