### PR TITLE
fix(password-manager): require confirmation for vault exports

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,29 @@
 
 ## What Has Been Built
 
+### Session 118 — Password Manager export hardening
+
+**Risk-gated vault export flow** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/export.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Replaced the one-click vault export with an export dialog that requires
+  fresh unlock-password re-authentication and the typed acknowledgement
+  `I understand the risks` before any download is generated.
+- Added an encrypted ZIP export as the default path. The ZIP contains a
+  manifest plus an AES-256-GCM encrypted vault payload derived from the user's
+  export file password with PBKDF2-SHA256.
+- Kept explicit plaintext JSON export available as an advanced option with
+  destructive styling and warning copy, while continuing to audit successful
+  export events without sending plaintext secrets or export passwords to the
+  Password Manager API.
+
+**Validation**
+- `node --experimental-strip-types --test lib/password-manager/export.test.mjs`
+- `pnpm --filter web type-check`
+- `pnpm --filter web lint` (passes with existing unrelated warnings)
+- `pnpm --filter web test:e2e -- tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --filter web test:unit` (one unrelated existing failure filed as
+  https://github.com/carrtech-dev/ct-ops/issues/1109)
+- `git diff --check`
+
 ### Session 117 — Password Manager focused workspace layout
 
 **Passwords-first vault workspace** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -80,7 +80,10 @@ import {
   createPasswordManagerClient,
 } from '@/lib/password-manager/client'
 import { normalizePasswordManagerUiError, shouldLogPasswordManagerError } from '@/lib/password-manager/errors'
-import { createPasswordManagerVaultExportBundle } from '@/lib/password-manager/export'
+import {
+  createPasswordManagerEncryptedVaultExportBundle,
+  createPasswordManagerVaultExportBundle,
+} from '@/lib/password-manager/export'
 import {
   createInitialPasswordManagerShellState,
   mapPasswordManagerErrorToShellView,
@@ -107,6 +110,9 @@ const GENERIC_UNLOCK_FAILURE =
 const GENERIC_SETUP_FAILURE = 'Password Manager setup could not be completed safely. Retry or relaunch.'
 const PASSWORD_MANAGER_MEMBER_ROLES = ['viewer', 'member', 'manager', 'owner'] as const
 const PASSWORD_MANAGER_CRYPTO_BATCH_SIZE = 8
+const PASSWORD_MANAGER_EXPORT_ACKNOWLEDGEMENT = 'I understand the risks'
+
+type PasswordManagerExportFormat = 'encrypted' | 'plaintext'
 
 export type PasswordManagerOrganisationUser = {
   id: string
@@ -245,6 +251,13 @@ export function PasswordManagerClientShell({
   const [entryNotes, setEntryNotes] = useState('')
   const [entryRevealId, setEntryRevealId] = useState<string | null>(null)
   const [editingEntryId, setEditingEntryId] = useState<string | null>(null)
+  const [exportDialogOpen, setExportDialogOpen] = useState(false)
+  const [exportFormat, setExportFormat] = useState<PasswordManagerExportFormat>('encrypted')
+  const [exportUnlockPassword, setExportUnlockPassword] = useState('')
+  const [exportPassword, setExportPassword] = useState('')
+  const [exportPasswordConfirm, setExportPasswordConfirm] = useState('')
+  const [exportAcknowledgement, setExportAcknowledgement] = useState('')
+  const [exportError, setExportError] = useState<string | null>(null)
   const vaultKeyCacheRef = useRef(new Map<string, Map<number, CryptoKey>>())
   const memberPublicKeyEnvelopeCacheRef = useRef<Record<string, PasswordManagerPublicKeyEnvelope>>({})
   const pendingVaultCreateRef = useRef<{
@@ -466,6 +479,7 @@ export function PasswordManagerClientShell({
     setEntryNotes('')
     setEntryRevealId(null)
     setEditingEntryId(null)
+    resetVaultExportDialog()
     setWorkspaceError(null)
     workspaceDispatch({ type: 'restart' })
   }, [state.view])
@@ -1471,21 +1485,83 @@ export function PasswordManagerClientShell({
     }
   }
 
-  async function handleVaultExport() {
+  function resetVaultExportDialog() {
+    setExportFormat('encrypted')
+    setExportUnlockPassword('')
+    setExportPassword('')
+    setExportPasswordConfirm('')
+    setExportAcknowledgement('')
+    setExportError(null)
+  }
+
+  function handleStartVaultExport() {
     if (!selectedVault) {
       setWorkspaceError('Select a vault before exporting it.')
       return
     }
 
+    resetVaultExportDialog()
+    setExportDialogOpen(true)
+  }
+
+  async function handleVaultExport() {
+    if (!selectedVault) {
+      setExportError('Select a vault before exporting it.')
+      return
+    }
+    if (!state.encryptedPrivateKeyEnvelope || !state.unlockMetadata) {
+      setExportError('Relaunch and unlock Password Manager before exporting a vault.')
+      return
+    }
+    if (!exportUnlockPassword) {
+      setExportError('Enter your unlock password to re-authenticate before exporting.')
+      return
+    }
+    if (exportAcknowledgement !== PASSWORD_MANAGER_EXPORT_ACKNOWLEDGEMENT) {
+      setExportError(`Type "${PASSWORD_MANAGER_EXPORT_ACKNOWLEDGEMENT}" before exporting.`)
+      return
+    }
+    if (exportFormat === 'encrypted') {
+      if (exportPassword.length < 12) {
+        setExportError('Choose an export file password with at least 12 characters.')
+        return
+      }
+      if (exportPassword !== exportPasswordConfirm) {
+        setExportError('The export file passwords do not match.')
+        return
+      }
+    }
+
     setWorkspacePending(true)
+    setExportError(null)
     setWorkspaceError(null)
     try {
-      const bundle = createPasswordManagerVaultExportBundle({
+      await decryptUserPrivateKeyEnvelope({
+        unlockPassword: exportUnlockPassword,
+        encryptedPrivateKeyEnvelope: state.encryptedPrivateKeyEnvelope,
+        kdfMetadata: state.unlockMetadata,
+      })
+
+      const exportInput = {
         vault: selectedVault,
         entries: entries.filter((entry) => entry.vaultId === selectedVault.id),
-      })
+      }
+      const bundle =
+        exportFormat === 'encrypted'
+          ? await createPasswordManagerEncryptedVaultExportBundle({
+              ...exportInput,
+              exportPassword,
+            })
+          : createPasswordManagerVaultExportBundle(exportInput)
+
       triggerBlobDownload(bundle.blob, bundle.fileName)
-      setStatusNotice(`Vault export packaged locally for ${selectedVault.metadata.name}.`)
+      setStatusNotice(
+        exportFormat === 'encrypted'
+          ? `Encrypted vault export packaged locally for ${selectedVault.metadata.name}.`
+          : `Plaintext vault export packaged locally for ${selectedVault.metadata.name}. Delete it as soon as it is no longer needed.`,
+      )
+      setExportDialogOpen(false)
+      resetVaultExportDialog()
       await client.auditExport({
         vaultId: selectedVault.id,
       })
@@ -1499,7 +1575,8 @@ export function PasswordManagerClientShell({
         return
       }
 
-      handleWorkspaceActionError(error, 'The vault could not be exported safely.')
+      const normalized = normalizePasswordManagerUiError(error, 'The vault could not be exported safely.')
+      setExportError(normalized.kind === 'message' ? normalized.message : 'The vault could not be exported safely.')
     } finally {
       setWorkspacePending(false)
     }
@@ -1601,7 +1678,7 @@ export function PasswordManagerClientShell({
           onEntryTitleChange={setEntryTitle}
           onEntryUrlChange={setEntryUrl}
           onEntryUsernameChange={setEntryUsername}
-          onExportVault={handleVaultExport}
+          onExportVault={handleStartVaultExport}
           onMemberPublicKeyEnvelopeInputChange={(userId, value) =>
             setMemberPublicKeyEnvelopeInputs((current) => ({ ...current, [userId]: value }))
           }
@@ -1648,6 +1725,124 @@ export function PasswordManagerClientShell({
           workspaceState={workspaceState}
         />
       ) : null}
+      <Dialog
+        open={exportDialogOpen}
+        onOpenChange={(open) => {
+          setExportDialogOpen(open)
+          if (!open && !workspacePending) {
+            resetVaultExportDialog()
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Export vault</DialogTitle>
+            <DialogDescription>
+              Vault exports can contain plaintext passwords, API keys, URLs, usernames, and notes. Anyone with access to
+              an unencrypted export can use those secrets.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
+            <Alert variant={exportFormat === 'plaintext' ? 'destructive' : 'default'}>
+              <ShieldAlert className="size-4" />
+              <AlertTitle>{exportFormat === 'plaintext' ? 'Plaintext export selected' : 'Encrypted export recommended'}</AlertTitle>
+              <AlertDescription>
+                {exportFormat === 'plaintext'
+                  ? 'Plain JSON is readable immediately after download. Use it only for a short migration window, then delete it securely.'
+                  : 'The ZIP contains an AES-GCM encrypted vault export protected by the export file password you choose below.'}
+              </AlertDescription>
+            </Alert>
+
+            <div className="grid gap-2">
+              <Label htmlFor="password-manager-export-format">Export format</Label>
+              <Select
+                value={exportFormat}
+                onValueChange={(value) => setExportFormat(value as PasswordManagerExportFormat)}
+                disabled={workspacePending}
+              >
+                <SelectTrigger id="password-manager-export-format">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="encrypted">Encrypted ZIP</SelectItem>
+                  <SelectItem value="plaintext">Plain JSON</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="password-manager-export-unlock-password">Unlock password</Label>
+              <Input
+                id="password-manager-export-unlock-password"
+                type="password"
+                value={exportUnlockPassword}
+                onChange={(event) => setExportUnlockPassword(event.target.value)}
+                autoComplete="current-password"
+                disabled={workspacePending}
+              />
+            </div>
+
+            {exportFormat === 'encrypted' ? (
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-export-file-password">Export file password</Label>
+                  <Input
+                    id="password-manager-export-file-password"
+                    type="password"
+                    value={exportPassword}
+                    onChange={(event) => setExportPassword(event.target.value)}
+                    autoComplete="new-password"
+                    disabled={workspacePending}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-export-file-password-confirm">Confirm export file password</Label>
+                  <Input
+                    id="password-manager-export-file-password-confirm"
+                    type="password"
+                    value={exportPasswordConfirm}
+                    onChange={(event) => setExportPasswordConfirm(event.target.value)}
+                    autoComplete="new-password"
+                    disabled={workspacePending}
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            <div className="grid gap-2">
+              <Label htmlFor="password-manager-export-acknowledgement">
+                Type &quot;{PASSWORD_MANAGER_EXPORT_ACKNOWLEDGEMENT}&quot;
+              </Label>
+              <Input
+                id="password-manager-export-acknowledgement"
+                value={exportAcknowledgement}
+                onChange={(event) => setExportAcknowledgement(event.target.value)}
+                disabled={workspacePending}
+              />
+            </div>
+
+            {exportError ? (
+              <Alert variant="destructive">
+                <AlertCircle className="size-4" />
+                <AlertTitle>Export blocked</AlertTitle>
+                <AlertDescription>{exportError}</AlertDescription>
+              </Alert>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setExportDialogOpen(false)} disabled={workspacePending}>
+              Cancel
+            </Button>
+            <Button
+              variant={exportFormat === 'plaintext' ? 'destructive' : 'default'}
+              onClick={() => void handleVaultExport()}
+              disabled={workspacePending}
+            >
+              {workspacePending ? 'Exporting...' : exportFormat === 'encrypted' ? 'Export encrypted ZIP' : 'Export plain JSON'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </section>
   )
 }
@@ -2059,7 +2254,7 @@ function PasswordManagerWorkspace({
   onEntryTitleChange: (value: string) => void
   onEntryUrlChange: (value: string) => void
   onEntryUsernameChange: (value: string) => void
-  onExportVault: () => Promise<void>
+  onExportVault: () => void
   onMemberPublicKeyEnvelopeInputChange: (userId: string, value: string) => void
   onMemberRemove: (member: MemberRecord) => Promise<void>
   onMemberRecipientLookupRequest: () => void

--- a/apps/web/lib/password-manager/export.test.mjs
+++ b/apps/web/lib/password-manager/export.test.mjs
@@ -1,34 +1,82 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { createPasswordManagerVaultExportBundle } from './export.ts'
+import JSZip from 'jszip'
 
-test('createPasswordManagerVaultExportBundle packages decrypted vault data for local download only', async () => {
-  const bundle = createPasswordManagerVaultExportBundle({
-    vault: {
-      id: 'vault-1',
-      metadata: { name: 'Shared Production', description: 'Critical systems' },
-      currentKeyEpoch: 3,
-      role: 'owner',
-      updatedAt: '2026-05-06T09:00:00Z',
-      wrappedVaultKeyEnvelope: { wrapped_key_b64: 'opaque' },
-    },
-    entries: [
-      {
-        id: 'entry-1',
-        vaultId: 'vault-1',
-        payload: {
-          title: 'Grafana',
-          username: 'admin',
-          password: 'super-secret',
-          url: 'https://grafana.example.test',
-          notes: 'Rotate quarterly',
-        },
-        keyEpoch: 3,
-        updatedAt: '2026-05-06T09:10:00Z',
+import {
+  createPasswordManagerEncryptedVaultExportBundle,
+  createPasswordManagerVaultExportBundle,
+} from './export.ts'
+
+const vaultExportInput = {
+  vault: {
+    id: 'vault-1',
+    metadata: { name: 'Shared Production', description: 'Critical systems' },
+    currentKeyEpoch: 3,
+    role: 'owner',
+    updatedAt: '2026-05-06T09:00:00Z',
+    wrappedVaultKeyEnvelope: { wrapped_key_b64: 'opaque' },
+  },
+  entries: [
+    {
+      id: 'entry-1',
+      vaultId: 'vault-1',
+      payload: {
+        title: 'Grafana',
+        username: 'admin',
+        password: 'super-secret',
+        url: 'https://grafana.example.test',
+        notes: 'Rotate quarterly',
       },
-    ],
-    exportedAt: '2026-05-06T09:15:00Z',
+      keyEpoch: 3,
+      updatedAt: '2026-05-06T09:10:00Z',
+    },
+  ],
+  exportedAt: '2026-05-06T09:15:00Z',
+}
+
+test('createPasswordManagerEncryptedVaultExportBundle packages encrypted vault data in a zip by default', async () => {
+  const bundle = await createPasswordManagerEncryptedVaultExportBundle({
+    ...vaultExportInput,
+    exportPassword: 'EncryptedExportPassword!42',
+  })
+
+  assert.equal(bundle.fileName, 'shared-production-2026-05-06T09-15-00Z.password-manager.zip')
+  assert.equal(bundle.mediaType, 'application/zip')
+
+  const zip = await JSZip.loadAsync(await bundle.blob.arrayBuffer())
+  const manifestFile = zip.file('manifest.json')
+  const encryptedExportFile = zip.file('vault-export.encrypted.json')
+
+  assert.ok(manifestFile)
+  assert.ok(encryptedExportFile)
+
+  const manifest = JSON.parse(await manifestFile.async('text'))
+  const encryptedExport = JSON.parse(await encryptedExportFile.async('text'))
+
+  assert.deepEqual(manifest, {
+    format: 'ct-ops-password-manager-export',
+    version: 1,
+    encrypted: true,
+    exported_at: '2026-05-06T09:15:00Z',
+    vault_name: 'Shared Production',
+    contents: ['vault-export.encrypted.json'],
+  })
+  assert.equal(encryptedExport.algorithm, 'pbkdf2-sha256+aes-256-gcm')
+  assert.equal(encryptedExport.version, 1)
+  assert.equal(encryptedExport.kdf.iterations, 600000)
+  assert.equal(typeof encryptedExport.kdf.salt_b64, 'string')
+  assert.equal(typeof encryptedExport.iv_b64, 'string')
+  assert.equal(typeof encryptedExport.ciphertext_b64, 'string')
+
+  const zipText = await bundle.blob.text()
+  assert.doesNotMatch(zipText, /super-secret/)
+  assert.doesNotMatch(zipText, /Rotate quarterly/)
+})
+
+test('createPasswordManagerVaultExportBundle packages decrypted vault data for explicit plaintext download only', async () => {
+  const bundle = createPasswordManagerVaultExportBundle({
+    ...vaultExportInput,
   })
 
   assert.equal(bundle.fileName, 'shared-production-2026-05-06T09-15-00Z.password-manager.json')

--- a/apps/web/lib/password-manager/export.ts
+++ b/apps/web/lib/password-manager/export.ts
@@ -2,21 +2,78 @@ import type {
   PasswordManagerEntrySummary,
   PasswordManagerVaultSummary,
 } from './workspace.ts'
+import JSZip from 'jszip'
+
+const EXPORT_KDF_ITERATIONS = 600_000
+const EXPORT_DERIVED_KEY_LENGTH = 32
+const EXPORT_SALT_BYTES = 16
+const EXPORT_IV_BYTES = 12
 
 export interface PasswordManagerVaultExportBundle {
   blob: Blob
   fileName: string
-  mediaType: 'application/json'
+  mediaType: 'application/json' | 'application/zip'
 }
 
-export function createPasswordManagerVaultExportBundle(input: {
+export interface PasswordManagerVaultExportInput {
   vault: PasswordManagerVaultSummary
   entries: PasswordManagerEntrySummary[]
   exportedAt?: string
-}): PasswordManagerVaultExportBundle {
+}
+
+export async function createPasswordManagerEncryptedVaultExportBundle(
+  input: PasswordManagerVaultExportInput & { exportPassword: string },
+): Promise<PasswordManagerVaultExportBundle> {
+  if (!input.exportPassword.trim()) {
+    throw new Error('Choose an export password before creating an encrypted vault export.')
+  }
+
   const exportedAt = input.exportedAt ?? new Date().toISOString()
-  const payload = {
-    exported_at: exportedAt,
+  const payload = createPasswordManagerVaultExportPayload({ ...input, exportedAt })
+  const encryptedPayload = await encryptVaultExportPayload(payload, input.exportPassword)
+  const zip = new JSZip()
+
+  zip.file(
+    'manifest.json',
+    JSON.stringify(
+      {
+        format: 'ct-ops-password-manager-export',
+        version: 1,
+        encrypted: true,
+        exported_at: exportedAt,
+        vault_name: input.vault.metadata.name,
+        contents: ['vault-export.encrypted.json'],
+      },
+      null,
+      2,
+    ),
+  )
+  zip.file('vault-export.encrypted.json', JSON.stringify(encryptedPayload, null, 2))
+
+  return {
+    blob: await zip.generateAsync({ type: 'blob', mimeType: 'application/zip' }),
+    fileName: `${slugifyFileStem(input.vault.metadata.name)}-${exportedAt.replaceAll(':', '-')}.password-manager.zip`,
+    mediaType: 'application/zip',
+  }
+}
+
+export function createPasswordManagerVaultExportBundle(
+  input: PasswordManagerVaultExportInput,
+): PasswordManagerVaultExportBundle {
+  const exportedAt = input.exportedAt ?? new Date().toISOString()
+  const payload = createPasswordManagerVaultExportPayload({ ...input, exportedAt })
+  const fileName = `${slugifyFileStem(input.vault.metadata.name)}-${exportedAt.replaceAll(':', '-')}.password-manager.json`
+
+  return {
+    blob: new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }),
+    fileName,
+    mediaType: 'application/json',
+  }
+}
+
+function createPasswordManagerVaultExportPayload(input: PasswordManagerVaultExportInput & { exportedAt: string }) {
+  return {
+    exported_at: input.exportedAt,
     vault: {
       id: input.vault.id,
       name: input.vault.metadata.name,
@@ -36,13 +93,87 @@ export function createPasswordManagerVaultExportBundle(input: {
       updated_at: entry.updatedAt,
     })),
   }
-  const fileName = `${slugifyFileStem(input.vault.metadata.name)}-${exportedAt.replaceAll(':', '-')}.password-manager.json`
+}
+
+async function encryptVaultExportPayload(payload: unknown, exportPassword: string) {
+  const crypto = getWebCrypto()
+  const salt = randomBytes(EXPORT_SALT_BYTES)
+  const iv = randomBytes(EXPORT_IV_BYTES)
+  const passwordMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(exportPassword),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  )
+  const exportKey = await crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt: toArrayBuffer(salt),
+      iterations: EXPORT_KDF_ITERATIONS,
+    },
+    passwordMaterial,
+    {
+      name: 'AES-GCM',
+      length: EXPORT_DERIVED_KEY_LENGTH * 8,
+    },
+    false,
+    ['encrypt'],
+  )
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(iv),
+    },
+    exportKey,
+    toArrayBuffer(new TextEncoder().encode(JSON.stringify(payload))),
+  )
 
   return {
-    blob: new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }),
-    fileName,
-    mediaType: 'application/json',
+    version: 1,
+    algorithm: 'pbkdf2-sha256+aes-256-gcm',
+    kdf: {
+      algorithm: 'pbkdf2-sha256',
+      iterations: EXPORT_KDF_ITERATIONS,
+      salt_b64: toBase64(salt),
+      derived_key_length: EXPORT_DERIVED_KEY_LENGTH,
+    },
+    iv_b64: toBase64(iv),
+    ciphertext_b64: toBase64(ciphertext),
   }
+}
+
+function getWebCrypto(): Crypto {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto API is required')
+  }
+  return globalThis.crypto
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(new ArrayBuffer(length))
+  getWebCrypto().getRandomValues(bytes)
+  return bytes
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const arrayBuffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(arrayBuffer).set(bytes)
+  return arrayBuffer
+}
+
+function toBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64')
+  }
+
+  let binary = ''
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]!)
+  }
+  return btoa(binary)
 }
 
 function slugifyFileStem(input: string): string {

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -10,6 +10,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
 
   const setupPassword = 'LocalUnlockPassword!42'
+  const exportPassword = 'EncryptedVaultExport!42'
   const entryPassword = 'SuperSecretPassword!99'
   const updatedEntryPassword = 'RotatedPassword!100'
   const entryNotes = 'Recovery codes and production notes'
@@ -73,6 +74,12 @@ test('hosted password manager flow keeps plaintext and key material inside the b
 
   const downloadPromise = page.waitForEvent('download')
   await page.getByRole('button', { name: 'Export vault' }).click()
+  await expect(page.getByRole('dialog', { name: 'Export vault' })).toBeVisible()
+  await page.getByLabel('Unlock password', { exact: true }).fill(setupPassword)
+  await page.getByLabel('Export file password', { exact: true }).fill(exportPassword)
+  await page.getByLabel('Confirm export file password').fill(exportPassword)
+  await page.getByLabel('Type "I understand the risks"').fill('I understand the risks')
+  await page.getByRole('button', { name: 'Export encrypted ZIP' }).click()
   await downloadPromise
 
   await entryCard.getByRole('button', { name: 'Edit' }).click()
@@ -147,6 +154,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   for (const request of passwordManagerMock.apiRequests()) {
     expect(request.credentialsCookie).toBe(true)
     expect(request.rawBody).not.toContain(setupPassword)
+    expect(request.rawBody).not.toContain(exportPassword)
     expect(request.rawBody).not.toContain(entryPassword)
     expect(request.rawBody).not.toContain(updatedEntryPassword)
     expect(request.rawBody).not.toContain(entryNotes)
@@ -156,6 +164,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
 
   for (const message of consoleMessages) {
     expect(message).not.toContain(setupPassword)
+    expect(message).not.toContain(exportPassword)
     expect(message).not.toContain(entryPassword)
     expect(message).not.toContain(updatedEntryPassword)
     expect(message).not.toContain(entryNotes)
@@ -165,6 +174,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
 
   for (const request of outboundBodies) {
     expect(request.body).not.toContain(setupPassword)
+    expect(request.body).not.toContain(exportPassword)
     expect(request.body).not.toContain(entryPassword)
     expect(request.body).not.toContain(updatedEntryPassword)
     expect(request.body).not.toContain(entryNotes)


### PR DESCRIPTION
## Summary\n- add a risk-gated vault export dialog requiring fresh unlock-password re-authentication and typed acknowledgement\n- default exports to an encrypted ZIP containing an AES-GCM encrypted vault payload protected by an export file password\n- keep plaintext JSON export as an explicit warned option and extend unit/E2E coverage\n\n## Validation\n- [x] node --experimental-strip-types --test lib/password-manager/export.test.mjs\n- [x] pnpm --filter web type-check\n- [x] pnpm --filter web lint (existing unrelated warnings only)\n- [x] pnpm --filter web test:e2e -- tests/e2e/tooling/password-manager.spec.ts\n- [ ] pnpm --filter web test:unit (fails in unrelated existing lib/agent/binary-integrity.test.mjs; filed #1109)\n- [x] git diff --check