### PR TITLE
feat(terminal): trust SSH host keys from agents

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -812,6 +812,7 @@ func (r *Runner) sendHeartbeatWithAgentID(stream agentv1.IngestService_Heartbeat
 		TaskProgress:                r.drainTaskProgress(),
 		TaskResults:                 r.drainTaskResults(),
 		PinnedServerCertFingerprint: r.currentPinnedFingerprint(),
+		SshHostKeys:                 collectSSHHostKeys(),
 	}
 
 	if err := stream.Send(req); err != nil {

--- a/agent/internal/heartbeat/ssh_host_keys.go
+++ b/agent/internal/heartbeat/ssh_host_keys.go
@@ -1,0 +1,55 @@
+package heartbeat
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+	"golang.org/x/crypto/ssh"
+)
+
+func collectSSHHostKeys() []*agentv1.SSHHostKey {
+	keys, err := collectSSHHostKeysFromDir("/etc/ssh")
+	if err != nil {
+		slog.Debug("collecting SSH host keys", "err", err)
+		return nil
+	}
+	return keys
+}
+
+func collectSSHHostKeysFromDir(dir string) ([]*agentv1.SSHHostKey, error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "ssh_host_*.pub"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+
+	keys := make([]*agentv1.SSHHostKey, 0, len(paths))
+	seen := map[string]bool{}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			slog.Debug("reading SSH host public key", "path", path, "err", err)
+			continue
+		}
+		pubKey, _, _, _, err := ssh.ParseAuthorizedKey(data)
+		if err != nil {
+			slog.Debug("parsing SSH host public key", "path", path, "err", err)
+			continue
+		}
+		fp := ssh.FingerprintSHA256(pubKey)
+		identity := pubKey.Type() + "\x00" + fp
+		if seen[identity] {
+			continue
+		}
+		seen[identity] = true
+		keys = append(keys, &agentv1.SSHHostKey{
+			Algorithm:         strings.TrimSpace(pubKey.Type()),
+			FingerprintSha256: fp,
+		})
+	}
+	return keys, nil
+}

--- a/agent/internal/heartbeat/ssh_host_keys_test.go
+++ b/agent/internal/heartbeat/ssh_host_keys_test.go
@@ -1,0 +1,55 @@
+package heartbeat
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestCollectSSHHostKeysFromDirReadsPublicHostKeys(t *testing.T) {
+	dir := t.TempDir()
+	_, public, err := generateTestSigner()
+	if err != nil {
+		t.Fatalf("generateTestSigner: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ssh_host_ed25519_key.pub"), ssh.MarshalAuthorizedKey(public), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "not_a_host_key.pub"), ssh.MarshalAuthorizedKey(public), 0o644); err != nil {
+		t.Fatalf("WriteFile ignored key: %v", err)
+	}
+
+	keys, err := collectSSHHostKeysFromDir(dir)
+	if err != nil {
+		t.Fatalf("collectSSHHostKeysFromDir() error = %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("keys len = %d, want 1", len(keys))
+	}
+	if keys[0].Algorithm != public.Type() {
+		t.Fatalf("algorithm = %q, want %q", keys[0].Algorithm, public.Type())
+	}
+	if keys[0].FingerprintSha256 != ssh.FingerprintSHA256(public) {
+		t.Fatalf("fingerprint = %q, want %q", keys[0].FingerprintSha256, ssh.FingerprintSHA256(public))
+	}
+}
+
+func generateTestSigner() (ssh.Signer, ssh.PublicKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	public, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+	return signer, public, nil
+}

--- a/apps/ingest/internal/db/queries/ssh_host_keys.go
+++ b/apps/ingest/internal/db/queries/ssh_host_keys.go
@@ -1,0 +1,276 @@
+package queries
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type SSHHostKey struct {
+	Algorithm         string `json:"algorithm"`
+	FingerprintSHA256 string `json:"fingerprintSha256"`
+}
+
+type sshHostKeyMetadata struct {
+	SSHHostKeySha256    string                 `json:"sshHostKeySha256,omitempty"`
+	SSHHostKeys         []SSHHostKey           `json:"sshHostKeys,omitempty"`
+	PendingSSHHostKeys  []SSHHostKey           `json:"pendingSshHostKeys,omitempty"`
+	SSHHostKeyStatus    string                 `json:"sshHostKeyStatus,omitempty"`
+	SSHHostKeyChangedAt string                 `json:"sshHostKeyChangedAt,omitempty"`
+	Extra               map[string]interface{} `json:"-"`
+}
+
+func (m *sshHostKeyMetadata) UnmarshalJSON(data []byte) error {
+	type alias sshHostKeyMetadata
+	var raw map[string]interface{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+	}
+	var parsed alias
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &parsed); err != nil {
+			return err
+		}
+	}
+	delete(raw, "sshHostKeySha256")
+	delete(raw, "sshHostKeys")
+	delete(raw, "pendingSshHostKeys")
+	delete(raw, "sshHostKeyStatus")
+	delete(raw, "sshHostKeyChangedAt")
+	*m = sshHostKeyMetadata(parsed)
+	m.Extra = raw
+	return nil
+}
+
+func (m sshHostKeyMetadata) MarshalJSON() ([]byte, error) {
+	raw := m.Extra
+	if raw == nil {
+		raw = map[string]interface{}{}
+	}
+	if m.SSHHostKeySha256 != "" {
+		raw["sshHostKeySha256"] = m.SSHHostKeySha256
+	} else {
+		delete(raw, "sshHostKeySha256")
+	}
+	if len(m.SSHHostKeys) > 0 {
+		raw["sshHostKeys"] = m.SSHHostKeys
+	} else {
+		delete(raw, "sshHostKeys")
+	}
+	if len(m.PendingSSHHostKeys) > 0 {
+		raw["pendingSshHostKeys"] = m.PendingSSHHostKeys
+	} else {
+		delete(raw, "pendingSshHostKeys")
+	}
+	if m.SSHHostKeyStatus != "" {
+		raw["sshHostKeyStatus"] = m.SSHHostKeyStatus
+	} else {
+		delete(raw, "sshHostKeyStatus")
+	}
+	if m.SSHHostKeyChangedAt != "" {
+		raw["sshHostKeyChangedAt"] = m.SSHHostKeyChangedAt
+	} else {
+		delete(raw, "sshHostKeyChangedAt")
+	}
+	return json.Marshal(raw)
+}
+
+func ReportSSHHostKeys(ctx context.Context, pool *pgxpool.Pool, hostID string, reported []SSHHostKey) error {
+	reported = normaliseSSHHostKeys(reported)
+	if len(reported) == 0 {
+		return nil
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	const selectQ = `
+		SELECT COALESCE(metadata, '{}'::jsonb)
+		FROM hosts
+		WHERE id = $1
+		  AND deleted_at IS NULL
+		FOR UPDATE
+	`
+	var metadata []byte
+	if err := tx.QueryRow(ctx, selectQ, hostID).Scan(&metadata); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+
+	next, changed, err := applyReportedSSHHostKeys(metadata, reported)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return tx.Commit(ctx)
+	}
+
+	nextJSON, err := json.Marshal(next)
+	if err != nil {
+		return err
+	}
+	const updateQ = `
+		UPDATE hosts
+		SET metadata = $2::jsonb,
+		    updated_at = NOW()
+		WHERE id = $1
+		  AND deleted_at IS NULL
+	`
+	if _, err := tx.Exec(ctx, updateQ, hostID, string(nextJSON)); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func AcceptPendingSSHHostKeys(ctx context.Context, pool *pgxpool.Pool, hostID string) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	const selectQ = `
+		SELECT COALESCE(metadata, '{}'::jsonb)
+		FROM hosts
+		WHERE id = $1
+		  AND deleted_at IS NULL
+		FOR UPDATE
+	`
+	var metadata []byte
+	if err := tx.QueryRow(ctx, selectQ, hostID).Scan(&metadata); err != nil {
+		return err
+	}
+
+	next, err := acceptPendingSSHHostKeysMetadata(metadata)
+	if err != nil {
+		return err
+	}
+	nextJSON, err := json.Marshal(next)
+	if err != nil {
+		return err
+	}
+	const updateQ = `
+		UPDATE hosts
+		SET metadata = $2::jsonb,
+		    updated_at = NOW()
+		WHERE id = $1
+		  AND deleted_at IS NULL
+	`
+	if _, err := tx.Exec(ctx, updateQ, hostID, string(nextJSON)); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func applyReportedSSHHostKeys(currentJSON []byte, reported []SSHHostKey) (sshHostKeyMetadata, bool, error) {
+	var current sshHostKeyMetadata
+	if len(currentJSON) > 0 {
+		if err := json.Unmarshal(currentJSON, &current); err != nil {
+			return current, false, err
+		}
+	}
+
+	reported = normaliseSSHHostKeys(reported)
+	if len(reported) == 0 {
+		return current, false, nil
+	}
+
+	trusted := normaliseSSHHostKeys(current.SSHHostKeys)
+	if len(trusted) == 0 && current.SSHHostKeySha256 != "" {
+		trusted = []SSHHostKey{{FingerprintSHA256: current.SSHHostKeySha256}}
+	}
+
+	if len(trusted) == 0 {
+		current.SSHHostKeys = reported
+		current.SSHHostKeySha256 = reported[0].FingerprintSHA256
+		current.PendingSSHHostKeys = nil
+		current.SSHHostKeyStatus = ""
+		current.SSHHostKeyChangedAt = ""
+		return current, true, nil
+	}
+
+	current.SSHHostKeys = trusted
+	current.SSHHostKeySha256 = trusted[0].FingerprintSHA256
+	if sameSSHHostKeys(trusted, reported) {
+		changed := len(current.PendingSSHHostKeys) > 0 || current.SSHHostKeyStatus != "" || current.SSHHostKeyChangedAt != ""
+		current.PendingSSHHostKeys = nil
+		current.SSHHostKeyStatus = ""
+		current.SSHHostKeyChangedAt = ""
+		return current, changed, nil
+	}
+
+	if sameSSHHostKeys(current.PendingSSHHostKeys, reported) && current.SSHHostKeyStatus == "changed" {
+		return current, false, nil
+	}
+
+	current.PendingSSHHostKeys = reported
+	current.SSHHostKeyStatus = "changed"
+	current.SSHHostKeyChangedAt = time.Now().UTC().Format(time.RFC3339)
+	return current, true, nil
+}
+
+func acceptPendingSSHHostKeysMetadata(currentJSON []byte) (sshHostKeyMetadata, error) {
+	var current sshHostKeyMetadata
+	if len(currentJSON) > 0 {
+		if err := json.Unmarshal(currentJSON, &current); err != nil {
+			return current, err
+		}
+	}
+	pending := normaliseSSHHostKeys(current.PendingSSHHostKeys)
+	if len(pending) == 0 {
+		return current, errors.New("no pending SSH host keys to accept")
+	}
+	current.SSHHostKeys = pending
+	current.SSHHostKeySha256 = pending[0].FingerprintSHA256
+	current.PendingSSHHostKeys = nil
+	current.SSHHostKeyStatus = ""
+	current.SSHHostKeyChangedAt = ""
+	return current, nil
+}
+
+func normaliseSSHHostKeys(keys []SSHHostKey) []SSHHostKey {
+	out := make([]SSHHostKey, 0, len(keys))
+	seen := map[string]bool{}
+	for _, key := range keys {
+		if key.FingerprintSHA256 == "" {
+			continue
+		}
+		identity := key.Algorithm + "\x00" + key.FingerprintSHA256
+		if seen[identity] {
+			continue
+		}
+		seen[identity] = true
+		out = append(out, key)
+	}
+	return out
+}
+
+func sameSSHHostKeys(a, b []SSHHostKey) bool {
+	a = normaliseSSHHostKeys(a)
+	b = normaliseSSHHostKeys(b)
+	if len(a) != len(b) {
+		return false
+	}
+	counts := map[string]int{}
+	for _, key := range a {
+		counts[key.FingerprintSHA256]++
+	}
+	for _, key := range b {
+		counts[key.FingerprintSHA256]--
+		if counts[key.FingerprintSHA256] < 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/ingest/internal/db/queries/ssh_host_keys_test.go
+++ b/apps/ingest/internal/db/queries/ssh_host_keys_test.go
@@ -1,0 +1,113 @@
+package queries
+
+import "testing"
+
+func TestApplyReportedSSHHostKeysAutoTrustsFirstReport(t *testing.T) {
+	current := []byte(`{"terminalEnabled": true}`)
+	reported := []SSHHostKey{
+		{Algorithm: "ssh-ed25519", FingerprintSHA256: "SHA256:ed25519"},
+		{Algorithm: "ecdsa-sha2-nistp256", FingerprintSHA256: "SHA256:ecdsa"},
+	}
+
+	next, changed, err := applyReportedSSHHostKeys(current, reported)
+	if err != nil {
+		t.Fatalf("applyReportedSSHHostKeys() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("applyReportedSSHHostKeys() changed = false, want true")
+	}
+	if next.SSHHostKeySha256 != "SHA256:ed25519" {
+		t.Fatalf("legacy fingerprint = %q, want SHA256:ed25519", next.SSHHostKeySha256)
+	}
+	if len(next.SSHHostKeys) != 2 {
+		t.Fatalf("trusted keys len = %d, want 2", len(next.SSHHostKeys))
+	}
+	if len(next.PendingSSHHostKeys) != 0 {
+		t.Fatalf("pending keys len = %d, want 0", len(next.PendingSSHHostKeys))
+	}
+	if next.SSHHostKeyStatus != "" {
+		t.Fatalf("status = %q, want empty", next.SSHHostKeyStatus)
+	}
+	if next.Extra["terminalEnabled"] != true {
+		t.Fatalf("terminalEnabled metadata was not preserved")
+	}
+}
+
+func TestApplyReportedSSHHostKeysStoresChangedKeysAsPending(t *testing.T) {
+	current := []byte(`{
+		"sshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:old"}
+		]
+	}`)
+	reported := []SSHHostKey{
+		{Algorithm: "ssh-ed25519", FingerprintSHA256: "SHA256:new"},
+	}
+
+	next, changed, err := applyReportedSSHHostKeys(current, reported)
+	if err != nil {
+		t.Fatalf("applyReportedSSHHostKeys() error = %v", err)
+	}
+	if !changed {
+		t.Fatalf("applyReportedSSHHostKeys() changed = false, want true")
+	}
+	if got := next.SSHHostKeys[0].FingerprintSHA256; got != "SHA256:old" {
+		t.Fatalf("trusted fingerprint = %q, want SHA256:old", got)
+	}
+	if len(next.PendingSSHHostKeys) != 1 || next.PendingSSHHostKeys[0].FingerprintSHA256 != "SHA256:new" {
+		t.Fatalf("pending keys = %#v, want SHA256:new", next.PendingSSHHostKeys)
+	}
+	if next.SSHHostKeyStatus != "changed" {
+		t.Fatalf("status = %q, want changed", next.SSHHostKeyStatus)
+	}
+	if next.SSHHostKeyChangedAt == "" {
+		t.Fatalf("changed timestamp was not set")
+	}
+}
+
+func TestApplyReportedSSHHostKeysKeepsLegacyFingerprintTrusted(t *testing.T) {
+	current := []byte(`{"sshHostKeySha256": "SHA256:legacy"}`)
+	reported := []SSHHostKey{
+		{Algorithm: "ssh-ed25519", FingerprintSHA256: "SHA256:legacy"},
+	}
+
+	next, changed, err := applyReportedSSHHostKeys(current, reported)
+	if err != nil {
+		t.Fatalf("applyReportedSSHHostKeys() error = %v", err)
+	}
+	if changed {
+		t.Fatalf("applyReportedSSHHostKeys() changed = true, want false")
+	}
+	if len(next.PendingSSHHostKeys) != 0 {
+		t.Fatalf("pending keys len = %d, want 0", len(next.PendingSSHHostKeys))
+	}
+}
+
+func TestAcceptPendingSSHHostKeysPromotesPendingKeys(t *testing.T) {
+	current := []byte(`{
+		"sshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:old"}
+		],
+		"pendingSshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:new"}
+		],
+		"sshHostKeyStatus": "changed",
+		"sshHostKeyChangedAt": "2026-05-06T20:00:00Z"
+	}`)
+
+	next, err := acceptPendingSSHHostKeysMetadata(current)
+	if err != nil {
+		t.Fatalf("acceptPendingSSHHostKeysMetadata() error = %v", err)
+	}
+	if len(next.SSHHostKeys) != 1 || next.SSHHostKeys[0].FingerprintSHA256 != "SHA256:new" {
+		t.Fatalf("trusted keys = %#v, want SHA256:new", next.SSHHostKeys)
+	}
+	if next.SSHHostKeySha256 != "SHA256:new" {
+		t.Fatalf("legacy fingerprint = %q, want SHA256:new", next.SSHHostKeySha256)
+	}
+	if len(next.PendingSSHHostKeys) != 0 {
+		t.Fatalf("pending keys len = %d, want 0", len(next.PendingSSHHostKeys))
+	}
+	if next.SSHHostKeyStatus != "" {
+		t.Fatalf("status = %q, want empty", next.SSHHostKeyStatus)
+	}
+}

--- a/apps/ingest/internal/db/queries/terminal_sessions.sql.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions.sql.go
@@ -2,6 +2,7 @@ package queries
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -68,23 +69,45 @@ func VerifySSHHostKey(ctx context.Context, pool *pgxpool.Pool, hostID string, fi
 	defer tx.Rollback(ctx)
 
 	const selectQ = `
-		SELECT metadata->>'sshHostKeySha256'
+		SELECT COALESCE(metadata, '{}'::jsonb)
 		FROM hosts
 		WHERE id = $1
 		  AND deleted_at IS NULL
 		FOR UPDATE
 	`
-	var current *string
-	if err := tx.QueryRow(ctx, selectQ, hostID).Scan(&current); err != nil {
+	var metadata []byte
+	if err := tx.QueryRow(ctx, selectQ, hostID).Scan(&metadata); err != nil {
 		if err == pgx.ErrNoRows {
 			return fmt.Errorf("host not found")
 		}
 		return err
 	}
-	if err := verifySSHHostKeyFingerprint(current, fingerprint); err != nil {
+	if err := verifySSHHostKeyMetadata(metadata, fingerprint); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+func verifySSHHostKeyMetadata(metadata []byte, fingerprint string) error {
+	var parsed sshHostKeyMetadata
+	if len(metadata) > 0 {
+		if err := json.Unmarshal(metadata, &parsed); err != nil {
+			return err
+		}
+	}
+	if parsed.SSHHostKeyStatus == "changed" && len(parsed.PendingSSHHostKeys) > 0 {
+		return ErrSSHHostKeyMismatch
+	}
+	trusted := normaliseSSHHostKeys(parsed.SSHHostKeys)
+	if len(trusted) == 0 {
+		return verifySSHHostKeyFingerprint(ptrOrNil(parsed.SSHHostKeySha256), fingerprint)
+	}
+	for _, key := range trusted {
+		if key.FingerprintSHA256 == fingerprint {
+			return nil
+		}
+	}
+	return ErrSSHHostKeyMismatch
 }
 
 func verifySSHHostKeyFingerprint(current *string, fingerprint string) error {
@@ -95,6 +118,13 @@ func verifySSHHostKeyFingerprint(current *string, fingerprint string) error {
 		return ErrSSHHostKeyMismatch
 	}
 	return nil
+}
+
+func ptrOrNil(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
 }
 
 // SetTerminalSessionEnded marks a terminal session as 'ended' with duration and

--- a/apps/ingest/internal/db/queries/terminal_sessions_test.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions_test.go
@@ -37,6 +37,52 @@ func TestVerifySSHHostKeyFingerprintAllowsPinnedMatch(t *testing.T) {
 	}
 }
 
+func TestVerifySSHHostKeyMetadataAllowsTrustedListMatch(t *testing.T) {
+	metadata := []byte(`{
+		"sshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:ed25519"},
+			{"algorithm": "ecdsa-sha2-nistp256", "fingerprintSha256": "SHA256:ecdsa"}
+		]
+	}`)
+
+	if err := verifySSHHostKeyMetadata(metadata, "SHA256:ecdsa"); err != nil {
+		t.Fatalf("verifySSHHostKeyMetadata() error = %v, want nil", err)
+	}
+}
+
+func TestVerifySSHHostKeyMetadataRejectsTrustedListMismatch(t *testing.T) {
+	metadata := []byte(`{
+		"sshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:ed25519"}
+		],
+		"pendingSshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:new"}
+		]
+	}`)
+
+	err := verifySSHHostKeyMetadata(metadata, "SHA256:new")
+	if !errors.Is(err, ErrSSHHostKeyMismatch) {
+		t.Fatalf("verifySSHHostKeyMetadata() error = %v, want ErrSSHHostKeyMismatch", err)
+	}
+}
+
+func TestVerifySSHHostKeyMetadataBlocksWhenPendingChangeExists(t *testing.T) {
+	metadata := []byte(`{
+		"sshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:old"}
+		],
+		"pendingSshHostKeys": [
+			{"algorithm": "ssh-ed25519", "fingerprintSha256": "SHA256:new"}
+		],
+		"sshHostKeyStatus": "changed"
+	}`)
+
+	err := verifySSHHostKeyMetadata(metadata, "SHA256:old")
+	if !errors.Is(err, ErrSSHHostKeyMismatch) {
+		t.Fatalf("verifySSHHostKeyMetadata() error = %v, want ErrSSHHostKeyMismatch", err)
+	}
+}
+
 func ptr(value string) *string {
 	return &value
 }

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -322,6 +322,22 @@ func (h *HeartbeatHandler) processHeartbeat(
 		slog.Warn("updating host vitals", "err", err)
 	}
 
+	if hostID != "" && len(req.SshHostKeys) > 0 {
+		keys := make([]queries.SSHHostKey, 0, len(req.SshHostKeys))
+		for _, key := range req.SshHostKeys {
+			if key == nil {
+				continue
+			}
+			keys = append(keys, queries.SSHHostKey{
+				Algorithm:         key.Algorithm,
+				FingerprintSHA256: key.FingerprintSha256,
+			})
+		}
+		if err := queries.ReportSSHHostKeys(ctx, h.pool, hostID, keys); err != nil {
+			slog.Warn("recording SSH host keys", "host_id", hostID, "err", err)
+		}
+	}
+
 	// Sync host↔network memberships based on current IP addresses.
 	if hostID != "" && len(ipAddresses) > 0 {
 		if err := queries.SyncHostNetworks(ctx, h.pool, orgID, hostID, ipAddresses); err != nil {

--- a/apps/web/app/(dashboard)/hosts/[id]/settings-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/settings-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Settings, Users, Cpu, HardDrive, MemoryStick, Plus, X, TerminalSquare, Tag as TagIcon } from 'lucide-react'
+import { AlertTriangle, KeyRound, Settings, Users, Cpu, HardDrive, MemoryStick, Plus, X, TerminalSquare, Tag as TagIcon } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { CheckCircle2 } from 'lucide-react'
 import { getHostCollectionSettings, updateHostCollectionSettings } from '@/lib/actions/host-settings'
-import { getHostTerminalSettings, updateHostTerminalSettings } from '@/lib/actions/terminal'
+import { getHostTerminalSettings, trustPendingSshHostKeys, updateHostTerminalSettings } from '@/lib/actions/terminal'
 import type { HostTerminalSettings } from '@/lib/actions/terminal'
 import { getOrgUsers } from '@/lib/actions/users'
 import { listResourceTags, replaceResourceTags } from '@/lib/actions/tags'
@@ -37,7 +37,7 @@ export function SettingsTab({ orgId, hostId, isAdmin }: SettingsTabProps) {
     queryFn: () => getHostCollectionSettings(orgId, hostId),
   })
 
-  const { data: terminalSettings, isLoading: terminalLoading } = useQuery({
+  const { data: terminalSettings } = useQuery({
     queryKey: ['host-terminal-settings', orgId, hostId],
     queryFn: () => getHostTerminalSettings(orgId, hostId),
   })
@@ -62,8 +62,21 @@ export function SettingsTab({ orgId, hostId, isAdmin }: SettingsTabProps) {
     },
   })
 
+  const trustSshHostKeyMutation = useMutation({
+    mutationFn: () => trustPendingSshHostKeys(orgId, hostId),
+    onSuccess: (result) => {
+      if ('error' in result) return
+      queryClient.invalidateQueries({ queryKey: ['host-terminal-settings', orgId, hostId] })
+    },
+  })
+
   function updateTerminalSetting(patch: Partial<HostTerminalSettings>) {
-    const base = currentTerminalSettings ?? { terminalEnabled: true, terminalAllowedUsers: [] }
+    const base = currentTerminalSettings ?? {
+      terminalEnabled: true,
+      terminalAllowedUsers: [],
+      sshHostKeys: [],
+      pendingSshHostKeys: [],
+    }
     setLocalTerminalSettings({ ...base, ...patch })
   }
 
@@ -92,6 +105,10 @@ export function SettingsTab({ orgId, hostId, isAdmin }: SettingsTabProps) {
   })
   const currentTags: EditorTag[] =
     localTags ?? (hostTags ?? []).map((t) => ({ id: t.resourceTagId, key: t.key, value: t.value }))
+  const trustSshHostKeyError =
+    trustSshHostKeyMutation.data && 'error' in trustSshHostKeyMutation.data
+      ? trustSshHostKeyMutation.data.error
+      : null
 
   const tagMutation = useMutation({
     mutationFn: (pairs: EditorTag[]) =>
@@ -496,6 +513,68 @@ export function SettingsTab({ orgId, hostId, isAdmin }: SettingsTabProps) {
                 </div>
               </div>
             )}
+
+            <div className="space-y-3 rounded-md border p-3">
+              <div className="flex items-center gap-2">
+                <KeyRound className="size-4 text-muted-foreground" />
+                <Label className="text-sm font-medium">SSH Host Keys</Label>
+              </div>
+              {currentTerminalSettings.sshHostKeys.length > 0 ? (
+                <div className="space-y-1">
+                  {currentTerminalSettings.sshHostKeys.map((key) => (
+                    <code
+                      key={`${key.algorithm ?? 'unknown'}:${key.fingerprintSha256}`}
+                      className="block overflow-hidden text-ellipsis rounded bg-muted px-2 py-1 text-xs"
+                      title={`${key.algorithm ?? 'unknown'} ${key.fingerprintSha256}`}
+                    >
+                      {key.algorithm ? `${key.algorithm} ` : ''}
+                      {key.fingerprintSha256}
+                    </code>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No SSH host key has been reported by the agent yet.
+                </p>
+              )}
+
+              {currentTerminalSettings.sshHostKeyStatus === 'changed' &&
+                currentTerminalSettings.pendingSshHostKeys.length > 0 && (
+                  <div className="space-y-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-950">
+                    <div className="flex items-start gap-2">
+                      <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">SSH host key changed</p>
+                        <p className="text-xs">
+                          Terminal sessions will stay blocked until an admin verifies and trusts the newly observed key.
+                        </p>
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      {currentTerminalSettings.pendingSshHostKeys.map((key) => (
+                        <code
+                          key={`${key.algorithm ?? 'unknown'}:${key.fingerprintSha256}`}
+                          className="block overflow-hidden text-ellipsis rounded bg-white/70 px-2 py-1 text-xs"
+                          title={`${key.algorithm ?? 'unknown'} ${key.fingerprintSha256}`}
+                        >
+                          {key.algorithm ? `${key.algorithm} ` : ''}
+                          {key.fingerprintSha256}
+                        </code>
+                      ))}
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={trustSshHostKeyMutation.isPending}
+                      onClick={() => trustSshHostKeyMutation.mutate()}
+                    >
+                      {trustSshHostKeyMutation.isPending ? 'Trusting...' : 'Trust new SSH host key'}
+                    </Button>
+                    {trustSshHostKeyError && <p className="text-xs text-destructive">{trustSshHostKeyError}</p>}
+                  </div>
+                )}
+            </div>
 
             {/* Terminal Save */}
             <div className="flex items-center gap-3 pt-2 border-t">

--- a/apps/web/lib/actions/terminal.ts
+++ b/apps/web/lib/actions/terminal.ts
@@ -10,7 +10,7 @@ import { createId } from '@paralleldrive/cuid2'
 import { createHash, randomBytes } from 'node:crypto'
 import { getRequiredSession } from '@/lib/auth/session'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
-import { parseHostMetadata } from '@/lib/db/schema/hosts'
+import { parseHostMetadata, type SshHostKeyMetadata } from '@/lib/db/schema/hosts'
 import { MEMBERSHIP_ROLES } from '@/lib/auth/roles'
 import { hasRole } from '@/lib/auth/guards'
 import { writeAuditEvent } from '@/lib/audit/events'
@@ -235,6 +235,10 @@ export async function updateOrgTerminalSettings(
 export interface HostTerminalSettings {
   terminalEnabled: boolean
   terminalAllowedUsers: string[]
+  sshHostKeys: SshHostKeyMetadata[]
+  pendingSshHostKeys: SshHostKeyMetadata[]
+  sshHostKeyStatus?: 'changed'
+  sshHostKeyChangedAt?: string
 }
 
 export async function getHostTerminalSettings(
@@ -250,6 +254,10 @@ export async function getHostTerminalSettings(
   return {
     terminalEnabled: meta.terminalEnabled !== false,
     terminalAllowedUsers: meta.terminalAllowedUsers ?? [],
+    sshHostKeys: normaliseHostKeys(meta.sshHostKeys, meta.sshHostKeySha256),
+    pendingSshHostKeys: normaliseHostKeys(meta.pendingSshHostKeys),
+    sshHostKeyStatus: meta.sshHostKeyStatus,
+    sshHostKeyChangedAt: meta.sshHostKeyChangedAt,
   }
 }
 
@@ -305,4 +313,88 @@ export async function updateHostTerminalSettings(
     logError('Failed to update host terminal settings:', err)
     return { error: 'An unexpected error occurred' }
   }
+}
+
+export async function trustPendingSshHostKeys(
+  orgId: string,
+  hostId: string,
+): Promise<{ success: true } | { error: string }> {
+  let session
+  try {
+    session = await requireOrgAdminAccess(orgId)
+  } catch {
+    return { error: 'You do not have permission to perform this action' }
+  }
+
+  try {
+    const host = await db.query.hosts.findFirst({
+      where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
+      columns: { id: true, metadata: true },
+    })
+    if (!host) return { error: 'Host not found' }
+
+    const currentMetadata = parseHostMetadata(host.metadata)
+    const pendingKeys = normaliseHostKeys(currentMetadata.pendingSshHostKeys)
+    if (pendingKeys.length === 0) {
+      return { error: 'No pending SSH host key is available to trust' }
+    }
+
+    const updatedMetadata = {
+      ...currentMetadata,
+      sshHostKeys: pendingKeys,
+      sshHostKeySha256: pendingKeys[0]?.fingerprintSha256,
+      pendingSshHostKeys: [],
+      sshHostKeyStatus: undefined,
+      sshHostKeyChangedAt: undefined,
+    }
+
+    await db
+      .update(hosts)
+      .set({ metadata: updatedMetadata, updatedAt: new Date() })
+      .where(and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId)))
+
+    await writeAuditEvent(db, {
+      organisationId: orgId,
+      actorUserId: session.user.id,
+      action: 'terminal.host_ssh_key.trusted',
+      targetType: 'host',
+      targetId: hostId,
+      summary: 'Trusted pending SSH host key for terminal access',
+      metadata: {
+        previous: {
+          sshHostKeys: normaliseHostKeys(currentMetadata.sshHostKeys, currentMetadata.sshHostKeySha256),
+          pendingSshHostKeys: pendingKeys,
+          sshHostKeyStatus: currentMetadata.sshHostKeyStatus,
+          sshHostKeyChangedAt: currentMetadata.sshHostKeyChangedAt,
+        },
+        next: {
+          sshHostKeys: pendingKeys,
+        },
+      },
+    })
+
+    return { success: true }
+  } catch (err) {
+    logError('Failed to trust pending SSH host key:', err)
+    return { error: 'An unexpected error occurred' }
+  }
+}
+
+function normaliseHostKeys(keys?: SshHostKeyMetadata[], legacyFingerprint?: string): SshHostKeyMetadata[] {
+  const result: SshHostKeyMetadata[] = []
+  const seen = new Set<string>()
+  for (const key of keys ?? []) {
+    if (!key.fingerprintSha256) continue
+    const identity = `${key.algorithm ?? ''}\0${key.fingerprintSha256}`
+    if (seen.has(identity)) continue
+    seen.add(identity)
+    result.push({
+      algorithm: key.algorithm,
+      fingerprintSha256: key.fingerprintSha256,
+    })
+  }
+  if (result.length === 0 && legacyFingerprint) {
+    result.push({ fingerprintSha256: legacyFingerprint })
+  }
+  return result
 }

--- a/apps/web/lib/db/schema/hosts.ts
+++ b/apps/web/lib/db/schema/hosts.ts
@@ -32,6 +32,11 @@ export interface HostCollectionSettings {
   }
 }
 
+export interface SshHostKeyMetadata {
+  algorithm?: string
+  fingerprintSha256: string
+}
+
 export const DEFAULT_COLLECTION_SETTINGS: HostCollectionSettings = {
   cpu: true,
   memory: true,
@@ -79,6 +84,16 @@ export const hostMetadataSchema = z.object({
   terminalEnabled: z.boolean().optional().catch(undefined),
   terminalAllowedUsers: z.array(z.string()).catch([]).optional(),
   sshHostKeySha256: z.string().optional().catch(undefined),
+  sshHostKeys: z.array(z.object({
+    algorithm: z.string().optional().catch(undefined),
+    fingerprintSha256: z.string(),
+  }).strip()).catch([]).optional(),
+  pendingSshHostKeys: z.array(z.object({
+    algorithm: z.string().optional().catch(undefined),
+    fingerprintSha256: z.string(),
+  }).strip()).catch([]).optional(),
+  sshHostKeyStatus: z.enum(['changed']).optional().catch(undefined),
+  sshHostKeyChangedAt: z.string().optional().catch(undefined),
   lastSoftwareScanAt: z.string().optional().catch(undefined),
   pendingTags: z.array(tagPairSchema).catch([]).optional(),
 }).strip()
@@ -109,6 +124,10 @@ export interface HostMetadata {
   terminalEnabled?: boolean
   terminalAllowedUsers?: string[]
   sshHostKeySha256?: string
+  sshHostKeys?: SshHostKeyMetadata[]
+  pendingSshHostKeys?: SshHostKeyMetadata[]
+  sshHostKeyStatus?: 'changed'
+  sshHostKeyChangedAt?: string
   lastSoftwareScanAt?: string    // ISO timestamp; avoid Date in JSONB (use .toISOString())
   // Tags supplied via the agent CLI --tag flag / token metadata at register
   // time. Stashed here until approveAgent merges them with org defaults and

--- a/proto/agent/v1/heartbeat.proto
+++ b/proto/agent/v1/heartbeat.proto
@@ -94,6 +94,11 @@ message AgentTaskResult {
   string error       = 5;  // human-readable error if task failed to start
 }
 
+message SSHHostKey {
+  string algorithm          = 1;
+  string fingerprint_sha256 = 2;
+}
+
 message HeartbeatRequest {
   string    agent_id      = 1;
   float     cpu_percent   = 2;
@@ -119,6 +124,7 @@ message HeartbeatRequest {
   // the agent can continue to verify downloads after an operator swap
   // without manual CA distribution on each agent host.
   string pinned_server_cert_fingerprint = 17;
+  repeated SSHHostKey ssh_host_keys = 18;
 }
 
 message HeartbeatResponse {

--- a/proto/gen/go/agent/v1/heartbeat.pb.go
+++ b/proto/gen/go/agent/v1/heartbeat.pb.go
@@ -780,6 +780,58 @@ func (x *AgentTaskResult) GetError() string {
 	return ""
 }
 
+type SSHHostKey struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm         string                 `protobuf:"bytes,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	FingerprintSha256 string                 `protobuf:"bytes,2,opt,name=fingerprint_sha256,json=fingerprintSha256,proto3" json:"fingerprint_sha256,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *SSHHostKey) Reset() {
+	*x = SSHHostKey{}
+	mi := &file_agent_v1_heartbeat_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHHostKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHHostKey) ProtoMessage() {}
+
+func (x *SSHHostKey) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_v1_heartbeat_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHHostKey.ProtoReflect.Descriptor instead.
+func (*SSHHostKey) Descriptor() ([]byte, []int) {
+	return file_agent_v1_heartbeat_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SSHHostKey) GetAlgorithm() string {
+	if x != nil {
+		return x.Algorithm
+	}
+	return ""
+}
+
+func (x *SSHHostKey) GetFingerprintSha256() string {
+	if x != nil {
+		return x.FingerprintSha256
+	}
+	return ""
+}
+
 type HeartbeatRequest struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	AgentId           string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
@@ -805,14 +857,15 @@ type HeartbeatRequest struct {
 	// on mismatch, it returns the current cert in pending_server_cert_pem so
 	// the agent can continue to verify downloads after an operator swap
 	// without manual CA distribution on each agent host.
-	PinnedServerCertFingerprint string `protobuf:"bytes,17,opt,name=pinned_server_cert_fingerprint,json=pinnedServerCertFingerprint,proto3" json:"pinned_server_cert_fingerprint,omitempty"`
+	PinnedServerCertFingerprint string        `protobuf:"bytes,17,opt,name=pinned_server_cert_fingerprint,json=pinnedServerCertFingerprint,proto3" json:"pinned_server_cert_fingerprint,omitempty"`
+	SshHostKeys                 []*SSHHostKey `protobuf:"bytes,18,rep,name=ssh_host_keys,json=sshHostKeys,proto3" json:"ssh_host_keys,omitempty"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
 
 func (x *HeartbeatRequest) Reset() {
 	*x = HeartbeatRequest{}
-	mi := &file_agent_v1_heartbeat_proto_msgTypes[11]
+	mi := &file_agent_v1_heartbeat_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -824,7 +877,7 @@ func (x *HeartbeatRequest) String() string {
 func (*HeartbeatRequest) ProtoMessage() {}
 
 func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_v1_heartbeat_proto_msgTypes[11]
+	mi := &file_agent_v1_heartbeat_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -837,7 +890,7 @@ func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatRequest) Descriptor() ([]byte, []int) {
-	return file_agent_v1_heartbeat_proto_rawDescGZIP(), []int{11}
+	return file_agent_v1_heartbeat_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HeartbeatRequest) GetAgentId() string {
@@ -959,6 +1012,13 @@ func (x *HeartbeatRequest) GetPinnedServerCertFingerprint() string {
 	return ""
 }
 
+func (x *HeartbeatRequest) GetSshHostKeys() []*SSHHostKey {
+	if x != nil {
+		return x.SshHostKeys
+	}
+	return nil
+}
+
 type HeartbeatResponse struct {
 	state                   protoimpl.MessageState    `protogen:"open.v1"`
 	Ok                      bool                      `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
@@ -992,7 +1052,7 @@ type HeartbeatResponse struct {
 
 func (x *HeartbeatResponse) Reset() {
 	*x = HeartbeatResponse{}
-	mi := &file_agent_v1_heartbeat_proto_msgTypes[12]
+	mi := &file_agent_v1_heartbeat_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1004,7 +1064,7 @@ func (x *HeartbeatResponse) String() string {
 func (*HeartbeatResponse) ProtoMessage() {}
 
 func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_v1_heartbeat_proto_msgTypes[12]
+	mi := &file_agent_v1_heartbeat_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1017,7 +1077,7 @@ func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
-	return file_agent_v1_heartbeat_proto_rawDescGZIP(), []int{12}
+	return file_agent_v1_heartbeat_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *HeartbeatResponse) GetOk() bool {
@@ -1206,7 +1266,11 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\texit_code\x18\x03 \x01(\x05R\bexitCode\x12\x1f\n" +
 	"\vresult_json\x18\x04 \x01(\tR\n" +
 	"resultJson\x12\x14\n" +
-	"\x05error\x18\x05 \x01(\tR\x05error\"\x85\x06\n" +
+	"\x05error\x18\x05 \x01(\tR\x05error\"Y\n" +
+	"\n" +
+	"SSHHostKey\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\tR\talgorithm\x12-\n" +
+	"\x12fingerprint_sha256\x18\x02 \x01(\tR\x11fingerprintSha256\"\xbf\x06\n" +
 	"\x10HeartbeatRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x1f\n" +
 	"\vcpu_percent\x18\x02 \x01(\x02R\n" +
@@ -1227,7 +1291,8 @@ const file_agent_v1_heartbeat_proto_rawDesc = "" +
 	"\rquery_results\x18\x0e \x03(\v2\x1a.agent.v1.AgentQueryResultR\fqueryResults\x12@\n" +
 	"\rtask_progress\x18\x0f \x03(\v2\x1b.agent.v1.AgentTaskProgressR\ftaskProgress\x12<\n" +
 	"\ftask_results\x18\x10 \x03(\v2\x19.agent.v1.AgentTaskResultR\vtaskResults\x12C\n" +
-	"\x1epinned_server_cert_fingerprint\x18\x11 \x01(\tR\x1bpinnedServerCertFingerprint\"\xa9\x06\n" +
+	"\x1epinned_server_cert_fingerprint\x18\x11 \x01(\tR\x1bpinnedServerCertFingerprint\x128\n" +
+	"\rssh_host_keys\x18\x12 \x03(\v2\x14.agent.v1.SSHHostKeyR\vsshHostKeys\"\xa9\x06\n" +
 	"\x11HeartbeatResponse\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x18\n" +
 	"\acommand\x18\x02 \x01(\tR\acommand\x12'\n" +
@@ -1259,7 +1324,7 @@ func file_agent_v1_heartbeat_proto_rawDescGZIP() []byte {
 	return file_agent_v1_heartbeat_proto_rawDescData
 }
 
-var file_agent_v1_heartbeat_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_agent_v1_heartbeat_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_agent_v1_heartbeat_proto_goTypes = []any{
 	(*DiskInfo)(nil),               // 0: agent.v1.DiskInfo
 	(*NetworkInterface)(nil),       // 1: agent.v1.NetworkInterface
@@ -1272,9 +1337,10 @@ var file_agent_v1_heartbeat_proto_goTypes = []any{
 	(*AgentTask)(nil),              // 8: agent.v1.AgentTask
 	(*AgentTaskProgress)(nil),      // 9: agent.v1.AgentTaskProgress
 	(*AgentTaskResult)(nil),        // 10: agent.v1.AgentTaskResult
-	(*HeartbeatRequest)(nil),       // 11: agent.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),      // 12: agent.v1.HeartbeatResponse
-	(*TerminalSessionRequest)(nil), // 13: agent.v1.TerminalSessionRequest
+	(*SSHHostKey)(nil),             // 11: agent.v1.SSHHostKey
+	(*HeartbeatRequest)(nil),       // 12: agent.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),      // 13: agent.v1.HeartbeatResponse
+	(*TerminalSessionRequest)(nil), // 14: agent.v1.TerminalSessionRequest
 }
 var file_agent_v1_heartbeat_proto_depIdxs = []int32{
 	5,  // 0: agent.v1.AgentQueryResult.ports:type_name -> agent.v1.PortInfo
@@ -1285,15 +1351,16 @@ var file_agent_v1_heartbeat_proto_depIdxs = []int32{
 	7,  // 5: agent.v1.HeartbeatRequest.query_results:type_name -> agent.v1.AgentQueryResult
 	9,  // 6: agent.v1.HeartbeatRequest.task_progress:type_name -> agent.v1.AgentTaskProgress
 	10, // 7: agent.v1.HeartbeatRequest.task_results:type_name -> agent.v1.AgentTaskResult
-	2,  // 8: agent.v1.HeartbeatResponse.checks:type_name -> agent.v1.CheckDefinition
-	4,  // 9: agent.v1.HeartbeatResponse.pending_queries:type_name -> agent.v1.AgentQuery
-	8,  // 10: agent.v1.HeartbeatResponse.pending_task:type_name -> agent.v1.AgentTask
-	13, // 11: agent.v1.HeartbeatResponse.pending_terminal_sessions:type_name -> agent.v1.TerminalSessionRequest
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	11, // 8: agent.v1.HeartbeatRequest.ssh_host_keys:type_name -> agent.v1.SSHHostKey
+	2,  // 9: agent.v1.HeartbeatResponse.checks:type_name -> agent.v1.CheckDefinition
+	4,  // 10: agent.v1.HeartbeatResponse.pending_queries:type_name -> agent.v1.AgentQuery
+	8,  // 11: agent.v1.HeartbeatResponse.pending_task:type_name -> agent.v1.AgentTask
+	14, // 12: agent.v1.HeartbeatResponse.pending_terminal_sessions:type_name -> agent.v1.TerminalSessionRequest
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_agent_v1_heartbeat_proto_init() }
@@ -1308,7 +1375,7 @@ func file_agent_v1_heartbeat_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_v1_heartbeat_proto_rawDesc), len(file_agent_v1_heartbeat_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
## Summary
- report SSH host public key fingerprints from agents on heartbeat
- auto-trust first observed host keys and store changed keys as pending metadata
- block terminal sessions while a host key change is pending, with an admin action to trust the new keys

## Validation
- go test ./agent/... ./apps/ingest/...
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint
- pnpm --dir apps/web test:unit