### PR TITLE
fix(ingest): consume enrolment tokens atomically

### DIFF
--- a/apps/ingest/internal/db/queries/enrolment.sql.go
+++ b/apps/ingest/internal/db/queries/enrolment.sql.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -30,6 +31,10 @@ type EnrolmentToken struct {
 	UsageCount     int
 	ExpiresAt      *time.Time
 	Metadata       EnrolmentTokenMetadata
+}
+
+type enrolmentQueryer interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
 // GetEnrolmentToken looks up a valid (non-deleted, non-expired, not exhausted)
@@ -66,9 +71,41 @@ func GetEnrolmentToken(ctx context.Context, pool *pgxpool.Pool, token string) (*
 	return &t, nil
 }
 
-// IncrementUsageCount atomically bumps the usage counter for an enrolment token.
-func IncrementUsageCount(ctx context.Context, pool *pgxpool.Pool, tokenID string) error {
-	const q = `UPDATE agent_enrolment_tokens SET usage_count = usage_count + 1, updated_at = NOW() WHERE id = $1`
-	_, err := pool.Exec(ctx, q, tokenID)
-	return err
+// ConsumeEnrolmentToken atomically validates and consumes one use of an
+// enrolment token. When max_uses has already been reached, pgx.ErrNoRows is
+// returned and no usage is consumed.
+func ConsumeEnrolmentToken(ctx context.Context, pool *pgxpool.Pool, token string) (*EnrolmentToken, error) {
+	return consumeEnrolmentToken(ctx, pool, token)
+}
+
+func consumeEnrolmentToken(ctx context.Context, queryer enrolmentQueryer, token string) (*EnrolmentToken, error) {
+	const q = `
+		WITH candidate AS (
+			SELECT id
+			FROM agent_enrolment_tokens
+			WHERE (token_hash = encode(sha256($1::bytea), 'hex') OR (token_hash IS NULL AND token = $1::text))
+			  AND deleted_at IS NULL
+			  AND (expires_at IS NULL OR expires_at > NOW())
+			  AND (max_uses IS NULL OR usage_count < max_uses)
+			FOR UPDATE
+		)
+		UPDATE agent_enrolment_tokens
+		SET usage_count = usage_count + 1, updated_at = NOW()
+		WHERE id = (SELECT id FROM candidate)
+		RETURNING id, organisation_id, label, token, auto_approve, max_uses, usage_count, expires_at, metadata
+	`
+	row := queryer.QueryRow(ctx, q, token)
+
+	var t EnrolmentToken
+	var rawMeta []byte
+	if err := row.Scan(
+		&t.ID, &t.OrganisationID, &t.Label, &t.Token,
+		&t.AutoApprove, &t.MaxUses, &t.UsageCount, &t.ExpiresAt, &rawMeta,
+	); err != nil {
+		return nil, err
+	}
+	if len(rawMeta) > 0 {
+		_ = json.Unmarshal(rawMeta, &t.Metadata)
+	}
+	return &t, nil
 }

--- a/apps/ingest/internal/db/queries/enrolment_test.go
+++ b/apps/ingest/internal/db/queries/enrolment_test.go
@@ -1,0 +1,61 @@
+package queries
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type fakeEnrolmentQueryer struct {
+	sql  string
+	args []any
+	err  error
+}
+
+func (f *fakeEnrolmentQueryer) QueryRow(_ context.Context, sql string, args ...any) pgx.Row {
+	f.sql = sql
+	f.args = args
+	return fakeEnrolmentRow{err: f.err}
+}
+
+type fakeEnrolmentRow struct {
+	err error
+}
+
+func (r fakeEnrolmentRow) Scan(_ ...any) error {
+	return r.err
+}
+
+func TestConsumeEnrolmentTokenAtomicallyChecksUsageLimit(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("stop after query capture")
+	queryer := &fakeEnrolmentQueryer{err: sentinel}
+
+	_, err := consumeEnrolmentToken(context.Background(), queryer, "token-secret")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("consumeEnrolmentToken error = %v, want sentinel scan error", err)
+	}
+
+	if !strings.Contains(queryer.sql, "UPDATE agent_enrolment_tokens") {
+		t.Fatalf("query does not update token usage: %s", queryer.sql)
+	}
+	if !strings.Contains(queryer.sql, "usage_count = usage_count + 1") {
+		t.Fatalf("query does not increment usage_count: %s", queryer.sql)
+	}
+	if !strings.Contains(queryer.sql, "max_uses IS NULL OR usage_count < max_uses") {
+		t.Fatalf("query does not enforce max_uses while consuming: %s", queryer.sql)
+	}
+	if !strings.Contains(queryer.sql, "FOR UPDATE") {
+		t.Fatalf("query does not lock the candidate token row: %s", queryer.sql)
+	}
+	if !strings.Contains(queryer.sql, "RETURNING id, organisation_id") {
+		t.Fatalf("query does not return the consumed token row: %s", queryer.sql)
+	}
+	if len(queryer.args) != 1 || queryer.args[0] != "token-secret" {
+		t.Fatalf("args = %#v, want token secret", queryer.args)
+	}
+}

--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -203,7 +203,20 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		}
 	}
 
-	// Step 4: Insert new agent
+	// Step 4: Atomically consume one token use before creating the new agent.
+	// Repeat registration with an existing public key returns above without
+	// consuming another use.
+	token, err = queries.ConsumeEnrolmentToken(ctx, h.pool, req.OrgToken)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, status.Error(codes.Unauthenticated, "invalid or expired enrolment token")
+		}
+		slog.Error("consuming enrolment token", "err", err)
+		return nil, status.Error(codes.Internal, "internal error")
+	}
+	orgID = token.OrganisationID
+
+	// Step 5: Insert new agent
 	agentStatus := "pending"
 	agentID, err := queries.InsertAgent(ctx, h.pool, orgID, hostname, req.PublicKey, agentStatus, token.ID, agentOS, agentArch)
 	if err != nil {
@@ -217,10 +230,6 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		if err := queries.UpsertPendingCSR(ctx, h.pool, agentID, req.CsrDer); err != nil {
 			slog.Warn("queueing CSR", "agent_id", agentID, "err", err)
 		}
-	}
-
-	if err := queries.IncrementUsageCount(ctx, h.pool, token.ID); err != nil {
-		slog.Warn("incrementing enrolment token usage", "err", err)
 	}
 
 	// Insert host row. When the token is NOT auto-approve, stash the merged
@@ -246,7 +255,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 
 	slog.Info("agent registered", "agent_id", agentID, "hostname", hostname, "auto_approve", token.AutoApprove)
 
-	// Step 5: Auto-approve if configured
+	// Step 6: Auto-approve if configured
 	if token.AutoApprove && collisionRequiringManualApproval == nil {
 		if err := queries.ApproveAgent(ctx, h.pool, agentID); err != nil {
 			slog.Error("auto-approving agent", "err", err)
@@ -298,7 +307,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		return resp, nil
 	}
 
-	// Step 6: Pending — waiting for admin approval
+	// Step 7: Pending — waiting for admin approval
 	message := "agent registered and awaiting admin approval"
 	if collisionRequiringManualApproval != nil {
 		message = "agent registered as separate pending host because hostname or IP matches an existing host; admin review required"


### PR DESCRIPTION
## Summary
- replace the unconditional enrolment token usage bump with an atomic validate-and-consume query
- consume a token use before creating a new agent while keeping repeat public-key registration idempotent
- add focused query coverage for max_uses enforcement and row locking

Fixes #984

## Tests
- go test ./apps/ingest/internal/db/queries
- go test ./apps/ingest/internal/handlers
- go test ./apps/ingest/internal/...