### PR TITLE
chore(password-manager): bump api release to v0.1.2

### DIFF
--- a/deploy/password-manager-release.json
+++ b/deploy/password-manager-release.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "repository": "carrtech-dev/ct-password-manager",
-  "git_tag": "api/v0.1.1",
-  "source_commit_sha": "059d5113acdc1783b85f9e3a5151e326258d01a9",
+  "git_tag": "api/v0.1.2",
+  "source_commit_sha": "cb714edc1e6d813655fc3dd352c7c0fd92f4699a",
   "image_repository": "ghcr.io/carrtech-dev/ct-password-manager/api",
-  "image_digest": "sha256:ccd97b4fd8f48dc9c58d990f7ece10dd6611aaabd1efd92bb0177c5b96577520",
-  "digest_reference": "ghcr.io/carrtech-dev/ct-password-manager/api@sha256:ccd97b4fd8f48dc9c58d990f7ece10dd6611aaabd1efd92bb0177c5b96577520",
+  "image_digest": "sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033",
+  "digest_reference": "ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033",
   "api_contract_version": "1.0.0",
   "api_contract_checksum_sha256": "a07ffa6c4c8a6f0b57611a1a7c380a8b8ea1a889f4449c4f2ce02f914c05cf95"
 }


### PR DESCRIPTION
## Summary
- pin CT-Ops to Password Manager API api/v0.1.2
- update the digest reference to the release containing the browser envelope validator fix

## Release metadata
- tag: api/v0.1.2
- source commit: cb714edc1e6d813655fc3dd352c7c0fd92f4699a
- image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033
- API contract version: 1.0.0
- API contract checksum: a07ffa6c4c8a6f0b57611a1a7c380a8b8ea1a889f4449c4f2ce02f914c05cf95
- attestation status: skipped for private-repo attestation support, per release metadata

## Validation
- python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
- bash deploy/scripts/test-password-manager-compose.sh
- bash deploy/scripts/test-password-manager-nginx.sh
- git diff --check
- docker pull ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033
- /Volumes/MacBookStorage-Dev/dev/carrtech/ct-password-manager/scripts/verify-release-image.sh ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033
- BETTER_AUTH_SECRET=build-time-placeholder POSTGRES_PASSWORD=build-time-placeholder PASSWORD_MANAGER_CT_OPS_ED25519_PRIVATE_KEY=build-time-placeholder docker compose -f docker-compose.single.yml config