### PR TITLE
fix(auth): complete local two-factor login

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
-import { signIn } from '@/lib/auth/client'
+import { authClient, signIn } from '@/lib/auth/client'
 import {
   getInviteAcceptPath,
   getInviteRegisterPath,
@@ -32,6 +32,12 @@ const domainLoginSchema = z.object({
 type LocalLoginValues = z.infer<typeof localLoginSchema>
 type DomainLoginValues = z.infer<typeof domainLoginSchema>
 type DomainTwoFactorMethod = 'totp' | 'backup_code'
+type LocalTwoFactorMethod = 'totp' | 'backup_code'
+
+type TwoFactorRedirectData = {
+  twoFactorRedirect: true
+  twoFactorMethods?: string[]
+}
 
 interface LoginFormProps {
   ldapLoginEnabled?: boolean
@@ -43,6 +49,15 @@ function isEmailNotVerifiedError(message: string, code?: string): boolean {
   return code === 'EMAIL_NOT_VERIFIED' || message.toLowerCase().includes('email not verified')
 }
 
+function isTwoFactorRedirectData(data: unknown): data is TwoFactorRedirectData {
+  if (!data || typeof data !== 'object') return false
+  return (data as { twoFactorRedirect?: unknown }).twoFactorRedirect === true
+}
+
+function cleanTwoFactorCode(code: string, method: LocalTwoFactorMethod): string {
+  return method === 'totp' ? code.replace(/\s+/g, '') : code.trim()
+}
+
 export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice = null }: LoginFormProps) {
   const router = useRouter()
   const inviteAcceptPath = getInviteAcceptPath(inviteToken)
@@ -50,6 +65,11 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
   const [canResendVerification, setCanResendVerification] = useState(false)
   const [verificationEmail, setVerificationEmail] = useState<string | null>(null)
   const [loginMode, setLoginMode] = useState<'local' | 'domain'>('local')
+  const [localTwoFactorRequired, setLocalTwoFactorRequired] = useState(false)
+  const [localTwoFactorMethods, setLocalTwoFactorMethods] = useState<LocalTwoFactorMethod[]>(['totp'])
+  const [localTwoFactorMethod, setLocalTwoFactorMethod] = useState<LocalTwoFactorMethod>('totp')
+  const [localTwoFactorCode, setLocalTwoFactorCode] = useState('')
+  const [localTwoFactorSubmitting, setLocalTwoFactorSubmitting] = useState(false)
   const [ldapTwoFactorRequired, setLdapTwoFactorRequired] = useState(false)
   const [ldapTwoFactorCode, setLdapTwoFactorCode] = useState('')
   const [ldapTwoFactorMethod, setLdapTwoFactorMethod] = useState<DomainTwoFactorMethod>('totp')
@@ -66,6 +86,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
     setServerError(null)
     setCanResendVerification(false)
     setVerificationEmail(null)
+    setLocalTwoFactorCode('')
     const result = await signIn.email({
       email: values.email,
       password: values.password,
@@ -80,7 +101,43 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
       return
     }
 
+    if (isTwoFactorRedirectData(result.data)) {
+      const methods = result.data.twoFactorMethods?.filter(
+        (method): method is LocalTwoFactorMethod => method === 'totp' || method === 'backup_code',
+      )
+      const availableMethods: LocalTwoFactorMethod[] = methods && methods.length > 0 ? methods : ['totp']
+      setLocalTwoFactorMethods(availableMethods)
+      setLocalTwoFactorMethod(availableMethods[0] ?? 'totp')
+      setLocalTwoFactorRequired(true)
+      return
+    }
+
     router.push(inviteAcceptPath ?? '/dashboard')
+  }
+
+  async function onLocalTwoFactorSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const code = cleanTwoFactorCode(localTwoFactorCode, localTwoFactorMethod)
+    if (!code) return
+
+    setServerError(null)
+    setLocalTwoFactorSubmitting(true)
+    try {
+      const result = localTwoFactorMethod === 'backup_code'
+        ? await authClient.twoFactor.verifyBackupCode({ code })
+        : await authClient.twoFactor.verifyTotp({ code })
+
+      if (result.error) {
+        setServerError(result.error.message ?? 'Invalid two-factor code.')
+        return
+      }
+
+      router.push(inviteAcceptPath ?? '/dashboard')
+    } catch {
+      setServerError('An unexpected error occurred.')
+    } finally {
+      setLocalTwoFactorSubmitting(false)
+    }
   }
 
   async function onDomainSubmit(values: DomainLoginValues) {
@@ -156,6 +213,13 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
     setLdapTwoFactorMethod('totp')
   }
 
+  function resetLocalTwoFactor() {
+    setLocalTwoFactorRequired(false)
+    setLocalTwoFactorCode('')
+    setLocalTwoFactorMethod('totp')
+    setLocalTwoFactorMethods(['totp'])
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -200,6 +264,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
                 setServerError(null)
                 setCanResendVerification(false)
                 setVerificationEmail(null)
+                resetLocalTwoFactor()
                 resetDomainTwoFactor()
               }}
             >
@@ -209,7 +274,91 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
         </div>
       )}
 
-      {loginMode === 'local' ? (
+      {loginMode === 'local' && localTwoFactorRequired ? (
+        <form onSubmit={onLocalTwoFactorSubmit}>
+          <CardContent className="space-y-4">
+            {serverError && (
+              <p className="text-sm text-destructive" data-testid="login-error">{serverError}</p>
+            )}
+            <div className="space-y-2 rounded-md border bg-muted/40 p-3 text-sm" data-testid="login-2fa-panel">
+              <p className="font-medium text-foreground">Second factor required</p>
+              <p className="text-muted-foreground">
+                Enter the code from your authenticator app or use one of your backup codes to finish signing in.
+              </p>
+            </div>
+            {localTwoFactorMethods.length > 1 && (
+              <div className="space-y-1.5">
+                <Label>Verification method</Label>
+                <div className="flex rounded-md border p-1 gap-1">
+                  {localTwoFactorMethods.includes('totp') && (
+                    <button
+                      type="button"
+                      className={`flex-1 px-3 py-1.5 text-sm rounded transition-colors ${
+                        localTwoFactorMethod === 'totp'
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                      onClick={() => setLocalTwoFactorMethod('totp')}
+                      data-testid="login-2fa-method-totp"
+                    >
+                      Authenticator
+                    </button>
+                  )}
+                  {localTwoFactorMethods.includes('backup_code') && (
+                    <button
+                      type="button"
+                      className={`flex-1 px-3 py-1.5 text-sm rounded transition-colors ${
+                        localTwoFactorMethod === 'backup_code'
+                          ? 'bg-primary text-primary-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                      onClick={() => setLocalTwoFactorMethod('backup_code')}
+                      data-testid="login-2fa-method-backup"
+                    >
+                      Backup Code
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Label htmlFor="login-two-factor-code">
+                {localTwoFactorMethod === 'totp' ? 'Authenticator code' : 'Backup code'}
+              </Label>
+              <Input
+                id="login-two-factor-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={localTwoFactorCode}
+                onChange={(event) => setLocalTwoFactorCode(event.target.value)}
+                data-testid="login-2fa-code"
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3">
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={localTwoFactorSubmitting || !cleanTwoFactorCode(localTwoFactorCode, localTwoFactorMethod)}
+              data-testid="login-2fa-submit"
+            >
+              {localTwoFactorSubmitting ? 'Verifying...' : 'Verify code'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                setServerError(null)
+                resetLocalTwoFactor()
+              }}
+            >
+              Start over
+            </Button>
+          </CardFooter>
+        </form>
+      ) : loginMode === 'local' ? (
         <form onSubmit={localForm.handleSubmit(onLocalSubmit)}>
           <CardContent className="space-y-4">
             {notice && (

--- a/apps/web/tests/e2e/auth/login.spec.ts
+++ b/apps/web/tests/e2e/auth/login.spec.ts
@@ -3,6 +3,25 @@ import { getTestDb } from '../fixtures/db'
 import { TEST_ORG } from '../fixtures/seed'
 import { waitForPasswordResetUrl } from '../fixtures/email'
 import { TEST_USER } from '../fixtures/seed'
+import { generateTotpCode } from '../../../lib/auth/ldap-two-factor'
+
+function decodeBase32Secret(secret: string): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  let bits = ''
+  let output = ''
+
+  for (const char of secret.replace(/=+$/, '').toUpperCase()) {
+    const value = alphabet.indexOf(char)
+    if (value === -1) continue
+    bits += value.toString(2).padStart(5, '0')
+  }
+
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    output += String.fromCharCode(parseInt(bits.slice(i, i + 8), 2))
+  }
+
+  return output
+}
 
 test('user can sign in with email and password and reach the dashboard', async ({ page }) => {
   await page.goto('/login')
@@ -53,6 +72,42 @@ test('user can request a password reset from the login screen and sign in with t
   await page.getByTestId('login-email').fill(TEST_USER.email)
   await page.getByTestId('login-password').fill(newPassword)
   await page.getByTestId('login-submit').click()
+
+  await page.waitForURL('**/dashboard')
+  await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+})
+
+test('user with authenticator 2FA can complete local sign in', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByTestId('login-email').fill(TEST_USER.email)
+  await page.getByTestId('login-password').fill(TEST_USER.password)
+  await page.getByTestId('login-submit').click()
+  await page.waitForURL('**/dashboard')
+
+  await page.goto('/profile')
+  await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible()
+  await expect(page.getByText('2FA is not enabled')).toBeVisible()
+  await page.getByTestId('profile-two-factor-password').fill(TEST_USER.password)
+  await page.getByTestId('profile-two-factor-start').click()
+
+  const secretInput = page.getByTestId('profile-two-factor-secret')
+  await expect(secretInput).toBeVisible()
+  const secret = decodeBase32Secret(await secretInput.inputValue())
+  const setupCode = generateTotpCode({ secret })
+
+  await page.getByTestId('profile-two-factor-code').fill(setupCode)
+  await page.getByTestId('profile-two-factor-verify').click()
+  await expect(page.getByTestId('profile-two-factor-success')).toContainText('enabled')
+
+  await page.context().clearCookies()
+  await page.goto('/login')
+  await page.getByTestId('login-email').fill(TEST_USER.email)
+  await page.getByTestId('login-password').fill(TEST_USER.password)
+  await page.getByTestId('login-submit').click()
+
+  await expect(page.getByTestId('login-2fa-panel')).toBeVisible()
+  await page.getByTestId('login-2fa-code').fill(generateTotpCode({ secret }))
+  await page.getByTestId('login-2fa-submit').click()
 
   await page.waitForURL('**/dashboard')
   await expect(page.getByTestId('dashboard-heading')).toBeVisible()


### PR DESCRIPTION
## Summary
- handle Better Auth local sign-in responses that require two-factor verification
- add a local second-factor prompt for authenticator and backup-code methods
- add E2E coverage for enabling TOTP and completing local 2FA sign-in

## Validation
- pnpm --dir apps/web test:e2e tests/e2e/auth/login.spec.ts --grep "authenticator 2FA"
- pnpm --dir apps/web test:e2e tests/e2e/auth/login.spec.ts
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec eslint app/'(auth)'/login/login-form.tsx tests/e2e/auth/login.spec.ts