### PR TITLE
fix(authz): require write access for tenant mutations

### DIFF
--- a/apps/web/lib/actions/action-auth-core.ts
+++ b/apps/web/lib/actions/action-auth-core.ts
@@ -1,4 +1,4 @@
-import { requireOrgAdmin, requireSameOrg } from '../auth/guards.ts'
+import { requireOrgAdmin, requireOrgWriteAccess as requireWriteAccess, requireSameOrg } from '../auth/guards.ts'
 
 export type OrgScopedUser = {
   organisationId: string | null
@@ -16,4 +16,8 @@ export function assertOrgAccess(user: OrgScopedUser, orgId: string): void {
 
 export function assertOrgAdminAccess(user: OrgAdminScopedUser, orgId: string): void {
   requireOrgAdmin(user, orgId)
+}
+
+export function assertOrgWriteAccess(user: OrgAdminScopedUser, orgId: string): void {
+  requireWriteAccess(user, orgId)
 }

--- a/apps/web/lib/actions/action-auth.test.mjs
+++ b/apps/web/lib/actions/action-auth.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { assertOrgAccess, assertOrgAdminAccess } from './action-auth-core.ts'
+import { assertOrgAccess, assertOrgAdminAccess, assertOrgWriteAccess } from './action-auth-core.ts'
 
 test('assertOrgAccess rejects inactive users', () => {
   assert.throws(
@@ -27,6 +27,29 @@ test('assertOrgAccess rejects cross-org access', () => {
 test('assertOrgAccess allows active users in their own organisation', () => {
   assert.doesNotThrow(
     () => assertOrgAccess({ organisationId: 'org-1', isActive: true, deletedAt: null }, 'org-1'),
+  )
+})
+
+test('assertOrgWriteAccess rejects read-only users in their own organisation', () => {
+  assert.throws(
+    () => assertOrgWriteAccess({
+      organisationId: 'org-1',
+      isActive: true,
+      deletedAt: null,
+      role: 'read_only',
+    }, 'org-1'),
+    /forbidden: write role required/,
+  )
+})
+
+test('assertOrgWriteAccess allows engineers in their own organisation', () => {
+  assert.doesNotThrow(
+    () => assertOrgWriteAccess({
+      organisationId: 'org-1',
+      isActive: true,
+      deletedAt: null,
+      role: 'engineer',
+    }, 'org-1'),
   )
 })
 

--- a/apps/web/lib/actions/action-auth.ts
+++ b/apps/web/lib/actions/action-auth.ts
@@ -1,5 +1,5 @@
 import { getRequiredSession, type RequiredSession } from '@/lib/auth/session'
-import { assertOrgAccess, assertOrgAdminAccess } from '@/lib/actions/action-auth-core'
+import { assertOrgAccess, assertOrgAdminAccess, assertOrgWriteAccess } from '@/lib/actions/action-auth-core'
 import { requireToolingAccess } from '@/lib/auth/tooling'
 
 export async function requireOrgAccess(orgId: string): Promise<RequiredSession> {
@@ -14,8 +14,14 @@ export async function requireOrgAdminAccess(orgId: string): Promise<RequiredSess
   return session
 }
 
+export async function requireOrgWriteAccess(orgId: string): Promise<RequiredSession> {
+  const session = await getRequiredSession()
+  assertOrgWriteAccess(session.user, orgId)
+  return session
+}
+
 export async function requireOrgToolingAccess(orgId: string): Promise<RequiredSession> {
-  const session = await requireOrgAccess(orgId)
+  const session = await requireOrgWriteAccess(orgId)
   requireToolingAccess(session.user)
   return session
 }

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -1,13 +1,12 @@
 'use server'
 
-import { requireOrgAccess, requireOrgAdminAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { createHmac } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { assertPublicHost, assertPublicUrl } from '@/lib/net/ssrf-guard'
 import { validateStoredNotificationChannelConfig } from '@/lib/actions/alerts-notification-security'
-import { getRequiredSession } from '@/lib/auth/session'
 import { writeAuditEvent } from '@/lib/audit/events'
 import { decrypt } from '@/lib/crypto/encrypt'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
@@ -154,7 +153,7 @@ export async function createGlobalAlertDefault(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const parsed = createGlobalAlertDefaultSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -186,8 +185,7 @@ export async function deleteGlobalAlertDefault(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
+  const session = await requireOrgAdminAccess(orgId)
   const existing = await db.query.alertRules.findFirst({
     where: and(
       eq(alertRules.id, ruleId),
@@ -225,7 +223,7 @@ export async function applyGlobalDefaultsToHost(
   orgId: string,
   hostId: string,
 ): Promise<void> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   const defaults = await getGlobalAlertDefaults(orgId)
   if (defaults.length === 0) return
 
@@ -247,7 +245,7 @@ export async function createAlertRule(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const parsed = createAlertRuleSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -279,7 +277,7 @@ export async function updateAlertRule(
   ruleId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const parsed = updateAlertRuleSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -313,8 +311,7 @@ export async function deleteAlertRule(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
-  const session = await getRequiredSession()
+  const session = await requireOrgWriteAccess(orgId)
   const existing = await db.query.alertRules.findFirst({
     where: and(
       eq(alertRules.id, ruleId),
@@ -436,7 +433,7 @@ export async function acknowledgeAlert(
   orgId: string,
   instanceId: string,
 ): Promise<{ success: true } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
+  const session = await requireOrgWriteAccess(orgId)
   const existing = await db.query.alertInstances.findFirst({
     where: and(
       eq(alertInstances.id, instanceId),
@@ -969,7 +966,7 @@ export async function createSilence(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  const session = await requireOrgAccess(orgId)
+  const session = await requireOrgWriteAccess(orgId)
   const parsed = createSilenceSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -1016,7 +1013,7 @@ export async function deleteSilence(
   orgId: string,
   silenceId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const existing = await db.query.alertSilences.findFirst({
     where: and(
       eq(alertSilences.id, silenceId),

--- a/apps/web/lib/actions/checks.ts
+++ b/apps/web/lib/actions/checks.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -105,7 +105,7 @@ export async function createCheck(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const parsed = createCheckSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -145,7 +145,7 @@ export async function updateCheck(
   checkId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const parsed = updateCheckSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -179,7 +179,7 @@ export async function deleteCheckHistory(
   orgId: string,
   checkId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const existing = await db.query.checks.findFirst({
     where: and(
       eq(checks.id, checkId),
@@ -198,7 +198,7 @@ export async function deleteCheck(
   orgId: string,
   checkId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const existing = await db.query.checks.findFirst({
     where: and(
       eq(checks.id, checkId),

--- a/apps/web/lib/actions/host-groups.ts
+++ b/apps/web/lib/actions/host-groups.ts
@@ -1,13 +1,13 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { hostGroups, hostGroupMembers, hosts } from '@/lib/db/schema'
 import { eq, and, isNull, sql } from 'drizzle-orm'
-import type { HostGroup, HostGroupMember } from '@/lib/db/schema'
+import type { HostGroup } from '@/lib/db/schema'
 import type { Host } from '@/lib/db/schema'
 
 export type HostGroupWithCount = HostGroup & { hostCount: number }
@@ -24,7 +24,7 @@ export async function createGroup(
   orgId: string,
   input: unknown,
 ): Promise<{ success: true; group: HostGroup } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const parsed = groupSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -52,7 +52,7 @@ export async function updateGroup(
   groupId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const parsed = groupSchema.safeParse(input)
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -76,7 +76,7 @@ export async function deleteGroup(
   orgId: string,
   groupId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     // Soft-delete the group
     const result = await db
@@ -140,7 +140,7 @@ export async function addHostToGroup(
   groupId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     // Check if already a member (including soft-deleted — restore if so)
     const existing = await db.query.hostGroupMembers.findFirst({
@@ -178,7 +178,7 @@ export async function removeHostFromGroup(
   groupId: string,
   hostId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const result = await db
       .update(hostGroupMembers)

--- a/apps/web/lib/actions/host-settings.ts
+++ b/apps/web/lib/actions/host-settings.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
 
 import { db } from '@/lib/db'
 import { hosts, organisations, checks } from '@/lib/db/schema'
@@ -36,7 +36,7 @@ export async function updateHostCollectionSettings(
   hostId: string,
   settings: HostCollectionSettings,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const host = await db.query.hosts.findFirst({
       where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
@@ -86,7 +86,7 @@ export async function updateOrgDefaultCollectionSettings(
   orgId: string,
   settings: HostCollectionSettings,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   try {
     const org = await db.query.organisations.findFirst({
       where: eq(organisations.id, orgId),

--- a/apps/web/lib/actions/mutation-authz.test.mjs
+++ b/apps/web/lib/actions/mutation-authz.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+const sources = {
+  'alerts.ts': readFileSync(path.join(here, 'alerts.ts'), 'utf8'),
+  'checks.ts': readFileSync(path.join(here, 'checks.ts'), 'utf8'),
+  'host-groups.ts': readFileSync(path.join(here, 'host-groups.ts'), 'utf8'),
+  'host-settings.ts': readFileSync(path.join(here, 'host-settings.ts'), 'utf8'),
+  'tag-rules.ts': readFileSync(path.join(here, 'tag-rules.ts'), 'utf8'),
+  'tags.ts': readFileSync(path.join(here, 'tags.ts'), 'utf8'),
+}
+
+function getActionSegment(fileName, action) {
+  const source = sources[fileName]
+  const start = source.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist in ${fileName}`)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? undefined : next)
+}
+
+const writeGuardedActions = [
+  ['alerts.ts', 'createAlertRule'],
+  ['alerts.ts', 'updateAlertRule'],
+  ['alerts.ts', 'deleteAlertRule'],
+  ['alerts.ts', 'acknowledgeAlert'],
+  ['alerts.ts', 'createSilence'],
+  ['alerts.ts', 'deleteSilence'],
+  ['checks.ts', 'createCheck'],
+  ['checks.ts', 'updateCheck'],
+  ['checks.ts', 'deleteCheckHistory'],
+  ['checks.ts', 'deleteCheck'],
+  ['host-groups.ts', 'createGroup'],
+  ['host-groups.ts', 'updateGroup'],
+  ['host-groups.ts', 'deleteGroup'],
+  ['host-groups.ts', 'addHostToGroup'],
+  ['host-groups.ts', 'removeHostFromGroup'],
+  ['host-settings.ts', 'updateHostCollectionSettings'],
+  ['tag-rules.ts', 'bulkAssignTags'],
+  ['tag-rules.ts', 'runTagRule'],
+  ['tag-rules.ts', 'runMatchingTagRules'],
+  ['tags.ts', 'assignTagsToResource'],
+  ['tags.ts', 'removeTagFromResource'],
+  ['tags.ts', 'replaceResourceTags'],
+]
+
+const adminGuardedActions = [
+  ['alerts.ts', 'createGlobalAlertDefault'],
+  ['alerts.ts', 'deleteGlobalAlertDefault'],
+  ['alerts.ts', 'applyGlobalDefaultsToHost'],
+  ['host-settings.ts', 'updateOrgDefaultCollectionSettings'],
+  ['tag-rules.ts', 'createTagRule'],
+  ['tag-rules.ts', 'updateTagRule'],
+  ['tag-rules.ts', 'deleteTagRule'],
+  ['tags.ts', 'updateOrgDefaultTags'],
+]
+
+test('tenant state mutations require write-capable org access', () => {
+  for (const [fileName, action] of writeGuardedActions) {
+    const segment = getActionSegment(fileName, action)
+
+    assert.match(
+      segment,
+      /(?:const session = )?await requireOrgWriteAccess\(orgId\)/,
+      `${fileName} ${action} must reject read-only users before mutating tenant state`,
+    )
+  }
+})
+
+test('organisation-wide defaults and rules require org admin access', () => {
+  for (const [fileName, action] of adminGuardedActions) {
+    const segment = getActionSegment(fileName, action)
+
+    assert.match(
+      segment,
+      /(?:const session = )?await requireOrgAdminAccess\(orgId\)/,
+      `${fileName} ${action} must require org admin access before mutating organisation-wide settings`,
+    )
+  }
+})

--- a/apps/web/lib/actions/session-actor.test.mjs
+++ b/apps/web/lib/actions/session-actor.test.mjs
@@ -43,7 +43,7 @@ test('alert mutations derive audit actors from the authenticated session', () =>
     )
     assert.match(
       segment,
-      /const session = await requireOrgAccess\(orgId\)/,
+      /const session = await requireOrg(?:Access|WriteAccess)\(orgId\)/,
       `${action} must capture the authenticated session`,
     )
     assert.match(

--- a/apps/web/lib/actions/tag-rules.ts
+++ b/apps/web/lib/actions/tag-rules.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -73,7 +73,7 @@ export async function bulkAssignTags(
   filter: HostFilter,
   pairs: TagPair[],
 ): Promise<{ success: true; applied: number } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const parsedFilter = hostFilterSchema.safeParse(filter)
     if (!parsedFilter.success) return { error: 'Invalid filter' }
@@ -106,7 +106,7 @@ export async function createTagRule(
   orgId: string,
   input: { name: string; filter: HostFilter; tags: TagPair[]; enabled?: boolean },
 ): Promise<{ success: true; id: string } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   try {
     const parsed = createRuleSchema.safeParse(input)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
@@ -134,7 +134,7 @@ export async function updateTagRule(
   ruleId: string,
   input: Partial<{ name: string; filter: HostFilter; tags: TagPair[]; enabled: boolean }>,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   try {
     const existing = await db.query.tagRules.findFirst({
       where: and(
@@ -175,7 +175,7 @@ export async function deleteTagRule(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   try {
     await db
       .update(tagRules)
@@ -195,7 +195,7 @@ export async function runTagRule(
   orgId: string,
   ruleId: string,
 ): Promise<{ success: true; applied: number } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const rule = await db.query.tagRules.findFirst({
       where: and(
@@ -221,7 +221,7 @@ export async function runMatchingTagRules(
   orgId: string,
   hostId: string,
 ): Promise<void> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   const host = await db.query.hosts.findFirst({
     where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
   })

--- a/apps/web/lib/actions/tags.ts
+++ b/apps/web/lib/actions/tags.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { logError } from '@/lib/logging'
-import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { requireOrgAccess, requireOrgAdminAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -120,7 +120,7 @@ export async function assignTagsToResource(
   resourceId: string,
   pairs: TagPair[],
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const parsed = z.array(tagPairSchema).safeParse(pairs)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid tags' }
@@ -157,7 +157,7 @@ export async function removeTagFromResource(
   orgId: string,
   resourceTagId: string,
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const row = await db.query.resourceTags.findFirst({
       where: and(eq(resourceTags.id, resourceTagId), eq(resourceTags.organisationId, orgId)),
@@ -186,7 +186,7 @@ export async function replaceResourceTags(
   resourceId: string,
   pairs: TagPair[],
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgWriteAccess(orgId)
   try {
     const parsed = z.array(tagPairSchema).safeParse(pairs)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid tags' }
@@ -299,7 +299,7 @@ export async function updateOrgDefaultTags(
   orgId: string,
   pairs: TagPair[],
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAccess(orgId)
+  await requireOrgAdminAccess(orgId)
   try {
     const parsed = z.array(tagPairSchema).safeParse(pairs)
     if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? 'Invalid tags' }


### PR DESCRIPTION
## Summary
- add a server-action write access helper backed by membership roles
- require write access for tenant mutations and admin access for organisation-wide defaults/rules
- add static authz coverage for representative mutation actions

Fixes #1044

## Tests
- node --experimental-strip-types --test apps/web/lib/actions/action-auth.test.mjs apps/web/lib/actions/mutation-authz.test.mjs apps/web/lib/actions/session-actor.test.mjs
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing warnings)
- pnpm --dir apps/web test:unit (210 pass; 2 fail locally because Testcontainers cannot find a container runtime: lib/db/rls.test.mjs, lib/integrations/ct-cve/db-nonce-store.test.mjs)