### PR TITLE
fix(certs): block DNS rebinding in tracked refresh

### DIFF
--- a/apps/ingest/internal/handlers/cert_refresh_sweeper.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper.go
@@ -179,8 +179,9 @@ func fetchLeafAndChain(ctx context.Context, trackedURL string, skipVerify bool) 
 }
 
 type fetchLeafAndChainOptions struct {
-	rootCAs    *x509.CertPool
-	skipVerify bool
+	rootCAs          *x509.CertPool
+	skipVerify       bool
+	allowPrivateHost bool
 }
 
 func fetchLeafAndChainWithOptions(
@@ -193,8 +194,16 @@ func fetchLeafAndChainWithOptions(
 		return nil, nil, err
 	}
 
+	dialHost := host
+	if !opts.allowPrivateHost {
+		dialHost, err = assertPublicHost(host)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	dialer := &net.Dialer{Timeout: certRefreshDialTimout}
-	rawConn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	rawConn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(dialHost, strconv.Itoa(port)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("tcp dial: %w", err)
 	}

--- a/apps/ingest/internal/handlers/cert_refresh_sweeper_test.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper_test.go
@@ -27,7 +27,8 @@ func TestFetchLeafAndChainVerifiesTrustedRootsByDefault(t *testing.T) {
 	}
 
 	leaf, chain, err := fetchLeafAndChainWithOptions(context.Background(), serverCert.url, fetchLeafAndChainOptions{
-		rootCAs: roots,
+		rootCAs:          roots,
+		allowPrivateHost: true,
 	})
 	if err != nil {
 		t.Fatalf("fetchLeafAndChainWithOptions() error = %v", err)
@@ -51,9 +52,23 @@ func TestFetchLeafAndChainRejectsUntrustedRootsUnlessOptedOut(t *testing.T) {
 	}
 
 	if _, _, err := fetchLeafAndChainWithOptions(context.Background(), serverCert.url, fetchLeafAndChainOptions{
-		skipVerify: true,
+		skipVerify:       true,
+		allowPrivateHost: true,
 	}); err != nil {
 		t.Fatalf("fetchLeafAndChainWithOptions(skipVerify=true) error = %v", err)
+	}
+}
+
+func TestFetchLeafAndChainRejectsPrivateTrackedHostBeforeDial(t *testing.T) {
+	t.Parallel()
+
+	_, serverCert, closeServer := startTestTLSServer(t)
+	defer closeServer()
+
+	if _, _, err := fetchLeafAndChainWithOptions(context.Background(), serverCert.url, fetchLeafAndChainOptions{
+		skipVerify: true,
+	}); err == nil {
+		t.Fatal("expected private tracked host to be blocked before TLS dial")
 	}
 }
 
@@ -98,13 +113,13 @@ func startTestTLSServer(t *testing.T) ([]byte, testTLSServer, func()) {
 		Subject: pkix.Name{
 			CommonName: "localhost",
 		},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
-		IsCA:         false,
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		IsCA:        false,
 	}
 	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootCert, &leafKey.PublicKey, rootKey)
 	if err != nil {

--- a/apps/ingest/internal/handlers/notify.go
+++ b/apps/ingest/internal/handlers/notify.go
@@ -43,28 +43,28 @@ func isPrivateOrReservedIP(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified()
 }
 
-func assertPublicHost(host string) error {
+func assertPublicHost(host string) (string, error) {
 	normalizedHost := strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	if ip := net.ParseIP(normalizedHost); ip != nil {
 		if isPrivateOrReservedIP(ip) {
-			return fmt.Errorf("blocked private or reserved address: %s", ip.String())
+			return "", fmt.Errorf("blocked private or reserved address: %s", ip.String())
 		}
-		return nil
+		return ip.String(), nil
 	}
 
 	ips, err := net.LookupIP(normalizedHost)
 	if err != nil {
-		return fmt.Errorf("resolve host %q: %w", normalizedHost, err)
+		return "", fmt.Errorf("resolve host %q: %w", normalizedHost, err)
 	}
 	if len(ips) == 0 {
-		return fmt.Errorf("resolve host %q: no addresses returned", normalizedHost)
+		return "", fmt.Errorf("resolve host %q: no addresses returned", normalizedHost)
 	}
 	for _, ip := range ips {
 		if isPrivateOrReservedIP(ip) {
-			return fmt.Errorf("blocked private or reserved address: %s", ip.String())
+			return "", fmt.Errorf("blocked private or reserved address: %s", ip.String())
 		}
 	}
-	return nil
+	return ips[0].String(), nil
 }
 
 func assertPublicHTTPURL(rawURL string) error {
@@ -78,7 +78,8 @@ func assertPublicHTTPURL(rawURL string) error {
 	if parsed.Hostname() == "" {
 		return fmt.Errorf("missing outbound host")
 	}
-	return assertPublicHost(parsed.Hostname())
+	_, err = assertPublicHost(parsed.Hostname())
+	return err
 }
 
 // AlertEvent is the payload sent to webhook notification channels.
@@ -313,7 +314,7 @@ func dispatchSmtp(smtpChannels []queries.SmtpChannelRow, event AlertEvent) {
 			slog.Warn("dispatchSmtp: incomplete smtp configuration", "channel_id", ch.ID)
 			continue
 		}
-		if err := assertPublicHost(cfg.Host); err != nil {
+		if _, err := assertPublicHost(cfg.Host); err != nil {
 			slog.Warn("dispatchSmtp: blocked outbound target", "channel_id", ch.ID, "host", cfg.Host, "err", err)
 			continue
 		}

--- a/apps/ingest/internal/handlers/notify_ssrf_test.go
+++ b/apps/ingest/internal/handlers/notify_ssrf_test.go
@@ -18,16 +18,16 @@ func TestAssertPublicHTTPURLAllowsPublicTargets(t *testing.T) {
 }
 
 func TestAssertPublicHostRejectsPrivateTargets(t *testing.T) {
-	if err := assertPublicHost("127.0.0.1"); err == nil {
+	if _, err := assertPublicHost("127.0.0.1"); err == nil {
 		t.Fatal("expected private smtp host to be rejected")
 	}
-	if err := assertPublicHost("::1"); err == nil {
+	if _, err := assertPublicHost("::1"); err == nil {
 		t.Fatal("expected private IPv6 smtp host to be rejected")
 	}
 }
 
 func TestAssertPublicHostAllowsPublicTargets(t *testing.T) {
-	if err := assertPublicHost("8.8.8.8"); err != nil {
+	if _, err := assertPublicHost("8.8.8.8"); err != nil {
 		t.Fatalf("expected public smtp host to be allowed: %v", err)
 	}
 }

--- a/apps/web/lib/actions/certificates.ts
+++ b/apps/web/lib/actions/certificates.ts
@@ -14,10 +14,8 @@ import { computeExpiryStatus } from '@/lib/certificates/expiry'
 import {
   fetchCertificateFromUrl,
   parseCertificateBuffer,
-  resolveUrlTarget,
   type ParsedCertificate,
 } from '@/lib/certificates/fetch'
-import { assertPublicHost } from '@/lib/net/ssrf-guard'
 import { createRateLimiter } from '@/lib/rate-limit'
 
 const trackFromUrlLimiter = createRateLimiter({
@@ -275,9 +273,7 @@ export async function trackCertificateFromUrl(
 
   let result
   try {
-    const { host } = resolveUrlTarget(url)
-    await assertPublicHost(host)
-    result = await fetchCertificateFromUrl(url)
+    result = await fetchCertificateFromUrl(url, undefined, undefined, { enforcePublicHost: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to fetch certificate'
     return { error: message }

--- a/apps/web/lib/certificates/fetch.test.mjs
+++ b/apps/web/lib/certificates/fetch.test.mjs
@@ -5,7 +5,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-import { parseCertificateBuffer } from './fetch.ts'
+import { fetchCertificateFromUrl, parseCertificateBuffer } from './fetch.ts'
 
 function generateCertificatePem() {
   const dir = mkdtempSync(join(tmpdir(), 'ct-ops-cert-'))
@@ -110,5 +110,12 @@ test('parseCertificateBuffer rejects oversized PEM payloads before parsing', () 
   assert.throws(
     () => parseCertificateBuffer(oversizedPem),
     /certificate PEM exceeds the 65536-byte size limit/,
+  )
+})
+
+test('fetchCertificateFromUrl rejects private resolved hosts before dialing TLS', async () => {
+  await assert.rejects(
+    () => fetchCertificateFromUrl('https://localhost', undefined, undefined, { enforcePublicHost: true }),
+    /private or reserved address/,
   )
 })

--- a/apps/web/lib/certificates/fetch.ts
+++ b/apps/web/lib/certificates/fetch.ts
@@ -1,6 +1,7 @@
 import * as tls from 'tls'
 import * as crypto from 'crypto'
 import * as forge from 'node-forge'
+import { assertPublicHost } from '../net/ssrf-guard.ts'
 
 export interface ParsedSAN {
   type: string
@@ -67,6 +68,10 @@ export interface FetchUrlResult {
   host: string
   port: number
   serverName: string
+}
+
+export interface FetchCertificateFromUrlOptions {
+  enforcePublicHost?: boolean
 }
 
 interface DerNode {
@@ -629,7 +634,11 @@ const MAX_CERT_BYTES = 65_536
 // Practical PKI chains are ≤ 5; cap at 10 to prevent memory exhaustion from crafted loops.
 const MAX_CHAIN_DEPTH = 10
 
-export function fetchCertPemsFromUrl(host: string, port: number, serverName: string): Promise<string[]> {
+export function fetchCertPemsFromUrl(
+  host: string,
+  port: number,
+  serverName: string,
+): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const socket = tls.connect(
       { host, port, servername: serverName, rejectUnauthorized: false, timeout: 10_000 },
@@ -668,9 +677,11 @@ export async function fetchCertificateFromUrl(
   rawUrl: string,
   portOverride?: number,
   serverNameOverride?: string,
+  options: FetchCertificateFromUrlOptions = {},
 ): Promise<FetchUrlResult> {
   const { host, port, serverName } = resolveUrlTarget(rawUrl, portOverride, serverNameOverride)
-  const pems = await fetchCertPemsFromUrl(host, port, serverName)
+  const dialHost = options.enforcePublicHost ? await assertPublicHost(host) : host
+  const pems = await fetchCertPemsFromUrl(dialHost, port, serverName)
   const chain = pems.length > 1 ? buildChain(pems) : []
   const certificate = parseCertPem(pems[0]!)
   certificate.chain = chain


### PR DESCRIPTION
## Summary
- resolve and validate tracked certificate hosts immediately before TLS fetches
- dial the validated public IP while preserving the original hostname for SNI and certificate verification
- make the ingest refresh sweeper repeat the public-host guard on every stored URL refresh

Fixes #968

## Tests
- node --experimental-strip-types --test lib/certificates/fetch.test.mjs
- pnpm --dir apps/web type-check
- go test ./internal/handlers -run 'TestFetchLeafAndChain|TestAssertPublicHost|TestAssertPublicHTTPURL' -count=1
- go test ./internal/handlers -count=1
- go test ./... -count=1