### PR TITLE
feat(web): add password manager route shell

### DIFF
--- a/apps/web/app/(dashboard)/password-manager/page.tsx
+++ b/apps/web/app/(dashboard)/password-manager/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
+import { PasswordManagerClientShell } from './password-manager-client'
+
+export const metadata: Metadata = {
+  title: 'Password Manager',
+}
+
+export default async function PasswordManagerPage() {
+  const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
+
+  const orgId = session.user.organisationId!
+
+  return <PasswordManagerClientShell key={orgId} orgId={orgId} />
+}

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { useEffect, useMemo, useReducer } from 'react'
+import { AlertCircle, KeyRound, Lock, RefreshCcw, ShieldAlert, Vault } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { logWarn } from '@/lib/logging'
+import { createPasswordManagerClient } from '@/lib/password-manager/client'
+import {
+  createInitialPasswordManagerShellState,
+  mapPasswordManagerErrorToShellView,
+  reducePasswordManagerShellState,
+  type PasswordManagerShellState,
+} from '@/lib/password-manager/shell'
+
+const PASSWORD_MANAGER_API_BASE_URL =
+  process.env.NEXT_PUBLIC_PASSWORD_MANAGER_API_BASE_URL?.trim() || '/password-manager-api/'
+const PASSWORD_MANAGER_LAUNCH_PATH = '/api/password-manager/launch-assertion'
+
+export function PasswordManagerClientShell({ orgId }: { orgId: string }) {
+  const client = useMemo(
+    () =>
+      createPasswordManagerClient({
+        apiBaseUrl: PASSWORD_MANAGER_API_BASE_URL,
+        launchPath: PASSWORD_MANAGER_LAUNCH_PATH,
+      }),
+    [],
+  )
+  const [state, dispatch] = useReducer(
+    reducePasswordManagerShellState,
+    orgId,
+    createInitialPasswordManagerShellState,
+  )
+
+  useEffect(() => {
+    if (state.view !== 'launching') {
+      return
+    }
+
+    let cancelled = false
+
+    async function launch() {
+      try {
+        await client.launch()
+        const setupStatus = await client.getSetupStatus()
+        if (cancelled) {
+          return
+        }
+
+        dispatch({
+          type: 'launch-succeeded',
+          setupConfigured: setupStatus.configured,
+        })
+      } catch (error) {
+        if (cancelled) {
+          return
+        }
+
+        const view = mapPasswordManagerErrorToShellView(error)
+        logWarn('[password-manager] route shell launch failed', error, {
+          organisationId: state.organisationId,
+          shellView: view,
+        })
+        dispatch({ type: 'launch-failed', view })
+      }
+    }
+
+    void launch()
+
+    return () => {
+      cancelled = true
+    }
+  }, [client, state.launchNonce, state.organisationId, state.view])
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6" data-testid="password-manager-shell">
+      <header className="flex flex-col gap-3 rounded-3xl border border-border/60 bg-linear-to-br from-background via-background to-muted/40 p-6 shadow-xs">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge variant="outline">Tooling</Badge>
+          <Badge variant="secondary">Hosted at /password-manager</Badge>
+        </div>
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Password Manager</h1>
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            CT-Ops launches the Password Manager session, but secret material remains in browser-only code paths.
+          </p>
+        </div>
+      </header>
+
+      <PasswordManagerShellCard state={state} onRetry={() => dispatch({ type: 'restart-launch' })} />
+    </section>
+  )
+}
+
+function PasswordManagerShellCard({
+  state,
+  onRetry,
+}: {
+  state: PasswordManagerShellState
+  onRetry: () => void
+}) {
+  switch (state.view) {
+    case 'launching':
+      return (
+        <ShellCard
+          icon={RefreshCcw}
+          eyebrow="Launching"
+          title="Starting your Password Manager session"
+          description="CT-Ops is minting a fresh launch assertion and exchanging it for a Password Manager session."
+          statusLabel="Launching"
+          statusVariant="secondary"
+          testId="password-manager-state-launching"
+        />
+      )
+    case 'locked':
+      return (
+        <ShellCard
+          icon={KeyRound}
+          eyebrow={state.setupConfigured ? 'Locked' : 'First use'}
+          title={state.setupConfigured ? 'Unlock your Password Manager workspace' : 'Set up your unlock profile'}
+          description={
+            state.setupConfigured
+              ? 'Your encrypted unlock profile is available. The unlock controls and vault workspace attach to this shell next.'
+              : 'No encrypted unlock profile is stored yet. The browser-side setup and unlock flow attaches to this shell next.'
+          }
+          statusLabel={state.setupConfigured ? 'Locked' : 'Setup required'}
+          statusVariant="outline"
+          testId="password-manager-state-locked"
+          footer={
+            <Alert>
+              <Lock className="size-4" />
+              <AlertTitle>Browser-only boundary preserved</AlertTitle>
+              <AlertDescription>
+                CT-Ops only brokers launch assertions. Vault keys, unlock secrets, and plaintext values stay out of this route shell.
+              </AlertDescription>
+            </Alert>
+          }
+        />
+      )
+    case 'unlocked':
+      return (
+        <ShellCard
+          icon={Vault}
+          eyebrow="Unlocked"
+          title="Password Manager workspace is active"
+          description="Vaults, entries, sharing controls, and audit-aware actions render inside this shell once the unlock session is active."
+          statusLabel="Unlocked"
+          statusVariant="secondary"
+          testId="password-manager-state-unlocked"
+        />
+      )
+    case 'session-expired':
+      return (
+        <ShellCard
+          icon={AlertCircle}
+          eyebrow="Session expired"
+          title="Launch again to continue"
+          description="The Password Manager session is no longer valid. Relaunch to fetch a fresh CT-Ops assertion and clear local shell state."
+          statusLabel="Relaunch required"
+          statusVariant="destructive"
+          testId="password-manager-state-session-expired"
+          actions={<Button onClick={onRetry}>Relaunch</Button>}
+        />
+      )
+    case 'access-denied':
+      return (
+        <ShellCard
+          icon={ShieldAlert}
+          eyebrow="Access denied"
+          title="Password Manager access is restricted"
+          description="Your current CT-Ops session does not have access to launch the Password Manager for this organisation."
+          statusLabel="Access denied"
+          statusVariant="destructive"
+          testId="password-manager-state-access-denied"
+          actions={<Button variant="outline" onClick={onRetry}>Retry launch</Button>}
+        />
+      )
+    case 'object-unavailable':
+      return (
+        <ShellCard
+          icon={AlertCircle}
+          eyebrow="Unavailable"
+          title="The requested Password Manager state is unavailable"
+          description="The Password Manager service returned a generic unavailable response. Relaunch to re-check access and current object state."
+          statusLabel="Unavailable"
+          statusVariant="outline"
+          testId="password-manager-state-object-unavailable"
+          actions={<Button variant="outline" onClick={onRetry}>Retry launch</Button>}
+        />
+      )
+    case 'operational-failure':
+      return (
+        <ShellCard
+          icon={ShieldAlert}
+          eyebrow="Operational failure"
+          title="Password Manager is temporarily unavailable"
+          description="The launch path could not complete safely. Retry after checking the Password Manager service and CT-Ops launch configuration."
+          statusLabel="Failure"
+          statusVariant="destructive"
+          testId="password-manager-state-operational-failure"
+          actions={<Button onClick={onRetry}>Retry launch</Button>}
+        />
+      )
+  }
+}
+
+function ShellCard({
+  icon: Icon,
+  eyebrow,
+  title,
+  description,
+  statusLabel,
+  statusVariant,
+  testId,
+  actions,
+  footer,
+}: {
+  icon: typeof RefreshCcw
+  eyebrow: string
+  title: string
+  description: string
+  statusLabel: string
+  statusVariant: 'secondary' | 'outline' | 'destructive'
+  testId: string
+  actions?: React.ReactNode
+  footer?: React.ReactNode
+}) {
+  return (
+    <Card className="overflow-hidden border-border/60 shadow-xs" data-testid={testId}>
+      <CardHeader className="gap-3 border-b border-border/60 bg-muted/20">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 items-center justify-center rounded-2xl bg-primary/8 text-primary">
+              <Icon className="size-5" />
+            </div>
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{eyebrow}</p>
+              <CardTitle>{title}</CardTitle>
+            </div>
+          </div>
+          <Badge variant={statusVariant}>{statusLabel}</Badge>
+        </div>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      {actions ? (
+        <CardContent className="pt-4">
+          <div className="flex flex-wrap gap-3">{actions}</div>
+        </CardContent>
+      ) : null}
+      {footer ? <CardFooter>{footer}</CardFooter> : null}
+    </Card>
+  )
+}

--- a/apps/web/components/shared/command-palette/providers.tsx
+++ b/apps/web/components/shared/command-palette/providers.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react'
 import { listHosts } from '@/lib/actions/agents'
 import { canAccessTooling } from '@/lib/auth/tooling'
+import { PASSWORD_MANAGER_COMMAND_ITEM } from '@/lib/password-manager/navigation'
 import type { CommandPaletteItem } from './types'
 
 const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
@@ -40,6 +41,7 @@ const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
   { id: 'nav-reports-software', label: 'Installed Software Report', icon: Package, href: '/reports/software' },
   { id: 'nav-reports-patch-status', label: 'Patch Status Report', icon: ShieldCheck, href: '/reports/patch-status' },
   { id: 'nav-reports-vulnerabilities', label: 'Vulnerability Report', icon: ShieldAlert, href: '/reports/vulnerabilities' },
+  PASSWORD_MANAGER_COMMAND_ITEM,
   { id: 'nav-cert-checker', label: 'SSL Certificate Checker', icon: ScanSearch, href: '/certificate-checker' },
   { id: 'nav-dir-lookup', label: 'Directory User Lookup', icon: FolderSearch, href: '/directory-lookup' },
   { id: 'nav-bundlers', label: 'Air-gap Bundlers', icon: Package, href: '/bundlers' },
@@ -55,6 +57,7 @@ const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
 ]
 
 const TOOLING_ITEM_IDS = new Set([
+  'nav-password-manager',
   'nav-cert-checker',
   'nav-dir-lookup',
   'nav-bundlers',

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -44,6 +44,7 @@ import { cn } from '@/lib/utils'
 import { TerminalPanelTrigger } from '@/components/terminal'
 import type { LicenceTier } from '@/lib/features'
 import { canAccessTooling } from '@/lib/auth/tooling'
+import { PASSWORD_MANAGER_NAV_ITEM } from '@/lib/password-manager/navigation'
 import pkg from '../../package.json'
 
 const WEB_VERSION = `v${pkg.version}`
@@ -96,6 +97,7 @@ const reportingNav: NavItem[] = [
 ]
 
 const toolingNav: NavItem[] = [
+  PASSWORD_MANAGER_NAV_ITEM,
   { title: 'SSL Certificate Checker', href: '/certificate-checker', icon: ScanSearch },
   { title: 'Directory User Lookup', href: '/directory-lookup', icon: FolderSearch },
   { title: 'Air-gap Bundlers', href: '/bundlers', icon: Package },

--- a/apps/web/lib/password-manager/navigation.test.mjs
+++ b/apps/web/lib/password-manager/navigation.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  PASSWORD_MANAGER_COMMAND_ITEM,
+  PASSWORD_MANAGER_NAV_ITEM,
+} from './navigation.ts'
+
+test('Password Manager sidebar navigation targets the hosted route', () => {
+  assert.equal(PASSWORD_MANAGER_NAV_ITEM.title, 'Password Manager')
+  assert.equal(PASSWORD_MANAGER_NAV_ITEM.href, '/password-manager')
+  assert.equal(PASSWORD_MANAGER_NAV_ITEM.testId, 'sidebar-password-manager')
+})
+
+test('Password Manager command palette item exposes route and search keywords', () => {
+  assert.equal(PASSWORD_MANAGER_COMMAND_ITEM.id, 'nav-password-manager')
+  assert.equal(PASSWORD_MANAGER_COMMAND_ITEM.label, 'Password Manager')
+  assert.equal(PASSWORD_MANAGER_COMMAND_ITEM.href, '/password-manager')
+  assert.deepEqual(
+    PASSWORD_MANAGER_COMMAND_ITEM.keywords,
+    ['vault', 'secrets', 'credentials', 'tooling'],
+  )
+})

--- a/apps/web/lib/password-manager/navigation.ts
+++ b/apps/web/lib/password-manager/navigation.ts
@@ -1,0 +1,16 @@
+import { Lock } from 'lucide-react'
+
+export const PASSWORD_MANAGER_NAV_ITEM = {
+  title: 'Password Manager',
+  href: '/password-manager',
+  icon: Lock,
+  testId: 'sidebar-password-manager',
+} as const
+
+export const PASSWORD_MANAGER_COMMAND_ITEM = {
+  id: 'nav-password-manager',
+  label: 'Password Manager',
+  icon: Lock,
+  href: '/password-manager',
+  keywords: ['vault', 'secrets', 'credentials', 'tooling'] as string[],
+} as const

--- a/apps/web/lib/password-manager/shell.test.mjs
+++ b/apps/web/lib/password-manager/shell.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { PasswordManagerApiError } from './client.ts'
+import {
+  createInitialPasswordManagerShellState,
+  mapPasswordManagerErrorToShellView,
+  reducePasswordManagerShellState,
+} from './shell.ts'
+
+test('launch success enters the locked shell and records setup status', () => {
+  const initial = createInitialPasswordManagerShellState('org-alpha')
+  const next = reducePasswordManagerShellState(initial, {
+    type: 'launch-succeeded',
+    setupConfigured: false,
+  })
+
+  assert.deepEqual(next, {
+    organisationId: 'org-alpha',
+    launchNonce: 0,
+    setupConfigured: false,
+    view: 'locked',
+  })
+})
+
+test('organisation changes tear down local state and restart launch', () => {
+  const locked = {
+    organisationId: 'org-alpha',
+    launchNonce: 0,
+    setupConfigured: true,
+    view: 'unlocked',
+  }
+
+  const next = reducePasswordManagerShellState(locked, {
+    type: 'organisation-changed',
+    organisationId: 'org-bravo',
+  })
+
+  assert.deepEqual(next, {
+    organisationId: 'org-bravo',
+    launchNonce: 1,
+    setupConfigured: null,
+    view: 'launching',
+  })
+})
+
+test('explicit relaunch clears local shell state and increments launch nonce', () => {
+  const locked = {
+    organisationId: 'org-alpha',
+    launchNonce: 3,
+    setupConfigured: true,
+    view: 'locked',
+  }
+
+  const next = reducePasswordManagerShellState(locked, { type: 'restart-launch' })
+
+  assert.deepEqual(next, {
+    organisationId: 'org-alpha',
+    launchNonce: 4,
+    setupConfigured: null,
+    view: 'launching',
+  })
+})
+
+test('API errors map to safe shell views', () => {
+  assert.equal(
+    mapPasswordManagerErrorToShellView(new PasswordManagerApiError(401, 'session_expired')),
+    'session-expired',
+  )
+  assert.equal(
+    mapPasswordManagerErrorToShellView(new PasswordManagerApiError(403, 'forbidden')),
+    'access-denied',
+  )
+  assert.equal(
+    mapPasswordManagerErrorToShellView(new PasswordManagerApiError(404, 'not_found')),
+    'object-unavailable',
+  )
+  assert.equal(
+    mapPasswordManagerErrorToShellView(new PasswordManagerApiError(503, 'upstream_error')),
+    'operational-failure',
+  )
+  assert.equal(
+    mapPasswordManagerErrorToShellView(new Error('network failure')),
+    'operational-failure',
+  )
+})

--- a/apps/web/lib/password-manager/shell.ts
+++ b/apps/web/lib/password-manager/shell.ts
@@ -1,0 +1,97 @@
+import { PasswordManagerApiError } from './client.ts'
+
+export type PasswordManagerShellView =
+  | 'launching'
+  | 'locked'
+  | 'unlocked'
+  | 'session-expired'
+  | 'access-denied'
+  | 'object-unavailable'
+  | 'operational-failure'
+
+export interface PasswordManagerShellState {
+  organisationId: string
+  launchNonce: number
+  setupConfigured: boolean | null
+  view: PasswordManagerShellView
+}
+
+export type PasswordManagerShellEvent =
+  | { type: 'launch-succeeded'; setupConfigured: boolean }
+  | { type: 'launch-failed'; view: Exclude<PasswordManagerShellView, 'launching' | 'locked' | 'unlocked'> }
+  | { type: 'unlock-succeeded' }
+  | { type: 'lock' }
+  | { type: 'restart-launch' }
+  | { type: 'organisation-changed'; organisationId: string }
+
+export function createInitialPasswordManagerShellState(organisationId: string): PasswordManagerShellState {
+  return {
+    organisationId,
+    launchNonce: 0,
+    setupConfigured: null,
+    view: 'launching',
+  }
+}
+
+export function mapPasswordManagerErrorToShellView(
+  error: unknown,
+): Exclude<PasswordManagerShellView, 'launching' | 'locked' | 'unlocked'> {
+  if (error instanceof PasswordManagerApiError) {
+    switch (error.status) {
+      case 401:
+        return 'session-expired'
+      case 403:
+        return 'access-denied'
+      case 404:
+        return 'object-unavailable'
+      default:
+        return 'operational-failure'
+    }
+  }
+
+  return 'operational-failure'
+}
+
+export function reducePasswordManagerShellState(
+  state: PasswordManagerShellState,
+  event: PasswordManagerShellEvent,
+): PasswordManagerShellState {
+  switch (event.type) {
+    case 'launch-succeeded':
+      return {
+        ...state,
+        setupConfigured: event.setupConfigured,
+        view: 'locked',
+      }
+    case 'launch-failed':
+      return {
+        ...state,
+        setupConfigured: null,
+        view: event.view,
+      }
+    case 'unlock-succeeded':
+      return {
+        ...state,
+        view: 'unlocked',
+      }
+    case 'lock':
+      return {
+        ...state,
+        view: 'locked',
+      }
+    case 'restart-launch':
+      return {
+        ...state,
+        launchNonce: state.launchNonce + 1,
+        setupConfigured: null,
+        view: 'launching',
+      }
+    case 'organisation-changed':
+      return {
+        organisationId: event.organisationId,
+        launchNonce: state.launchNonce + 1,
+        setupConfigured: null,
+        view: 'launching',
+      }
+  }
+}

--- a/apps/web/tests/e2e/tooling/access-control.spec.ts
+++ b/apps/web/tests/e2e/tooling/access-control.spec.ts
@@ -22,9 +22,10 @@ test('read-only users cannot access tooling pages or certificate checker API', a
   try {
     await page.goto('/dashboard')
     await expect(page.getByText('Tooling')).toHaveCount(0)
+    await expect(page.getByRole('link', { name: 'Password Manager' })).toHaveCount(0)
     await expect(page.getByRole('link', { name: 'SSL Certificate Checker' })).toHaveCount(0)
 
-    for (const path of ['/certificate-checker', '/directory-lookup', '/tasks', '/build-docs']) {
+    for (const path of ['/password-manager', '/certificate-checker', '/directory-lookup', '/tasks', '/build-docs']) {
       await page.goto(path)
       await expect(page).toHaveURL(/\/dashboard$/)
     }
@@ -40,6 +41,14 @@ test('read-only users cannot access tooling pages or certificate checker API', a
     })
     expect(response.status()).toBe(403)
     await expect(response.json()).resolves.toMatchObject({ ok: false, error: 'Forbidden' })
+
+    const launchAssertionResponse = await page.request.post(`${baseURL}/api/password-manager/launch-assertion`, {
+      headers: {
+        origin: baseURL!,
+      },
+    })
+    expect(launchAssertionResponse.status()).toBe(403)
+    await expect(launchAssertionResponse.json()).resolves.toMatchObject({ error: 'Forbidden' })
   } finally {
     await sql`UPDATE "user" SET role = 'org_admin', updated_at = NOW() WHERE id = ${userId}`
   }


### PR DESCRIPTION
## Summary
- add the hosted `/password-manager` route shell and launch-state reducer around the existing Password Manager client
- expose Password Manager in the Tooling sidebar and command palette
- extend tooling access-control coverage for the new route and launch assertion gate

## Validation
- `pnpm install --frozen-lockfile`
- `node --experimental-strip-types --test apps/web/lib/password-manager/navigation.test.mjs apps/web/lib/password-manager/shell.test.mjs`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint` (existing repo warnings only)
- `BETTER_AUTH_URL=https://ops.example.test BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder pnpm --dir apps/web build`
- `pnpm --dir apps/web test:unit` (fails in this environment because existing container-backed tests cannot start without a local container runtime)
- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/access-control.spec.ts` (fails in this environment because testcontainers cannot find a working container runtime)
- `git diff --check`