### PR TITLE
fix(profile): derive updates from session

### DIFF
--- a/apps/web/app/(dashboard)/profile/profile-client.tsx
+++ b/apps/web/app/(dashboard)/profile/profile-client.tsx
@@ -101,7 +101,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
   })
 
   const notifMutation = useMutation({
-    mutationFn: (enabled: boolean) => updateNotificationPreference(user.id, orgId, enabled),
+    mutationFn: (enabled: boolean) => updateNotificationPreference(enabled),
     onSuccess: (result) => {
       if ('error' in result) {
         setNotifError(result.error)
@@ -124,7 +124,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
   })
 
   const nameMutation = useMutation({
-    mutationFn: (values: NameValues) => updateName(user.id, values.name),
+    mutationFn: (values: NameValues) => updateName(values.name),
     onSuccess: (result) => {
       if ('error' in result) {
         nameForm.setError('name', { message: result.error })
@@ -549,7 +549,7 @@ export function ProfileClient({ user, orgId }: ProfileClientProps) {
                     setCurrentTheme(option.value)
                     applyTheme(option.value)
                     setThemeSaving(true)
-                    await updateTheme(user.id, option.value)
+                    await updateTheme(option.value)
                     setThemeSaving(false)
                   }}
                   className={`flex flex-col items-center gap-2 rounded-lg border px-5 py-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 ${

--- a/apps/web/app/(setup)/setup-email/page.tsx
+++ b/apps/web/app/(setup)/setup-email/page.tsx
@@ -21,5 +21,5 @@ export default async function SetupEmailPage() {
 
   if (!user || !user.email.endsWith('@ldap.local')) redirect('/dashboard')
 
-  return <SetupEmailForm userId={user.id} username={user.name} />
+  return <SetupEmailForm username={user.name} />
 }

--- a/apps/web/app/(setup)/setup-email/setup-email-form.tsx
+++ b/apps/web/app/(setup)/setup-email/setup-email-form.tsx
@@ -22,11 +22,10 @@ const emailSchema = z.object({
 type EmailValues = z.infer<typeof emailSchema>
 
 interface SetupEmailFormProps {
-  userId: string
   username: string
 }
 
-export function SetupEmailForm({ userId, username }: SetupEmailFormProps) {
+export function SetupEmailForm({ username }: SetupEmailFormProps) {
   const router = useRouter()
   const [serverError, setServerError] = useState<string | null>(null)
 
@@ -39,7 +38,7 @@ export function SetupEmailForm({ userId, username }: SetupEmailFormProps) {
   })
 
   const { mutate, isPending } = useMutation({
-    mutationFn: (values: EmailValues) => updateEmail(userId, values.email),
+    mutationFn: (values: EmailValues) => updateEmail(values.email),
     onSuccess: (result) => {
       if ('error' in result) {
         setServerError(result.error)

--- a/apps/web/lib/actions/profile-authz.test.mjs
+++ b/apps/web/lib/actions/profile-authz.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const profileSource = readFileSync(path.join(here, 'profile.ts'), 'utf8')
+
+function getActionSegment(action) {
+  const start = profileSource.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist`)
+  const next = profileSource.indexOf('\nexport async function ', start + 1)
+  return profileSource.slice(start, next === -1 ? undefined : next)
+}
+
+test('profile self-service actions derive the target user from the authenticated session', () => {
+  for (const action of ['updateName', 'updateEmail', 'updateTheme']) {
+    const segment = getActionSegment(action)
+    const signature = segment.slice(0, segment.indexOf('): Promise'))
+
+    assert.doesNotMatch(
+      signature,
+      /\buserId\s*:/,
+      `${action} must not accept a caller-controlled userId`,
+    )
+    assert.match(
+      segment,
+      /const session = await getRequiredSession\(\)/,
+      `${action} must authenticate and load the session`,
+    )
+    assert.match(
+      segment,
+      /session\.user\.id/,
+      `${action} must update the authenticated session user`,
+    )
+  }
+})
+
+test('notification preference action derives user and organisation from the authenticated session', () => {
+  const segment = getActionSegment('updateNotificationPreference')
+  const signature = segment.slice(0, segment.indexOf('): Promise'))
+
+  assert.doesNotMatch(
+    signature,
+    /\b(?:userId|orgId)\s*:/,
+    'updateNotificationPreference must not accept caller-controlled userId or orgId',
+  )
+  assert.match(
+    segment,
+    /const session = await getRequiredSession\(\)/,
+    'updateNotificationPreference must authenticate and load the session',
+  )
+  assert.match(
+    segment,
+    /session\.user\.id/,
+    'updateNotificationPreference must update the authenticated session user',
+  )
+  assert.match(
+    segment,
+    /session\.user\.organisationId/,
+    'updateNotificationPreference must read organisation policy from the authenticated session organisation',
+  )
+})

--- a/apps/web/lib/actions/profile.ts
+++ b/apps/web/lib/actions/profile.ts
@@ -8,25 +8,25 @@ import { eq } from 'drizzle-orm'
 import { headers, cookies } from 'next/headers'
 import { getBetterAuthOrigin } from '@/lib/auth/env'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
+import { getRequiredSession } from '@/lib/auth/session'
 
 const updateNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
 })
 
-export async function updateName(
-  userId: string,
-  name: string,
-): Promise<{ success: true } | { error: string }> {
+export async function updateName(name: string): Promise<{ success: true } | { error: string }> {
   const parsed = updateNameSchema.safeParse({ name })
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid name' }
   }
 
+  const session = await getRequiredSession()
+
   try {
     await db
       .update(users)
       .set({ name: parsed.data.name, updatedAt: new Date() })
-      .where(eq(users.id, userId))
+      .where(eq(users.id, session.user.id))
 
     return { success: true }
   } catch (err) {
@@ -42,27 +42,26 @@ const updateEmailSchema = z.object({
     .refine((e) => !e.endsWith('@ldap.local'), 'Please enter a real email address'),
 })
 
-export async function updateEmail(
-  userId: string,
-  email: string,
-): Promise<{ success: true } | { error: string }> {
+export async function updateEmail(email: string): Promise<{ success: true } | { error: string }> {
   const parsed = updateEmailSchema.safeParse({ email })
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid email' }
   }
 
+  const session = await getRequiredSession()
+
   try {
     const existing = await db.query.users.findFirst({
       where: eq(users.email, parsed.data.email),
     })
-    if (existing && existing.id !== userId) {
+    if (existing && existing.id !== session.user.id) {
       return { error: 'This email address is already in use' }
     }
 
     await db
       .update(users)
       .set({ email: parsed.data.email, updatedAt: new Date() })
-      .where(eq(users.id, userId))
+      .where(eq(users.id, session.user.id))
 
     return { success: true }
   } catch (err) {
@@ -73,20 +72,19 @@ export async function updateEmail(
 
 const themeSchema = z.enum(['light', 'dark', 'system'])
 
-export async function updateTheme(
-  userId: string,
-  theme: string,
-): Promise<{ success: true } | { error: string }> {
+export async function updateTheme(theme: string): Promise<{ success: true } | { error: string }> {
   const parsed = themeSchema.safeParse(theme)
   if (!parsed.success) {
     return { error: 'Invalid theme value' }
   }
 
+  const session = await getRequiredSession()
+
   try {
     await db
       .update(users)
       .set({ theme: parsed.data, updatedAt: new Date() })
-      .where(eq(users.id, userId))
+      .where(eq(users.id, session.user.id))
 
     const cookieStore = await cookies()
     cookieStore.set('theme', parsed.data, {
@@ -103,11 +101,13 @@ export async function updateTheme(
   }
 }
 
-export async function updateNotificationPreference(
-  userId: string,
-  orgId: string,
-  enabled: boolean,
-): Promise<{ success: true } | { error: string }> {
+export async function updateNotificationPreference(enabled: boolean): Promise<{ success: true } | { error: string }> {
+  const session = await getRequiredSession()
+  const orgId = session.user.organisationId
+  if (!orgId) {
+    return { error: 'Organisation context is required' }
+  }
+
   // Check whether the org allows users to opt out
   const org = await db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
@@ -124,7 +124,7 @@ export async function updateNotificationPreference(
     await db
       .update(users)
       .set({ notificationsEnabled: enabled, updatedAt: new Date() })
-      .where(eq(users.id, userId))
+      .where(eq(users.id, session.user.id))
     return { success: true }
   } catch {
     return { error: 'Failed to update notification preference' }


### PR DESCRIPTION
## Summary
- derive profile name, email, theme, and notification preference mutations from `getRequiredSession()`
- remove caller-supplied user/org identifiers from profile client and setup-email calls
- add profile action guard tests so self-service updates cannot regain client-controlled identity parameters

Fixes #1112

## Tests
- `pnpm --dir apps/web exec node --experimental-strip-types --test lib/actions/profile-authz.test.mjs`
- `pnpm --dir apps/web exec node --experimental-strip-types --test 'lib/actions/*.test.mjs'`\n- `pnpm --dir apps/web type-check`\n- `pnpm --dir apps/web lint` (passes with existing warnings)\n\n## Notes\n- Full `pnpm --dir apps/web test:unit` is not clean locally: known unrelated `binary-integrity` failure plus Testcontainers failures because no container runtime is available.