### PR TITLE
fix(auth): select LDAP login integration

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -10,11 +10,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authClient, signIn } from '@/lib/auth/client'
 import {
   getInviteAcceptPath,
   getInviteRegisterPath,
 } from '@/lib/auth/invite-redirects'
+import type { LdapLoginOption } from '@/lib/auth/ldap-login-options'
 
 const localLoginSchema = z.object({
   email: z.string().email('Enter a valid email address'),
@@ -40,7 +42,7 @@ type TwoFactorRedirectData = {
 }
 
 interface LoginFormProps {
-  ldapLoginEnabled?: boolean
+  ldapLoginOptions?: LdapLoginOption[]
   inviteToken?: string | null
   notice?: string | null
 }
@@ -58,9 +60,11 @@ function cleanTwoFactorCode(code: string, method: LocalTwoFactorMethod): string 
   return method === 'totp' ? code.replace(/\s+/g, '') : code.trim()
 }
 
-export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice = null }: LoginFormProps) {
+export function LoginForm({ ldapLoginOptions = [], inviteToken = null, notice = null }: LoginFormProps) {
   const router = useRouter()
   const inviteAcceptPath = getInviteAcceptPath(inviteToken)
+  const ldapLoginEnabled = ldapLoginOptions.length > 0
+  const defaultLdapLoginOption = ldapLoginOptions[0] ?? null
   const [serverError, setServerError] = useState<string | null>(null)
   const [canResendVerification, setCanResendVerification] = useState(false)
   const [verificationEmail, setVerificationEmail] = useState<string | null>(null)
@@ -73,6 +77,7 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
   const [ldapTwoFactorRequired, setLdapTwoFactorRequired] = useState(false)
   const [ldapTwoFactorCode, setLdapTwoFactorCode] = useState('')
   const [ldapTwoFactorMethod, setLdapTwoFactorMethod] = useState<DomainTwoFactorMethod>('totp')
+  const [selectedLdapIntegrationId, setSelectedLdapIntegrationId] = useState(defaultLdapLoginOption?.id ?? '')
 
   const localForm = useForm<LocalLoginValues>({
     resolver: zodResolver(localLoginSchema),
@@ -80,6 +85,9 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
 
   const domainForm = useForm<DomainLoginValues>({
     resolver: zodResolver(domainLoginSchema),
+    defaultValues: {
+      organisationSlug: defaultLdapLoginOption?.organisationSlug ?? '',
+    },
   })
 
   async function onLocalSubmit(values: LocalLoginValues) {
@@ -507,15 +515,31 @@ export function LoginForm({ ldapLoginEnabled = false, inviteToken = null, notice
             ) : (
               <>
                 <div className="space-y-1.5">
-                  <Label htmlFor="domain-organisation">Organisation slug</Label>
-                  <Input
-                    id="domain-organisation"
-                    type="text"
-                    autoComplete="organization"
-                    placeholder="acme"
-                    {...domainForm.register('organisationSlug')}
-                    data-testid="domain-login-organisation"
-                  />
+                  <Label htmlFor="domain-organisation">Domain integration</Label>
+                  <Select
+                    value={selectedLdapIntegrationId}
+                    onValueChange={(value) => {
+                      const option = ldapLoginOptions.find((candidate) => candidate.id === value)
+                      if (!option) return
+                      setSelectedLdapIntegrationId(option.id)
+                      domainForm.setValue('organisationSlug', option.organisationSlug, {
+                        shouldDirty: true,
+                        shouldTouch: true,
+                        shouldValidate: true,
+                      })
+                    }}
+                  >
+                    <SelectTrigger id="domain-organisation" data-testid="domain-login-organisation">
+                      <SelectValue placeholder="Select an integration" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ldapLoginOptions.map((option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   {domainForm.formState.errors.organisationSlug && (
                     <p className="text-xs text-destructive">{domainForm.formState.errors.organisationSlug.message}</p>
                   )}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { LoginForm } from './login-form'
-import { hasLdapLoginEnabled } from '@/lib/actions/ldap'
+import { getLdapLoginOptions } from '@/lib/actions/ldap'
 import { getInviteAcceptPath } from '@/lib/auth/invite-redirects'
 import {
   getAuthenticatedRedirectPath,
@@ -41,12 +41,12 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     if (redirectPath) redirect(redirectPath)
   }
 
-  const ldapEnabled = await hasLdapLoginEnabled()
+  const ldapLoginOptions = await getLdapLoginOptions()
   const resetComplete = readParam(params.reset) === '1'
 
   return (
     <LoginForm
-      ldapLoginEnabled={ldapEnabled}
+      ldapLoginOptions={ldapLoginOptions}
       inviteToken={inviteToken}
       notice={resetComplete ? 'Your password has been reset. Sign in with your new password.' : null}
     />

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -5,13 +5,17 @@ import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/ac
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
-import { ldapConfigurations } from '@/lib/db/schema'
+import { ldapConfigurations, organisations } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
 import { encrypt, decrypt } from '@/lib/crypto/encrypt'
 import {
   sanitiseLdapConfigurationForClient,
   type LdapConfigurationSafe,
 } from '@/lib/ldap/config-client'
+import {
+  buildLdapLoginOptions,
+  type LdapLoginOption,
+} from '@/lib/auth/ldap-login-options'
 import { testConnection as ldapTestConnection, searchUsers, lookupUserByDn, escapeLdapFilterValue } from '@/lib/ldap/client'
 import type { LdapUser, LdapUserDetail } from '@/lib/ldap/client'
 
@@ -352,4 +356,25 @@ export async function hasLdapLoginEnabled(): Promise<boolean> {
     columns: { id: true },
   })
   return config != null
+}
+
+export async function getLdapLoginOptions(): Promise<LdapLoginOption[]> {
+  const rows = await db
+    .select({
+      ldapConfigurationId: ldapConfigurations.id,
+      ldapConfigurationName: ldapConfigurations.name,
+      organisationName: organisations.name,
+      organisationSlug: organisations.slug,
+    })
+    .from(ldapConfigurations)
+    .innerJoin(organisations, eq(ldapConfigurations.organisationId, organisations.id))
+    .where(and(
+      eq(ldapConfigurations.enabled, true),
+      eq(ldapConfigurations.allowLogin, true),
+      isNull(ldapConfigurations.deletedAt),
+      isNull(organisations.deletedAt),
+    ))
+    .orderBy(organisations.name, ldapConfigurations.name)
+
+  return buildLdapLoginOptions(rows)
 }

--- a/apps/web/lib/auth/ldap-login-options.test.mjs
+++ b/apps/web/lib/auth/ldap-login-options.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildLdapLoginOptions } from './ldap-login-options.ts'
+
+test('buildLdapLoginOptions uses the integration name when an organisation has one login integration', () => {
+  assert.deepEqual(
+    buildLdapLoginOptions([
+      {
+        ldapConfigurationId: 'ldap_ctops',
+        ldapConfigurationName: 'ctops',
+        organisationName: 'CT-Ops',
+        organisationSlug: 'ct-ops',
+      },
+    ]),
+    [
+      {
+        id: 'ldap_ctops',
+        organisationSlug: 'ct-ops',
+        label: 'ctops',
+      },
+    ],
+  )
+})
+
+test('buildLdapLoginOptions returns each login integration as a selectable option', () => {
+  assert.deepEqual(
+    buildLdapLoginOptions([
+      {
+        ldapConfigurationId: 'ldap_primary',
+        ldapConfigurationName: 'Primary AD',
+        organisationName: 'Carrtech',
+        organisationSlug: 'carrtech',
+      },
+      {
+        ldapConfigurationId: 'ldap_backup',
+        ldapConfigurationName: 'Backup AD',
+        organisationName: 'Carrtech',
+        organisationSlug: 'carrtech',
+      },
+    ]),
+    [
+      {
+        id: 'ldap_primary',
+        organisationSlug: 'carrtech',
+        label: 'Primary AD',
+      },
+      {
+        id: 'ldap_backup',
+        organisationSlug: 'carrtech',
+        label: 'Backup AD',
+      },
+    ],
+  )
+})
+
+test('buildLdapLoginOptions disambiguates duplicate integration names', () => {
+  assert.deepEqual(
+    buildLdapLoginOptions([
+      {
+        ldapConfigurationId: 'ldap_acme',
+        ldapConfigurationName: 'Primary AD',
+        organisationName: 'Acme',
+        organisationSlug: 'acme',
+      },
+      {
+        ldapConfigurationId: 'ldap_beta',
+        ldapConfigurationName: 'Primary AD',
+        organisationName: 'Beta',
+        organisationSlug: 'beta',
+      },
+    ]),
+    [
+      {
+        id: 'ldap_acme',
+        organisationSlug: 'acme',
+        label: 'Primary AD (Acme)',
+      },
+      {
+        id: 'ldap_beta',
+        organisationSlug: 'beta',
+        label: 'Primary AD (Beta)',
+      },
+    ],
+  )
+})

--- a/apps/web/lib/auth/ldap-login-options.ts
+++ b/apps/web/lib/auth/ldap-login-options.ts
@@ -1,0 +1,31 @@
+export type LdapLoginOption = {
+  id: string
+  organisationSlug: string
+  label: string
+}
+
+export type LdapLoginOptionRow = {
+  ldapConfigurationId: string
+  ldapConfigurationName: string
+  organisationName: string
+  organisationSlug: string
+}
+
+export function buildLdapLoginOptions(rows: readonly LdapLoginOptionRow[]): LdapLoginOption[] {
+  const nameCounts = new Map<string, number>()
+
+  for (const row of rows) {
+    nameCounts.set(row.ldapConfigurationName, (nameCounts.get(row.ldapConfigurationName) ?? 0) + 1)
+  }
+
+  return rows.map((row) => {
+    const hasDuplicateName = (nameCounts.get(row.ldapConfigurationName) ?? 0) > 1
+    return {
+      id: row.ldapConfigurationId,
+      organisationSlug: row.organisationSlug,
+      label: hasDuplicateName
+        ? `${row.ldapConfigurationName} (${row.organisationName})`
+        : row.ldapConfigurationName,
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- replace the LDAP login organisation slug text field with a dropdown of enabled web-login LDAP integrations
- submit the selected integration's organisation slug internally so LDAP auth still uses tenant-scoped backend checks
- add unit coverage for LDAP login option labels and duplicate integration-name disambiguation

## Validation
- node --experimental-strip-types --test lib/auth/ldap-login-options.test.mjs lib/auth/ldap-tenant.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings outside this change)