### PR TITLE
fix(ldap): support UPN login search

### DIFF
--- a/apps/web/lib/ldap/auth-filter.ts
+++ b/apps/web/lib/ldap/auth-filter.ts
@@ -1,0 +1,31 @@
+// RFC 4515 §3: escape special characters before interpolating user input into LDAP filters.
+export function escapeLdapFilterValue(value: string): string {
+  return value
+    .replace(/\\/g, '\\5c')
+    .replace(/\*/g, '\\2a')
+    .replace(/\(/g, '\\28')
+    .replace(/\)/g, '\\29')
+    .replace(/\0/g, '\\00')
+}
+
+function interpolateUsernameFilter(filter: string, username: string): string {
+  return filter.replace('{{username}}', escapeLdapFilterValue(username))
+}
+
+export function buildAuthenticateUserSearchFilter(
+  configuredFilter: string,
+  username: string,
+): string {
+  const filters = [
+    interpolateUsernameFilter(configuredFilter, username),
+  ]
+
+  const atIndex = username.indexOf('@')
+  if (atIndex > 0 && atIndex < username.length - 1) {
+    filters.push(`(userPrincipalName=${escapeLdapFilterValue(username)})`)
+    filters.push(interpolateUsernameFilter(configuredFilter, username.slice(0, atIndex)))
+  }
+
+  const uniqueFilters = [...new Set(filters)]
+  return uniqueFilters.length === 1 ? uniqueFilters[0]! : `(|${uniqueFilters.join('')})`
+}

--- a/apps/web/lib/ldap/client-auth-filter.test.mjs
+++ b/apps/web/lib/ldap/client-auth-filter.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildAuthenticateUserSearchFilter } from './auth-filter.ts'
+
+test('buildAuthenticateUserSearchFilter preserves the configured username filter', () => {
+  assert.equal(
+    buildAuthenticateUserSearchFilter('(sAMAccountName={{username}})', 'simon.carr'),
+    '(sAMAccountName=simon.carr)',
+  )
+})
+
+test('buildAuthenticateUserSearchFilter allows Active Directory UPN logins', () => {
+  assert.equal(
+    buildAuthenticateUserSearchFilter('(sAMAccountName={{username}})', 'simon.carr@carrtech.local'),
+    '(|(sAMAccountName=simon.carr@carrtech.local)(userPrincipalName=simon.carr@carrtech.local)(sAMAccountName=simon.carr))',
+  )
+})
+
+test('buildAuthenticateUserSearchFilter escapes UPN local parts before interpolation', () => {
+  assert.equal(
+    buildAuthenticateUserSearchFilter('(sAMAccountName={{username}})', 'sim(on)*@carrtech.local'),
+    '(|(sAMAccountName=sim\\28on\\29\\2a@carrtech.local)(userPrincipalName=sim\\28on\\29\\2a@carrtech.local)(sAMAccountName=sim\\28on\\29\\2a))',
+  )
+})

--- a/apps/web/lib/ldap/client.ts
+++ b/apps/web/lib/ldap/client.ts
@@ -2,6 +2,7 @@ import { Client } from 'ldapts'
 import { decrypt } from '@/lib/crypto/encrypt'
 import type { LdapConfiguration } from '@/lib/db/schema'
 import { getTlsOptions } from './tls-options'
+import { buildAuthenticateUserSearchFilter } from './auth-filter'
 
 export interface LdapUser {
   dn: string
@@ -16,15 +17,7 @@ export interface LdapUser {
   passwordLastChangedAt?: Date | null
 }
 
-// RFC 4515 §3: escape special characters before interpolating user input into LDAP filters.
-export function escapeLdapFilterValue(value: string): string {
-  return value
-    .replace(/\\/g, '\\5c')
-    .replace(/\*/g, '\\2a')
-    .replace(/\(/g, '\\28')
-    .replace(/\)/g, '\\29')
-    .replace(/\0/g, '\\00')
-}
+export { escapeLdapFilterValue } from './auth-filter'
 
 function safeDecrypt(value: string): string {
   try { return decrypt(value) } catch { return value }
@@ -316,7 +309,7 @@ export async function authenticateUser(
 
     const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
 
-    const searchFilter = config.userSearchFilter.replace('{{username}}', escapeLdapFilterValue(username))
+    const searchFilter = buildAuthenticateUserSearchFilter(config.userSearchFilter, username)
 
     const { searchEntries } = await client.search(searchBase, {
       filter: searchFilter,


### PR DESCRIPTION
## Summary
- build LDAP auth search filters through a pure helper that keeps RFC 4515 escaping centralized
- when a username is entered as a UPN, search by the configured username filter, userPrincipalName, and the UPN local part
- add unit coverage for short-name, UPN, and escaped UPN-local-part filter construction

## Validation
- node --experimental-strip-types --test lib/ldap/client-auth-filter.test.mjs lib/ldap/tls-options.test.mjs lib/auth/ldap-tenant.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings outside this change)

## Live LDAP smoke test
- verified the provided AD test account can bind over LDAPS using both UPN and NETBIOS forms
- verified the configured OU/search filters find test.account and simon.carr by short name and UPN
- verified search result DN bind succeeds for the provided test account
