### PR TITLE
test(web): extend e2e route warmup timeout

### DIFF
--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -74,7 +74,7 @@ const authenticatedApiRoutes = [
   '/api/system/health',
 ]
 
-setup.setTimeout(180_000)
+setup.setTimeout(420_000)
 
 setup('seed test organisation and warm Next routes', async ({ browser, baseURL }) => {
   if (!baseURL) throw new Error('baseURL must be configured')


### PR DESCRIPTION
## Summary\n- extend the E2E auth setup timeout so full route warmup can finish under cold Next dev compilation\n- unblocks the bundlers spec from being skipped by setup timeout in the reported batch-only path\n\n## Tests\n- pnpm exec tsc --noEmit --pretty false\n- pnpm test:e2e --project=chromium tests/e2e/bundlers/bundlers.spec.ts:3\n\nCloses #991