### PR TITLE
fix(ldap): constrain detail lookup DNs

### DIFF
--- a/apps/web/lib/ldap/client.ts
+++ b/apps/web/lib/ldap/client.ts
@@ -3,6 +3,7 @@ import { decrypt } from '@/lib/crypto/encrypt'
 import type { LdapConfiguration } from '@/lib/db/schema'
 import { getTlsOptions } from './tls-options'
 import { buildAuthenticateUserSearchFilter } from './auth-filter'
+import { isDnWithinSearchBase, resolveSearchBase } from './dn-scope'
 
 export interface LdapUser {
   dn: string
@@ -47,14 +48,6 @@ async function connectAndBind(config: LdapConfiguration, dn: string, password: s
   }
   await client.bind(dn, password)
   return client
-}
-
-/** Resolve a search base: if it already ends with baseDn, use as-is; otherwise append baseDn. */
-function resolveSearchBase(subBase: string | null | undefined, baseDn: string): string {
-  if (!subBase) return baseDn
-  // If the sub-base already contains the base DN (case-insensitive), use it directly
-  if (subBase.toLowerCase().endsWith(baseDn.toLowerCase())) return subBase
-  return `${subBase},${baseDn}`
 }
 
 function getBindPassword(config: LdapConfiguration): string {
@@ -249,6 +242,10 @@ export async function lookupUserByDn(
   config: LdapConfiguration,
   dn: string,
 ): Promise<LdapUserDetail | null> {
+  if (!isDnWithinSearchBase(dn, config)) {
+    throw new Error('DN is outside the configured user search base')
+  }
+
   let client: Client | undefined
   try {
     client = await connectAndBind(config, getBindDn(config), getBindPassword(config))

--- a/apps/web/lib/ldap/dn-scope.test.mjs
+++ b/apps/web/lib/ldap/dn-scope.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { isDnWithinSearchBase, resolveSearchBase } from './dn-scope.ts'
+
+test('resolveSearchBase appends relative user search bases to the configured base DN', () => {
+  assert.equal(
+    resolveSearchBase('ou=People', 'dc=example,dc=com'),
+    'ou=People,dc=example,dc=com',
+  )
+})
+
+test('resolveSearchBase preserves absolute user search bases under the configured base DN', () => {
+  assert.equal(
+    resolveSearchBase('ou=People,dc=example,dc=com', 'dc=example,dc=com'),
+    'ou=People,dc=example,dc=com',
+  )
+})
+
+test('isDnWithinSearchBase allows a DN below the configured user search base', () => {
+  assert.equal(
+    isDnWithinSearchBase(
+      'cn=Alice,ou=People,dc=example,dc=com',
+      { baseDn: 'dc=example,dc=com', userSearchBase: 'ou=People' },
+    ),
+    true,
+  )
+})
+
+test('isDnWithinSearchBase rejects sibling OUs under the directory base DN', () => {
+  assert.equal(
+    isDnWithinSearchBase(
+      'cn=Service,ou=Privileged,dc=example,dc=com',
+      { baseDn: 'dc=example,dc=com', userSearchBase: 'ou=People' },
+    ),
+    false,
+  )
+})
+
+test('isDnWithinSearchBase rejects parent and root DNs', () => {
+  assert.equal(
+    isDnWithinSearchBase(
+      'dc=example,dc=com',
+      { baseDn: 'dc=example,dc=com', userSearchBase: 'ou=People' },
+    ),
+    false,
+  )
+})
+
+test('isDnWithinSearchBase rejects malformed DNs', () => {
+  assert.equal(
+    isDnWithinSearchBase(
+      'cn=Alice,ou=People,dc=example,dc=com\\',
+      { baseDn: 'dc=example,dc=com', userSearchBase: 'ou=People' },
+    ),
+    false,
+  )
+})
+
+test('isDnWithinSearchBase handles escaped comma and equals signs inside attribute values', () => {
+  assert.equal(
+    isDnWithinSearchBase(
+      'cn=Doe\\, Jane\\=Admin,ou=People,dc=example,dc=com',
+      { baseDn: 'dc=example,dc=com', userSearchBase: 'ou=People' },
+    ),
+    true,
+  )
+})

--- a/apps/web/lib/ldap/dn-scope.ts
+++ b/apps/web/lib/ldap/dn-scope.ts
@@ -1,0 +1,118 @@
+export type LdapSearchScopeConfig = {
+  baseDn: string
+  userSearchBase?: string | null
+}
+
+function splitUnescaped(value: string, separators: Set<string>): string[] | null {
+  const parts: string[] = []
+  let current = ''
+  let escaped = false
+
+  for (const char of value) {
+    if (escaped) {
+      current += `\\${char}`
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (separators.has(char)) {
+      if (!current.trim()) return null
+      parts.push(current.trim())
+      current = ''
+      continue
+    }
+    current += char
+  }
+
+  if (escaped || !current.trim()) return null
+  parts.push(current.trim())
+  return parts
+}
+
+function findUnescapedEquals(value: string): number {
+  let escaped = false
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+    if (char === '=') return index
+  }
+  return -1
+}
+
+function normaliseDnValue(value: string): string {
+  return value
+    .replace(/\\([0-9a-fA-F]{2}|.)/g, (_match, escaped: string) => {
+      if (/^[0-9a-fA-F]{2}$/.test(escaped)) {
+        return String.fromCharCode(Number.parseInt(escaped, 16))
+      }
+      return escaped
+    })
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+function normaliseRdn(rdn: string): string | null {
+  const attrs = splitUnescaped(rdn, new Set(['+']))
+  if (!attrs) return null
+
+  const normalisedAttrs: string[] = []
+  for (const attr of attrs) {
+    const equalsIndex = findUnescapedEquals(attr)
+    if (equalsIndex <= 0) return null
+
+    const name = attr.slice(0, equalsIndex).trim().toLowerCase()
+    const value = attr.slice(equalsIndex + 1)
+    if (!name || !value.trim()) return null
+    normalisedAttrs.push(`${name}=${normaliseDnValue(value)}`)
+  }
+
+  return normalisedAttrs.sort().join('+')
+}
+
+function parseDn(dn: string): string[] | null {
+  const rdns = splitUnescaped(dn, new Set([',', ';']))
+  if (!rdns) return null
+
+  const normalised = rdns.map(normaliseRdn)
+  if (normalised.some((rdn) => rdn == null)) return null
+  return normalised as string[]
+}
+
+function isDnAtOrBelowBase(dn: string, baseDn: string, allowBase: boolean): boolean {
+  const dnRdns = parseDn(dn)
+  const baseRdns = parseDn(baseDn)
+  if (!dnRdns || !baseRdns) return false
+  if (dnRdns.length < baseRdns.length) return false
+  if (!allowBase && dnRdns.length === baseRdns.length) return false
+
+  for (let offset = 1; offset <= baseRdns.length; offset += 1) {
+    if (dnRdns[dnRdns.length - offset] !== baseRdns[baseRdns.length - offset]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/** Resolve a search base: if it is absolute under baseDn, use as-is; otherwise append baseDn. */
+export function resolveSearchBase(subBase: string | null | undefined, baseDn: string): string {
+  if (!subBase) return baseDn
+  if (isDnAtOrBelowBase(subBase, baseDn, true)) return subBase
+  return `${subBase},${baseDn}`
+}
+
+export function isDnWithinSearchBase(dn: string, config: LdapSearchScopeConfig): boolean {
+  const searchBase = resolveSearchBase(config.userSearchBase, config.baseDn)
+  return isDnAtOrBelowBase(dn, searchBase, false)
+}


### PR DESCRIPTION
## Summary
- add canonical LDAP DN scope checks for directory detail lookups
- reject malformed, parent/root, and sibling OU DNs before binding/searching LDAP
- cover relative/absolute search bases plus escaped comma/equal DN values

Closes #982

## Tests
- node --experimental-strip-types --test apps/web/lib/ldap/dn-scope.test.mjs apps/web/lib/ldap/client-auth-filter.test.mjs apps/web/lib/ldap/config-client.test.mjs apps/web/lib/ldap/tls-options.test.mjs
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing warnings)