### PR TITLE
fix(web): reject blocked certificate checker ports

### DIFF
--- a/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/certificate-checker-client.tsx
@@ -58,7 +58,10 @@ import {
 } from '@/components/ui/table'
 import type { ParsedCertificate, CertCheckerResponse } from '@/app/api/tools/certificate-checker/route'
 import { trackCertificateFromUrl, trackCertificateFromUpload } from '@/lib/actions/certificates'
-import { getAllowedCertificateCheckerPorts } from '@/lib/net/certificate-checker-policy'
+import {
+  assertAllowedCertificateCheckerPort,
+  getAllowedCertificateCheckerPorts,
+} from '@/lib/net/certificate-checker-policy'
 
 // ─── Utility helpers ─────────────────────────────────────────────────────────
 
@@ -803,8 +806,22 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
 
   async function submit() {
     if (!url.trim()) return
-    setLoading(true)
     setError(null)
+
+    const requestedPort = port ? Number(port) : 443
+    if (!Number.isInteger(requestedPort) || requestedPort < 1 || requestedPort > 65535) {
+      setError('Port must be between 1 and 65535.')
+      return
+    }
+
+    try {
+      assertAllowedCertificateCheckerPort(requestedPort)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Port is not allowed.')
+      return
+    }
+
+    setLoading(true)
     try {
       const resolvedKey = keyText.trim() || (keyFile ? await readFileAsText(keyFile) : undefined)
       const res = await fetch('/api/tools/certificate-checker', {
@@ -813,7 +830,7 @@ function UrlTab({ onResult }: { onResult: (cert: ParsedCertificate, source: Trac
         body: JSON.stringify({
           action: 'fetch-url',
           url: url.trim(),
-          port: port ? parseInt(port, 10) : 443,
+          port: requestedPort,
           servername: servername.trim() || undefined,
           keyPem: resolvedKey || undefined,
         }),

--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -74,6 +74,8 @@ const authenticatedApiRoutes = [
   '/api/system/health',
 ]
 
+const routeWarmupTimeoutMs = 60_000
+
 setup.setTimeout(420_000)
 
 setup('seed test organisation and warm Next routes', async ({ browser, baseURL }) => {
@@ -85,7 +87,7 @@ setup('seed test organisation and warm Next routes', async ({ browser, baseURL }
   const publicPage = await publicContext.newPage()
   try {
     for (const route of publicRoutes) {
-      const response = await publicPage.goto(route, { waitUntil: 'domcontentloaded', timeout: 30_000 })
+      const response = await publicPage.goto(route, { waitUntil: 'domcontentloaded', timeout: routeWarmupTimeoutMs })
       if (response && response.status() >= 500) {
         throw new Error(`Warmup navigation for ${route} failed with ${response.status()}`)
       }
@@ -100,7 +102,7 @@ setup('seed test organisation and warm Next routes', async ({ browser, baseURL }
 
   try {
     for (const route of authenticatedRoutes) {
-      const response = await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 30_000 })
+      const response = await page.goto(route, { waitUntil: 'domcontentloaded', timeout: routeWarmupTimeoutMs })
       if (response && response.status() >= 500) {
         throw new Error(`Warmup navigation for ${route} failed with ${response.status()}`)
       }


### PR DESCRIPTION
## Summary
- reject blocked certificate-checker URL ports in the client before issuing the API request
- reuse the shared certificate-checker port policy for the client error text
- increase E2E route warmup per-navigation timeout so targeted certificate-checker runs reach the spec under cold Next route compilation

Closes #992

## Tests
- pnpm --filter web test:e2e --project=chromium tests/e2e/certificate-checker/url-port-validation.spec.ts:3
- pnpm --filter web exec tsc --noEmit --pretty false
- pnpm --filter web exec eslint app/'(dashboard)'/certificate-checker/certificate-checker-client.tsx tests/e2e/auth.setup.ts