### PR TITLE
feat(web): add password manager unlock flow

### DIFF
--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -1,13 +1,21 @@
 'use client'
 
-import { useEffect, useMemo, useReducer } from 'react'
-import { AlertCircle, KeyRound, Lock, RefreshCcw, ShieldAlert, Vault } from 'lucide-react'
+import { useEffect, useMemo, useReducer, useState, type FormEvent, type ReactNode } from 'react'
+import { AlertCircle, KeyRound, Lock, LogOut, RefreshCcw, ShieldAlert, Vault } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { logWarn } from '@/lib/logging'
-import { createPasswordManagerClient } from '@/lib/password-manager/client'
+import {
+  createUnlockProfile,
+  decryptUserPrivateKeyEnvelope,
+  type PasswordManagerEncryptedPrivateKeyEnvelope,
+  type PasswordManagerKdfMetadata,
+} from '@/lib/password-manager/browser-crypto'
+import { PasswordManagerApiError, createPasswordManagerClient } from '@/lib/password-manager/client'
 import {
   createInitialPasswordManagerShellState,
   mapPasswordManagerErrorToShellView,
@@ -18,6 +26,13 @@ import {
 const PASSWORD_MANAGER_API_BASE_URL =
   process.env.NEXT_PUBLIC_PASSWORD_MANAGER_API_BASE_URL?.trim() || '/password-manager-api/'
 const PASSWORD_MANAGER_LAUNCH_PATH = '/api/password-manager/launch-assertion'
+const GENERIC_UNLOCK_FAILURE =
+  'Password Manager could not unlock with the provided materials. Retry or relaunch.'
+const GENERIC_SETUP_FAILURE = 'Password Manager setup could not be completed safely. Retry or relaunch.'
+
+function toClientPayload<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
 
 export function PasswordManagerClientShell({ orgId }: { orgId: string }) {
   const client = useMemo(
@@ -33,6 +48,14 @@ export function PasswordManagerClientShell({ orgId }: { orgId: string }) {
     orgId,
     createInitialPasswordManagerShellState,
   )
+  const [setupPassword, setSetupPassword] = useState('')
+  const [setupPasswordConfirm, setSetupPasswordConfirm] = useState('')
+  const [unlockPassword, setUnlockPassword] = useState('')
+  const [setupPending, setSetupPending] = useState(false)
+  const [unlockPending, setUnlockPending] = useState(false)
+  const [refreshPending, setRefreshPending] = useState(false)
+  const [logoutPending, setLogoutPending] = useState(false)
+  const [statusNotice, setStatusNotice] = useState<string | null>(null)
 
   useEffect(() => {
     if (state.view !== 'launching') {
@@ -74,32 +97,316 @@ export function PasswordManagerClientShell({ orgId }: { orgId: string }) {
     }
   }, [client, state.launchNonce, state.organisationId, state.view])
 
+  useEffect(() => {
+    if (state.view !== 'locked' || !state.setupConfigured || state.unlockMetadata) {
+      return
+    }
+
+    let cancelled = false
+
+    async function loadUnlockMetadata() {
+      try {
+        const response = await client.getUnlockMetadata()
+        if (cancelled) {
+          return
+        }
+
+        dispatch({
+          type: 'unlock-metadata-loaded',
+          kdfMetadata: response.kdf_metadata as unknown as PasswordManagerKdfMetadata,
+        })
+      } catch (error) {
+        if (cancelled) {
+          return
+        }
+
+        if (error instanceof PasswordManagerApiError) {
+          dispatch({
+            type: 'launch-failed',
+            view: mapPasswordManagerErrorToShellView(error),
+          })
+          return
+        }
+
+        dispatch({ type: 'launch-failed', view: 'operational-failure' })
+      }
+    }
+
+    void loadUnlockMetadata()
+
+    return () => {
+      cancelled = true
+    }
+  }, [client, state.setupConfigured, state.unlockMetadata, state.view])
+
+  async function handleSetupSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (setupPending) {
+      return
+    }
+
+    setStatusNotice(null)
+
+    if (!setupPassword || !setupPasswordConfirm) {
+      dispatch({ type: 'setup-failed', message: 'Choose and confirm an unlock password to continue.' })
+      return
+    }
+    if (setupPassword !== setupPasswordConfirm) {
+      dispatch({ type: 'setup-failed', message: 'The unlock passwords do not match.' })
+      return
+    }
+
+    setSetupPending(true)
+    try {
+      const profile = await createUnlockProfile(setupPassword)
+      await client.putUserKey({
+        encryptedPrivateKeyEnvelope: toClientPayload(profile.encryptedPrivateKeyEnvelope) as never,
+        kdfMetadata: toClientPayload(profile.kdfMetadata) as never,
+      })
+      const keyPair = await decryptUserPrivateKeyEnvelope({
+        unlockPassword: setupPassword,
+        encryptedPrivateKeyEnvelope: profile.encryptedPrivateKeyEnvelope,
+        kdfMetadata: profile.kdfMetadata,
+      })
+
+      dispatch({
+        type: 'setup-succeeded',
+        encryptedPrivateKeyEnvelope: profile.encryptedPrivateKeyEnvelope,
+        kdfMetadata: profile.kdfMetadata,
+        keyPair,
+      })
+      setSetupPassword('')
+      setSetupPasswordConfirm('')
+      setUnlockPassword('')
+      setStatusNotice('Unlock profile created and loaded locally for this browser session.')
+    } catch (error) {
+      if (error instanceof PasswordManagerApiError) {
+        if (error.status === 409) {
+          dispatch({ type: 'launch-succeeded', setupConfigured: true })
+          setStatusNotice('An unlock profile already exists for this account. Enter your unlock password to continue.')
+          return
+        }
+        if (error.status === 401 || error.status === 403 || error.status === 404) {
+          dispatch({
+            type: 'launch-failed',
+            view: mapPasswordManagerErrorToShellView(error),
+          })
+          return
+        }
+      }
+
+      logWarn('[password-manager] setup failed', error, {
+        organisationId: state.organisationId,
+      })
+      dispatch({ type: 'setup-failed', message: GENERIC_SETUP_FAILURE })
+    } finally {
+      setSetupPending(false)
+    }
+  }
+
+  async function handleUnlockSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (unlockPending) {
+      return
+    }
+
+    setStatusNotice(null)
+
+    if (!unlockPassword) {
+      dispatch({ type: 'unlock-failed', message: 'Enter your unlock password to continue.', needsRelaunch: false })
+      return
+    }
+
+    setUnlockPending(true)
+    try {
+      let encryptedEnvelope = state.encryptedPrivateKeyEnvelope
+      let kdfMetadata = state.unlockMetadata
+
+      if (!encryptedEnvelope) {
+        const userKey = await client.getUserKey()
+        encryptedEnvelope = userKey.encrypted_private_key_envelope as unknown as PasswordManagerEncryptedPrivateKeyEnvelope
+        dispatch({
+          type: 'unlock-material-loaded',
+          encryptedPrivateKeyEnvelope: encryptedEnvelope,
+        })
+        if (!kdfMetadata) {
+          kdfMetadata = userKey.kdf_metadata as unknown as PasswordManagerKdfMetadata
+          dispatch({
+            type: 'unlock-metadata-loaded',
+            kdfMetadata,
+          })
+        }
+      }
+
+      if (!encryptedEnvelope || !kdfMetadata) {
+        throw new Error('Password Manager unlock materials are incomplete')
+      }
+
+      const keyPair = await decryptUserPrivateKeyEnvelope({
+        unlockPassword,
+        encryptedPrivateKeyEnvelope: encryptedEnvelope,
+        kdfMetadata,
+      })
+
+      dispatch({
+        type: 'unlock-succeeded',
+        encryptedPrivateKeyEnvelope: encryptedEnvelope,
+        kdfMetadata,
+        keyPair,
+      })
+      setUnlockPassword('')
+      setStatusNotice('Password Manager unlocked in browser memory only.')
+    } catch (error) {
+      logWarn('[password-manager] unlock failed', error, {
+        organisationId: state.organisationId,
+      })
+      dispatch({
+        type: 'unlock-failed',
+        message: GENERIC_UNLOCK_FAILURE,
+        needsRelaunch: error instanceof PasswordManagerApiError && error.status === 401,
+      })
+    } finally {
+      setUnlockPending(false)
+    }
+  }
+
+  async function handleRefreshSession() {
+    if (refreshPending) {
+      return
+    }
+
+    setRefreshPending(true)
+    setStatusNotice(null)
+    try {
+      await client.refreshSession()
+      setStatusNotice('Password Manager session refreshed.')
+    } catch (error) {
+      logWarn('[password-manager] session refresh failed', error, {
+        organisationId: state.organisationId,
+      })
+      if (error instanceof PasswordManagerApiError) {
+        dispatch({
+          type: 'launch-failed',
+          view: mapPasswordManagerErrorToShellView(error),
+        })
+        return
+      }
+      dispatch({ type: 'launch-failed', view: 'operational-failure' })
+    } finally {
+      setRefreshPending(false)
+    }
+  }
+
+  async function handleLogout() {
+    if (logoutPending) {
+      return
+    }
+
+    setLogoutPending(true)
+    setStatusNotice(null)
+    try {
+      await client.logout()
+    } catch (error) {
+      logWarn('[password-manager] logout failed', error, {
+        organisationId: state.organisationId,
+      })
+    } finally {
+      dispatch({ type: 'restart-launch' })
+      setSetupPassword('')
+      setSetupPasswordConfirm('')
+      setUnlockPassword('')
+      setLogoutPending(false)
+    }
+  }
+
+  function handleManualLock() {
+    dispatch({ type: 'lock' })
+    setUnlockPassword('')
+    setStatusNotice('Decrypted Password Manager state cleared from browser memory.')
+  }
+
   return (
     <section className="mx-auto flex w-full max-w-6xl flex-col gap-6" data-testid="password-manager-shell">
-      <header className="flex flex-col gap-3 rounded-3xl border border-border/60 bg-linear-to-br from-background via-background to-muted/40 p-6 shadow-xs">
-        <div className="flex flex-wrap items-center gap-3">
-          <Badge variant="outline">Tooling</Badge>
-          <Badge variant="secondary">Hosted at /password-manager</Badge>
+      <header className="flex flex-col gap-4 rounded-3xl border border-border/60 bg-linear-to-br from-background via-background to-muted/40 p-6 shadow-xs">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge variant="outline">Tooling</Badge>
+            <Badge variant="secondary">Hosted at /password-manager</Badge>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={handleRefreshSession} disabled={refreshPending}>
+              <RefreshCcw className="mr-2 size-4" />
+              {refreshPending ? 'Refreshing…' : 'Refresh session'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleLogout} disabled={logoutPending}>
+              <LogOut className="mr-2 size-4" />
+              {logoutPending ? 'Ending session…' : 'End session'}
+            </Button>
+          </div>
         </div>
         <div className="flex flex-col gap-2">
           <h1 className="text-3xl font-semibold tracking-tight text-foreground">Password Manager</h1>
           <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-            CT-Ops launches the Password Manager session, but secret material remains in browser-only code paths.
+            CT-Ops launches the session only. Unlock passwords, decrypted key material, and plaintext secrets remain in
+            browser-only code paths.
           </p>
         </div>
+        {statusNotice ? (
+          <Alert>
+            <RefreshCcw className="size-4" />
+            <AlertTitle>Session status</AlertTitle>
+            <AlertDescription>{statusNotice}</AlertDescription>
+          </Alert>
+        ) : null}
       </header>
 
-      <PasswordManagerShellCard state={state} onRetry={() => dispatch({ type: 'restart-launch' })} />
+      <PasswordManagerShellCard
+        state={state}
+        setupPassword={setupPassword}
+        setupPasswordConfirm={setupPasswordConfirm}
+        setupPending={setupPending}
+        unlockPassword={unlockPassword}
+        unlockPending={unlockPending}
+        onSetupPasswordChange={setSetupPassword}
+        onSetupPasswordConfirmChange={setSetupPasswordConfirm}
+        onUnlockPasswordChange={setUnlockPassword}
+        onRetry={() => dispatch({ type: 'restart-launch' })}
+        onLock={handleManualLock}
+        onSetupSubmit={handleSetupSubmit}
+        onUnlockSubmit={handleUnlockSubmit}
+      />
     </section>
   )
 }
 
 function PasswordManagerShellCard({
   state,
+  setupPassword,
+  setupPasswordConfirm,
+  setupPending,
+  unlockPassword,
+  unlockPending,
+  onSetupPasswordChange,
+  onSetupPasswordConfirmChange,
+  onUnlockPasswordChange,
   onRetry,
+  onLock,
+  onSetupSubmit,
+  onUnlockSubmit,
 }: {
   state: PasswordManagerShellState
+  setupPassword: string
+  setupPasswordConfirm: string
+  setupPending: boolean
+  unlockPassword: string
+  unlockPending: boolean
+  onSetupPasswordChange: (value: string) => void
+  onSetupPasswordConfirmChange: (value: string) => void
+  onUnlockPasswordChange: (value: string) => void
   onRetry: () => void
+  onLock: () => void
+  onSetupSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>
+  onUnlockSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>
 }) {
   switch (state.view) {
     case 'launching':
@@ -115,27 +422,114 @@ function PasswordManagerShellCard({
         />
       )
     case 'locked':
-      return (
+      return state.setupConfigured ? (
         <ShellCard
           icon={KeyRound}
-          eyebrow={state.setupConfigured ? 'Locked' : 'First use'}
-          title={state.setupConfigured ? 'Unlock your Password Manager workspace' : 'Set up your unlock profile'}
-          description={
-            state.setupConfigured
-              ? 'Your encrypted unlock profile is available. The unlock controls and vault workspace attach to this shell next.'
-              : 'No encrypted unlock profile is stored yet. The browser-side setup and unlock flow attaches to this shell next.'
-          }
-          statusLabel={state.setupConfigured ? 'Locked' : 'Setup required'}
+          eyebrow="Locked"
+          title="Unlock your Password Manager workspace"
+          description="Your encrypted unlock profile is stored. Enter the unlock password locally in this browser to decrypt the session key pair."
+          statusLabel={state.unlockMetadata ? 'Ready to unlock' : 'Preparing unlock'}
           statusVariant="outline"
           testId="password-manager-state-locked"
           footer={
-            <Alert>
-              <Lock className="size-4" />
-              <AlertTitle>Browser-only boundary preserved</AlertTitle>
-              <AlertDescription>
-                CT-Ops only brokers launch assertions. Vault keys, unlock secrets, and plaintext values stay out of this route shell.
-              </AlertDescription>
-            </Alert>
+            <div className="flex w-full flex-col gap-4">
+              {state.unlockError ? (
+                <Alert variant="destructive">
+                  <ShieldAlert className="size-4" />
+                  <AlertTitle>Unlock failed safely</AlertTitle>
+                  <AlertDescription>{state.unlockError}</AlertDescription>
+                </Alert>
+              ) : null}
+              <form className="grid gap-4" onSubmit={onUnlockSubmit}>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-unlock-password">Unlock password</Label>
+                  <Input
+                    id="password-manager-unlock-password"
+                    type="password"
+                    value={unlockPassword}
+                    autoComplete="current-password"
+                    onChange={(event) => onUnlockPasswordChange(event.target.value)}
+                    disabled={unlockPending || !state.unlockMetadata}
+                  />
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Button type="submit" disabled={unlockPending || !state.unlockMetadata}>
+                    {unlockPending ? 'Unlocking…' : 'Unlock'}
+                  </Button>
+                  {state.needsRelaunch ? (
+                    <Button type="button" variant="outline" onClick={onRetry}>
+                      Relaunch
+                    </Button>
+                  ) : null}
+                </div>
+              </form>
+              <Alert>
+                <Lock className="size-4" />
+                <AlertTitle>Browser-only boundary preserved</AlertTitle>
+                <AlertDescription>
+                  CT-Ops brokers launch assertions only. Decrypted Password Manager keys are never persisted outside
+                  this browser session.
+                </AlertDescription>
+              </Alert>
+            </div>
+          }
+        />
+      ) : (
+        <ShellCard
+          icon={KeyRound}
+          eyebrow="First use"
+          title="Create your unlock profile"
+          description="Generate a browser-only keypair and protect the private key with a local unlock password before using Password Manager."
+          statusLabel="Setup required"
+          statusVariant="outline"
+          testId="password-manager-state-setup-required"
+          footer={
+            <div className="flex w-full flex-col gap-4">
+              {state.setupError ? (
+                <Alert variant="destructive">
+                  <ShieldAlert className="size-4" />
+                  <AlertTitle>Setup blocked</AlertTitle>
+                  <AlertDescription>{state.setupError}</AlertDescription>
+                </Alert>
+              ) : null}
+              <form className="grid gap-4" onSubmit={onSetupSubmit}>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-setup-password">Unlock password</Label>
+                  <Input
+                    id="password-manager-setup-password"
+                    type="password"
+                    value={setupPassword}
+                    autoComplete="new-password"
+                    onChange={(event) => onSetupPasswordChange(event.target.value)}
+                    disabled={setupPending}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-setup-password-confirm">Confirm unlock password</Label>
+                  <Input
+                    id="password-manager-setup-password-confirm"
+                    type="password"
+                    value={setupPasswordConfirm}
+                    autoComplete="new-password"
+                    onChange={(event) => onSetupPasswordConfirmChange(event.target.value)}
+                    disabled={setupPending}
+                  />
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Button type="submit" disabled={setupPending}>
+                    {setupPending ? 'Generating browser-only keys…' : 'Create unlock profile'}
+                  </Button>
+                </div>
+              </form>
+              <Alert>
+                <Vault className="size-4" />
+                <AlertTitle>Encrypted setup only</AlertTitle>
+                <AlertDescription>
+                  The setup call uploads only the encrypted private-key envelope and KDF metadata required for future
+                  browser-side unlock.
+                </AlertDescription>
+              </Alert>
+            </div>
           }
         />
       )
@@ -145,10 +539,26 @@ function PasswordManagerShellCard({
           icon={Vault}
           eyebrow="Unlocked"
           title="Password Manager workspace is active"
-          description="Vaults, entries, sharing controls, and audit-aware actions render inside this shell once the unlock session is active."
+          description="The unlock keypair is loaded in browser memory. Vault and entry workflows attach to this shell next."
           statusLabel="Unlocked"
           statusVariant="secondary"
           testId="password-manager-state-unlocked"
+          actions={
+            <Button variant="outline" onClick={onLock}>
+              <Lock className="mr-2 size-4" />
+              Lock now
+            </Button>
+          }
+          footer={
+            <Alert>
+              <KeyRound className="size-4" />
+              <AlertTitle>Decrypted state is ephemeral</AlertTitle>
+              <AlertDescription>
+                Manual lock, logout, relaunch, and organisation changes purge the active Password Manager key material
+                from browser memory.
+              </AlertDescription>
+            </Alert>
+          }
         />
       )
     case 'session-expired':
@@ -174,7 +584,11 @@ function PasswordManagerShellCard({
           statusLabel="Access denied"
           statusVariant="destructive"
           testId="password-manager-state-access-denied"
-          actions={<Button variant="outline" onClick={onRetry}>Retry launch</Button>}
+          actions={
+            <Button variant="outline" onClick={onRetry}>
+              Retry launch
+            </Button>
+          }
         />
       )
     case 'object-unavailable':
@@ -187,7 +601,11 @@ function PasswordManagerShellCard({
           statusLabel="Unavailable"
           statusVariant="outline"
           testId="password-manager-state-object-unavailable"
-          actions={<Button variant="outline" onClick={onRetry}>Retry launch</Button>}
+          actions={
+            <Button variant="outline" onClick={onRetry}>
+              Retry launch
+            </Button>
+          }
         />
       )
     case 'operational-failure':
@@ -224,8 +642,8 @@ function ShellCard({
   statusLabel: string
   statusVariant: 'secondary' | 'outline' | 'destructive'
   testId: string
-  actions?: React.ReactNode
-  footer?: React.ReactNode
+  actions?: ReactNode
+  footer?: ReactNode
 }) {
   return (
     <Card className="overflow-hidden border-border/60 shadow-xs" data-testid={testId}>

--- a/apps/web/lib/password-manager/browser-crypto.test.mjs
+++ b/apps/web/lib/password-manager/browser-crypto.test.mjs
@@ -26,6 +26,20 @@ test('unlock profile generation and decrypt round-trip stays browser-only', asyn
   assert.equal(decrypted.privateKey.algorithm.name, 'RSA-OAEP')
 })
 
+test('decryptUserPrivateKeyEnvelope rejects invalid unlock secrets without exposing plaintext', async () => {
+  const profile = await createUnlockProfile('correct horse battery staple')
+
+  await assert.rejects(
+    () =>
+      decryptUserPrivateKeyEnvelope({
+        unlockPassword: 'wrong battery horse staple',
+        encryptedPrivateKeyEnvelope: profile.encryptedPrivateKeyEnvelope,
+        kdfMetadata: profile.kdfMetadata,
+      }),
+    /operation/i,
+  )
+})
+
 test('vault key wrapping and entry encryption round-trip', async () => {
   const owner = await createUnlockProfile('owner password')
   const ownerKeys = await decryptUserPrivateKeyEnvelope({

--- a/apps/web/lib/password-manager/shell.test.mjs
+++ b/apps/web/lib/password-manager/shell.test.mjs
@@ -17,8 +17,105 @@ test('launch success enters the locked shell and records setup status', () => {
 
   assert.deepEqual(next, {
     organisationId: 'org-alpha',
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: null,
     launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
     setupConfigured: false,
+    unlockError: null,
+    unlockMetadata: null,
+    view: 'locked',
+  })
+})
+
+test('setup completion stores encrypted materials and unlocks without persisting plaintext', () => {
+  const initial = reducePasswordManagerShellState(createInitialPasswordManagerShellState('org-alpha'), {
+    type: 'launch-succeeded',
+    setupConfigured: false,
+  })
+  const keyPair = { privateKey: { kind: 'private' }, publicKey: { kind: 'public' } }
+  const next = reducePasswordManagerShellState(initial, {
+    type: 'setup-succeeded',
+    encryptedPrivateKeyEnvelope: { ciphertext_b64: 'ciphertext' },
+    kdfMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
+    keyPair,
+  })
+
+  assert.deepEqual(next, {
+    organisationId: 'org-alpha',
+    activeKeyPair: keyPair,
+    encryptedPrivateKeyEnvelope: { ciphertext_b64: 'ciphertext' },
+    launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
+    setupConfigured: true,
+    unlockError: null,
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
+    view: 'unlocked',
+  })
+})
+
+test('manual lock clears decrypted key material without forcing setup again', () => {
+  const unlocked = {
+    organisationId: 'org-alpha',
+    activeKeyPair: { privateKey: { kind: 'private' }, publicKey: { kind: 'public' } },
+    encryptedPrivateKeyEnvelope: { ciphertext_b64: 'ciphertext' },
+    launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
+    setupConfigured: true,
+    unlockError: null,
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
+    view: 'unlocked',
+  }
+
+  const next = reducePasswordManagerShellState(unlocked, { type: 'lock' })
+
+  assert.deepEqual(next, {
+    organisationId: 'org-alpha',
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: { ciphertext_b64: 'ciphertext' },
+    launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
+    setupConfigured: true,
+    unlockError: null,
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
+    view: 'locked',
+  })
+})
+
+test('generic unlock failures keep the shell locked and avoid revealing the root cause', () => {
+  const locked = {
+    organisationId: 'org-alpha',
+    activeKeyPair: { privateKey: { kind: 'private' }, publicKey: { kind: 'public' } },
+    encryptedPrivateKeyEnvelope: null,
+    launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
+    setupConfigured: true,
+    unlockError: null,
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
+    view: 'unlocked',
+  }
+
+  const next = reducePasswordManagerShellState(locked, {
+    type: 'unlock-failed',
+    message: 'Password Manager could not unlock with the provided materials. Retry or relaunch.',
+    needsRelaunch: true,
+  })
+
+  assert.deepEqual(next, {
+    organisationId: 'org-alpha',
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: null,
+    launchNonce: 0,
+    needsRelaunch: true,
+    setupError: null,
+    setupConfigured: true,
+    unlockError: 'Password Manager could not unlock with the provided materials. Retry or relaunch.',
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
     view: 'locked',
   })
 })
@@ -26,8 +123,14 @@ test('launch success enters the locked shell and records setup status', () => {
 test('organisation changes tear down local state and restart launch', () => {
   const locked = {
     organisationId: 'org-alpha',
+    activeKeyPair: { privateKey: { kind: 'private' }, publicKey: { kind: 'public' } },
+    encryptedPrivateKeyEnvelope: { ciphertext_b64: 'ciphertext' },
     launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
     setupConfigured: true,
+    unlockError: null,
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
     view: 'unlocked',
   }
 
@@ -38,8 +141,14 @@ test('organisation changes tear down local state and restart launch', () => {
 
   assert.deepEqual(next, {
     organisationId: 'org-bravo',
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: null,
     launchNonce: 1,
+    needsRelaunch: false,
+    setupError: null,
     setupConfigured: null,
+    unlockError: null,
+    unlockMetadata: null,
     view: 'launching',
   })
 })
@@ -47,8 +156,14 @@ test('organisation changes tear down local state and restart launch', () => {
 test('explicit relaunch clears local shell state and increments launch nonce', () => {
   const locked = {
     organisationId: 'org-alpha',
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: { ciphertext_b64: 'ciphertext' },
     launchNonce: 3,
+    needsRelaunch: true,
+    setupError: null,
     setupConfigured: true,
+    unlockError: 'Password Manager could not unlock with the provided materials. Retry or relaunch.',
+    unlockMetadata: { algorithm: 'pbkdf2-sha256', iterations: 600000, salt_b64: 'salt', derived_key_length: 32 },
     view: 'locked',
   }
 
@@ -56,8 +171,14 @@ test('explicit relaunch clears local shell state and increments launch nonce', (
 
   assert.deepEqual(next, {
     organisationId: 'org-alpha',
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: null,
     launchNonce: 4,
+    needsRelaunch: false,
+    setupError: null,
     setupConfigured: null,
+    unlockError: null,
+    unlockMetadata: null,
     view: 'launching',
   })
 })

--- a/apps/web/lib/password-manager/shell.ts
+++ b/apps/web/lib/password-manager/shell.ts
@@ -1,4 +1,8 @@
 import { PasswordManagerApiError } from './client.ts'
+import type {
+  PasswordManagerEncryptedPrivateKeyEnvelope,
+  PasswordManagerKdfMetadata,
+} from './browser-crypto.ts'
 
 export type PasswordManagerShellView =
   | 'launching'
@@ -9,17 +13,43 @@ export type PasswordManagerShellView =
   | 'object-unavailable'
   | 'operational-failure'
 
+export interface PasswordManagerActiveKeyPair {
+  privateKey: unknown
+  publicKey: unknown
+}
+
 export interface PasswordManagerShellState {
   organisationId: string
+  activeKeyPair: PasswordManagerActiveKeyPair | null
+  encryptedPrivateKeyEnvelope: PasswordManagerEncryptedPrivateKeyEnvelope | null
   launchNonce: number
+  needsRelaunch: boolean
+  setupError: string | null
   setupConfigured: boolean | null
+  unlockError: string | null
+  unlockMetadata: PasswordManagerKdfMetadata | null
   view: PasswordManagerShellView
 }
 
 export type PasswordManagerShellEvent =
   | { type: 'launch-succeeded'; setupConfigured: boolean }
   | { type: 'launch-failed'; view: Exclude<PasswordManagerShellView, 'launching' | 'locked' | 'unlocked'> }
-  | { type: 'unlock-succeeded' }
+  | { type: 'unlock-metadata-loaded'; kdfMetadata: PasswordManagerKdfMetadata }
+  | { type: 'setup-failed'; message: string }
+  | {
+      type: 'setup-succeeded'
+      encryptedPrivateKeyEnvelope: PasswordManagerEncryptedPrivateKeyEnvelope
+      kdfMetadata: PasswordManagerKdfMetadata
+      keyPair: PasswordManagerActiveKeyPair
+    }
+  | { type: 'unlock-material-loaded'; encryptedPrivateKeyEnvelope: PasswordManagerEncryptedPrivateKeyEnvelope }
+  | {
+      type: 'unlock-succeeded'
+      encryptedPrivateKeyEnvelope: PasswordManagerEncryptedPrivateKeyEnvelope
+      kdfMetadata: PasswordManagerKdfMetadata
+      keyPair: PasswordManagerActiveKeyPair
+    }
+  | { type: 'unlock-failed'; message: string; needsRelaunch: boolean }
   | { type: 'lock' }
   | { type: 'restart-launch' }
   | { type: 'organisation-changed'; organisationId: string }
@@ -27,8 +57,14 @@ export type PasswordManagerShellEvent =
 export function createInitialPasswordManagerShellState(organisationId: string): PasswordManagerShellState {
   return {
     organisationId,
+    activeKeyPair: null,
+    encryptedPrivateKeyEnvelope: null,
     launchNonce: 0,
+    needsRelaunch: false,
+    setupError: null,
     setupConfigured: null,
+    unlockError: null,
+    unlockMetadata: null,
     view: 'launching',
   }
 }
@@ -60,38 +96,98 @@ export function reducePasswordManagerShellState(
     case 'launch-succeeded':
       return {
         ...state,
+        activeKeyPair: null,
+        encryptedPrivateKeyEnvelope: null,
+        needsRelaunch: false,
+        setupError: null,
         setupConfigured: event.setupConfigured,
+        unlockError: null,
+        unlockMetadata: null,
         view: 'locked',
       }
     case 'launch-failed':
       return {
         ...state,
+        activeKeyPair: null,
+        encryptedPrivateKeyEnvelope: null,
+        needsRelaunch: false,
         setupConfigured: null,
+        setupError: null,
+        unlockError: null,
+        unlockMetadata: null,
         view: event.view,
+      }
+    case 'unlock-metadata-loaded':
+      return {
+        ...state,
+        unlockMetadata: event.kdfMetadata,
+      }
+    case 'setup-failed':
+      return {
+        ...state,
+        activeKeyPair: null,
+        encryptedPrivateKeyEnvelope: null,
+        needsRelaunch: false,
+        setupError: event.message,
+        unlockError: null,
+        view: 'locked',
+      }
+    case 'setup-succeeded':
+      return {
+        ...state,
+        activeKeyPair: event.keyPair,
+        encryptedPrivateKeyEnvelope: event.encryptedPrivateKeyEnvelope,
+        needsRelaunch: false,
+        setupConfigured: true,
+        setupError: null,
+        unlockError: null,
+        unlockMetadata: event.kdfMetadata,
+        view: 'unlocked',
+      }
+    case 'unlock-material-loaded':
+      return {
+        ...state,
+        encryptedPrivateKeyEnvelope: event.encryptedPrivateKeyEnvelope,
       }
     case 'unlock-succeeded':
       return {
         ...state,
+        activeKeyPair: event.keyPair,
+        encryptedPrivateKeyEnvelope: event.encryptedPrivateKeyEnvelope,
+        needsRelaunch: false,
+        setupError: null,
+        unlockError: null,
+        unlockMetadata: event.kdfMetadata,
         view: 'unlocked',
+      }
+    case 'unlock-failed':
+      return {
+        ...state,
+        activeKeyPair: null,
+        encryptedPrivateKeyEnvelope: null,
+        needsRelaunch: event.needsRelaunch,
+        setupError: null,
+        unlockError: event.message,
+        view: 'locked',
       }
     case 'lock':
       return {
         ...state,
+        activeKeyPair: null,
+        needsRelaunch: false,
+        setupError: null,
+        unlockError: null,
         view: 'locked',
       }
     case 'restart-launch':
       return {
-        ...state,
+        ...createInitialPasswordManagerShellState(state.organisationId),
         launchNonce: state.launchNonce + 1,
-        setupConfigured: null,
-        view: 'launching',
       }
     case 'organisation-changed':
       return {
-        organisationId: event.organisationId,
+        ...createInitialPasswordManagerShellState(event.organisationId),
         launchNonce: state.launchNonce + 1,
-        setupConfigured: null,
-        view: 'launching',
       }
   }
 }


### PR DESCRIPTION
## Summary
- add first-use Password Manager setup and browser-only unlock handling to the /password-manager route shell
- keep encrypted envelopes and KDF metadata in safe client state while clearing decrypted keys on lock, relaunch, logout, and org changes
- extend Password Manager shell and browser-crypto tests for setup, unlock failure, relock, and relaunch transitions

## Validation
- pnpm install --frozen-lockfile
- pnpm --dir apps/web type-check
- node --experimental-strip-types --test apps/web/lib/password-manager/shell.test.mjs apps/web/lib/password-manager/browser-crypto.test.mjs
- BETTER_AUTH_URL=https://ops.example.test BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder pnpm --dir apps/web build
- pnpm --dir apps/web lint
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/access-control.spec.ts (fails here: testcontainers cannot find a working container runtime)
- git diff --check