### PR TITLE
fix(password-manager): rename vault settings action

### DIFF
--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -3264,7 +3264,7 @@ function PasswordManagerWorkspace({
               <CardFooter className="flex flex-wrap gap-2">
                 <Button variant="outline" onClick={() => void onRenameVault()} disabled={workspacePending}>
                   <Pencil className="mr-2 size-4" />
-                  Rename vault
+                  Save Settings
                 </Button>
                 <Button variant="destructive" onClick={() => setDeleteVaultDialogOpen(true)} disabled={workspacePending}>
                   <Trash2 className="mr-2 size-4" />


### PR DESCRIPTION
## Summary
- Change the vault settings save button label from "Rename vault" to "Save Settings"

## Validation
- pnpm --dir apps/web lint "app/(dashboard)/password-manager/password-manager-client.tsx"