### PR TITLE
test(password-manager): add hosted e2e leak coverage

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,34 @@
 
 ## What Has Been Built
 
+### Session 113 — Password Manager hosted no-plaintext E2E coverage
+
+**Hosted Password Manager E2E leak assertions** (`apps/web/tests/e2e/fixtures/test.ts`, `apps/web/tests/e2e/fixtures/password-manager.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Added a Password Manager Playwright mock fixture that intercepts the hosted
+  `/password-manager-api/` traffic, simulates session launch/setup/unlock,
+  vault and entry CRUD, member sharing and revocation, key rotation, audit
+  hooks, session expiry, and organisation switches, and records outbound
+  request bodies plus headers for leak checks.
+- Added a targeted hosted Password Manager E2E spec that covers launch,
+  browser-only setup, relaunch + unlock, vault create/delete, entry
+  create/reveal/copy/export/edit/delete, member add/remove, rotation prompts,
+  session refresh expiry handling, and organisation switching from the CT-Ops
+  hosted route shell.
+- Added network and browser-surface assertions proving the hosted flow does not
+  send unlock passwords, plaintext entry values, or plaintext-shaped key fields
+  to either the CT-Ops launch-assertion route or the proxied Password Manager
+  API, keeps audit POST bodies empty, reuses credentialed session requests, and
+  avoids leaking secrets through browser console output or page errors.
+
+**Validation**
+- `pnpm install --frozen-lockfile`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web lint 'tests/e2e/fixtures/test.ts' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'`
+- `BETTER_AUTH_URL=https://ops.example.test BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder pnpm --dir apps/web build`
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts` (blocked locally: `testcontainers` could not find a working container runtime on this machine)
+- `git diff --check`
+
 ### Session 112 — Password Manager sharing and key rotation UI
 
 **Hosted sharing and revocation workflow** (`apps/web/app/(dashboard)/password-manager/page.tsx`, `apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/browser-crypto.ts`, `apps/web/lib/password-manager/browser-crypto.test.mjs`, `apps/web/lib/password-manager/client.test.mjs`)

--- a/apps/web/tests/e2e/fixtures/password-manager.ts
+++ b/apps/web/tests/e2e/fixtures/password-manager.ts
@@ -1,0 +1,584 @@
+import { randomUUID, generateKeyPairSync } from 'node:crypto'
+import type { BrowserContext, Route } from '@playwright/test'
+import { getTestDb } from './db'
+import { TEST_USER } from './seed'
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
+
+export interface PasswordManagerMockRequest {
+  method: string
+  path: string
+  headers: Record<string, string>
+  rawBody: string
+  jsonBody: JsonValue | null
+  credentialsCookie: boolean
+}
+
+interface PasswordManagerMemberEnvelope {
+  version: number
+  algorithm: string
+  public_key_spki_b64: string
+}
+
+interface PasswordManagerMockState {
+  sessionToken: string | null
+  launchAssertions: string[]
+  userKey:
+    | {
+        encrypted_private_key_envelope: JsonValue
+        kdf_metadata: JsonValue
+      }
+    | null
+  currentUserId: string
+  currentOrganisationId: string
+  failNextRefresh: boolean
+  requests: PasswordManagerMockRequest[]
+  vaults: Map<
+    string,
+    {
+      record: Record<string, JsonValue>
+      entries: Map<string, Record<string, JsonValue>>
+      members: Map<string, Record<string, JsonValue>>
+      nextEntryNumber: number
+      nextEpochNumber: number
+    }
+  >
+}
+
+export interface PasswordManagerMockController {
+  getMemberEnvelope(userId: string): PasswordManagerMemberEnvelope
+  failNextRefreshWithSessionExpiry(): void
+  switchAuthenticatedOrganisation(): Promise<void>
+  launchAssertions(): string[]
+  requestsFor(method: string, path: string): PasswordManagerMockRequest[]
+  auditRequests(): PasswordManagerMockRequest[]
+  apiRequests(): PasswordManagerMockRequest[]
+  detectPlaintextLeak(): string | null
+}
+
+const PM_API_PREFIX = '/password-manager-api'
+const PM_SESSION_COOKIE = 'pm_session'
+const PLAINTEXT_FIELD_NAMES = new Set([
+  'plaintext',
+  'private_key',
+  'password',
+  'secret',
+  'unlock_key',
+  'derived_key',
+  'vault_key',
+  'entry_key',
+])
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function decodeJwtPayload(assertion: string): Record<string, string> {
+  const [, payload] = assertion.split('.')
+  if (!payload) throw new Error('launch assertion payload missing')
+  const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8')) as Record<string, string>
+}
+
+function parseJsonBody(rawBody: string): JsonValue | null {
+  if (!rawBody) return null
+  try {
+    return JSON.parse(rawBody) as JsonValue
+  } catch {
+    return null
+  }
+}
+
+function jsonValueOrFallback(value: JsonValue | undefined, fallback: JsonValue): JsonValue {
+  return value === undefined ? fallback : value
+}
+
+function numberValueOrFallback(value: JsonValue | undefined, fallback: number): number {
+  return typeof value === 'number' ? value : fallback
+}
+
+function readRecordJsonValue(record: Record<string, JsonValue>, key: string, fallback: JsonValue): JsonValue {
+  const value = record[key]
+  return value === undefined ? fallback : value
+}
+
+function readRecordStringValue(record: Record<string, JsonValue>, key: string, fallback: string): string {
+  const value = record[key]
+  return typeof value === 'string' ? value : fallback
+}
+
+function isPlainObject(value: JsonValue): value is { [key: string]: JsonValue } {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function findPlaintextField(value: JsonValue): string | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const leak = findPlaintextField(item)
+      if (leak) return leak
+    }
+    return null
+  }
+
+  if (!isPlainObject(value)) {
+    return null
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (PLAINTEXT_FIELD_NAMES.has(key.toLowerCase())) {
+      return key
+    }
+    const leak = findPlaintextField(nested)
+    if (leak) return leak
+  }
+
+  return null
+}
+
+function createMemberEnvelope(): PasswordManagerMemberEnvelope {
+  const { publicKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { format: 'der', type: 'spki' },
+    privateKeyEncoding: { format: 'pem', type: 'pkcs8' },
+  })
+
+  return {
+    version: 1,
+    algorithm: 'rsa-oaep-256',
+    public_key_spki_b64: publicKey.toString('base64'),
+  }
+}
+
+async function getCurrentUserState() {
+  const sql = getTestDb()
+  const rows = await sql<Array<{ user_id: string; organisation_id: string }>>`
+    SELECT id AS user_id, organisation_id
+    FROM "user"
+    WHERE email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  if (rows.length !== 1 || !rows[0]?.organisation_id) {
+    throw new Error('expected seeded test user with organisation')
+  }
+  return rows[0]
+}
+
+async function fulfillJson(route: Route, status: number, body: JsonValue, headers: Record<string, string> = {}) {
+  await route.fulfill({
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+async function fulfillEmpty(route: Route, status: number, headers: Record<string, string> = {}) {
+  await route.fulfill({
+    status,
+    headers,
+    body: '',
+  })
+}
+
+export async function createPasswordManagerMock(context: BrowserContext): Promise<PasswordManagerMockController> {
+  const currentUser = await getCurrentUserState()
+  const memberEnvelopes = new Map<string, PasswordManagerMemberEnvelope>([['user-2', createMemberEnvelope()]])
+
+  const state: PasswordManagerMockState = {
+    sessionToken: null,
+    launchAssertions: [],
+    userKey: null,
+    currentUserId: currentUser.user_id,
+    currentOrganisationId: currentUser.organisation_id,
+    failNextRefresh: false,
+    requests: [],
+    vaults: new Map(),
+  }
+
+  await context.route('**/password-manager-api/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const path = url.pathname.startsWith(PM_API_PREFIX) ? url.pathname.slice(PM_API_PREFIX.length) || '/' : url.pathname
+    const method = request.method().toUpperCase()
+    const headers = Object.fromEntries(Object.entries(request.headers()).map(([key, value]) => [key.toLowerCase(), value]))
+    const rawBody = request.postData() ?? ''
+    const jsonBody = parseJsonBody(rawBody)
+
+    state.requests.push({
+      method,
+      path,
+      headers,
+      rawBody,
+      jsonBody,
+      credentialsCookie: headers.cookie?.includes(`${PM_SESSION_COOKIE}=`) ?? false,
+    })
+
+    const sessionCookie = headers.cookie?.includes(`${PM_SESSION_COOKIE}=${state.sessionToken}`) ?? false
+    const ensureSession = async () => {
+      if (!state.sessionToken || !sessionCookie) {
+        await fulfillJson(route, 401, { error: 'session_expired' })
+        return false
+      }
+      return true
+    }
+
+    if (method === 'POST' && path === '/launch/ct-ops') {
+      const assertion = isPlainObject(jsonBody) && typeof jsonBody.assertion === 'string' ? jsonBody.assertion : ''
+      if (!assertion) {
+        await fulfillJson(route, 400, { error: 'missing_assertion' })
+        return
+      }
+
+      const payload = decodeJwtPayload(assertion)
+      state.launchAssertions.push(assertion)
+      state.currentUserId = payload.ct_ops_user_id || state.currentUserId
+      state.currentOrganisationId = payload.ct_ops_organization_id || state.currentOrganisationId
+      state.sessionToken = randomUUID()
+
+      await fulfillEmpty(route, 204, {
+        'Set-Cookie': `${PM_SESSION_COOKIE}=${state.sessionToken}; Path=/; HttpOnly; SameSite=Lax`,
+      })
+      return
+    }
+
+    if (method === 'GET' && path === '/setup-status') {
+      if (!await ensureSession()) return
+      await fulfillJson(route, 200, { configured: state.userKey !== null })
+      return
+    }
+
+    if (method === 'PUT' && path === '/user-key') {
+      if (!await ensureSession()) return
+      state.userKey = {
+        encrypted_private_key_envelope: isPlainObject(jsonBody) ? (jsonBody.encrypted_private_key_envelope ?? null) : null,
+        kdf_metadata: isPlainObject(jsonBody) ? (jsonBody.kdf_metadata ?? null) : null,
+      }
+      await fulfillEmpty(route, 204)
+      return
+    }
+
+    if (method === 'GET' && path === '/unlock-metadata') {
+      if (!await ensureSession()) return
+      if (!state.userKey) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+      await fulfillJson(route, 200, { kdf_metadata: state.userKey.kdf_metadata })
+      return
+    }
+
+    if (method === 'GET' && path === '/user-key') {
+      if (!await ensureSession()) return
+      if (!state.userKey) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+      await fulfillJson(route, 200, state.userKey as unknown as JsonValue)
+      return
+    }
+
+    if (method === 'POST' && path === '/sessions/refresh') {
+      if (!await ensureSession()) return
+      if (state.failNextRefresh) {
+        state.failNextRefresh = false
+        state.sessionToken = null
+        await fulfillJson(route, 401, { error: 'session_expired' })
+        return
+      }
+      await fulfillEmpty(route, 204)
+      return
+    }
+
+    if (method === 'POST' && path === '/sessions/logout') {
+      state.sessionToken = null
+      await fulfillEmpty(route, 204, {
+        'Set-Cookie': `${PM_SESSION_COOKIE}=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax`,
+      })
+      return
+    }
+
+    if (!await ensureSession()) return
+
+    if (method === 'GET' && path === '/vaults') {
+      await fulfillJson(route, 200, {
+        vaults: Array.from(state.vaults.values()).map((vault) => vault.record),
+      })
+      return
+    }
+
+    if (method === 'POST' && path === '/vaults' && isPlainObject(jsonBody)) {
+      const id = `vault-${state.vaults.size + 1}`
+      const createdAt = nowIso()
+      const record = {
+        id,
+        encrypted_metadata: jsonBody.encrypted_metadata ?? {},
+        wrapped_vault_key_envelope: jsonBody.wrapped_vault_key_envelope ?? {},
+        role: 'owner',
+        current_key_epoch: 1,
+        created_at: createdAt,
+        updated_at: createdAt,
+      }
+      state.vaults.set(id, {
+        record,
+        entries: new Map(),
+        members: new Map([
+          [
+            state.currentUserId,
+            {
+              user_id: state.currentUserId,
+              role: 'owner',
+              wrapped_vault_key_envelope: jsonBody.wrapped_vault_key_envelope ?? {},
+              key_epoch: 1,
+              created_at: createdAt,
+              updated_at: createdAt,
+            },
+          ],
+        ]),
+        nextEntryNumber: 1,
+        nextEpochNumber: 2,
+      })
+      await fulfillJson(route, 200, record)
+      return
+    }
+
+    const vaultMatch = path.match(/^\/vaults\/([^/]+)$/)
+    if (vaultMatch) {
+      const vault = state.vaults.get(vaultMatch[1]!)
+      if (!vault) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+
+      if (method === 'GET') {
+        await fulfillJson(route, 200, vault.record)
+        return
+      }
+      if (method === 'PATCH' && isPlainObject(jsonBody)) {
+        vault.record.encrypted_metadata = jsonValueOrFallback(
+          jsonBody.encrypted_metadata,
+          readRecordJsonValue(vault.record, 'encrypted_metadata', {}),
+        )
+        vault.record.updated_at = nowIso()
+        await fulfillJson(route, 200, vault.record)
+        return
+      }
+      if (method === 'DELETE') {
+        state.vaults.delete(vaultMatch[1]!)
+        await fulfillEmpty(route, 204)
+        return
+      }
+    }
+
+    const entriesMatch = path.match(/^\/vaults\/([^/]+)\/entries$/)
+    if (entriesMatch) {
+      const vault = state.vaults.get(entriesMatch[1]!)
+      if (!vault) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+
+      if (method === 'GET') {
+        await fulfillJson(route, 200, { entries: Array.from(vault.entries.values()) })
+        return
+      }
+      if (method === 'POST' && isPlainObject(jsonBody)) {
+        const id = `entry-${vault.nextEntryNumber++}`
+        const createdAt = nowIso()
+        const record = {
+          id,
+          vault_id: entriesMatch[1]!,
+          encrypted_payload: jsonValueOrFallback(jsonBody.encrypted_payload, {}),
+          key_epoch: numberValueOrFallback(jsonBody.key_epoch, Number(vault.record.current_key_epoch)),
+          created_at: createdAt,
+          updated_at: createdAt,
+        }
+        vault.entries.set(id, record)
+        await fulfillJson(route, 200, record)
+        return
+      }
+    }
+
+    const entryMatch = path.match(/^\/vaults\/([^/]+)\/entries\/([^/]+)$/)
+    if (entryMatch) {
+      const vault = state.vaults.get(entryMatch[1]!)
+      const entry = vault?.entries.get(entryMatch[2]!)
+      if (!vault || !entry) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+
+      if (method === 'GET') {
+        await fulfillJson(route, 200, entry)
+        return
+      }
+      if (method === 'PATCH' && isPlainObject(jsonBody)) {
+        entry.encrypted_payload = jsonValueOrFallback(
+          jsonBody.encrypted_payload,
+          readRecordJsonValue(entry, 'encrypted_payload', {}),
+        )
+        entry.key_epoch = numberValueOrFallback(jsonBody.key_epoch, Number(entry.key_epoch))
+        entry.updated_at = nowIso()
+        await fulfillJson(route, 200, entry)
+        return
+      }
+      if (method === 'DELETE') {
+        vault.entries.delete(entryMatch[2]!)
+        await fulfillEmpty(route, 204)
+        return
+      }
+    }
+
+    const membersMatch = path.match(/^\/vaults\/([^/]+)\/members$/)
+    if (membersMatch) {
+      const vault = state.vaults.get(membersMatch[1]!)
+      if (!vault) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+
+      if (method === 'GET') {
+        await fulfillJson(route, 200, { members: Array.from(vault.members.values()) })
+        return
+      }
+      if (method === 'POST' && isPlainObject(jsonBody) && typeof jsonBody.user_id === 'string') {
+        const timestamp = nowIso()
+        const record = {
+          user_id: jsonBody.user_id,
+          role: typeof jsonBody.role === 'string' ? jsonBody.role : 'viewer',
+          wrapped_vault_key_envelope: jsonValueOrFallback(jsonBody.wrapped_vault_key_envelope, {}),
+          key_epoch: numberValueOrFallback(jsonBody.key_epoch, Number(vault.record.current_key_epoch)),
+          created_at: timestamp,
+          updated_at: timestamp,
+        }
+        vault.members.set(record.user_id, record)
+        await fulfillJson(route, 200, record)
+        return
+      }
+    }
+
+    const memberMatch = path.match(/^\/vaults\/([^/]+)\/members\/([^/]+)$/)
+    if (memberMatch) {
+      const vault = state.vaults.get(memberMatch[1]!)
+      const member = vault?.members.get(decodeURIComponent(memberMatch[2]!))
+      if (!vault || !member) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+
+      if (method === 'PATCH' && isPlainObject(jsonBody)) {
+        member.role = typeof jsonBody.role === 'string' ? jsonBody.role : readRecordStringValue(member, 'role', 'viewer')
+        member.wrapped_vault_key_envelope = jsonValueOrFallback(
+          jsonBody.wrapped_vault_key_envelope,
+          readRecordJsonValue(member, 'wrapped_vault_key_envelope', {}),
+        )
+        member.key_epoch = numberValueOrFallback(jsonBody.key_epoch, Number(member.key_epoch))
+        member.updated_at = nowIso()
+        await fulfillJson(route, 200, member)
+        return
+      }
+      if (method === 'DELETE') {
+        vault.members.delete(decodeURIComponent(memberMatch[2]!))
+        await fulfillEmpty(route, 204)
+        return
+      }
+    }
+
+    const rotateMatch = path.match(/^\/vaults\/([^/]+)\/key-epochs$/)
+    if (rotateMatch) {
+      const vault = state.vaults.get(rotateMatch[1]!)
+      if (!vault || !isPlainObject(jsonBody) || !Array.isArray(jsonBody.members)) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+      const epoch = vault.nextEpochNumber++
+      vault.record.current_key_epoch = epoch
+      vault.record.updated_at = nowIso()
+      for (const member of jsonBody.members) {
+        if (!isPlainObject(member) || typeof member.user_id !== 'string') continue
+        const current = vault.members.get(member.user_id)
+        if (!current) continue
+        current.wrapped_vault_key_envelope = jsonValueOrFallback(
+          member.wrapped_vault_key_envelope,
+          readRecordJsonValue(current, 'wrapped_vault_key_envelope', {}),
+        )
+        current.key_epoch = epoch
+        current.updated_at = nowIso()
+      }
+      await fulfillJson(route, 200, {
+        id: `epoch-${epoch}`,
+        vault_id: rotateMatch[1]!,
+        epoch,
+        rotation_reason: typeof jsonBody.rotation_reason === 'string' ? jsonBody.rotation_reason : 'membership_changed',
+        created_at: nowIso(),
+      })
+      return
+    }
+
+    if (
+      method === 'POST' &&
+      (/^\/vaults\/[^/]+\/entries\/[^/]+\/(?:copy-audit|reveal-audit)$/.test(path) || /^\/vaults\/[^/]+\/export-audit$/.test(path))
+    ) {
+      await fulfillEmpty(route, 204)
+      return
+    }
+
+    await fulfillJson(route, 500, { error: 'unhandled_mock_route', path, method })
+  })
+
+  return {
+    getMemberEnvelope(userId: string) {
+      const envelope = memberEnvelopes.get(userId)
+      if (!envelope) {
+        const generated = createMemberEnvelope()
+        memberEnvelopes.set(userId, generated)
+        return generated
+      }
+      return envelope
+    },
+    failNextRefreshWithSessionExpiry() {
+      state.failNextRefresh = true
+    },
+    async switchAuthenticatedOrganisation() {
+      const sql = getTestDb()
+      const orgId = `org-switched-${Date.now()}`
+      await sql`
+        INSERT INTO organisations (id, name, slug)
+        VALUES (${orgId}, ${'Switched Org'}, ${`switched-org-${Date.now()}`})
+      `
+      await sql`
+        UPDATE "user"
+        SET organisation_id = ${orgId}, updated_at = NOW()
+        WHERE email = ${TEST_USER.email}
+      `
+      state.currentOrganisationId = orgId
+      state.sessionToken = null
+      state.userKey = null
+      state.vaults.clear()
+    },
+    launchAssertions() {
+      return [...state.launchAssertions]
+    },
+    requestsFor(method: string, path: string) {
+      return state.requests.filter((request) => request.method === method && request.path === path)
+    },
+    auditRequests() {
+      return state.requests.filter((request) => request.path.endsWith('/copy-audit') || request.path.endsWith('/reveal-audit') || request.path.endsWith('/export-audit'))
+    },
+    apiRequests() {
+      return state.requests.filter((request) => request.path !== '/launch/ct-ops' && request.path !== '/sessions/logout')
+    },
+    detectPlaintextLeak() {
+      for (const request of state.requests) {
+        if (!request.jsonBody) continue
+        const leak = findPlaintextField(request.jsonBody)
+        if (leak) {
+          return `${request.method} ${request.path} contains disallowed field ${leak}`
+        }
+      }
+      return null
+    },
+  }
+}

--- a/apps/web/tests/e2e/fixtures/test.ts
+++ b/apps/web/tests/e2e/fixtures/test.ts
@@ -1,11 +1,13 @@
 import { test as base, expect, type Page } from '@playwright/test'
 import { truncateAppTables } from './db'
 import { getStorageStatePath } from './auth'
+import { createPasswordManagerMock, type PasswordManagerMockController } from './password-manager'
 import { seedOrgAndUser } from './seed'
 
 type Fixtures = {
   autoTruncate: void
   authenticatedPage: Page
+  passwordManagerMock: PasswordManagerMockController
 }
 
 export const test = base.extend<Fixtures>({
@@ -28,6 +30,11 @@ export const test = base.extend<Fixtures>({
     } finally {
       await context.close()
     }
+  },
+
+  passwordManagerMock: async ({ authenticatedPage }, use) => {
+    const mock = await createPasswordManagerMock(authenticatedPage.context())
+    await use(mock)
   },
 })
 

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '../fixtures/test'
+
+test('hosted password manager flow keeps plaintext and key material inside the browser', async ({
+  authenticatedPage: page,
+  passwordManagerMock,
+}) => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+
+  const setupPassword = 'LocalUnlockPassword!42'
+  const entryPassword = 'SuperSecretPassword!99'
+  const updatedEntryPassword = 'RotatedPassword!100'
+  const entryNotes = 'Recovery codes and production notes'
+
+  const consoleMessages: string[] = []
+  const pageErrors: string[] = []
+  const outboundBodies: Array<{ url: string; body: string }> = []
+  page.on('console', (message) => {
+    consoleMessages.push(message.text())
+  })
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message)
+  })
+  page.on('request', (request) => {
+    if (!request.url().includes('/password-manager') || request.method() === 'GET') {
+      return
+    }
+    outboundBodies.push({
+      url: request.url(),
+      body: request.postData() ?? '',
+    })
+  })
+
+  await page.goto('/password-manager')
+  await expect(page.getByTestId('password-manager-shell')).toBeVisible()
+  await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()
+
+  await page.getByLabel('Unlock password').fill(setupPassword)
+  await page.getByLabel('Confirm unlock password').fill(setupPassword)
+  await page.getByRole('button', { name: 'Create unlock profile' }).click()
+
+  await expect(page.getByTestId('password-manager-workspace')).toBeVisible()
+  await expect(page.getByText('Unlock profile created and loaded locally for this browser session.')).toBeVisible()
+
+  await page.getByLabel('Vault name').fill('Shared production')
+  await page.getByLabel('Description').fill('Primary production credentials')
+  await page.getByRole('button', { name: 'Create encrypted vault' }).click()
+
+  const vaultButton = page.getByTestId('password-manager-vault-vault-1')
+  await expect(vaultButton).toContainText('Shared production')
+
+  await page.getByLabel('Title').fill('Grafana admin')
+  await page.getByLabel('Username').fill('ops-admin')
+  await page.getByLabel('Password').fill(entryPassword)
+  await page.getByLabel('URL').fill('https://grafana.example.test')
+  await page.getByLabel('Notes').fill(entryNotes)
+  await page.getByRole('button', { name: 'Create encrypted entry' }).click()
+
+  const entryCard = page.getByTestId('password-manager-entry-entry-1')
+  await expect(entryCard).toContainText('Grafana admin')
+  await expect(entryCard).toContainText('ops-admin')
+
+  await entryCard.getByRole('button', { name: 'Reveal password' }).click()
+  await expect(entryCard.getByText(entryPassword)).toBeVisible()
+
+  await entryCard.getByRole('button', { name: 'Copy password' }).click()
+  await expect
+    .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(entryPassword)
+
+  const downloadPromise = page.waitForEvent('download')
+  await page.getByRole('button', { name: 'Export vault' }).click()
+  await downloadPromise
+
+  await entryCard.getByRole('button', { name: 'Edit' }).click()
+  await page.getByLabel('Password').fill(updatedEntryPassword)
+  await page.getByRole('button', { name: 'Save encrypted entry' }).click()
+  await expect(entryCard.getByRole('button', { name: 'Hide password' })).toBeVisible()
+
+  await page.getByLabel('CT-Ops user ID').fill('user-2')
+  await page
+    .getByLabel('Member public-key envelope JSON')
+    .fill(JSON.stringify(passwordManagerMock.getMemberEnvelope('user-2')))
+  await page.getByRole('button', { name: 'Add member' }).click()
+  await expect(page.getByText('user-2')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Save role' }).click()
+  await page.getByRole('button', { name: 'Remove' }).click()
+  await expect(page.getByText('Key rotation recommended')).toBeVisible()
+
+  passwordManagerMock.failNextRefreshWithSessionExpiry()
+  await page.getByRole('button', { name: 'Refresh session' }).click()
+  await expect(page.getByTestId('password-manager-state-session-expired')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Relaunch' }).click()
+  await expect(page.getByTestId('password-manager-state-locked')).toBeVisible()
+  await page.getByLabel('Unlock password').fill(setupPassword)
+  await page.getByRole('button', { name: 'Unlock' }).click()
+  await expect(page.getByTestId('password-manager-workspace')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Rotate vault key' }).click()
+  await expect(page.getByText('Vault key rotated safely for the current active members.')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Delete entry' }).click()
+  await expect(page.getByTestId('password-manager-entry-entry-1')).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Delete vault' }).click()
+  await expect(page.getByTestId('password-manager-vault-vault-1')).toHaveCount(0)
+
+  await passwordManagerMock.switchAuthenticatedOrganisation()
+  await page.reload()
+  await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()
+
+  expect(passwordManagerMock.launchAssertions()).toHaveLength(2)
+  expect(passwordManagerMock.requestsFor('POST', '/vaults')).toHaveLength(1)
+  expect(passwordManagerMock.requestsFor('POST', '/vaults/vault-1/key-epochs')).toHaveLength(1)
+
+  const auditPaths = passwordManagerMock.auditRequests().map((request) => request.path)
+  expect(auditPaths).toEqual([
+    '/vaults/vault-1/entries/entry-1/reveal-audit',
+    '/vaults/vault-1/entries/entry-1/copy-audit',
+    '/vaults/vault-1/export-audit',
+  ])
+
+  for (const request of passwordManagerMock.auditRequests()) {
+    expect(request.rawBody).toBe('')
+  }
+
+  const createVaultRequests = passwordManagerMock.requestsFor('POST', '/vaults')
+  expect(createVaultRequests[0]?.headers['idempotency-key']).toBeTruthy()
+
+  const rotateRequests = passwordManagerMock.requestsFor('POST', '/vaults/vault-1/key-epochs')
+  expect(rotateRequests[0]?.headers['idempotency-key']).toBeTruthy()
+
+  for (const request of passwordManagerMock.apiRequests()) {
+    expect(request.credentialsCookie).toBe(true)
+    expect(request.rawBody).not.toContain(setupPassword)
+    expect(request.rawBody).not.toContain(entryPassword)
+    expect(request.rawBody).not.toContain(updatedEntryPassword)
+    expect(request.rawBody).not.toContain(entryNotes)
+  }
+
+  expect(passwordManagerMock.detectPlaintextLeak()).toBeNull()
+
+  for (const message of consoleMessages) {
+    expect(message).not.toContain(setupPassword)
+    expect(message).not.toContain(entryPassword)
+    expect(message).not.toContain(updatedEntryPassword)
+    expect(message).not.toContain(entryNotes)
+  }
+
+  expect(pageErrors).toEqual([])
+
+  for (const request of outboundBodies) {
+    expect(request.body).not.toContain(setupPassword)
+    expect(request.body).not.toContain(entryPassword)
+    expect(request.body).not.toContain(updatedEntryPassword)
+    expect(request.body).not.toContain(entryNotes)
+  }
+})


### PR DESCRIPTION
## Summary
- add a Password Manager Playwright mock fixture for the hosted `/password-manager-api/` surface
- add a hosted Password Manager E2E spec covering launch, setup, unlock, CRUD, sharing, revoke, rotation, audit, session expiry, and organisation switch flows
- assert no unlock passwords or plaintext entry content leave the browser through CT-Ops launch or Password Manager API requests, console logs, or page errors

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint 'tests/e2e/fixtures/test.ts' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'`
- `BETTER_AUTH_URL=https://ops.example.test BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder pnpm --dir apps/web build`
- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts` *(fails locally: `testcontainers` could not find a working container runtime on this machine)*
- `git diff --check`
