### PR TITLE
feat(profile): add 2fa qr setup code

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,22 @@
 
 ## What Has Been Built
 
+### Session 120 — Profile 2FA QR setup
+
+**Authenticator setup QR code** (`apps/web/app/(dashboard)/profile/profile-client.tsx`, `apps/web/tests/e2e/profile/profile.spec.ts`)
+- Added a scan-ready QR code to the profile two-factor setup flow, generated
+  from the Better Auth `totpURI` returned when setup starts.
+- Kept the setup key and full authenticator URI visible as manual fallback
+  options for users who cannot scan the QR code.
+- Extended the profile 2FA E2E flow to assert the QR code renders before using
+  the setup key to generate and verify the TOTP code.
+
+**Validation**
+- `pnpm --filter web add react-qr-code`
+- `pnpm --dir apps/web test:e2e tests/e2e/profile/profile.spec.ts --grep "enable and disable authenticator"`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web lint` (passes with existing unrelated warnings)
+
 ### Session 119 — Password Manager entry templates
 
 **Template-driven entry modal** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/workspace.ts`, `apps/web/lib/password-manager/export.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)

--- a/apps/web/app/(dashboard)/profile/profile-client.tsx
+++ b/apps/web/app/(dashboard)/profile/profile-client.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
+import QRCode from 'react-qr-code'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button } from '@/components/ui/button'
@@ -420,6 +421,26 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
 
           {!twoFactorEnabled && twoFactorUri && (
             <div className="space-y-4">
+              <div className="flex flex-col gap-4 rounded-md border bg-background p-4 sm:flex-row sm:items-center">
+                <div
+                  className="flex size-44 shrink-0 items-center justify-center rounded-md bg-white p-3"
+                  data-testid="profile-two-factor-qr"
+                  aria-label="Authenticator app QR code"
+                >
+                  <QRCode
+                    value={twoFactorUri}
+                    size={152}
+                    level="M"
+                    className="h-full w-full"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">Scan with your authenticator app</p>
+                  <p className="text-xs text-muted-foreground">
+                    Use the QR code first. If scanning is unavailable, enter the setup key manually.
+                  </p>
+                </div>
+              </div>
               <div className="space-y-1.5">
                 <Label htmlFor="profile-two-factor-secret">Authenticator setup key</Label>
                 <div className="flex gap-2">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -60,6 +60,7 @@
     "react-dom": "19.2.5",
     "react-hook-form": "^7.75.0",
     "react-markdown": "^10.1.0",
+    "react-qr-code": "^2.0.21",
     "recharts": "^3.8.1",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",

--- a/apps/web/tests/e2e/profile/profile.spec.ts
+++ b/apps/web/tests/e2e/profile/profile.spec.ts
@@ -134,6 +134,9 @@ test('authenticated user can enable and disable authenticator app 2FA from profi
 
   const secretInput = page.getByTestId('profile-two-factor-secret')
   await expect(secretInput).toBeVisible()
+  const qrCode = page.getByTestId('profile-two-factor-qr')
+  await expect(qrCode).toBeVisible()
+  await expect(qrCode.locator('svg')).toBeVisible()
   const secret = decodeBase32Secret(await secretInput.inputValue())
   const code = generateTotpCode({ secret })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
+      react-qr-code:
+        specifier: ^2.0.21
+        version: 2.0.21(react@19.2.5)
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1)
@@ -3171,6 +3174,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -6391,6 +6395,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qr.js@0.0.0:
+    resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -6456,6 +6463,11 @@ packages:
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-qr-code@2.0.21:
+    resolution: {integrity: sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==}
+    peerDependencies:
+      react: '*'
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -15168,6 +15180,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qr.js@0.0.0: {}
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -15291,6 +15305,12 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-qr-code@2.0.21(react@19.2.5):
+    dependencies:
+      prop-types: 15.8.1
+      qr.js: 0.0.0
+      react: 19.2.5
 
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add a scan-ready QR code to the profile TOTP setup flow
- keep setup key and URI manual fallback options
- cover the QR display in the profile 2FA E2E flow

## Validation
- pnpm --dir apps/web test:e2e tests/e2e/profile/profile.spec.ts --grep "enable and disable authenticator"
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing unrelated warnings)