### PR TITLE
fix(auth): respect invite signup verification policy

### DIFF
--- a/apps/web/app/(setup)/onboarding/page.tsx
+++ b/apps/web/app/(setup)/onboarding/page.tsx
@@ -5,13 +5,25 @@ import { headers } from 'next/headers'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
+import { getPendingInviteForEmail } from '@/lib/actions/auth'
+import { getInviteAcceptPath } from '@/lib/auth/invite-redirects'
 import { OnboardingForm } from './onboarding-form'
 
 export const metadata: Metadata = {
   title: 'Create your organisation',
 }
 
-export default async function OnboardingPage() {
+type OnboardingPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+function readParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null
+  return value ?? null
+}
+
+export default async function OnboardingPage({ searchParams }: OnboardingPageProps) {
+  const params = await searchParams
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session) redirect('/login')
 
@@ -22,6 +34,11 @@ export default async function OnboardingPage() {
   })
 
   if (user?.organisationId) redirect('/dashboard')
+  if (user?.email && !readParam(params.inviteError)) {
+    const invite = await getPendingInviteForEmail(user.email)
+    const inviteAcceptPath = getInviteAcceptPath(invite?.token)
+    if (inviteAcceptPath) redirect(inviteAcceptPath)
+  }
 
   return <OnboardingForm />
 }

--- a/apps/web/app/accept-invite/page.tsx
+++ b/apps/web/app/accept-invite/page.tsx
@@ -19,6 +19,9 @@ export default async function AcceptInvitePage({ searchParams }: AcceptInvitePag
   const session = await getRequiredSession()
   const result = await acceptInvite(token, session.user.id)
   if ('error' in result) {
+    if (!session.user.organisationId) {
+      redirect(`/onboarding?inviteError=${encodeURIComponent(result.error)}`)
+    }
     redirect(`/login?error=${encodeURIComponent(result.error)}`)
   }
 

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -4,10 +4,11 @@ import { logError } from '@/lib/logging'
 import { headers } from 'next/headers'
 import { db } from '@/lib/db'
 import { invitations, users } from '@/lib/db/schema'
-import { eq, and, isNull, gt } from 'drizzle-orm'
+import { eq, and, isNull, gt, sql } from 'drizzle-orm'
 import type { Invitation } from '@/lib/db/schema'
 import { createRateLimiter } from '@/lib/rate-limit'
 import { getClientIpFromHeaders } from '@/lib/client-ip'
+import { getRequireEmailVerification } from '@/lib/auth/env'
 import { getPrimaryRole, normalizeAssignedRoles } from '@/lib/auth/roles'
 import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
 
@@ -34,6 +35,21 @@ export async function getInviteByToken(token: string): Promise<Invitation | null
   const invite = await db.query.invitations.findFirst({
     where: and(
       eq(invitations.token, token),
+      isNull(invitations.deletedAt),
+      isNull(invitations.acceptedAt),
+      gt(invitations.expiresAt, new Date()),
+    ),
+  })
+  return invite ?? null
+}
+
+export async function getPendingInviteForEmail(email: string): Promise<Invitation | null> {
+  const normalizedEmail = normalizeEmail(email)
+  if (!normalizedEmail) return null
+
+  const invite = await db.query.invitations.findFirst({
+    where: and(
+      sql`lower(${invitations.email}) = ${normalizedEmail}`,
       isNull(invitations.deletedAt),
       isNull(invitations.acceptedAt),
       gt(invitations.expiresAt, new Date()),
@@ -77,7 +93,7 @@ export async function acceptInvite(
       return { error: 'This account already belongs to an organisation' }
     }
 
-    if (!user.emailVerified) {
+    if (getRequireEmailVerification() && !user.emailVerified) {
       return { error: 'Verify your email before accepting this invitation' }
     }
 

--- a/apps/web/lib/actions/organisations.ts
+++ b/apps/web/lib/actions/organisations.ts
@@ -6,6 +6,8 @@ import { db } from '@/lib/db'
 import { organisations, users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import type { Organisation } from '@/lib/db/schema'
+import { getPendingInviteForEmail } from '@/lib/actions/auth'
+import { getRequiredSession } from '@/lib/auth/session'
 
 const createOrganisationSchema = z.object({
   name: z.string().min(2).max(100),
@@ -24,6 +26,20 @@ export async function createOrganisation(
   }
 
   try {
+    const session = await getRequiredSession()
+    if (session.user.id !== userId) {
+      return { error: 'You can only create an organisation for your own account' }
+    }
+    const user = session.user
+    if (user.organisationId) {
+      return { error: 'This account already belongs to an organisation' }
+    }
+
+    const pendingInvite = await getPendingInviteForEmail(user.email)
+    if (pendingInvite) {
+      return { error: 'Accept your pending organisation invitation before creating a new organisation' }
+    }
+
     const existing = await db.query.organisations.findFirst({
       where: eq(organisations.slug, parsed.data.slug),
     })

--- a/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
+++ b/apps/web/tests/e2e/auth/invite-acceptance.spec.ts
@@ -3,6 +3,8 @@ import { getTestDb } from '../fixtures/db'
 import { TEST_USER, TEST_ORG } from '../fixtures/seed'
 import { issueTestLicence } from '../fixtures/licence'
 
+const requireEmailVerification = process.env.REQUIRE_EMAIL_VERIFICATION !== 'false'
+
 test('invite acceptance rejects logged-in users whose email does not match the invitation', async ({
   page,
 }) => {
@@ -66,7 +68,7 @@ test('invite acceptance rejects logged-in users whose email does not match the i
 
   await page.goto(`/accept-invite?token=${inviteToken}`)
 
-  await page.waitForURL('**/onboarding')
+  await page.waitForURL(/\/onboarding(?:\?|$)/)
   await expect(page.getByText('Create your organisation', { exact: true })).toBeVisible()
 
   const [attacker] = await sql<Array<{ organisation_id: string | null; role: string }>>`
@@ -163,6 +165,80 @@ test('invite acceptance attaches the matching user to the organisation', async (
     LIMIT 1
   `
   expect(invite?.accepted_at).not.toBeNull()
+})
+
+test('invite signup without required email verification joins the inviting organisation', async ({
+  page,
+}) => {
+  test.skip(requireEmailVerification, 'email verification is required for this run')
+
+  const sql = getTestDb()
+  const suffix = Date.now().toString()
+  const invitedEmail = `invite-signup-${suffix}@example.com`
+  const invitedPassword = 'TestPassword123!'
+  const inviteToken = `invite-signup-token-${suffix}`
+
+  await sql`
+    INSERT INTO invitations (
+      id,
+      email,
+      role,
+      token,
+      organisation_id,
+      invited_by_id,
+      expires_at,
+      created_at,
+      updated_at
+    )
+    VALUES (
+      ${`invite-signup-${suffix}`},
+      ${invitedEmail},
+      'org_admin',
+      ${inviteToken},
+      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      (SELECT id FROM "user" WHERE email = ${TEST_USER.email}),
+      NOW() + INTERVAL '1 day',
+      NOW(),
+      NOW()
+    )
+  `
+
+  await page.goto(`/register?invite=${inviteToken}`)
+  await expect(page.getByLabel('Email')).toHaveValue(invitedEmail)
+  await page.getByLabel('Full name').fill('Invite Signup User')
+  await page.getByLabel(/^Password$/).fill(invitedPassword)
+  await page.getByLabel(/^Confirm password$/).fill(invitedPassword)
+  await page.getByRole('button', { name: 'Create account' }).click()
+
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+  await expect(page.getByText('Create your organisation', { exact: true })).toHaveCount(0)
+
+  const [invitee] = await sql<Array<{
+    organisation_id: string | null
+    role: string
+    roles: string[]
+    email_verified: boolean
+  }>>`
+    SELECT organisation_id, role, roles, email_verified
+    FROM "user"
+    WHERE email = ${invitedEmail}
+    LIMIT 1
+  `
+  expect(invitee?.organisation_id).not.toBeNull()
+  expect(invitee?.role).toBe('org_admin')
+  expect(invitee?.roles).toEqual(['org_admin'])
+  expect(invitee?.email_verified).toBe(false)
+
+  const [invite] = await sql<Array<{ accepted_at: Date | null; email: string; token: string }>>`
+    SELECT accepted_at, email, token
+    FROM invitations
+    WHERE token = ${inviteToken}
+    LIMIT 1
+  `
+  expect(invite?.accepted_at).not.toBeNull()
+  expect(invite?.email).toBe(invitedEmail)
+  expect(invite?.token).toBe(inviteToken)
 })
 
 test('authenticated invited user without an organisation redeems invite link instead of onboarding', async ({


### PR DESCRIPTION
## Summary
- respect REQUIRE_EMAIL_VERIFICATION when accepting organisation invites
- redirect signed-in users with pending invites away from onboarding, while avoiding retry loops after invite errors
- block organisation creation server-side when the account has a valid pending invite
- add E2E coverage for /register?invite=token signup when email verification is disabled

## Root cause
Invite signup preserved the /accept-invite callback, but acceptInvite always rejected users with email_verified=false. In deployments with REQUIRE_EMAIL_VERIFICATION=false, normal signup/login/onboarding allowed unverified users, so the invite acceptance failed and the unaffiliated session fell through to onboarding, where creating a new organisation made the original invite unrecoverable.

## Validation
- REQUIRE_EMAIL_VERIFICATION=false node tests/e2e/runner.mjs tests/e2e/auth/invite-acceptance.spec.ts --grep "invite signup without required email verification"
- node tests/e2e/runner.mjs tests/e2e/auth/invite-acceptance.spec.ts
- pnpm --filter web type-check