### PR TITLE
fix(ingest): throttle unauthenticated registrations

### DIFF
--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -18,14 +18,15 @@ import (
 
 // RegisterHandler implements the Register RPC.
 type RegisterHandler struct {
-	pool   *pgxpool.Pool
-	issuer *auth.JWTIssuer
-	ca     *pki.AgentCA
+	pool                *pgxpool.Pool
+	issuer              *auth.JWTIssuer
+	ca                  *pki.AgentCA
+	registrationLimiter *RegistrationLimiter
 }
 
 // NewRegisterHandler creates a RegisterHandler.
 func NewRegisterHandler(pool *pgxpool.Pool, issuer *auth.JWTIssuer, ca *pki.AgentCA) *RegisterHandler {
-	return &RegisterHandler{pool: pool, issuer: issuer, ca: ca}
+	return &RegisterHandler{pool: pool, issuer: issuer, ca: ca, registrationLimiter: NewDefaultRegistrationLimiter()}
 }
 
 type hostCollisionDecision int
@@ -67,6 +68,10 @@ func existingAgentBelongsToTokenOrg(existing *queries.AgentRow, tokenOrgID strin
 func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error) {
 	if req.OrgToken == "" || req.PublicKey == "" {
 		return nil, status.Error(codes.InvalidArgument, "org_token and public_key are required")
+	}
+	if err := h.registrationLimiter.Allow(ctx, req.OrgToken); err != nil {
+		slog.Warn("throttling agent registration attempt", "err", err)
+		return nil, err
 	}
 
 	hostname := "unknown"

--- a/apps/ingest/internal/handlers/register_rate_limiter.go
+++ b/apps/ingest/internal/handlers/register_rate_limiter.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultRegistrationSourceLimit      = 120
+	defaultRegistrationSourceTokenLimit = 30
+	defaultRegistrationWindow           = time.Minute
+)
+
+type RegistrationLimiterConfig struct {
+	SourceLimit      int
+	SourceTokenLimit int
+	Window           time.Duration
+	Now              func() time.Time
+}
+
+type RegistrationLimiter struct {
+	mu      sync.Mutex
+	config  RegistrationLimiterConfig
+	buckets map[string]registrationAttemptBucket
+}
+
+type registrationAttemptBucket struct {
+	count   int
+	resetAt time.Time
+}
+
+func NewRegistrationLimiter(config RegistrationLimiterConfig) *RegistrationLimiter {
+	if config.SourceLimit <= 0 {
+		config.SourceLimit = defaultRegistrationSourceLimit
+	}
+	if config.SourceTokenLimit <= 0 {
+		config.SourceTokenLimit = defaultRegistrationSourceTokenLimit
+	}
+	if config.Window <= 0 {
+		config.Window = defaultRegistrationWindow
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	return &RegistrationLimiter{
+		config:  config,
+		buckets: make(map[string]registrationAttemptBucket),
+	}
+}
+
+func NewDefaultRegistrationLimiter() *RegistrationLimiter {
+	return NewRegistrationLimiter(RegistrationLimiterConfig{})
+}
+
+func (l *RegistrationLimiter) Allow(ctx context.Context, orgToken string) error {
+	if l == nil {
+		return nil
+	}
+
+	now := l.config.Now()
+	sourceKey := "source:" + registrationSource(ctx)
+	sourceTokenKey := sourceKey + ":token:" + tokenHashPrefix(orgToken)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.allowBucket(sourceKey, now, l.config.SourceLimit) || !l.allowBucket(sourceTokenKey, now, l.config.SourceTokenLimit) {
+		return status.Error(codes.ResourceExhausted, "too many registration attempts; retry later")
+	}
+	return nil
+}
+
+func (l *RegistrationLimiter) allowBucket(key string, now time.Time, limit int) bool {
+	bucket := l.buckets[key]
+	if bucket.resetAt.IsZero() || !now.Before(bucket.resetAt) {
+		bucket = registrationAttemptBucket{resetAt: now.Add(l.config.Window)}
+	}
+	if bucket.count >= limit {
+		l.buckets[key] = bucket
+		return false
+	}
+	bucket.count++
+	l.buckets[key] = bucket
+	return true
+}
+
+func registrationSource(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p == nil || p.Addr == nil {
+		return "unknown"
+	}
+	if tcp, ok := p.Addr.(*net.TCPAddr); ok {
+		return tcp.IP.String()
+	}
+	host, _, err := net.SplitHostPort(p.Addr.String())
+	if err == nil && host != "" {
+		return host
+	}
+	return p.Addr.String()
+}
+
+func tokenHashPrefix(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/apps/ingest/internal/handlers/register_rate_limiter_test.go
+++ b/apps/ingest/internal/handlers/register_rate_limiter_test.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+func TestRegistrationLimiterBlocksRepeatedSourceAndTokenAttempts(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewRegistrationLimiter(RegistrationLimiterConfig{
+		SourceLimit:      100,
+		SourceTokenLimit: 2,
+		Window:           time.Minute,
+		Now:              fixedClock(time.Unix(100, 0)),
+	})
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("203.0.113.9"), Port: 43123}})
+
+	for range 2 {
+		if err := limiter.Allow(ctx, "enrolment-token-a"); err != nil {
+			t.Fatalf("Allow() unexpected error = %v", err)
+		}
+	}
+
+	if err := limiter.Allow(ctx, "enrolment-token-a"); err == nil {
+		t.Fatal("Allow() accepted repeated attempts for the same source/token")
+	}
+}
+
+func TestRegistrationLimiterSeparatesTokenPrefixes(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewRegistrationLimiter(RegistrationLimiterConfig{
+		SourceLimit:      100,
+		SourceTokenLimit: 1,
+		Window:           time.Minute,
+		Now:              fixedClock(time.Unix(100, 0)),
+	})
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("203.0.113.9"), Port: 43123}})
+
+	if err := limiter.Allow(ctx, "enrolment-token-a"); err != nil {
+		t.Fatalf("Allow(first token) error = %v", err)
+	}
+	if err := limiter.Allow(ctx, "enrolment-token-b"); err != nil {
+		t.Fatalf("Allow(second token) error = %v", err)
+	}
+}
+
+func TestRegistrationLimiterExpiresWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(100, 0)
+	limiter := NewRegistrationLimiter(RegistrationLimiterConfig{
+		SourceLimit:      1,
+		SourceTokenLimit: 1,
+		Window:           time.Minute,
+		Now: func() time.Time {
+			return now
+		},
+	})
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("203.0.113.9"), Port: 43123}})
+
+	if err := limiter.Allow(ctx, "enrolment-token-a"); err != nil {
+		t.Fatalf("Allow(first window) error = %v", err)
+	}
+	if err := limiter.Allow(ctx, "enrolment-token-a"); err == nil {
+		t.Fatal("Allow() accepted repeated attempt inside the same window")
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	if err := limiter.Allow(ctx, "enrolment-token-a"); err != nil {
+		t.Fatalf("Allow(next window) error = %v", err)
+	}
+}
+
+func TestRegisterThrottlesBeforeTokenLookup(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewRegistrationLimiter(RegistrationLimiterConfig{
+		SourceLimit:      1,
+		SourceTokenLimit: 1,
+		Window:           time.Minute,
+		Now:              fixedClock(time.Unix(100, 0)),
+	})
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.TCPAddr{IP: net.ParseIP("203.0.113.9"), Port: 43123}})
+	if err := limiter.Allow(ctx, "enrolment-token-a"); err != nil {
+		t.Fatalf("preconsuming limiter allowance: %v", err)
+	}
+
+	handler := &RegisterHandler{registrationLimiter: limiter}
+	_, err := handler.Register(ctx, &agentv1.RegisterRequest{
+		OrgToken:  "enrolment-token-a",
+		PublicKey: "agent-public-key",
+	})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("Register() error code = %v, want %v (err=%v)", status.Code(err), codes.ResourceExhausted, err)
+	}
+}
+
+func fixedClock(now time.Time) func() time.Time {
+	return func() time.Time {
+		return now
+	}
+}


### PR DESCRIPTION
## Summary
- add an in-memory Register RPC limiter keyed by peer source and enrolment-token hash prefix
- enforce the limiter before the enrolment-token database lookup
- cover limiter windows, per-token separation, and pre-lookup handler throttling

Fixes #969

## Tests
- go test ./apps/ingest/internal/handlers -run 'TestRegistrationLimiter|TestRegisterThrottles'
- go test ./apps/ingest/internal/...
- go test ./apps/ingest/...

## Notes
- The repo does not currently have codex/codex-automation labels, so no automation label was added.