### PR TITLE
fix(auth): align LDAP session cookie with secure auth URL

### DIFF
--- a/apps/web/app/api/auth/ldap/route.ts
+++ b/apps/web/app/api/auth/ldap/route.ts
@@ -7,9 +7,13 @@ import { authenticateUser } from '@/lib/ldap/client'
 import { createId } from '@paralleldrive/cuid2'
 import { randomBytes } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
-import { getBetterAuthSecret } from '@/lib/auth/env'
+import { getBetterAuthSecret, getBetterAuthUrl } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
-import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
+import {
+  getBetterAuthSessionCookieName,
+  makeSessionCookieValue,
+  shouldUseSecureSessionCookie,
+} from '@/lib/auth/session-cookie'
 import { normalizeLdapTenantSlug } from '@/lib/auth/ldap-tenant'
 import { getClientIpFromHeaders } from '@/lib/client-ip'
 import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
@@ -60,6 +64,7 @@ export async function POST(request: NextRequest) {
     const tenantSlug = normalizeLdapTenantSlug(organisationSlug)
 
     const authSecret = getBetterAuthSecret()
+    const authUrl = getBetterAuthUrl()
 
     if (!username || !password) {
       return NextResponse.json({ error: 'Username and password are required' }, { status: 400 })
@@ -240,6 +245,8 @@ export async function POST(request: NextRequest) {
       })
 
       const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
+      const cookieName = getBetterAuthSessionCookieName(authUrl)
+      const secureCookie = shouldUseSecureSessionCookie(authUrl)
 
       const response = NextResponse.json({
         success: true,
@@ -253,7 +260,7 @@ export async function POST(request: NextRequest) {
       // Set the cookie with an already-encoded value (Next.js would double-encode otherwise).
       response.headers.append(
         'Set-Cookie',
-        `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
+        `${cookieName}=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${secureCookie ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
       )
 
       await passwordLoginAttemptGuard.reset(accountKey)

--- a/apps/web/app/api/auth/ldap/verify/route.ts
+++ b/apps/web/app/api/auth/ldap/verify/route.ts
@@ -5,9 +5,13 @@ import { sessions, totpCredentials, users, verifications } from '@/lib/db/schema
 import { eq } from 'drizzle-orm'
 import { randomBytes } from 'crypto'
 import { createRateLimiter } from '@/lib/rate-limit'
-import { getBetterAuthSecret } from '@/lib/auth/env'
+import { getBetterAuthSecret, getBetterAuthUrl } from '@/lib/auth/env'
 import { passwordLoginAttemptGuard } from '@/lib/auth/login-attempts'
-import { makeSessionCookieValue } from '@/lib/auth/session-cookie'
+import {
+  getBetterAuthSessionCookieName,
+  makeSessionCookieValue,
+  shouldUseSecureSessionCookie,
+} from '@/lib/auth/session-cookie'
 import { assertUserCanAccessSeat, SeatAdmissionError } from '@/lib/seat-admission'
 import { getClientIpFromHeaders } from '@/lib/client-ip'
 import {
@@ -54,6 +58,7 @@ export async function POST(request: NextRequest) {
     const twoFactorMethod = body.twoFactorMethod
 
     const authSecret = getBetterAuthSecret()
+    const authUrl = getBetterAuthUrl()
     const signedChallengeCookie = request.cookies.get(LDAP_TWO_FACTOR_COOKIE_NAME)?.value
     const challengeId = await readSignedLdapTwoFactorCookieValue(signedChallengeCookie, authSecret)
 
@@ -158,6 +163,8 @@ export async function POST(request: NextRequest) {
     })
 
     const cookieValue = await makeSessionCookieValue(sessionToken, authSecret)
+    const cookieName = getBetterAuthSessionCookieName(authUrl)
+    const secureCookie = shouldUseSecureSessionCookie(authUrl)
     await db.delete(verifications).where(eq(verifications.identifier, challengeId))
     await passwordLoginAttemptGuard.reset(challenge.username)
 
@@ -172,7 +179,7 @@ export async function POST(request: NextRequest) {
 
     response.headers.append(
       'Set-Cookie',
-      `better-auth.session_token=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${process.env.NODE_ENV === 'production' ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
+      `${cookieName}=${cookieValue}; Path=/; HttpOnly; SameSite=Lax${secureCookie ? '; Secure' : ''}; Expires=${expiresAt.toUTCString()}`,
     )
     response.cookies.set(LDAP_TWO_FACTOR_COOKIE_NAME, '', {
       path: '/',

--- a/apps/web/lib/auth/session-cookie.test.mjs
+++ b/apps/web/lib/auth/session-cookie.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  getBetterAuthSessionCookieName,
+  shouldUseSecureSessionCookie,
+} from './session-cookie.ts'
+
+test('manual session cookies use Better Auth secure prefix for HTTPS deployments', () => {
+  assert.equal(shouldUseSecureSessionCookie('https://ct-ops/api/auth', 'development'), true)
+  assert.equal(getBetterAuthSessionCookieName('https://ct-ops/api/auth', 'development'), '__Secure-better-auth.session_token')
+})
+
+test('manual session cookies keep the local development cookie name for HTTP', () => {
+  assert.equal(shouldUseSecureSessionCookie('http://localhost:3000/api/auth', 'development'), false)
+  assert.equal(getBetterAuthSessionCookieName('http://localhost:3000/api/auth', 'development'), 'better-auth.session_token')
+})
+
+test('manual session cookies are secure in production even when URL parsing is unavailable', () => {
+  assert.equal(shouldUseSecureSessionCookie('http://ct-ops/api/auth', 'production'), true)
+  assert.equal(getBetterAuthSessionCookieName('http://ct-ops/api/auth', 'production'), '__Secure-better-auth.session_token')
+})

--- a/apps/web/lib/auth/session-cookie.ts
+++ b/apps/web/lib/auth/session-cookie.ts
@@ -14,3 +14,12 @@ export async function makeSessionCookieValue(token: string, secret: string): Pro
   const base64Sig = btoa(String.fromCharCode(...new Uint8Array(sig)))
   return encodeURIComponent(`${token}.${base64Sig}`)
 }
+
+export function shouldUseSecureSessionCookie(authUrl: string, nodeEnv = process.env.NODE_ENV): boolean {
+  return authUrl.startsWith('https://') || nodeEnv === 'production'
+}
+
+export function getBetterAuthSessionCookieName(authUrl: string, nodeEnv = process.env.NODE_ENV): string {
+  const securePrefix = shouldUseSecureSessionCookie(authUrl, nodeEnv) ? '__Secure-' : ''
+  return `${securePrefix}better-auth.session_token`
+}


### PR DESCRIPTION
## Summary
- set LDAP-created Better Auth session cookies with the secure-prefixed cookie name when BETTER_AUTH_URL is HTTPS
- apply the same behavior to LDAP two-factor completion
- add unit coverage for HTTP, HTTPS, and production cookie naming

## Validation
- node --experimental-strip-types --test apps/web/lib/auth/session-cookie.test.mjs apps/web/lib/auth/session-cookie-names.test.mjs
- pnpm --filter web type-check
- node --experimental-strip-types --test apps/web/lib/auth/*.test.mjs