### PR TITLE
fix(password-manager): close hosted readiness gaps

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,38 @@
 
 ## What Has Been Built
 
+### Session 114 — Password Manager release readiness closeout
+
+**Bundled Password Manager release evidence refresh** (`PROGRESS.md`, `apps/docs/docs/deployment/docker-compose.md`, `apps/web/lib/password-manager/client.ts`, `apps/web/lib/password-manager/client.test.mjs`, `apps/web/tests/e2e/runner.mjs`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Closed the hosted-client portability gap that surfaced during the task-16
+  verification pass: relative CT-Ops launch assertion paths now stay relative
+  instead of being rewritten to `http://localhost/...`, and browser-side
+  idempotency keys now come from runtime Web Crypto rather than `node:crypto`.
+- Strengthened the hosted Password Manager regression coverage so the client
+  contract test asserts the relative launch-path behavior, the E2E runner
+  supplies the launch-signing key and instance ID required by the hosted flow,
+  and the Playwright spec uses more stable selectors around unlock and member
+  actions.
+- Updated the public deployment guide so the bundled Password Manager services
+  are named explicitly in the single-host compose stack, the digest-pinned
+  `PASSWORD_MANAGER_API_IMAGE` flow is called out in the update path, and
+  backup or restore guidance now includes `password_manager_db_data`, `.env`,
+  and `deploy/password-manager-release.json`.
+
+**Validation**
+- `node --experimental-strip-types --test apps/web/lib/password-manager/client.test.mjs`
+- `pnpm install --frozen-lockfile`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts`
+- `python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json`
+- `bash deploy/scripts/test-password-manager-compose.sh`
+- `bash deploy/scripts/test-password-manager-nginx.sh`
+- `bash deploy/scripts/test-password-manager-startup.sh`
+- `bash deploy/scripts/test-support-data.sh`
+- `BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder docker compose -f docker-compose.single.yml config`
+- `git diff --check`
+
 ### Session 113 — Password Manager hosted no-plaintext E2E coverage
 
 **Hosted Password Manager E2E leak assertions** (`apps/web/tests/e2e/fixtures/test.ts`, `apps/web/tests/e2e/fixtures/password-manager.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)

--- a/apps/docs/docs/deployment/docker-compose.md
+++ b/apps/docs/docs/deployment/docker-compose.md
@@ -1,6 +1,6 @@
 # Docker Compose Deployment
 
-The recommended way to run CT-Ops in production is via `docker-compose.single.yml`. This deploys the full stack (web, ingest, database) on a single host using digest-pinned images from GHCR.
+The recommended way to run CT-Ops in production is via `docker-compose.single.yml`. This deploys the full stack (web, ingest, database, and the bundled Password Manager services) on a single host using digest-pinned images from GHCR.
 
 ---
 
@@ -114,6 +114,9 @@ The one-shot `migrate` container applies database migrations before web and inge
 |---|---|---|---|
 | `nginx` | `nginx@sha256:...` | **443**, **80** | TLS terminator for browser traffic |
 | `db` | `timescale/timescaledb@sha256:...` | 127.0.0.1:5432 | PostgreSQL + TimescaleDB |
+| `password-manager-db` | `postgres@sha256:...` | none | Bundled CT Password Manager PostgreSQL database on the internal compose network |
+| `password-manager-migrate` | `ghcr.io/carrtech-dev/ct-password-manager/api@sha256:...` | none | One-shot Password Manager migration job that must finish before the API starts |
+| `password-manager-api` | `ghcr.io/carrtech-dev/ct-password-manager/api@sha256:...` | none | Bundled CT Password Manager API, reverse proxied by CT-Ops at `/password-manager-api/` |
 | `web` | `ghcr.io/carrtech-dev/ct-ops/web@sha256:...` | 127.0.0.1:3000 | Next.js web app (reached via nginx) |
 | `ingest` | `ghcr.io/carrtech-dev/ct-ops/ingest@sha256:...` | **9443**, 127.0.0.1:8080 | Agent gRPC (:9443 direct, bypasses nginx) + JWKS on loopback |
 
@@ -149,6 +152,10 @@ checksum that the current CT-Ops line is expected to integrate with. Bump it in
 the same CT-Ops pull request that validates compatibility against the selected
 Password Manager release; do not treat it as an operator override.
 
+Release bundles also stamp `PASSWORD_MANAGER_API_IMAGE` to that digest-pinned
+reference by default, so the bundled `password-manager-migrate` and
+`password-manager-api` services stay aligned with the reviewed descriptor.
+
 ---
 
 ## Backups
@@ -164,6 +171,18 @@ docker compose -f docker-compose.single.yml exec db \
 docker compose -f docker-compose.single.yml cp \
   ingest:/var/lib/ct-ops/jwt_key.pem ./jwt_key.pem.bak
 ```
+
+If you use the bundled Password Manager, also keep these restore inputs
+together:
+
+- the `password_manager_db_data` Docker volume
+- the deployment `.env` file, which stores the generated Password Manager
+  bootstrap secrets and launch-signing keys
+- `deploy/password-manager-release.json`, which records the reviewed Password
+  Manager image digest and API contract metadata
+
+On host-level restore, restore those three artifacts alongside the main CT-Ops
+database backup before restarting the stack.
 
 ---
 

--- a/apps/web/lib/password-manager/client.test.mjs
+++ b/apps/web/lib/password-manager/client.test.mjs
@@ -86,7 +86,7 @@ test('launch fetches a fresh assertion and exchanges it with Password Manager us
   await client.launch()
 
   assert.equal(calls.length, 2)
-  assert.equal(calls[0].url, 'http://localhost/api/password-manager/launch-assertion')
+  assert.equal(calls[0].url, '/api/password-manager/launch-assertion')
   assert.equal(calls[0].init.method, 'POST')
   assert.equal(calls[0].init.credentials, 'include')
 
@@ -132,6 +132,50 @@ test('createVault and rotateVaultKeys preserve the supplied Idempotency-Key head
 
   assert.equal(calls[0].init.headers['Idempotency-Key'], 'vault-create-key')
   assert.equal(calls[1].init.headers['Idempotency-Key'], 'rotate-key')
+})
+
+test('createVault generates an Idempotency-Key through the runtime crypto API when one is not supplied', async () => {
+  const calls = []
+  const originalCrypto = globalThis.crypto
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: {
+      randomUUID: () => 'generated-idempotency-key',
+    },
+  })
+
+  try {
+    const client = createPasswordManagerClient({
+      apiBaseUrl: 'https://ops.example.test/password-manager-api',
+      fetch: async (input, init = {}) => {
+        calls.push({
+          url: input instanceof Request ? input.url : String(input),
+          init,
+        })
+        return createJsonResponse(201, {
+          id: 'vault-1',
+          encrypted_metadata: { ciphertext_b64: 'meta' },
+          wrapped_vault_key_envelope: { wrapped_key_b64: 'wrapped' },
+          role: 'owner',
+          current_key_epoch: 1,
+          created_at: '2026-05-05T18:00:00Z',
+          updated_at: '2026-05-05T18:00:00Z',
+        })
+      },
+    })
+
+    await client.createVault({
+      encryptedMetadata: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
+      wrappedVaultKeyEnvelope: { version: 1, algorithm: 'rsa-oaep-256', wrapped_key_b64: 'Yw==' },
+    })
+  } finally {
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: originalCrypto,
+    })
+  }
+
+  assert.equal(calls[0].init.headers['Idempotency-Key'], 'generated-idempotency-key')
 })
 
 test('audit routes send empty bodies only', async () => {

--- a/apps/web/lib/password-manager/client.ts
+++ b/apps/web/lib/password-manager/client.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto'
-
 type JsonPrimitive = string | number | boolean | null
 export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue }
 type JsonObject = { [key: string]: JsonValue }
@@ -167,6 +165,22 @@ function requireNonEmptyString(value: string, field: string): string {
   return trimmed
 }
 
+function createIdempotencyKey(): string {
+  const randomUUID = globalThis.crypto?.randomUUID
+  if (typeof randomUUID !== 'function') {
+    throw new Error('crypto.randomUUID() is required for Password Manager idempotency keys')
+  }
+  return randomUUID.call(globalThis.crypto)
+}
+
+function resolveLaunchPathUrl(launchPath: string): string {
+  const trimmed = requireNonEmptyString(launchPath, 'launchPath')
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed
+  }
+  return trimmed
+}
+
 async function parseResponse(response: Response): Promise<unknown> {
   if (response.status === 204) {
     return undefined
@@ -214,7 +228,7 @@ async function extractAssertion(
     throw new Error('Either launchPath or launchAssertionSupplier must be configured')
   }
 
-  const response = await fetchImpl(new URL(launchPath, 'http://localhost').toString(), {
+  const response = await fetchImpl(resolveLaunchPathUrl(launchPath), {
     method: 'POST',
     credentials: 'include',
   })
@@ -424,7 +438,7 @@ export function createPasswordManagerClient(options: PasswordManagerClientOption
     }): Promise<VaultRecord> {
       return requestJson<VaultRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.createVault, {
         headers: {
-          'Idempotency-Key': input.idempotencyKey ?? randomUUID(),
+          'Idempotency-Key': input.idempotencyKey ?? createIdempotencyKey(),
         },
         body: createVaultPayload(input),
       })
@@ -567,7 +581,7 @@ export function createPasswordManagerClient(options: PasswordManagerClientOption
       return requestJson<KeyEpochRecord>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.rotateVaultKeys, {
         pathParams: { vaultID: requireNonEmptyString(input.vaultId, 'vaultId') },
         headers: {
-          'Idempotency-Key': input.idempotencyKey ?? randomUUID(),
+          'Idempotency-Key': input.idempotencyKey ?? createIdempotencyKey(),
         },
         body: createRotateVaultKeysPayload(input),
       })

--- a/apps/web/tests/e2e/runner.mjs
+++ b/apps/web/tests/e2e/runner.mjs
@@ -28,6 +28,9 @@ const { privateKey: e2eLicencePrivateKey, publicKey: e2eLicencePublicKey } = gen
   privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
   publicKeyEncoding: { type: 'spki', format: 'pem' },
 })
+const { privateKey: e2ePasswordManagerLaunchPrivateKey } = generateKeyPairSync('ed25519', {
+  privateKeyEncoding: { type: 'pkcs8', format: 'der' },
+})
 
 async function main() {
   console.log('[e2e] starting TimescaleDB container (tmpfs)')
@@ -52,11 +55,14 @@ async function main() {
     process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? 'e2e-test-secret-do-not-use-in-prod'
     process.env.BETTER_AUTH_URL = appUrl
     process.env.BETTER_AUTH_TRUSTED_ORIGINS = appUrl
+    process.env.CT_OPS_INSTANCE_ID = process.env.CT_OPS_INSTANCE_ID ?? 'ct-ops-e2e-instance'
     process.env.E2E_PORT = String(port)
     process.env.AUTH_EMAIL_CAPTURE_FILE = authEmailCaptureFile
     process.env.E2E = '1'
     process.env.E2E_DISABLE_AGENT_CACHE_PREWARM = '1'
     process.env.POSTGRES_POOL_MAX = process.env.POSTGRES_POOL_MAX ?? '2'
+    process.env.PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY =
+      process.env.PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY ?? e2ePasswordManagerLaunchPrivateKey.toString('base64')
     process.env.LICENCE_PUBLIC_KEY = e2eLicencePublicKey
     process.env.E2E_LICENCE_PRIVATE_KEY = e2eLicencePrivateKey
 

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -4,6 +4,8 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   authenticatedPage: page,
   passwordManagerMock,
 }) => {
+  test.setTimeout(60_000)
+
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
 
   const setupPassword = 'LocalUnlockPassword!42'
@@ -34,8 +36,8 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await expect(page.getByTestId('password-manager-shell')).toBeVisible()
   await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()
 
-  await page.getByLabel('Unlock password').fill(setupPassword)
-  await page.getByLabel('Confirm unlock password').fill(setupPassword)
+  await page.getByLabel('Unlock password', { exact: true }).fill(setupPassword)
+  await page.getByLabel('Confirm unlock password', { exact: true }).fill(setupPassword)
   await page.getByRole('button', { name: 'Create unlock profile' }).click()
 
   await expect(page.getByTestId('password-manager-workspace')).toBeVisible()
@@ -83,8 +85,9 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await page.getByRole('button', { name: 'Add member' }).click()
   await expect(page.getByText('user-2')).toBeVisible()
 
-  await page.getByRole('button', { name: 'Save role' }).click()
-  await page.getByRole('button', { name: 'Remove' }).click()
+  const memberCard = page.locator('div.rounded-2xl').filter({ hasText: 'user-2' })
+  await memberCard.getByRole('button', { name: 'Save role' }).click()
+  await memberCard.getByRole('button', { name: 'Remove' }).click()
   await expect(page.getByText('Key rotation recommended')).toBeVisible()
 
   passwordManagerMock.failNextRefreshWithSessionExpiry()
@@ -93,7 +96,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
 
   await page.getByRole('button', { name: 'Relaunch' }).click()
   await expect(page.getByTestId('password-manager-state-locked')).toBeVisible()
-  await page.getByLabel('Unlock password').fill(setupPassword)
+  await page.getByLabel('Unlock password', { exact: true }).fill(setupPassword)
   await page.getByRole('button', { name: 'Unlock' }).click()
   await expect(page.getByTestId('password-manager-workspace')).toBeVisible()
 


### PR DESCRIPTION
## Summary
- fix hosted Password Manager client portability by keeping relative launch assertion paths relative and sourcing browser idempotency keys from runtime Web Crypto
- harden the hosted Password Manager E2E runner/spec around launch-signing env and more stable selectors
- refresh deployment/progress docs for the bundled Password Manager services and restore inputs

## Validation
- node --experimental-strip-types --test apps/web/lib/password-manager/client.test.mjs
- pnpm install --frozen-lockfile
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts
- python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
- bash deploy/scripts/test-password-manager-compose.sh
- bash deploy/scripts/test-password-manager-nginx.sh
- bash deploy/scripts/test-password-manager-startup.sh
- bash deploy/scripts/test-support-data.sh
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder docker compose -f docker-compose.single.yml config
- git diff --check

## Follow-up
- Filed hydration mismatch warning follow-up: #1086
