### PR TITLE
fix(setup): repair legacy password manager public keys

### DIFF
--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -191,8 +191,66 @@ EOF
   printf '%s\n%s\n' "$private_key" "$public_key"
 }
 
+derive_password_manager_launch_public_key() {
+  local private_key="$1"
+  local tmpdir private_der public_der public_key python_bin node_bin
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/ct-ops-pm-launch-key.XXXXXX")"
+  private_der="${tmpdir}/private.der"
+  public_der="${tmpdir}/public.der"
+
+  if ! printf '%s' "$private_key" | openssl base64 -d -A > "$private_der" 2>/dev/null; then
+    rm -rf "$tmpdir"
+    return 1
+  fi
+
+  if openssl pkey -inform DER -in "$private_der" -pubout -outform DER 2>/dev/null | tail -c 32 > "$public_der"; then
+    public_key="$(base64 < "$public_der" | tr -d '\n')"
+    rm -rf "$tmpdir"
+    printf '%s\n' "$public_key"
+    return 0
+  fi
+
+  if python_bin="$(find_python_for_ed25519)" && CT_PM_PRIVATE_KEY="$private_key" "$python_bin" - <<'EOF' 2>/dev/null
+import base64
+import os
+from cryptography.hazmat.primitives import serialization
+
+private_key = serialization.load_der_private_key(
+    base64.b64decode(os.environ["CT_PM_PRIVATE_KEY"]),
+    password=None,
+)
+print(base64.b64encode(private_key.public_key().public_bytes(
+    encoding=serialization.Encoding.Raw,
+    format=serialization.PublicFormat.Raw,
+)).decode("ascii"))
+EOF
+  then
+    rm -rf "$tmpdir"
+    return 0
+  fi
+
+  if node_bin="$(find_optional_command node)"; then
+    CT_PM_PRIVATE_KEY="$private_key" "$node_bin" - <<'EOF'
+const { createPrivateKey, createPublicKey } = require('node:crypto')
+
+const privateKey = createPrivateKey({
+  key: Buffer.from(process.env.CT_PM_PRIVATE_KEY, 'base64'),
+  format: 'der',
+  type: 'pkcs8',
+})
+process.stdout.write(createPublicKey(privateKey).export({ format: 'der', type: 'spki' }).subarray(-32).toString('base64') + '\n')
+EOF
+    rm -rf "$tmpdir"
+    return 0
+  fi
+
+  rm -rf "$tmpdir"
+  return 1
+}
+
 ensure_password_manager_bootstrap() {
-  local issuer trusted_origins cookie_secure instance_id generated_private_key generated_public_key keypair_output
+  local issuer trusted_origins cookie_secure instance_id generated_private_key generated_public_key keypair_output repaired_public_key
 
   if [ -z "${PASSWORD_MANAGER_DB_PASSWORD:-}" ]; then
     require_openssl "generate PASSWORD_MANAGER_DB_PASSWORD on first run"
@@ -236,6 +294,22 @@ ensure_password_manager_bootstrap() {
     esac
     upsert_env_var "PASSWORD_MANAGER_SESSION_COOKIE_SECURE" "$cookie_secure"
     echo "Set PASSWORD_MANAGER_SESSION_COOKIE_SECURE in .env."
+  fi
+
+  if [ -n "${PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY:-}" ]; then
+    if repaired_public_key="$(derive_password_manager_launch_public_key "$PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY")"; then
+      if [ "${PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY:-}" != "$repaired_public_key" ]; then
+        upsert_env_var "PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY" "$repaired_public_key"
+        PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY="$repaired_public_key"
+        echo "Repaired Password Manager launch-signing public key in .env."
+      fi
+    else
+      upsert_env_var "PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY" ""
+      upsert_env_var "PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY" ""
+      PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=""
+      PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY=""
+      echo "Discarded invalid Password Manager launch-signing keypair from .env."
+    fi
   fi
 
   if [ -z "${PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY:-}" ] || [ -z "${PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY:-}" ]; then

--- a/deploy/scripts/test-password-manager-startup.sh
+++ b/deploy/scripts/test-password-manager-startup.sh
@@ -89,6 +89,23 @@ assert_ed25519_pair_matches() {
   fi
 }
 
+generate_legacy_spki_keypair() {
+  local tmpdir private_pem private_der private_key legacy_public_key raw_public_key
+
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "'"$tmpdir"'"' RETURN
+  private_pem="${tmpdir}/private.pem"
+  private_der="${tmpdir}/private.der"
+
+  openssl genpkey -algorithm ED25519 -out "$private_pem" >/dev/null 2>&1
+  openssl pkey -in "$private_pem" -outform DER -out "$private_der" >/dev/null 2>&1
+  private_key="$(base64 < "$private_der" | tr -d '\n')"
+  legacy_public_key="$(openssl pkey -in "$private_pem" -pubout -outform DER | base64 | tr -d '\n')"
+  raw_public_key="$(openssl pkey -in "$private_pem" -pubout -outform DER | tail -c 32 | base64 | tr -d '\n')"
+
+  printf '%s\n%s\n%s\n' "$private_key" "$legacy_public_key" "$raw_public_key"
+}
+
 assert_password_manager_bootstrap() {
   local env_file="$1"
   local expected_issuer="$2"
@@ -121,6 +138,55 @@ assert_password_manager_bootstrap() {
 
   assert_ed25519_pair_matches "$public_key" "$private_key"
   assert_file_mode_600 "$env_file"
+}
+
+run_bundle_start_repairs_legacy_public_key_test() {
+  local tmpdir mockbin bundle_dir docker_log keypair private_key legacy_public_key raw_public_key
+
+  tmpdir="$(mktemp -d)"
+  trap 'chmod -R u+w "'"$tmpdir"'" 2>/dev/null || true; rm -rf "'"$tmpdir"'"' RETURN
+  mockbin="${tmpdir}/mockbin"
+  bundle_dir="${tmpdir}/bundle"
+  docker_log="${tmpdir}/docker.log"
+  mkdir -p "$mockbin" "$bundle_dir/deploy/nginx" "$bundle_dir/deploy/dev-tls" "$bundle_dir/deploy/tls"
+  make_mock_docker "$mockbin"
+
+  keypair="$(generate_legacy_spki_keypair)"
+  private_key="$(printf '%s\n' "$keypair" | sed -n '1p')"
+  legacy_public_key="$(printf '%s\n' "$keypair" | sed -n '2p')"
+  raw_public_key="$(printf '%s\n' "$keypair" | sed -n '3p')"
+
+  cp "$BUNDLE_START_SCRIPT" "$bundle_dir/start.sh"
+  printf 'services: {}\n' > "$bundle_dir/docker-compose.yml"
+  printf 'events {}\nhttp { server { listen 443 ssl; } }\n' > "$bundle_dir/deploy/nginx/nginx.conf"
+  cat > "$bundle_dir/.env" <<EOF
+BETTER_AUTH_URL=https://ct-ops.example.test
+BETTER_AUTH_TRUSTED_ORIGINS=https://ct-ops.example.test
+BETTER_AUTH_SECRET=test-auth-secret
+POSTGRES_PASSWORD=test-postgres-password
+PASSWORD_MANAGER_DB_PASSWORD=pm-db-password
+CT_OPS_INSTANCE_ID=ct-ops-existing
+PASSWORD_MANAGER_CT_OPS_ISSUER=https://ct-ops.example.test
+PASSWORD_MANAGER_CT_OPS_AUDIENCE=ct-password-manager
+PASSWORD_MANAGER_CT_OPS_PRODUCT=ct-password-manager
+PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY=${legacy_public_key}
+PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=${private_key}
+PASSWORD_MANAGER_TRUSTED_ORIGINS=https://ct-ops.example.test
+PASSWORD_MANAGER_SESSION_COOKIE_SECURE=true
+EOF
+
+  (
+    cd "$bundle_dir" &&
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" MOCK_DOCKER_LOG="$docker_log" ./start.sh >/dev/null 2>&1
+  )
+
+  [ "$(assert_env_value "$bundle_dir/.env" PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY)" = "$private_key" ]
+  [ "$(assert_env_value "$bundle_dir/.env" PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY)" = "$raw_public_key" ]
+  assert_password_manager_bootstrap \
+    "$bundle_dir/.env" \
+    "https://ct-ops.example.test" \
+    "https://ct-ops.example.test" \
+    "true"
 }
 
 run_root_start_bootstrap_test() {
@@ -214,6 +280,7 @@ EOF
 main() {
   run_root_start_bootstrap_test
   run_bundle_start_bootstrap_test
+  run_bundle_start_repairs_legacy_public_key_test
   echo "password manager startup bootstrap tests passed"
 }
 

--- a/start.sh
+++ b/start.sh
@@ -211,8 +211,66 @@ EOF
   printf '%s\n%s\n' "$private_key" "$public_key"
 }
 
+derive_password_manager_launch_public_key() {
+  local private_key="$1"
+  local tmpdir private_der public_der public_key python_bin node_bin
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/ct-ops-pm-launch-key.XXXXXX")"
+  private_der="${tmpdir}/private.der"
+  public_der="${tmpdir}/public.der"
+
+  if ! printf '%s' "$private_key" | openssl base64 -d -A > "$private_der" 2>/dev/null; then
+    rm -rf "$tmpdir"
+    return 1
+  fi
+
+  if openssl pkey -inform DER -in "$private_der" -pubout -outform DER 2>/dev/null | tail -c 32 > "$public_der"; then
+    public_key="$(base64 < "$public_der" | tr -d '\n')"
+    rm -rf "$tmpdir"
+    printf '%s\n' "$public_key"
+    return 0
+  fi
+
+  if python_bin="$(find_python_for_ed25519)" && CT_PM_PRIVATE_KEY="$private_key" "$python_bin" - <<'EOF' 2>/dev/null
+import base64
+import os
+from cryptography.hazmat.primitives import serialization
+
+private_key = serialization.load_der_private_key(
+    base64.b64decode(os.environ["CT_PM_PRIVATE_KEY"]),
+    password=None,
+)
+print(base64.b64encode(private_key.public_key().public_bytes(
+    encoding=serialization.Encoding.Raw,
+    format=serialization.PublicFormat.Raw,
+)).decode("ascii"))
+EOF
+  then
+    rm -rf "$tmpdir"
+    return 0
+  fi
+
+  if node_bin="$(find_optional_command node)"; then
+    CT_PM_PRIVATE_KEY="$private_key" "$node_bin" - <<'EOF'
+const { createPrivateKey, createPublicKey } = require('node:crypto')
+
+const privateKey = createPrivateKey({
+  key: Buffer.from(process.env.CT_PM_PRIVATE_KEY, 'base64'),
+  format: 'der',
+  type: 'pkcs8',
+})
+process.stdout.write(createPublicKey(privateKey).export({ format: 'der', type: 'spki' }).subarray(-32).toString('base64') + '\n')
+EOF
+    rm -rf "$tmpdir"
+    return 0
+  fi
+
+  rm -rf "$tmpdir"
+  return 1
+}
+
 ensure_password_manager_bootstrap() {
-  local issuer trusted_origins cookie_secure instance_id generated_private_key generated_public_key keypair_output
+  local issuer trusted_origins cookie_secure instance_id generated_private_key generated_public_key keypair_output repaired_public_key
 
   if [ -z "${PASSWORD_MANAGER_DB_PASSWORD:-}" ]; then
     require_openssl "generate PASSWORD_MANAGER_DB_PASSWORD"
@@ -256,6 +314,22 @@ ensure_password_manager_bootstrap() {
     esac
     upsert_env_var "PASSWORD_MANAGER_SESSION_COOKIE_SECURE" "$cookie_secure"
     echo "Set PASSWORD_MANAGER_SESSION_COOKIE_SECURE in .env."
+  fi
+
+  if [ -n "${PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY:-}" ]; then
+    if repaired_public_key="$(derive_password_manager_launch_public_key "$PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY")"; then
+      if [ "${PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY:-}" != "$repaired_public_key" ]; then
+        upsert_env_var "PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY" "$repaired_public_key"
+        PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY="$repaired_public_key"
+        echo "Repaired Password Manager launch-signing public key in .env."
+      fi
+    else
+      upsert_env_var "PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY" ""
+      upsert_env_var "PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY" ""
+      PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=""
+      PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY=""
+      echo "Discarded invalid Password Manager launch-signing keypair from .env."
+    fi
   fi
 
   if [ -z "${PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY:-}" ] || [ -z "${PASSWORD_MANAGER_CT_OPS_ED25519_PUBLIC_KEY:-}" ]; then


### PR DESCRIPTION
## Summary
- detect legacy/mismatched Password Manager Ed25519 public keys during startup
- derive and rewrite the raw 32-byte public key from the preserved private key
- regenerate the launch keypair only when the private key itself is invalid
- add regression coverage for a preserved legacy SPKI public key in .env

## Validation
- bash deploy/scripts/test-password-manager-startup.sh
- bash -n start.sh && bash -n deploy/customer-bundle/start.sh && git diff --check
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder docker compose -f docker-compose.single.yml config >/tmp/ct-ops-compose-config-legacy-key.out