### PR TITLE
fix(terminal): throttle ssh authentication attempts

### DIFF
--- a/apps/ingest/internal/db/queries/terminal_sessions.sql.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions.sql.go
@@ -2,17 +2,25 @@ package queries
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TerminalSessionInfo is returned after validating and activating a terminal session.
 type TerminalSessionInfo struct {
 	OrganisationID string
+	UserID         string
 	HostID         string
 	Host           string
 	Username       string
@@ -42,7 +50,8 @@ func ValidateAndActivateTerminalSession(ctx context.Context, pool *pgxpool.Pool,
 		  AND h.id                = ts.host_id
 		  AND h.organisation_id   = ts.organisation_id
 		  AND h.deleted_at        IS NULL
-		RETURNING ts.organisation_id, ts.host_id,
+			RETURNING ts.organisation_id, ts.host_id,
+		          ts.user_id,
 		          COALESCE(NULLIF(h.hostname, ''), h.ip_addresses->>0) AS host,
 		          COALESCE(ts.username, '') AS username,
 		          COALESCE((o.metadata->>'terminalLoggingEnabled')::boolean, false) AS logging_enabled
@@ -51,6 +60,7 @@ func ValidateAndActivateTerminalSession(ctx context.Context, pool *pgxpool.Pool,
 	err := pool.QueryRow(ctx, q, sessionID, tokenHash).Scan(
 		&info.OrganisationID,
 		&info.HostID,
+		&info.UserID,
 		&info.Host,
 		&info.Username,
 		&info.LoggingEnabled,
@@ -59,6 +69,284 @@ func ValidateAndActivateTerminalSession(ctx context.Context, pool *pgxpool.Pool,
 		return nil, fmt.Errorf("terminal session not found or expired: %w", err)
 	}
 	return &info, nil
+}
+
+const (
+	terminalAuthWindow      = 15 * time.Minute
+	terminalAuthMaxFailures = 5
+	terminalAuthBaseLockout = 5 * time.Minute
+	terminalAuthMaxLockout  = time.Hour
+)
+
+type TerminalAuthThrottleStatus struct {
+	Allowed    bool
+	RetryAfter time.Duration
+
+	state terminalAuthThrottleState
+}
+
+type terminalAuthThrottleKey struct {
+	scope string
+	key   string
+}
+
+type terminalAuthThrottleState struct {
+	hits         []time.Time
+	lockoutLevel int
+	lockedUntil  time.Time
+}
+
+// CheckTerminalAuthThrottle verifies that another SSH password attempt is
+// currently allowed for both user/host/username and source/host/username
+// scopes. It also persists pruning of expired failure windows.
+func CheckTerminalAuthThrottle(ctx context.Context, pool *pgxpool.Pool, info TerminalSessionInfo, source string) (TerminalAuthThrottleStatus, error) {
+	return mutateTerminalAuthThrottle(ctx, pool, info, source, applyTerminalAuthCheck)
+}
+
+// RecordTerminalAuthFailure records a failed SSH password attempt in durable
+// throttle state and returns whether subsequent attempts remain allowed.
+func RecordTerminalAuthFailure(ctx context.Context, pool *pgxpool.Pool, info TerminalSessionInfo, source string) (TerminalAuthThrottleStatus, error) {
+	return mutateTerminalAuthThrottle(ctx, pool, info, source, applyTerminalAuthFailure)
+}
+
+// ResetTerminalAuthThrottle clears failure counters after a successful SSH
+// authentication so a past typo does not keep penalising legitimate use.
+func ResetTerminalAuthThrottle(ctx context.Context, pool *pgxpool.Pool, info TerminalSessionInfo, source string) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	for _, key := range terminalAuthThrottleKeys(info, source) {
+		if _, err := tx.Exec(ctx, `DELETE FROM security_throttles WHERE scope = $1 AND key = $2`, key.scope, key.key); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func mutateTerminalAuthThrottle(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	info TerminalSessionInfo,
+	source string,
+	apply func(terminalAuthThrottleState, time.Time) TerminalAuthThrottleStatus,
+) (TerminalAuthThrottleStatus, error) {
+	keys := terminalAuthThrottleKeys(info, source)
+	if len(keys) == 0 {
+		return TerminalAuthThrottleStatus{Allowed: true}, nil
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return TerminalAuthThrottleStatus{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	now := time.Now().UTC()
+	result := TerminalAuthThrottleStatus{Allowed: true}
+	for _, key := range keys {
+		state, err := loadTerminalAuthThrottleState(ctx, tx, key)
+		if err != nil {
+			return TerminalAuthThrottleStatus{}, err
+		}
+
+		status := apply(state, now)
+		if err := storeTerminalAuthThrottleState(ctx, tx, key, status.state); err != nil {
+			return TerminalAuthThrottleStatus{}, err
+		}
+		if !status.Allowed && (result.Allowed || status.RetryAfter > result.RetryAfter) {
+			result = TerminalAuthThrottleStatus{Allowed: false, RetryAfter: status.RetryAfter}
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return TerminalAuthThrottleStatus{}, err
+	}
+	return result, nil
+}
+
+type terminalThrottleTx interface {
+	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
+	QueryRow(context.Context, string, ...interface{}) pgx.Row
+}
+
+func loadTerminalAuthThrottleState(ctx context.Context, tx terminalThrottleTx, key terminalAuthThrottleKey) (terminalAuthThrottleState, error) {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO security_throttles (scope, key, hits, lockout_level)
+		VALUES ($1, $2, '[]'::jsonb, 0)
+		ON CONFLICT (scope, key) DO NOTHING
+	`, key.scope, key.key); err != nil {
+		return terminalAuthThrottleState{}, err
+	}
+
+	var hitsText string
+	var lockoutLevel int
+	var lockedUntil *time.Time
+	if err := tx.QueryRow(ctx, `
+		SELECT hits::text, lockout_level, locked_until
+		FROM security_throttles
+		WHERE scope = $1 AND key = $2
+		FOR UPDATE
+	`, key.scope, key.key).Scan(&hitsText, &lockoutLevel, &lockedUntil); err != nil {
+		return terminalAuthThrottleState{}, err
+	}
+
+	var rawHits []int64
+	if err := json.Unmarshal([]byte(hitsText), &rawHits); err != nil {
+		rawHits = nil
+	}
+	hits := make([]time.Time, 0, len(rawHits))
+	for _, hit := range rawHits {
+		if hit > 0 {
+			hits = append(hits, time.UnixMilli(hit).UTC())
+		}
+	}
+
+	state := terminalAuthThrottleState{
+		hits:         hits,
+		lockoutLevel: lockoutLevel,
+	}
+	if lockedUntil != nil {
+		state.lockedUntil = lockedUntil.UTC()
+	}
+	return state, nil
+}
+
+func storeTerminalAuthThrottleState(ctx context.Context, tx terminalThrottleTx, key terminalAuthThrottleKey, state terminalAuthThrottleState) error {
+	rawHits := make([]int64, 0, len(state.hits))
+	for _, hit := range state.hits {
+		rawHits = append(rawHits, hit.UTC().UnixMilli())
+	}
+	hitsJSON, err := json.Marshal(rawHits)
+	if err != nil {
+		return err
+	}
+
+	var lockedUntil any
+	if !state.lockedUntil.IsZero() {
+		lockedUntil = state.lockedUntil.UTC()
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE security_throttles
+		SET hits = $3::jsonb,
+		    lockout_level = $4,
+		    locked_until = $5,
+		    updated_at = NOW()
+		WHERE scope = $1 AND key = $2
+	`, key.scope, key.key, string(hitsJSON), state.lockoutLevel, lockedUntil)
+	return err
+}
+
+func applyTerminalAuthCheck(state terminalAuthThrottleState, now time.Time) TerminalAuthThrottleStatus {
+	state.hits = pruneTerminalAuthHits(state.hits, now)
+	if !state.lockedUntil.IsZero() && state.lockedUntil.After(now) {
+		return TerminalAuthThrottleStatus{
+			Allowed:    false,
+			RetryAfter: state.lockedUntil.Sub(now),
+			state:      state,
+		}
+	}
+	state.lockedUntil = time.Time{}
+	return TerminalAuthThrottleStatus{Allowed: true, state: state}
+}
+
+func applyTerminalAuthFailure(state terminalAuthThrottleState, now time.Time) TerminalAuthThrottleStatus {
+	state = applyTerminalAuthCheck(state, now).state
+	if !state.lockedUntil.IsZero() && state.lockedUntil.After(now) {
+		return TerminalAuthThrottleStatus{
+			Allowed:    false,
+			RetryAfter: state.lockedUntil.Sub(now),
+			state:      state,
+		}
+	}
+
+	state.hits = append(state.hits, now)
+	if len(state.hits) < terminalAuthMaxFailures {
+		return TerminalAuthThrottleStatus{Allowed: true, state: state}
+	}
+
+	state.hits = nil
+	state.lockoutLevel++
+	lockout := terminalAuthLockoutDuration(state.lockoutLevel)
+	state.lockedUntil = now.Add(lockout)
+	return TerminalAuthThrottleStatus{
+		Allowed:    false,
+		RetryAfter: lockout,
+		state:      state,
+	}
+}
+
+func terminalAuthLockoutDuration(lockoutLevel int) time.Duration {
+	if lockoutLevel <= 1 {
+		return terminalAuthBaseLockout
+	}
+	lockout := terminalAuthBaseLockout
+	for i := 1; i < lockoutLevel; i++ {
+		if lockout >= terminalAuthMaxLockout/2 {
+			return terminalAuthMaxLockout
+		}
+		lockout *= 2
+	}
+	if lockout > terminalAuthMaxLockout {
+		return terminalAuthMaxLockout
+	}
+	return lockout
+}
+
+func pruneTerminalAuthHits(hits []time.Time, now time.Time) []time.Time {
+	cutoff := now.Add(-terminalAuthWindow)
+	pruned := hits[:0]
+	for _, hit := range hits {
+		if hit.After(cutoff) {
+			pruned = append(pruned, hit)
+		}
+	}
+	return pruned
+}
+
+func terminalAuthThrottleKeys(info TerminalSessionInfo, source string) []terminalAuthThrottleKey {
+	username := strings.ToLower(strings.TrimSpace(info.Username))
+	if info.OrganisationID == "" || info.HostID == "" || username == "" {
+		return nil
+	}
+
+	keys := []terminalAuthThrottleKey{}
+	if info.UserID != "" {
+		keys = append(keys, terminalAuthThrottleKey{
+			scope: "terminal:ssh:user-host-username",
+			key:   terminalAuthThrottleKeyHash(info.OrganisationID, info.UserID, info.HostID, username),
+		})
+	}
+	keys = append(keys, terminalAuthThrottleKey{
+		scope: "terminal:ssh:source-host-username",
+		key:   terminalAuthThrottleKeyHash(info.OrganisationID, terminalAuthSource(source), info.HostID, username),
+	})
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].scope == keys[j].scope {
+			return keys[i].key < keys[j].key
+		}
+		return keys[i].scope < keys[j].scope
+	})
+	return keys
+}
+
+func terminalAuthSource(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "unknown"
+	}
+	if host, _, err := net.SplitHostPort(source); err == nil && host != "" {
+		return host
+	}
+	return source
+}
+
+func terminalAuthThrottleKeyHash(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:])
 }
 
 func VerifySSHHostKey(ctx context.Context, pool *pgxpool.Pool, hostID string, fingerprint string) error {

--- a/apps/ingest/internal/db/queries/terminal_sessions_test.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions_test.go
@@ -3,6 +3,7 @@ package queries
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestVerifySSHHostKeyFingerprintRejectsUnpinnedHosts(t *testing.T) {
@@ -80,6 +81,118 @@ func TestVerifySSHHostKeyMetadataBlocksWhenPendingChangeExists(t *testing.T) {
 	err := verifySSHHostKeyMetadata(metadata, "SHA256:old")
 	if !errors.Is(err, ErrSSHHostKeyMismatch) {
 		t.Fatalf("verifySSHHostKeyMetadata() error = %v, want ErrSSHHostKeyMismatch", err)
+	}
+}
+
+func TestTerminalAuthThrottleKeysIncludeUserHostUsernameAndSource(t *testing.T) {
+	info := TerminalSessionInfo{
+		OrganisationID: "org-1",
+		UserID:         "user-1",
+		HostID:         "host-1",
+		Username:       "Admin",
+	}
+
+	keys := terminalAuthThrottleKeys(info, "203.0.113.10")
+	if len(keys) != 2 {
+		t.Fatalf("terminalAuthThrottleKeys() length = %d, want 2", len(keys))
+	}
+
+	byScope := map[string]string{}
+	for _, key := range keys {
+		byScope[key.scope] = key.key
+	}
+	userKey := byScope["terminal:ssh:user-host-username"]
+	sourceKey := byScope["terminal:ssh:source-host-username"]
+	if userKey == "" {
+		t.Fatal("missing user-host-username throttle key")
+	}
+	if sourceKey == "" {
+		t.Fatal("missing source-host-username throttle key")
+	}
+	if userKey == sourceKey {
+		t.Fatal("expected distinct throttle keys for user and source scopes")
+	}
+}
+
+func TestTerminalAuthThrottleKeyNormalisesUsernameAndSource(t *testing.T) {
+	base := TerminalSessionInfo{
+		OrganisationID: "org-1",
+		UserID:         "user-1",
+		HostID:         "host-1",
+		Username:       "Admin",
+	}
+	upper := terminalAuthThrottleKeys(base, "203.0.113.10:49152")
+
+	base.Username = " admin "
+	lower := terminalAuthThrottleKeys(base, "203.0.113.10")
+
+	upperByScope := map[string]string{}
+	lowerByScope := map[string]string{}
+	for _, key := range upper {
+		upperByScope[key.scope] = key.key
+	}
+	for _, key := range lower {
+		lowerByScope[key.scope] = key.key
+	}
+
+	if upperByScope["terminal:ssh:user-host-username"] != lowerByScope["terminal:ssh:user-host-username"] {
+		t.Fatal("expected username case/space differences to map to the same user throttle key")
+	}
+	if upperByScope["terminal:ssh:source-host-username"] != lowerByScope["terminal:ssh:source-host-username"] {
+		t.Fatal("expected source host/port differences to map to the same source throttle key")
+	}
+}
+
+func TestApplyTerminalAuthFailureLocksAfterLimit(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	state := terminalAuthThrottleState{}
+
+	var status TerminalAuthThrottleStatus
+	for i := 0; i < terminalAuthMaxFailures; i++ {
+		status = applyTerminalAuthFailure(state, now)
+		state = status.state
+	}
+
+	if status.Allowed {
+		t.Fatal("expected terminal auth throttle to block after max failures")
+	}
+	if status.RetryAfter <= 0 {
+		t.Fatalf("RetryAfter = %v, want positive duration", status.RetryAfter)
+	}
+	if len(state.hits) != 0 {
+		t.Fatalf("state.hits length = %d, want reset after lockout", len(state.hits))
+	}
+	if state.lockoutLevel != 1 {
+		t.Fatalf("state.lockoutLevel = %d, want 1", state.lockoutLevel)
+	}
+	if !state.lockedUntil.After(now) {
+		t.Fatalf("state.lockedUntil = %v, want after %v", state.lockedUntil, now)
+	}
+}
+
+func TestTerminalAuthLockoutDurationCapsAtMaximum(t *testing.T) {
+	if got := terminalAuthLockoutDuration(32); got != terminalAuthMaxLockout {
+		t.Fatalf("terminalAuthLockoutDuration(32) = %v, want %v", got, terminalAuthMaxLockout)
+	}
+}
+
+func TestApplyTerminalAuthCheckPrunesExpiredLockout(t *testing.T) {
+	now := time.Unix(100, 0).UTC()
+	state := terminalAuthThrottleState{
+		hits:         []time.Time{now.Add(-terminalAuthWindow - time.Second), now.Add(-time.Minute)},
+		lockoutLevel: 1,
+		lockedUntil:  now.Add(-time.Second),
+	}
+
+	status := applyTerminalAuthCheck(state, now)
+	if !status.Allowed {
+		t.Fatal("expected expired lockout to allow a new attempt")
+	}
+	if len(status.state.hits) != 1 {
+		t.Fatalf("pruned hits length = %d, want 1", len(status.state.hits))
+	}
+	if !status.state.lockedUntil.IsZero() {
+		t.Fatalf("lockedUntil = %v, want zero after expiry", status.state.lockedUntil)
 	}
 }
 

--- a/apps/ingest/internal/handlers/terminal_ws.go
+++ b/apps/ingest/internal/handlers/terminal_ws.go
@@ -99,6 +99,20 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	source := terminalRemoteAddr(r.RemoteAddr)
+	throttleStatus, err := queries.CheckTerminalAuthThrottle(ctx, h.pool, *info, source)
+	if err != nil {
+		slog.Warn("terminal ws: auth throttle check failed", "session_id", sessionID, "host_id", info.HostID, "username", info.Username, "err", err)
+		writeWS(ctx, conn, wsMessage{Type: "error", Msg: "Unable to verify SSH authentication rate limits"})
+		return
+	}
+	if !throttleStatus.Allowed {
+		_ = queries.SetTerminalSessionError(context.Background(), h.pool, sessionID, "ssh authentication throttled")
+		slog.Warn("terminal ws: SSH authentication throttled", "session_id", sessionID, "host_id", info.HostID, "username", info.Username, "retry_after", throttleStatus.RetryAfter.String())
+		writeWS(ctx, conn, wsMessage{Type: "error", Msg: "Too many SSH authentication attempts. Try again later."})
+		return
+	}
+
 	slog.Info("terminal ws: opening SSH session", "session_id", sessionID, "host_id", info.HostID, "username", info.Username)
 	sshClient, sshSession, stdin, stdout, err := h.openSSHSession(ctx, info.HostID, info.Host, info.Username, authMsg.Password)
 	authMsg.Password = ""
@@ -109,10 +123,19 @@ func (h *TerminalWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, queries.ErrSSHHostKeyNotTrusted) || errors.Is(err, queries.ErrSSHHostKeyMismatch) {
 			reason = "ssh host key verification failed"
 			message = "SSH host key verification failed"
+		} else if isSSHAuthenticationFailure(err) {
+			if status, recordErr := queries.RecordTerminalAuthFailure(context.Background(), h.pool, *info, source); recordErr != nil {
+				slog.Warn("terminal ws: failed to record SSH authentication failure", "session_id", sessionID, "host_id", info.HostID, "username", info.Username, "err", recordErr)
+			} else if !status.Allowed {
+				slog.Warn("terminal ws: SSH authentication locked out", "session_id", sessionID, "host_id", info.HostID, "username", info.Username, "retry_after", status.RetryAfter.String())
+			}
 		}
 		_ = queries.SetTerminalSessionError(context.Background(), h.pool, sessionID, reason)
 		writeWS(ctx, conn, wsMessage{Type: "error", Msg: message})
 		return
+	}
+	if err := queries.ResetTerminalAuthThrottle(context.Background(), h.pool, *info, source); err != nil {
+		slog.Warn("terminal ws: failed to reset SSH auth throttle", "session_id", sessionID, "host_id", info.HostID, "username", info.Username, "err", err)
 	}
 	defer sshClient.Close()
 	defer sshSession.Close()
@@ -315,6 +338,23 @@ func (h *TerminalWSHandler) openSSHSession(ctx context.Context, hostID, host, us
 	}
 
 	return client, session, stdin, stdout, nil
+}
+
+func terminalRemoteAddr(remoteAddr string) string {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return "unknown"
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	return remoteAddr
+}
+
+func isSSHAuthenticationFailure(err error) bool {
+	var authErr *ssh.ServerAuthError
+	return errors.As(err, &authErr)
 }
 
 func writeWS(ctx context.Context, conn *websocket.Conn, msg wsMessage) error {

--- a/apps/ingest/internal/handlers/terminal_ws_security_test.go
+++ b/apps/ingest/internal/handlers/terminal_ws_security_test.go
@@ -1,12 +1,15 @@
 package handlers
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/crypto/ssh"
 )
 
 func TestTerminalWSAcceptOptionsDefaultToSameOrigin(t *testing.T) {
@@ -40,6 +43,24 @@ func TestTerminalWSAcceptOptionsAllowConfiguredOrigins(t *testing.T) {
 func TestTerminalWSAcceptOptionsRejectInvalidOrigins(t *testing.T) {
 	if _, err := terminalWSAcceptOptions([]string{"not-a-url"}); err == nil {
 		t.Fatal("expected invalid origin to be rejected")
+	}
+}
+
+func TestTerminalRemoteAddrNormalisesHostPort(t *testing.T) {
+	if got := terminalRemoteAddr("203.0.113.10:49152"); got != "203.0.113.10" {
+		t.Fatalf("terminalRemoteAddr() = %q, want source IP", got)
+	}
+	if got := terminalRemoteAddr("[2001:db8::1]:49152"); got != "2001:db8::1" {
+		t.Fatalf("terminalRemoteAddr() = %q, want IPv6 source", got)
+	}
+}
+
+func TestIsSSHAuthenticationFailure(t *testing.T) {
+	if !isSSHAuthenticationFailure(&ssh.ServerAuthError{}) {
+		t.Fatal("expected ssh.ServerAuthError to count as an authentication failure")
+	}
+	if isSSHAuthenticationFailure(errors.New("network unreachable")) {
+		t.Fatal("expected generic network errors not to count as authentication failures")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add durable terminal SSH authentication throttling using existing security_throttles storage
- enforce user/host/username and source/host/username lockouts before dialing SSH
- record SSH auth failures and clear throttle state after successful authentication

Fixes #970

## Tests
- go test ./apps/ingest/...
