### PR TITLE
feat(password-manager): add member recipient selector

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -24,6 +24,8 @@
 - Added a Password Manager client call for the new vault-scoped
   `/member-recipients` lookup, caching returned public-key envelopes in browser
   memory and using the mapped Password Manager user ID when adding members.
+- Pinned the bundled Password Manager API descriptor and compose image refs to
+  `api/v0.1.3`, which contains the recipient-readiness endpoint.
 - Extended the hosted Password Manager Playwright mock and seed data so E2E
   coverage exercises recipient readiness lookup without sending unlock
   passwords, plaintext entry values, private-key envelopes, or KDF metadata.
@@ -32,10 +34,13 @@
 - `pnpm install --frozen-lockfile`
 - `pnpm --dir apps/web type-check`
 - `node --experimental-strip-types --test apps/web/lib/password-manager/browser-crypto.test.mjs`
-- `PASSWORD_MANAGER_OPENAPI_CONTRACT_PATH=/Volumes/MacBookStorage-Dev/dev/carrtech/ct-password-manager-recipient-public-keys/docs/api-contract/openapi.json node --experimental-strip-types --test apps/web/lib/password-manager/browser-crypto.test.mjs apps/web/lib/password-manager/client.test.mjs`
+- `node --experimental-strip-types --test apps/web/lib/password-manager/browser-crypto.test.mjs apps/web/lib/password-manager/client.test.mjs`
 - `pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/client.ts' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'`
 - `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
 - `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts`
+- `python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json`
+- `bash deploy/scripts/test-password-manager-release-contract.sh`
+- `bash deploy/scripts/test-password-manager-compose.sh`
 - `git diff --check`
 
 ### Session 115 — Password Manager API image source of truth

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,29 @@
 
 ## What Has Been Built
 
+### Session 116 — Password Manager member recipient lookup
+
+**Vault member selector and public-key lookup** (`apps/web/app/(dashboard)/password-manager/page.tsx`, `apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/client.ts`, `apps/web/tests/e2e/fixtures/password-manager.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Replaced the manual CT-Ops user ID and pasted public-key JSON add-member
+  controls with a searchable organisation-user selector that disables existing
+  members and users who have not completed Password Manager setup.
+- Added a Password Manager client call for the new vault-scoped
+  `/member-recipients` lookup, caching returned public-key envelopes in browser
+  memory and using the mapped Password Manager user ID when adding members.
+- Extended the hosted Password Manager Playwright mock and seed data so E2E
+  coverage exercises recipient readiness lookup without sending unlock
+  passwords, plaintext entry values, private-key envelopes, or KDF metadata.
+
+**Validation**
+- `pnpm install --frozen-lockfile`
+- `pnpm --dir apps/web type-check`
+- `node --experimental-strip-types --test apps/web/lib/password-manager/browser-crypto.test.mjs`
+- `PASSWORD_MANAGER_OPENAPI_CONTRACT_PATH=/Volumes/MacBookStorage-Dev/dev/carrtech/ct-password-manager-recipient-public-keys/docs/api-contract/openapi.json node --experimental-strip-types --test apps/web/lib/password-manager/browser-crypto.test.mjs apps/web/lib/password-manager/client.test.mjs`
+- `pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/client.ts' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts`
+- `git diff --check`
+
 ### Session 115 — Password Manager API image source of truth
 
 **Descriptor-derived bundled API image** (`docker-compose.single.yml`, `.env.example`, `start.sh`, `deploy/customer-bundle/start.sh`, `deploy/customer-bundle/upgrade.sh`, `.github/workflows/agent-release.yml`, `.github/workflows/customer-bundle-check.yml`, `deploy/scripts/test-password-manager-compose.sh`, `deploy/scripts/test-password-manager-release-contract.sh`, `deploy/scripts/test-password-manager-startup.sh`, `deploy/scripts/test-upgrade.sh`, `deploy/customer-bundle/README.md`, `apps/docs/docs/deployment/docker-compose.md`, `apps/web/lib/password-manager/client.test.mjs`)

--- a/apps/web/app/(dashboard)/password-manager/page.tsx
+++ b/apps/web/app/(dashboard)/password-manager/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
+import { and, asc, eq, isNull } from 'drizzle-orm'
 import { getRequiredSession } from '@/lib/auth/session'
 import { canAccessTooling } from '@/lib/auth/tooling'
+import { db } from '@/lib/db'
+import { users } from '@/lib/db/schema'
 import { PasswordManagerClientShell } from './password-manager-client'
 
 export const metadata: Metadata = {
@@ -14,6 +17,22 @@ export default async function PasswordManagerPage() {
 
   const orgId = session.user.organisationId!
   const currentUserId = session.user.id
+  const organisationUsers = await db.query.users.findMany({
+    where: and(eq(users.organisationId, orgId), eq(users.isActive, true), isNull(users.deletedAt)),
+    orderBy: [asc(users.name), asc(users.email)],
+    columns: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  })
 
-  return <PasswordManagerClientShell key={orgId} orgId={orgId} currentUserId={currentUserId} />
+  return (
+    <PasswordManagerClientShell
+      key={orgId}
+      orgId={orgId}
+      currentUserId={currentUserId}
+      organisationUsers={organisationUsers}
+    />
+  )
 }

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -13,6 +13,8 @@ import {
 } from 'react'
 import {
   AlertCircle,
+  Check,
+  ChevronsUpDown,
   Copy,
   Download,
   Eye,
@@ -33,8 +35,10 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
 import { Textarea } from '@/components/ui/textarea'
@@ -61,6 +65,7 @@ import {
   PasswordManagerApiError,
   type EntryRecord,
   type MemberRecord,
+  type MemberRecipientRecord,
   type VaultRecord,
   createPasswordManagerClient,
 } from '@/lib/password-manager/client'
@@ -92,6 +97,12 @@ const GENERIC_UNLOCK_FAILURE =
 const GENERIC_SETUP_FAILURE = 'Password Manager setup could not be completed safely. Retry or relaunch.'
 const PASSWORD_MANAGER_MEMBER_ROLES = ['viewer', 'member', 'manager', 'owner'] as const
 
+export type PasswordManagerOrganisationUser = {
+  id: string
+  name: string | null
+  email: string
+}
+
 function toClientPayload<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
@@ -102,6 +113,10 @@ function createIdempotencyKey() {
 
 function isMembershipConflictError(error: unknown): boolean {
   return error instanceof PasswordManagerApiError && error.status === 409 && error.code === 'membership_conflict'
+}
+
+function canManageVaultRole(role: string): boolean {
+  return role === 'owner' || role === 'manager'
 }
 
 function sortMembers(members: MemberRecord[]): MemberRecord[] {
@@ -136,9 +151,11 @@ function triggerBlobDownload(blob: Blob, fileName: string) {
 export function PasswordManagerClientShell({
   currentUserId,
   orgId,
+  organisationUsers,
 }: {
   currentUserId: string
   orgId: string
+  organisationUsers: PasswordManagerOrganisationUser[]
 }) {
   const client = useMemo(
     () =>
@@ -184,7 +201,9 @@ export function PasswordManagerClientShell({
   const [renameVaultDescription, setRenameVaultDescription] = useState('')
   const [memberUserId, setMemberUserId] = useState('')
   const [memberRole, setMemberRole] = useState<(typeof PASSWORD_MANAGER_MEMBER_ROLES)[number]>('viewer')
-  const [memberPublicKeyEnvelopeText, setMemberPublicKeyEnvelopeText] = useState('')
+  const [memberRecipients, setMemberRecipients] = useState<Record<string, MemberRecipientRecord>>({})
+  const [memberRecipientsPending, setMemberRecipientsPending] = useState(false)
+  const [currentPasswordManagerUserId, setCurrentPasswordManagerUserId] = useState<string | null>(null)
   const [memberRoleEdits, setMemberRoleEdits] = useState<Record<string, string>>({})
   const [memberPublicKeyEnvelopeInputs, setMemberPublicKeyEnvelopeInputs] = useState<Record<string, string>>({})
   const [rotationPrompt, setRotationPrompt] = useState<string | null>(null)
@@ -394,7 +413,9 @@ export function PasswordManagerClientShell({
     setRenameVaultDescription('')
     setMemberUserId('')
     setMemberRole('viewer')
-    setMemberPublicKeyEnvelopeText('')
+    setMemberRecipients({})
+    setMemberRecipientsPending(false)
+    setCurrentPasswordManagerUserId(null)
     setMemberRoleEdits({})
     setMemberPublicKeyEnvelopeInputs({})
     setRotationPrompt(null)
@@ -424,6 +445,7 @@ export function PasswordManagerClientShell({
       memberPublicKeyEnvelopeCacheRef.current = {
         ...memberPublicKeyEnvelopeCacheRef.current,
         [currentUserId]: envelope,
+        ...(currentPasswordManagerUserId ? { [currentPasswordManagerUserId]: envelope } : {}),
       }
     }
 
@@ -432,7 +454,86 @@ export function PasswordManagerClientShell({
     return () => {
       cancelled = true
     }
-  }, [currentUserId, state.activeKeyPair, state.view])
+  }, [currentPasswordManagerUserId, currentUserId, state.activeKeyPair, state.view])
+
+  useEffect(() => {
+    if (state.view !== 'unlocked' || !selectedVault || !canManageVaultRole(selectedVault.role)) {
+      setMemberRecipients({})
+      setMemberRecipientsPending(false)
+      return
+    }
+
+    const externalUserIds = organisationUsers.map((user) => user.id)
+    if (externalUserIds.length === 0) {
+      setMemberRecipients({})
+      setMemberRecipientsPending(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function loadMemberRecipients() {
+      setMemberRecipientsPending(true)
+      try {
+        const chunks: string[][] = []
+        for (let index = 0; index < externalUserIds.length; index += 100) {
+          chunks.push(externalUserIds.slice(index, index + 100))
+        }
+        const responses = await Promise.all(
+          chunks.map((chunk) =>
+            client.lookupMemberRecipients({
+              vaultId: selectedVault!.id,
+              externalUserIds: chunk,
+            }),
+          ),
+        )
+        if (cancelled) {
+          return
+        }
+
+        const nextRecipients: Record<string, MemberRecipientRecord> = {}
+        const nextEnvelopeCache: Record<string, PasswordManagerPublicKeyEnvelope> = {}
+        let nextCurrentPasswordManagerUserId: string | null = null
+        for (const recipient of responses.flatMap((response) => response.recipients)) {
+          nextRecipients[recipient.external_user_id] = recipient
+          if (recipient.external_user_id === currentUserId) {
+            nextCurrentPasswordManagerUserId = recipient.user_id
+          }
+          if (recipient.setup_configured && recipient.public_key_envelope) {
+            nextEnvelopeCache[recipient.user_id] = recipient.public_key_envelope as unknown as PasswordManagerPublicKeyEnvelope
+          }
+        }
+
+        setMemberRecipients(nextRecipients)
+        setCurrentPasswordManagerUserId(nextCurrentPasswordManagerUserId)
+        memberPublicKeyEnvelopeCacheRef.current = {
+          ...memberPublicKeyEnvelopeCacheRef.current,
+          ...nextEnvelopeCache,
+        }
+        setMemberPublicKeyEnvelopeInputs((current) => {
+          const next = { ...current }
+          for (const [userId, envelope] of Object.entries(nextEnvelopeCache)) {
+            next[userId] = JSON.stringify(envelope, null, 2)
+          }
+          return next
+        })
+      } catch (error) {
+        if (!cancelled) {
+          handleWorkspaceEffectError(error, 'Password Manager member recipients could not be loaded safely.')
+        }
+      } finally {
+        if (!cancelled) {
+          setMemberRecipientsPending(false)
+        }
+      }
+    }
+
+    void loadMemberRecipients()
+
+    return () => {
+      cancelled = true
+    }
+  }, [client, currentUserId, organisationUsers, selectedVault, state.view])
 
   useEffect(() => {
     if (state.view !== 'unlocked' || !state.activeKeyPair) {
@@ -954,21 +1055,31 @@ export function PasswordManagerClientShell({
       return
     }
 
-    const userId = memberUserId.trim()
-    if (!userId) {
-      setWorkspaceError('Enter a CT-Ops user ID to add a member safely.')
+    const externalUserId = memberUserId.trim()
+    if (!externalUserId) {
+      setWorkspaceError('Select an organisation user to add as a member.')
+      return
+    }
+
+    const recipient = memberRecipients[externalUserId]
+    if (!recipient) {
+      setWorkspaceError('Password Manager has not seen that organisation user yet. Ask them to launch Password Manager once, then retry.')
+      return
+    }
+    if (!recipient.setup_configured || !recipient.public_key_envelope) {
+      setWorkspaceError('That user has not set up Password Manager yet. Ask them to launch and set up Password Manager before adding them.')
       return
     }
 
     setWorkspacePending(true)
     setWorkspaceError(null)
     try {
-      const parsedEnvelope = JSON.parse(memberPublicKeyEnvelopeText) as PasswordManagerPublicKeyEnvelope
+      const parsedEnvelope = recipient.public_key_envelope as unknown as PasswordManagerPublicKeyEnvelope
       const memberPublicKey = await importPublicKeyEnvelope(parsedEnvelope)
       const wrappedVaultKeyEnvelope = await wrapVaultKeyForMember(vaultKey, memberPublicKey)
       const created = await client.addMember({
         vaultId: selectedVault.id,
-        userId,
+        userId: recipient.user_id,
         role: memberRole,
         wrappedVaultKeyEnvelope: toClientPayload(wrappedVaultKeyEnvelope) as never,
         keyEpoch: selectedVault.currentKeyEpoch,
@@ -982,13 +1093,10 @@ export function PasswordManagerClientShell({
       setMemberPublicKeyEnvelopeInputs((current) => ({ ...current, [created.user_id]: JSON.stringify(parsedEnvelope, null, 2) }))
       setMemberUserId('')
       setMemberRole('viewer')
-      setMemberPublicKeyEnvelopeText('')
       setStatusNotice('Member added with a wrapped vault key only.')
     } catch (error) {
       if (isMembershipConflictError(error)) {
         setWorkspaceError('Password Manager rejected that membership change because owner safety or current membership state would be violated. Refresh and retry.')
-      } else if (error instanceof SyntaxError) {
-        setWorkspaceError('Paste a valid Password Manager public-key envelope JSON document for the new member.')
       } else {
         handleWorkspaceActionError(error, 'The member could not be added safely.')
       }
@@ -1051,7 +1159,7 @@ export function PasswordManagerClientShell({
 
       for (const member of members) {
         let memberPublicKey: CryptoKey
-        if (member.user_id === currentUserId) {
+        if (member.user_id === currentPasswordManagerUserId) {
           memberPublicKey = state.activeKeyPair.publicKey as CryptoKey
         } else {
           const cachedEnvelope = memberPublicKeyEnvelopeCacheRef.current[member.user_id]
@@ -1118,7 +1226,7 @@ export function PasswordManagerClientShell({
       )
       pendingRotationRef.current = null
       setRotationPrompt(null)
-      setStatusNotice('Vault key rotated for active members using browser-only key wrapping.')
+      setStatusNotice('Vault key rotated safely for the current active members.')
     } catch (error) {
       handleWorkspaceActionError(error, 'The vault key could not be rotated safely. Retry the same encrypted request.')
     } finally {
@@ -1139,7 +1247,7 @@ export function PasswordManagerClientShell({
         userId: member.user_id,
       })
 
-      if (member.user_id === currentUserId) {
+      if (member.user_id === currentPasswordManagerUserId) {
         vaultKeyCacheRef.current.delete(selectedVault.id)
         setVaults((current) => current.filter((vault) => vault.id !== selectedVault.id))
         setEntries([])
@@ -1387,7 +1495,7 @@ export function PasswordManagerClientShell({
         <PasswordManagerWorkspace
           createVaultDescription={createVaultDescription}
           createVaultName={createVaultName}
-          currentUserId={currentUserId}
+          currentPasswordManagerUserId={currentPasswordManagerUserId}
           deferredEntryFilter={deferredEntryFilter}
           deferredVaultFilter={deferredVaultFilter}
           editingEntryId={editingEntryId}
@@ -1401,12 +1509,14 @@ export function PasswordManagerClientShell({
           entryUrl={entryUrl}
           entryUsername={entryUsername}
           memberPublicKeyEnvelopeInputs={memberPublicKeyEnvelopeInputs}
-          memberPublicKeyEnvelopeText={memberPublicKeyEnvelopeText}
+          memberRecipients={memberRecipients}
+          memberRecipientsPending={memberRecipientsPending}
           memberRole={memberRole}
           memberRoleEdits={memberRoleEdits}
           memberUserId={memberUserId}
           members={members}
           membersPending={membersPending}
+          organisationUsers={organisationUsers}
           onCopyPassword={handleCopyPassword}
           onCreateVault={runVaultCreate}
           onCreateVaultDescriptionChange={setCreateVaultDescription}
@@ -1421,7 +1531,6 @@ export function PasswordManagerClientShell({
           onEntryUrlChange={setEntryUrl}
           onEntryUsernameChange={setEntryUsername}
           onExportVault={handleVaultExport}
-          onMemberPublicKeyEnvelopeChange={setMemberPublicKeyEnvelopeText}
           onMemberPublicKeyEnvelopeInputChange={(userId, value) =>
             setMemberPublicKeyEnvelopeInputs((current) => ({ ...current, [userId]: value }))
           }
@@ -1790,7 +1899,7 @@ function ShellCard({
 function PasswordManagerWorkspace({
   createVaultDescription,
   createVaultName,
-  currentUserId,
+  currentPasswordManagerUserId,
   deferredEntryFilter,
   deferredVaultFilter,
   editingEntryId,
@@ -1804,12 +1913,14 @@ function PasswordManagerWorkspace({
   entryUrl,
   entryUsername,
   memberPublicKeyEnvelopeInputs,
-  memberPublicKeyEnvelopeText,
+  memberRecipients,
+  memberRecipientsPending,
   memberRole,
   memberRoleEdits,
   memberUserId,
   members,
   membersPending,
+  organisationUsers,
   onCopyPassword,
   onCreateVault,
   onCreateVaultDescriptionChange,
@@ -1824,7 +1935,6 @@ function PasswordManagerWorkspace({
   onEntryUrlChange,
   onEntryUsernameChange,
   onExportVault,
-  onMemberPublicKeyEnvelopeChange,
   onMemberPublicKeyEnvelopeInputChange,
   onMemberRemove,
   onMemberRoleChange,
@@ -1857,7 +1967,7 @@ function PasswordManagerWorkspace({
 }: {
   createVaultDescription: string
   createVaultName: string
-  currentUserId: string
+  currentPasswordManagerUserId: string | null
   deferredEntryFilter: string
   deferredVaultFilter: string
   editingEntryId: string | null
@@ -1871,12 +1981,14 @@ function PasswordManagerWorkspace({
   entryUrl: string
   entryUsername: string
   memberPublicKeyEnvelopeInputs: Record<string, string>
-  memberPublicKeyEnvelopeText: string
+  memberRecipients: Record<string, MemberRecipientRecord>
+  memberRecipientsPending: boolean
   memberRole: (typeof PASSWORD_MANAGER_MEMBER_ROLES)[number]
   memberRoleEdits: Record<string, string>
   memberUserId: string
   members: MemberRecord[]
   membersPending: boolean
+  organisationUsers: PasswordManagerOrganisationUser[]
   onCopyPassword: (entry: PasswordManagerEntrySummary) => Promise<void>
   onCreateVault: () => Promise<void>
   onCreateVaultDescriptionChange: (value: string) => void
@@ -1891,7 +2003,6 @@ function PasswordManagerWorkspace({
   onEntryUrlChange: (value: string) => void
   onEntryUsernameChange: (value: string) => void
   onExportVault: () => Promise<void>
-  onMemberPublicKeyEnvelopeChange: (value: string) => void
   onMemberPublicKeyEnvelopeInputChange: (userId: string, value: string) => void
   onMemberRemove: (member: MemberRecord) => Promise<void>
   onMemberRoleChange: (role: (typeof PASSWORD_MANAGER_MEMBER_ROLES)[number]) => void
@@ -1922,6 +2033,14 @@ function PasswordManagerWorkspace({
   workspacePending: boolean
   workspaceState: PasswordManagerWorkspaceState
 }) {
+  const [memberSelectorOpen, setMemberSelectorOpen] = useState(false)
+  const memberIds = new Set(members.map((member) => member.user_id))
+  const selectedOrganisationUser = organisationUsers.find((user) => user.id === memberUserId) ?? null
+  const selectedRecipient = memberUserId ? memberRecipients[memberUserId] : undefined
+  const selectedMemberLabel = selectedOrganisationUser
+    ? `${selectedOrganisationUser.name || selectedOrganisationUser.email} (${selectedOrganisationUser.email})`
+    : 'Select user'
+
   return (
     <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]" data-testid="password-manager-workspace">
       <Card className="border-border/60 shadow-xs">
@@ -2074,7 +2193,7 @@ function PasswordManagerWorkspace({
               <div>
                 <CardTitle>Members</CardTitle>
                 <CardDescription>
-                  Share and revoke access with wrapped vault keys only. Public-key envelopes stay in browser memory unless you paste them again.
+                  Share and revoke access with wrapped vault keys only. Public-key envelopes stay in browser memory for active sessions.
                 </CardDescription>
               </div>
               {selectedVault ? <Badge variant="outline">Vault role: {selectedVault.role}</Badge> : null}
@@ -2136,11 +2255,11 @@ function PasswordManagerWorkspace({
                         value={memberPublicKeyEnvelopeInputs[member.user_id] ?? ''}
                         onChange={(event) => onMemberPublicKeyEnvelopeInputChange(member.user_id, event.target.value)}
                         placeholder={
-                          member.user_id === currentUserId
+                          member.user_id === currentPasswordManagerUserId
                             ? 'Current session key is already available locally.'
                             : '{"version":1,"algorithm":"rsa-oaep-256","public_key_spki_b64":"..."}'
                         }
-                        disabled={member.user_id === currentUserId}
+                        disabled={member.user_id === currentPasswordManagerUserId}
                       />
                     </div>
                   ) : null}
@@ -2153,13 +2272,65 @@ function PasswordManagerWorkspace({
                 <Separator />
                 <div className="grid gap-4 lg:grid-cols-2">
                   <div className="grid gap-2">
-                    <Label htmlFor="password-manager-member-user-id">CT-Ops user ID</Label>
-                    <Input
-                      id="password-manager-member-user-id"
-                      value={memberUserId}
-                      onChange={(event) => onMemberUserIdChange(event.target.value)}
-                      placeholder="user-1234"
-                    />
+                    <Label>Organisation user</Label>
+                    <Popover open={memberSelectorOpen} onOpenChange={setMemberSelectorOpen}>
+                      <PopoverTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="h-10 justify-between"
+                          disabled={workspacePending || memberRecipientsPending || !canManageVaultRole(selectedVault.role)}
+                          data-testid="password-manager-member-user-selector"
+                        >
+                          <span className="truncate">{memberRecipientsPending ? 'Loading users...' : selectedMemberLabel}</span>
+                          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-[360px] p-0" align="start">
+                        <Command>
+                          <CommandInput placeholder="Search organisation users..." />
+                          <CommandList>
+                            <CommandEmpty>No organisation users found.</CommandEmpty>
+                            <CommandGroup>
+                              {organisationUsers.map((user) => {
+                                const recipient = memberRecipients[user.id]
+                                const alreadyMember = recipient ? memberIds.has(recipient.user_id) : false
+                                const ready = Boolean(recipient?.setup_configured && recipient.public_key_envelope && !alreadyMember)
+                                const status = alreadyMember
+                                  ? 'Already a member'
+                                  : recipient?.setup_configured
+                                    ? 'Ready'
+                                    : 'Password Manager not set up'
+                                return (
+                                  <CommandItem
+                                    key={user.id}
+                                    value={`${user.name ?? ''} ${user.email}`}
+                                    disabled={!ready}
+                                    onSelect={() => {
+                                      onMemberUserIdChange(user.id)
+                                      setMemberSelectorOpen(false)
+                                    }}
+                                    data-testid={`password-manager-member-user-option-${user.id}`}
+                                  >
+                                    <div className="min-w-0">
+                                      <div className="truncate font-medium">{user.name || user.email}</div>
+                                      <div className="truncate text-xs text-muted-foreground">{user.email}</div>
+                                    </div>
+                                    <Badge variant={ready ? 'secondary' : 'outline'} className="ml-auto shrink-0">
+                                      {status}
+                                    </Badge>
+                                    {memberUserId === user.id ? <Check className="size-4" /> : null}
+                                  </CommandItem>
+                                )
+                              })}
+                            </CommandGroup>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                    {selectedRecipient && !selectedRecipient.setup_configured ? (
+                      <p className="text-xs text-muted-foreground">This user must launch and set up Password Manager before receiving a vault key.</p>
+                    ) : null}
                   </div>
                   <div className="grid gap-2">
                     <Label>Role</Label>
@@ -2177,23 +2348,23 @@ function PasswordManagerWorkspace({
                     </Select>
                   </div>
                 </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="password-manager-member-public-key-envelope">Member public-key envelope JSON</Label>
-                  <Textarea
-                    id="password-manager-member-public-key-envelope"
-                    value={memberPublicKeyEnvelopeText}
-                    onChange={(event) => onMemberPublicKeyEnvelopeChange(event.target.value)}
-                    placeholder='{"version":1,"algorithm":"rsa-oaep-256","public_key_spki_b64":"..."}'
-                  />
-                </div>
                 <div className="flex flex-wrap gap-2">
-                  <Button onClick={() => void onMemberSave()} disabled={workspacePending || !selectedVault}>
+                  <Button
+                    onClick={() => void onMemberSave()}
+                    disabled={
+                      workspacePending ||
+                      memberRecipientsPending ||
+                      !selectedVault ||
+                      !selectedRecipient?.setup_configured ||
+                      !selectedRecipient.public_key_envelope
+                    }
+                  >
                     <Plus className="mr-2 size-4" />
                     Add member
                   </Button>
                   <Button variant="outline" onClick={() => void onRetryRotation()} disabled={workspacePending || !selectedVault}>
                     <RotateCcw className="mr-2 size-4" />
-                    {rotationPrompt ? 'Rotate vault key' : 'Retry saved rotation'}
+                    Rotate vault key
                   </Button>
                 </div>
               </>

--- a/apps/web/lib/password-manager/client.test.mjs
+++ b/apps/web/lib/password-manager/client.test.mjs
@@ -14,12 +14,17 @@ import {
   createRotateVaultKeysPayload,
   createUserKeyPayload,
   createVaultPayload,
+  lookupMemberRecipientsPayload,
   updateEntryPayload,
   updateMemberPayload,
   updateVaultPayload,
 } from './client.ts'
 
 function loadPinnedContract() {
+  if (process.env.PASSWORD_MANAGER_OPENAPI_CONTRACT_PATH) {
+    return JSON.parse(readFileSync(process.env.PASSWORD_MANAGER_OPENAPI_CONTRACT_PATH, 'utf8'))
+  }
+
   const currentFilePath = fileURLToPath(import.meta.url)
   let currentDir = path.dirname(currentFilePath)
 
@@ -132,6 +137,45 @@ test('createVault and rotateVaultKeys preserve the supplied Idempotency-Key head
 
   assert.equal(calls[0].init.headers['Idempotency-Key'], 'vault-create-key')
   assert.equal(calls[1].init.headers['Idempotency-Key'], 'rotate-key')
+})
+
+test('lookupMemberRecipients posts CT-Ops user IDs for a vault-scoped public key lookup', async () => {
+  const calls = []
+  const client = createPasswordManagerClient({
+    apiBaseUrl: 'https://ops.example.test/password-manager-api',
+    fetch: async (input, init = {}) => {
+      calls.push({
+        url: input instanceof Request ? input.url : String(input),
+        init,
+      })
+      return createJsonResponse(200, {
+        recipients: [
+          {
+            external_user_id: 'ct-user-2',
+            user_id: 'pm-user-2',
+            email: 'two@example.test',
+            display_name: 'User Two',
+            setup_configured: true,
+            public_key_envelope: {
+              version: 1,
+              algorithm: 'rsa-oaep-256',
+              public_key_spki_b64: 'cHVibGljLWtleQ==',
+            },
+          },
+        ],
+      })
+    },
+  })
+
+  const response = await client.lookupMemberRecipients({
+    vaultId: 'vault-1',
+    externalUserIds: ['ct-user-2'],
+  })
+
+  assert.equal(calls[0].url, 'https://ops.example.test/password-manager-api/vaults/vault-1/member-recipients')
+  assert.equal(calls[0].init.method, 'POST')
+  assert.deepEqual(JSON.parse(calls[0].init.body), { external_user_ids: ['ct-user-2'] })
+  assert.equal(response.recipients[0].public_key_envelope.public_key_spki_b64, 'cHVibGljLWtleQ==')
 })
 
 test('createVault generates an Idempotency-Key through the runtime crypto API when one is not supplied', async () => {
@@ -303,6 +347,11 @@ test('request payload helpers serialize supported encrypted shapes', () => {
   }), {
     encrypted_payload: { version: 1, algorithm: 'aes-256-gcm', iv_b64: 'aQ==', ciphertext_b64: 'Yg==' },
     key_epoch: 4,
+  })
+  assert.deepEqual(lookupMemberRecipientsPayload({
+    externalUserIds: ['user-1', 'user-2'],
+  }), {
+    external_user_ids: ['user-1', 'user-2'],
   })
   assert.deepEqual(createMemberPayload({
     userId: 'user-1',

--- a/apps/web/lib/password-manager/client.ts
+++ b/apps/web/lib/password-manager/client.ts
@@ -43,6 +43,7 @@ export const PASSWORD_MANAGER_CLIENT_ROUTE_SPECS = {
   auditReveal: { method: 'POST', path: '/vaults/{vaultID}/entries/{entryID}/reveal-audit' },
   auditExport: { method: 'POST', path: '/vaults/{vaultID}/export-audit' },
   listMembers: { method: 'GET', path: '/vaults/{vaultID}/members' },
+  lookupMemberRecipients: { method: 'POST', path: '/vaults/{vaultID}/member-recipients' },
   addMember: { method: 'POST', path: '/vaults/{vaultID}/members' },
   updateMember: { method: 'PATCH', path: '/vaults/{vaultID}/members/{userID}' },
   removeMember: { method: 'DELETE', path: '/vaults/{vaultID}/members/{userID}' },
@@ -107,6 +108,15 @@ export interface MemberRecord {
   key_epoch: number
   created_at: string
   updated_at: string
+}
+
+export interface MemberRecipientRecord {
+  external_user_id: string
+  user_id: string
+  email: string
+  display_name: string
+  setup_configured: boolean
+  public_key_envelope: JsonObject | null
 }
 
 export interface KeyEpochRecord {
@@ -351,6 +361,14 @@ export function createMemberPayload(input: {
   }
 }
 
+export function lookupMemberRecipientsPayload(input: {
+  externalUserIds: string[]
+}): JsonObject {
+  return {
+    external_user_ids: input.externalUserIds.map((userId) => requireNonEmptyString(userId, 'externalUserId')),
+  }
+}
+
 export function updateMemberPayload(input: {
   role: string
   wrappedVaultKeyEnvelope: JsonObject
@@ -525,6 +543,16 @@ export function createPasswordManagerClient(options: PasswordManagerClientOption
     async listMembers(vaultId: string): Promise<{ members: MemberRecord[] }> {
       return requestJson<{ members: MemberRecord[] }>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.listMembers, {
         pathParams: { vaultID: requireNonEmptyString(vaultId, 'vaultId') },
+      })
+    },
+
+    async lookupMemberRecipients(input: {
+      vaultId: string
+      externalUserIds: string[]
+    }): Promise<{ recipients: MemberRecipientRecord[] }> {
+      return requestJson<{ recipients: MemberRecipientRecord[] }>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.lookupMemberRecipients, {
+        pathParams: { vaultID: requireNonEmptyString(input.vaultId, 'vaultId') },
+        body: lookupMemberRecipientsPayload(input),
       })
     },
 

--- a/apps/web/tests/e2e/fixtures/password-manager.ts
+++ b/apps/web/tests/e2e/fixtures/password-manager.ts
@@ -1,7 +1,7 @@
 import { randomUUID, generateKeyPairSync } from 'node:crypto'
 import type { BrowserContext, Route } from '@playwright/test'
 import { getTestDb } from './db'
-import { TEST_USER } from './seed'
+import { TEST_PASSWORD_MANAGER_MEMBER, TEST_USER } from './seed'
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
 
@@ -108,6 +108,19 @@ function readRecordStringValue(record: Record<string, JsonValue>, key: string, f
   return typeof value === 'string' ? value : fallback
 }
 
+function readObjectNumberValue(record: { [key: string]: JsonValue }, key: string, fallback: number): number {
+  const value = record[key]
+  return typeof value === 'number' ? value : fallback
+}
+
+function publicEnvelopeJson(envelope: PasswordManagerMemberEnvelope): { [key: string]: JsonValue } {
+  return {
+    version: envelope.version,
+    algorithm: envelope.algorithm,
+    public_key_spki_b64: envelope.public_key_spki_b64,
+  }
+}
+
 function isPlainObject(value: JsonValue): value is { [key: string]: JsonValue } {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
@@ -164,6 +177,20 @@ async function getCurrentUserState() {
   return rows[0]
 }
 
+async function getPasswordManagerMemberState() {
+  const sql = getTestDb()
+  const rows = await sql<Array<{ user_id: string; organisation_id: string }>>`
+    SELECT id AS user_id, organisation_id
+    FROM "user"
+    WHERE email = ${TEST_PASSWORD_MANAGER_MEMBER.email}
+    LIMIT 1
+  `
+  if (rows.length !== 1 || !rows[0]?.organisation_id) {
+    throw new Error('expected seeded Password Manager member with organisation')
+  }
+  return rows[0]
+}
+
 async function fulfillJson(route: Route, status: number, body: JsonValue, headers: Record<string, string> = {}) {
   await route.fulfill({
     status,
@@ -185,7 +212,8 @@ async function fulfillEmpty(route: Route, status: number, headers: Record<string
 
 export async function createPasswordManagerMock(context: BrowserContext): Promise<PasswordManagerMockController> {
   const currentUser = await getCurrentUserState()
-  const memberEnvelopes = new Map<string, PasswordManagerMemberEnvelope>([['user-2', createMemberEnvelope()]])
+  const passwordManagerMember = await getPasswordManagerMemberState()
+  const memberEnvelopes = new Map<string, PasswordManagerMemberEnvelope>([[passwordManagerMember.user_id, createMemberEnvelope()]])
 
   const state: PasswordManagerMockState = {
     sessionToken: null,
@@ -306,6 +334,49 @@ export async function createPasswordManagerMock(context: BrowserContext): Promis
       await fulfillJson(route, 200, {
         vaults: Array.from(state.vaults.values()).map((vault) => vault.record),
       })
+      return
+    }
+
+    const memberRecipientsMatch = path.match(/^\/vaults\/([^/]+)\/member-recipients$/)
+    if (memberRecipientsMatch && method === 'POST' && isPlainObject(jsonBody) && Array.isArray(jsonBody.external_user_ids)) {
+      const vault = state.vaults.get(memberRecipientsMatch[1]!)
+      if (!vault) {
+        await fulfillJson(route, 404, { error: 'not_found' })
+        return
+      }
+
+      const recipients: JsonValue[] = jsonBody.external_user_ids
+        .filter((value): value is string => typeof value === 'string')
+        .map((externalUserId) => {
+          const currentEncryptedEnvelope = state.userKey?.encrypted_private_key_envelope
+          if (externalUserId === state.currentUserId && currentEncryptedEnvelope !== undefined && isPlainObject(currentEncryptedEnvelope)) {
+            const encryptedEnvelope = currentEncryptedEnvelope
+            return {
+              external_user_id: externalUserId,
+              user_id: externalUserId,
+              email: TEST_USER.email,
+              display_name: TEST_USER.name,
+              setup_configured: true,
+              public_key_envelope: {
+                version: readObjectNumberValue(encryptedEnvelope, 'version', 1),
+                algorithm: readRecordStringValue(encryptedEnvelope, 'algorithm', 'rsa-oaep-256'),
+                public_key_spki_b64: readRecordStringValue(encryptedEnvelope, 'public_key_spki_b64', ''),
+              },
+            }
+          }
+
+          const memberEnvelope = memberEnvelopes.get(externalUserId)
+          return {
+            external_user_id: externalUserId,
+            user_id: externalUserId,
+            email: externalUserId === passwordManagerMember.user_id ? TEST_PASSWORD_MANAGER_MEMBER.email : `${externalUserId}@example.test`,
+            display_name: externalUserId === passwordManagerMember.user_id ? TEST_PASSWORD_MANAGER_MEMBER.name : externalUserId,
+            setup_configured: Boolean(memberEnvelope),
+            public_key_envelope: memberEnvelope ? publicEnvelopeJson(memberEnvelope) : null,
+          }
+        })
+
+      await fulfillJson(route, 200, { recipients })
       return
     }
 

--- a/apps/web/tests/e2e/fixtures/seed.ts
+++ b/apps/web/tests/e2e/fixtures/seed.ts
@@ -8,6 +8,11 @@ export const TEST_USER = {
   name: 'E2E Test User',
 } as const
 
+export const TEST_PASSWORD_MANAGER_MEMBER = {
+  email: 'password-manager-member@example.com',
+  name: 'Password Manager Member',
+} as const
+
 export const TEST_ORG = {
   name: 'E2E Test Org',
   slug: 'e2e-test-org',
@@ -69,6 +74,42 @@ export async function seedOrgAndUser(): Promise<void> {
         role = EXCLUDED.role,
         roles = EXCLUDED.roles,
         is_active = EXCLUDED.is_active
+  `
+
+  await sql`
+    INSERT INTO "user" (
+      id,
+      name,
+      email,
+      email_verified,
+      created_at,
+      updated_at,
+      organisation_id,
+      role,
+      roles,
+      is_active
+    )
+    VALUES (
+      ${createId()},
+      ${TEST_PASSWORD_MANAGER_MEMBER.name},
+      ${TEST_PASSWORD_MANAGER_MEMBER.email},
+      true,
+      NOW(),
+      NOW(),
+      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      'member',
+      '[]'::jsonb,
+      true
+    )
+    ON CONFLICT (email) DO UPDATE
+    SET name = EXCLUDED.name,
+        email_verified = EXCLUDED.email_verified,
+        updated_at = NOW(),
+        organisation_id = EXCLUDED.organisation_id,
+        role = EXCLUDED.role,
+        roles = EXCLUDED.roles,
+        is_active = EXCLUDED.is_active,
+        deleted_at = NULL
   `
 
   await sql`

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../fixtures/test'
+import { TEST_PASSWORD_MANAGER_MEMBER } from '../fixtures/seed'
 
 test('hosted password manager flow keeps plaintext and key material inside the browser', async ({
   authenticatedPage: page,
@@ -78,14 +79,18 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await page.getByRole('button', { name: 'Save encrypted entry' }).click()
   await expect(entryCard.getByRole('button', { name: 'Hide password' })).toBeVisible()
 
-  await page.getByLabel('CT-Ops user ID').fill('user-2')
-  await page
-    .getByLabel('Member public-key envelope JSON')
-    .fill(JSON.stringify(passwordManagerMock.getMemberEnvelope('user-2')))
+  await page.getByTestId('password-manager-member-user-selector').click()
+  await page.getByText(TEST_PASSWORD_MANAGER_MEMBER.email).click()
   await page.getByRole('button', { name: 'Add member' }).click()
-  await expect(page.getByText('user-2')).toBeVisible()
+  await expect.poll(() => passwordManagerMock.requestsFor('POST', '/vaults/vault-1/members').length).toBe(1)
+  const addMemberRequest = passwordManagerMock.requestsFor('POST', '/vaults/vault-1/members')[0]
+  const addedMemberUserId =
+    addMemberRequest?.jsonBody && typeof addMemberRequest.jsonBody === 'object' && !Array.isArray(addMemberRequest.jsonBody)
+      ? String(addMemberRequest.jsonBody.user_id)
+      : ''
+  await expect(page.getByText(addedMemberUserId)).toBeVisible()
 
-  const memberCard = page.locator('div.rounded-2xl').filter({ hasText: 'user-2' })
+  const memberCard = page.locator('div.rounded-2xl').filter({ hasText: addedMemberUserId })
   await memberCard.getByRole('button', { name: 'Save role' }).click()
   await memberCard.getByRole('button', { name: 'Remove' }).click()
   await expect(page.getByText('Key rotation recommended')).toBeVisible()
@@ -113,7 +118,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await page.reload()
   await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()
 
-  expect(passwordManagerMock.launchAssertions()).toHaveLength(2)
+  expect(passwordManagerMock.launchAssertions()).toHaveLength(3)
   expect(passwordManagerMock.requestsFor('POST', '/vaults')).toHaveLength(1)
   expect(passwordManagerMock.requestsFor('POST', '/vaults/vault-1/key-epochs')).toHaveLength(1)
 

--- a/deploy/password-manager-release.json
+++ b/deploy/password-manager-release.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "repository": "carrtech-dev/ct-password-manager",
-  "git_tag": "api/v0.1.2",
-  "source_commit_sha": "cb714edc1e6d813655fc3dd352c7c0fd92f4699a",
+  "git_tag": "api/v0.1.3",
+  "source_commit_sha": "74cc8d1840efec5da00f8d90afbd2ed2969de987",
   "image_repository": "ghcr.io/carrtech-dev/ct-password-manager/api",
-  "image_digest": "sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033",
-  "digest_reference": "ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033",
+  "image_digest": "sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7",
+  "digest_reference": "ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7",
   "api_contract_version": "1.0.0",
-  "api_contract_checksum_sha256": "a07ffa6c4c8a6f0b57611a1a7c380a8b8ea1a889f4449c4f2ce02f914c05cf95"
+  "api_contract_checksum_sha256": "bbb7dc110d36a9239784945a0fff85dccff3e8cc7f43178a0b05031585239dde"
 }

--- a/deploy/scripts/test-password-manager-release-contract.sh
+++ b/deploy/scripts/test-password-manager-release-contract.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 DESCRIPTOR="${REPO_ROOT}/deploy/password-manager-release.json"
 CLIENT_TEST="${REPO_ROOT}/apps/web/lib/password-manager/client.test.mjs"
 
-expected_ref="ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033"
+expected_ref="ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7"
 
 python3 "${REPO_ROOT}/deploy/scripts/validate-password-manager-release.py" "$DESCRIPTOR" >/dev/null
 

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -34,7 +34,7 @@ services:
       start_period: 10s
 
   password-manager-migrate:
-    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033
+    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7
     restart: "no"
     depends_on:
       password-manager-db:
@@ -52,7 +52,7 @@ services:
     command: ["-action", "up"]
 
   password-manager-api:
-    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:55669d3af9bfc0ab80388ff3c69ac4f75db86d768adf9a35b33402f87feaa033
+    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7
     restart: unless-stopped
     depends_on:
       password-manager-db:


### PR DESCRIPTION
## Summary
- replace manual vault member user ID and public-key JSON inputs with a searchable organisation-user selector
- fetch Password Manager recipient readiness/public keys in browser memory and wrap vault keys with the mapped PM user ID
- pin the bundled Password Manager API to api/v0.1.3, which includes POST /vaults/{vaultID}/member-recipients
- update client contract tests and hosted Password Manager E2E fixtures for recipient lookup

## Validation
- pnpm install --frozen-lockfile
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/client.ts' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'
- node --experimental-strip-types --test apps/web/lib/password-manager/browser-crypto.test.mjs apps/web/lib/password-manager/client.test.mjs
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts
- python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
- bash deploy/scripts/test-password-manager-release-contract.sh
- bash deploy/scripts/test-password-manager-compose.sh
- git diff --check