### PR TITLE
test(web): open licence settings for activation token e2e

### DIFF
--- a/apps/web/tests/e2e/settings/activation-token.spec.ts
+++ b/apps/web/tests/e2e/settings/activation-token.spec.ts
@@ -4,9 +4,9 @@ import { TEST_ORG } from '../fixtures/seed'
 
 test('admin can generate an activation token from settings', async ({ authenticatedPage: page }) => {
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
-  await page.goto('/settings')
+  await page.goto('/settings/licence')
 
-  await expect(page.getByTestId('settings-heading')).toBeVisible()
+  await expect(page.getByTestId('settings-heading')).toContainText('Organisation')
   await page.getByTestId('activation-token-generate').click()
 
   const activationToken = page.getByTestId('activation-token')


### PR DESCRIPTION
## Summary
- update the activation token E2E to open `/settings/licence`, where the licence/activation token controls now render
- keep the readiness assertion tied to the settings heading before interacting with the generate control

Fixes #989

## Tests
- `pnpm exec eslint tests/e2e/settings/activation-token.spec.ts`
- `pnpm test:e2e --project=chromium tests/e2e/settings/activation-token.spec.ts:5` (blocked locally: Testcontainers could not find a working container runtime strategy)