### PR TITLE
fix(ingest): bind heartbeat JWT to mTLS identity

### DIFF
--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -64,10 +64,10 @@ func (h *HeartbeatHandler) Heartbeat(stream agentv1.IngestService_HeartbeatServe
 		return status.Errorf(codes.Internal, "receiving first heartbeat: %v", err)
 	}
 
-	// Validate JWT
-	agentID, _, err := h.issuer.ValidateAgentToken(first.AgentId)
+	// Validate the JWT and bind it to the verified mTLS client identity.
+	agentID, _, err := h.authenticateFirstHeartbeat(ctx, first.AgentId)
 	if err != nil {
-		return status.Error(codes.Unauthenticated, "invalid or missing JWT")
+		return err
 	}
 
 	// Verify agent is active
@@ -275,6 +275,21 @@ loop:
 
 	slog.Info("heartbeat stream ended, agent marked offline", "agent_id", agentID)
 	return nil
+}
+
+func (h *HeartbeatHandler) authenticateFirstHeartbeat(ctx context.Context, token string) (agentID string, orgID string, err error) {
+	agentID, orgID, err = h.issuer.ValidateAgentToken(token)
+	if err != nil {
+		return "", "", status.Error(codes.Unauthenticated, "invalid or missing JWT")
+	}
+	id, ok := pki.IdentityFromContext(ctx)
+	if !ok || id == nil {
+		return "", "", status.Error(codes.Unauthenticated, "missing client identity")
+	}
+	if id.AgentID != agentID || id.OrgID != orgID {
+		return "", "", status.Error(codes.Unauthenticated, "client identity mismatch")
+	}
+	return agentID, orgID, nil
 }
 
 func (h *HeartbeatHandler) processHeartbeat(

--- a/apps/ingest/internal/handlers/heartbeat_test.go
+++ b/apps/ingest/internal/handlers/heartbeat_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/carrtech-dev/ct-ops/ingest/internal/auth"
+	"github.com/carrtech-dev/ct-ops/ingest/internal/pki"
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
 )
 
@@ -73,5 +74,70 @@ func TestHeartbeatRejectsInvalidFirstMessageJWT(t *testing.T) {
 	err = handler.Heartbeat(stream)
 	if status.Code(err) != codes.Unauthenticated {
 		t.Fatalf("Heartbeat() code = %v, want %v (err=%v)", status.Code(err), codes.Unauthenticated, err)
+	}
+}
+
+func TestHeartbeatAuthenticateFirstMessageBindsMTLSIdentity(t *testing.T) {
+	t.Parallel()
+
+	issuer, err := auth.NewJWTIssuer(nil, filepath.Join(t.TempDir(), "jwt.pem"), "test-issuer", time.Hour)
+	if err != nil {
+		t.Fatalf("NewJWTIssuer: %v", err)
+	}
+	token, err := issuer.IssueAgentToken("agent-123", "org-456")
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+
+	handler := NewHeartbeatHandler(nil, issuer, nil, nil, "", nil, nil)
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		wantCode codes.Code
+	}{
+		{
+			name:     "missing identity",
+			ctx:      context.Background(),
+			wantCode: codes.Unauthenticated,
+		},
+		{
+			name: "mismatched agent",
+			ctx: pki.WithIdentity(context.Background(), &pki.Identity{
+				OrgID:   "org-456",
+				AgentID: "agent-other",
+			}),
+			wantCode: codes.Unauthenticated,
+		},
+		{
+			name: "mismatched organisation",
+			ctx: pki.WithIdentity(context.Background(), &pki.Identity{
+				OrgID:   "org-other",
+				AgentID: "agent-123",
+			}),
+			wantCode: codes.Unauthenticated,
+		},
+		{
+			name: "matching identity",
+			ctx: pki.WithIdentity(context.Background(), &pki.Identity{
+				OrgID:   "org-456",
+				AgentID: "agent-123",
+			}),
+			wantCode: codes.OK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentID, orgID, err := handler.authenticateFirstHeartbeat(tt.ctx, token)
+			if status.Code(err) != tt.wantCode {
+				t.Fatalf("authenticateFirstHeartbeat() code = %v, want %v (err=%v)", status.Code(err), tt.wantCode, err)
+			}
+			if tt.wantCode == codes.OK {
+				if agentID != "agent-123" || orgID != "org-456" {
+					t.Fatalf("authenticateFirstHeartbeat() = (%q, %q), want (agent-123, org-456)", agentID, orgID)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- bind heartbeat JWT authentication to the verified mTLS identity before DB lookup
- reject missing or mismatched heartbeat client identities with Unauthenticated
- add focused heartbeat auth tests for missing, mismatched, and matching identities

Fixes #1055

## Tests
- go test ./apps/ingest/internal/handlers -count=1
- go test ./apps/ingest/... -count=1