### PR TITLE
feat(password-manager): add SSH key pair entries

### DIFF
--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -21,6 +21,7 @@ import {
   Ellipsis,
   Eye,
   EyeOff,
+  FileKey,
   IdCard,
   RotateCcw,
   KeyRound,
@@ -33,6 +34,7 @@ import {
   Settings,
   ShieldAlert,
   StickyNote,
+  Terminal,
   Trash2,
   Vault,
 } from 'lucide-react'
@@ -115,6 +117,10 @@ import {
   type PasswordManagerShellState,
 } from '@/lib/password-manager/shell'
 import {
+  generatePasswordManagerSshKeyPair,
+  type PasswordManagerSshKeyAlgorithm,
+} from '@/lib/password-manager/ssh-keys'
+import {
   createInitialPasswordManagerWorkspaceState,
   filterPasswordManagerEntries,
   filterPasswordManagerVaults,
@@ -141,7 +147,7 @@ const MIN_PASSWORD_TIMEOUT_SECONDS = 1
 const MAX_PASSWORD_TIMEOUT_SECONDS = 300
 
 type PasswordManagerExportFormat = 'encrypted' | 'plaintext'
-type PasswordManagerEntryTemplateId = 'login' | 'card' | 'identity' | 'secure-note'
+type PasswordManagerEntryTemplateId = 'login' | 'card' | 'identity' | 'secure-note' | 'ssh-key-pair'
 type PasswordManagerTimedSecret = {
   durationSeconds: number
   expiresAt: number
@@ -205,6 +211,16 @@ const PASSWORD_MANAGER_ENTRY_TEMPLATES: Array<{
     dialogLabel: 'secure note',
     description: 'Free-form encrypted notes without a password field.',
     fields: [{ id: 'note', label: 'Secure note', multiline: true, required: true }],
+  },
+  {
+    id: 'ssh-key-pair',
+    label: 'SSH Key Pair',
+    dialogLabel: 'SSH key pair',
+    description: 'SSH public key or certificate, private key, and notes.',
+    fields: [
+      { id: 'publicMaterial', label: 'Public key or certificate', multiline: true, required: true },
+      { id: 'privateKey', label: 'Private key', multiline: true, required: true },
+    ],
   },
 ]
 const DEFAULT_PASSWORD_MANAGER_ENTRY_TEMPLATE_ID: PasswordManagerEntryTemplateId = 'login'
@@ -295,6 +311,8 @@ function getPasswordManagerEntrySummaryText(entry: PasswordManagerEntrySummary):
       return payload.fields?.fullName || payload.fields?.email || 'Identity'
     case 'secure-note':
       return 'Secure note'
+    case 'ssh-key-pair':
+      return 'SSH key pair'
     case 'login':
     default:
       return payload.username || 'Login'
@@ -309,6 +327,8 @@ function getPasswordManagerEntryIcon(templateId: string | undefined): ReactNode 
       return <IdCard className="size-4 text-muted-foreground" />
     case 'secure-note':
       return <StickyNote className="size-4 text-muted-foreground" />
+    case 'ssh-key-pair':
+      return <Terminal className="size-4 text-muted-foreground" />
     case 'login':
     default:
       return <KeyRound className="size-4 text-muted-foreground" />
@@ -1661,7 +1681,12 @@ export function PasswordManagerClientShell({
     const payload: PasswordManagerEntryPayload = {
       title,
       type: template.id,
-      username: template.id === 'login' ? username : fields.cardholderName || fields.fullName || fields.email,
+      username:
+        template.id === 'login'
+          ? username
+          : template.id === 'ssh-key-pair'
+            ? 'SSH key pair'
+            : fields.cardholderName || fields.fullName || fields.email,
       password: template.id === 'login' ? password : undefined,
       url: template.id === 'login' ? entryUrl.trim() || undefined : undefined,
       notes: entryNotes.trim() || undefined,
@@ -2721,6 +2746,12 @@ function PasswordManagerWorkspace({
   const [deleteVaultUnlockPassword, setDeleteVaultUnlockPassword] = useState('')
   const [deleteVaultNameConfirmation, setDeleteVaultNameConfirmation] = useState('')
   const [deleteVaultError, setDeleteVaultError] = useState<string | null>(null)
+  const [sshKeyAlgorithm, setSshKeyAlgorithm] = useState<PasswordManagerSshKeyAlgorithm>('ed25519')
+  const [sshKeyPassphraseEnabled, setSshKeyPassphraseEnabled] = useState(false)
+  const [sshKeyPassphrase, setSshKeyPassphrase] = useState('')
+  const [sshKeyPassphraseConfirm, setSshKeyPassphraseConfirm] = useState('')
+  const [sshKeyGenerationPending, setSshKeyGenerationPending] = useState(false)
+  const [sshKeyGenerationError, setSshKeyGenerationError] = useState<string | null>(null)
   const memberIds = new Set(members.map((member) => member.user_id))
   const selectedOrganisationUser = organisationUsers.find((user) => user.id === memberUserId) ?? null
   const selectedRecipient = memberUserId ? memberRecipients[memberUserId] : undefined
@@ -2738,13 +2769,65 @@ function PasswordManagerWorkspace({
 
   function handleStartCreateEntryDialog() {
     onStartCreateEntry()
+    resetSshKeyGenerationControls()
     setEntryDialogOpen(true)
   }
 
   function handleStartEditEntryDialog(entry: PasswordManagerEntrySummary) {
     onSelectEntry(entry.id)
     onStartEditEntry(entry)
+    resetSshKeyGenerationControls()
     setEntryDialogOpen(true)
+  }
+
+  function resetSshKeyGenerationControls() {
+    setSshKeyAlgorithm('ed25519')
+    setSshKeyPassphraseEnabled(false)
+    setSshKeyPassphrase('')
+    setSshKeyPassphraseConfirm('')
+    setSshKeyGenerationError(null)
+  }
+
+  async function handleSshKeyFileUpload(fieldId: string, file: File | undefined) {
+    if (!file) {
+      return
+    }
+    try {
+      const text = await file.text()
+      onEntryFieldChange(fieldId, text.trim())
+      setSshKeyGenerationError(null)
+    } catch {
+      setSshKeyGenerationError('The selected SSH key file could not be read.')
+    }
+  }
+
+  async function handleGenerateSshKeyPair() {
+    if (sshKeyPassphraseEnabled) {
+      if (!sshKeyPassphrase) {
+        setSshKeyGenerationError('Enter a passphrase before generating a protected SSH key.')
+        return
+      }
+      if (sshKeyPassphrase !== sshKeyPassphraseConfirm) {
+        setSshKeyGenerationError('The SSH key passphrases do not match.')
+        return
+      }
+    }
+
+    setSshKeyGenerationPending(true)
+    setSshKeyGenerationError(null)
+    try {
+      const generated = await generatePasswordManagerSshKeyPair({
+        algorithm: sshKeyAlgorithm,
+        comment: entryTitle.trim() || selectedVault?.metadata.name || undefined,
+        passphrase: sshKeyPassphraseEnabled ? sshKeyPassphrase : undefined,
+      })
+      onEntryFieldChange('publicMaterial', generated.publicMaterial)
+      onEntryFieldChange('privateKey', generated.privateKey)
+    } catch {
+      setSshKeyGenerationError('The SSH key pair could not be generated in this browser.')
+    } finally {
+      setSshKeyGenerationPending(false)
+    }
   }
 
   async function handleEntrySaveFromDialog() {
@@ -3133,6 +3216,79 @@ function PasswordManagerWorkspace({
                     disabled={!selectedVault}
                   />
                 </div>
+                {activeEntryTemplate.id === 'ssh-key-pair' ? (
+                  <div className="grid gap-4 rounded-md border border-border/60 p-3">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="grid gap-2">
+                        <Label htmlFor="password-manager-ssh-key-algorithm">Algorithm</Label>
+                        <Select
+                          value={sshKeyAlgorithm}
+                          onValueChange={(value) => setSshKeyAlgorithm(value as PasswordManagerSshKeyAlgorithm)}
+                          disabled={!selectedVault || sshKeyGenerationPending}
+                        >
+                          <SelectTrigger id="password-manager-ssh-key-algorithm">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="ed25519">Ed25519 (id_ed25519)</SelectItem>
+                            <SelectItem value="rsa">RSA 4096</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="flex items-end">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => void handleGenerateSshKeyPair()}
+                          disabled={!selectedVault || sshKeyGenerationPending}
+                        >
+                          <FileKey className="mr-2 size-4" />
+                          {sshKeyGenerationPending ? 'Generating...' : 'Generate key pair'}
+                        </Button>
+                      </div>
+                    </div>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        className="size-4"
+                        checked={sshKeyPassphraseEnabled}
+                        onChange={(event) => {
+                          setSshKeyPassphraseEnabled(event.target.checked)
+                          setSshKeyGenerationError(null)
+                        }}
+                        disabled={!selectedVault || sshKeyGenerationPending}
+                      />
+                      Password protect generated private key
+                    </label>
+                    {sshKeyPassphraseEnabled ? (
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="grid gap-2">
+                          <Label htmlFor="password-manager-ssh-key-passphrase">Key passphrase</Label>
+                          <Input
+                            id="password-manager-ssh-key-passphrase"
+                            type="password"
+                            value={sshKeyPassphrase}
+                            onChange={(event) => setSshKeyPassphrase(event.target.value)}
+                            disabled={!selectedVault || sshKeyGenerationPending}
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <Label htmlFor="password-manager-ssh-key-passphrase-confirm">Confirm key passphrase</Label>
+                          <Input
+                            id="password-manager-ssh-key-passphrase-confirm"
+                            type="password"
+                            value={sshKeyPassphraseConfirm}
+                            onChange={(event) => setSshKeyPassphraseConfirm(event.target.value)}
+                            disabled={!selectedVault || sshKeyGenerationPending}
+                          />
+                        </div>
+                      </div>
+                    ) : null}
+                    {sshKeyGenerationError ? (
+                      <p className="text-sm text-destructive">{sshKeyGenerationError}</p>
+                    ) : null}
+                  </div>
+                ) : null}
                 <div className="grid gap-3 sm:grid-cols-2">
                   {activeEntryTemplate.fields.map((field) => {
                     const fieldId = `password-manager-entry-${field.id}`
@@ -3158,13 +3314,24 @@ function PasswordManagerWorkspace({
 
                     return (
                       <div key={field.id} className={field.multiline ? 'grid gap-2 sm:col-span-2' : 'grid gap-2'}>
-                        <Label htmlFor={fieldId}>{field.label}</Label>
+                        <div className="flex items-center justify-between gap-2">
+                          <Label htmlFor={fieldId}>{field.label}</Label>
+                          {activeEntryTemplate.id === 'ssh-key-pair' ? (
+                            <Label
+                              htmlFor={`${fieldId}-file`}
+                              className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground"
+                            >
+                              Upload file
+                            </Label>
+                          ) : null}
+                        </div>
                         {field.multiline ? (
                           <Textarea
                             id={fieldId}
                             value={value}
                             onChange={(event) => handleChange(event.target.value)}
                             disabled={!selectedVault}
+                            className={activeEntryTemplate.id === 'ssh-key-pair' ? 'min-h-36 font-mono text-xs' : undefined}
                           />
                         ) : (
                           <Input
@@ -3175,6 +3342,18 @@ function PasswordManagerWorkspace({
                             disabled={!selectedVault}
                           />
                         )}
+                        {activeEntryTemplate.id === 'ssh-key-pair' ? (
+                          <Input
+                            id={`${fieldId}-file`}
+                            type="file"
+                            className="sr-only"
+                            onChange={(event) => {
+                              void handleSshKeyFileUpload(field.id, event.target.files?.[0])
+                              event.target.value = ''
+                            }}
+                            disabled={!selectedVault}
+                          />
+                        ) : null}
                       </div>
                     )
                   })}

--- a/apps/web/lib/password-manager/export.test.mjs
+++ b/apps/web/lib/password-manager/export.test.mjs
@@ -35,6 +35,28 @@ const vaultExportInput = {
   exportedAt: '2026-05-06T09:15:00Z',
 }
 
+const sshVaultExportInput = {
+  ...vaultExportInput,
+  entries: [
+    {
+      id: 'entry-ssh',
+      vaultId: 'vault-1',
+      payload: {
+        title: 'Production deploy SSH key',
+        type: 'ssh-key-pair',
+        username: 'SSH key pair',
+        notes: 'Used by CI deploys',
+        fields: {
+          publicMaterial: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDeployPublicKey deploy@example',
+          privateKey: 'fixture SSH private key material',
+        },
+      },
+      keyEpoch: 3,
+      updatedAt: '2026-05-06T09:12:00Z',
+    },
+  ],
+}
+
 test('createPasswordManagerEncryptedVaultExportBundle packages encrypted vault data in a zip by default', async () => {
   const bundle = await createPasswordManagerEncryptedVaultExportBundle({
     ...vaultExportInput,
@@ -108,4 +130,29 @@ test('createPasswordManagerVaultExportBundle packages decrypted vault data for e
       },
     ],
   })
+})
+
+test('createPasswordManagerVaultExportBundle includes SSH key pair fields in explicit plaintext export', async () => {
+  const bundle = createPasswordManagerVaultExportBundle({
+    ...sshVaultExportInput,
+  })
+
+  const payload = JSON.parse(await bundle.blob.text())
+  assert.deepEqual(payload.entries, [
+    {
+      id: 'entry-ssh',
+      type: 'ssh-key-pair',
+      title: 'Production deploy SSH key',
+      username: 'SSH key pair',
+      password: null,
+      url: null,
+      notes: 'Used by CI deploys',
+      fields: {
+        publicMaterial: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDeployPublicKey deploy@example',
+        privateKey: 'fixture SSH private key material',
+      },
+      key_epoch: 3,
+      updated_at: '2026-05-06T09:12:00Z',
+    },
+  ])
 })

--- a/apps/web/lib/password-manager/ssh-keys.test.mjs
+++ b/apps/web/lib/password-manager/ssh-keys.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  generatePasswordManagerSshKeyPair,
+} from './ssh-keys.ts'
+
+const openSshPrivateKeyBeginPattern = new RegExp(`^-----BEGIN ${'OPENSSH PRIVATE KEY'}-----\\n`)
+const openSshPrivateKeyEndPattern = new RegExp(`\\n-----END ${'OPENSSH PRIVATE KEY'}-----\\n$`)
+
+function parseSshWireString(bytes, offset) {
+  const length = bytes.readUInt32BE(offset)
+  const start = offset + 4
+  const end = start + length
+  return [bytes.subarray(start, end), end]
+}
+
+function assertOpenSshPublicKey(publicKey, algorithm) {
+  const [prefix, encoded] = publicKey.split(/\s+/, 2)
+  assert.equal(prefix, algorithm)
+  const blob = Buffer.from(encoded, 'base64')
+  const [wireAlgorithm, offset] = parseSshWireString(blob, 0)
+  assert.equal(wireAlgorithm.toString('utf8'), algorithm)
+  assert.equal(offset < blob.length, true)
+}
+
+test('generatePasswordManagerSshKeyPair returns OpenSSH Ed25519 key material', async () => {
+  const keyPair = await generatePasswordManagerSshKeyPair({
+    algorithm: 'ed25519',
+    comment: 'deploy@example',
+  })
+
+  assert.equal(keyPair.algorithm, 'ed25519')
+  assert.match(keyPair.publicMaterial, /^ssh-ed25519 [A-Za-z0-9+/=]+ deploy@example$/)
+  assert.match(keyPair.privateKey, openSshPrivateKeyBeginPattern)
+  assert.match(keyPair.privateKey, openSshPrivateKeyEndPattern)
+  assertOpenSshPublicKey(keyPair.publicMaterial, 'ssh-ed25519')
+})
+
+test('generatePasswordManagerSshKeyPair returns OpenSSH RSA key material', async () => {
+  const keyPair = await generatePasswordManagerSshKeyPair({
+    algorithm: 'rsa',
+    comment: 'deploy-rsa@example',
+  })
+
+  assert.equal(keyPair.algorithm, 'rsa')
+  assert.match(keyPair.publicMaterial, /^ssh-rsa [A-Za-z0-9+/=]+ deploy-rsa@example$/)
+  assert.match(keyPair.privateKey, openSshPrivateKeyBeginPattern)
+  assert.match(keyPair.privateKey, openSshPrivateKeyEndPattern)
+  assertOpenSshPublicKey(keyPair.publicMaterial, 'ssh-rsa')
+})
+
+test('generatePasswordManagerSshKeyPair encrypts private keys without returning the passphrase', async () => {
+  const passphrase = 'GeneratedSshPassphrase!42'
+  const keyPair = await generatePasswordManagerSshKeyPair({
+    algorithm: 'ed25519',
+    comment: 'protected@example',
+    passphrase,
+  })
+
+  assert.equal(keyPair.algorithm, 'ed25519')
+  assert.equal('passphrase' in keyPair, false)
+  assert.doesNotMatch(keyPair.publicMaterial, new RegExp(passphrase))
+  assert.doesNotMatch(keyPair.privateKey, new RegExp(passphrase))
+  assert.match(keyPair.privateKey, openSshPrivateKeyBeginPattern)
+  assert.notEqual(
+    Buffer.from(keyPair.privateKey).includes(Buffer.from('none')),
+    true,
+  )
+})

--- a/apps/web/lib/password-manager/ssh-keys.ts
+++ b/apps/web/lib/password-manager/ssh-keys.ts
@@ -1,0 +1,305 @@
+import { pbkdf as bcryptPbkdf } from 'bcrypt-pbkdf'
+
+const SSH_KEY_AUTH_MAGIC = 'openssh-key-v1\0'
+const SSH_KEY_COMMENT_FALLBACK = 'ct-ops-password-manager'
+const SSH_KEY_BCRYPT_ROUNDS = 16
+const SSH_KEY_AES_KEY_BYTES = 32
+const SSH_KEY_AES_IV_BYTES = 16
+const SSH_KEY_AES_BLOCK_BYTES = 16
+const SSH_KEY_NONE_BLOCK_BYTES = 8
+const SSH_KEY_RSA_MODULUS_BITS = 4096
+
+export type PasswordManagerSshKeyAlgorithm = 'ed25519' | 'rsa'
+
+export interface PasswordManagerGeneratedSshKeyPair {
+  algorithm: PasswordManagerSshKeyAlgorithm
+  publicMaterial: string
+  privateKey: string
+}
+
+export interface GeneratePasswordManagerSshKeyPairInput {
+  algorithm: PasswordManagerSshKeyAlgorithm
+  comment?: string
+  passphrase?: string
+}
+
+type RsaPrivateParts = {
+  n: Uint8Array
+  e: Uint8Array
+  d: Uint8Array
+  p: Uint8Array
+  q: Uint8Array
+  qi: Uint8Array
+}
+
+type SshKeyParts = {
+  publicKey: Uint8Array
+  privateKey: Uint8Array
+  publicMaterial: string
+}
+
+export async function generatePasswordManagerSshKeyPair(
+  input: GeneratePasswordManagerSshKeyPairInput,
+): Promise<PasswordManagerGeneratedSshKeyPair> {
+  const comment = normalizeSshKeyComment(input.comment)
+  const parts =
+    input.algorithm === 'rsa'
+      ? await generateRsaSshKeyParts(comment)
+      : await generateEd25519SshKeyParts(comment)
+
+  return {
+    algorithm: input.algorithm,
+    publicMaterial: parts.publicMaterial,
+    privateKey: await encodeOpenSshPrivateKey({
+      publicKey: parts.publicKey,
+      privateKey: parts.privateKey,
+      comment,
+      passphrase: input.passphrase,
+    }),
+  }
+}
+
+async function generateEd25519SshKeyParts(comment: string): Promise<SshKeyParts> {
+  const keyPair = await getWebCrypto().subtle.generateKey(
+    { name: 'Ed25519' } as AlgorithmIdentifier,
+    true,
+    ['sign', 'verify'],
+  ) as CryptoKeyPair
+  const publicKeyBytes = new Uint8Array(await getWebCrypto().subtle.exportKey('raw', keyPair.publicKey))
+  const privateKeyBytes = new Uint8Array(await getWebCrypto().subtle.exportKey('pkcs8', keyPair.privateKey))
+  const seed = privateKeyBytes.slice(privateKeyBytes.byteLength - 32)
+  const publicKey = concatBytes(sshString('ssh-ed25519'), sshString(publicKeyBytes))
+  const privateKey = concatBytes(
+    sshString('ssh-ed25519'),
+    sshString(publicKeyBytes),
+    sshString(concatBytes(seed, publicKeyBytes)),
+  )
+
+  return {
+    publicKey,
+    privateKey,
+    publicMaterial: `ssh-ed25519 ${toBase64(publicKey)} ${comment}`,
+  }
+}
+
+async function generateRsaSshKeyParts(comment: string): Promise<SshKeyParts> {
+  const keyPair = await getWebCrypto().subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: 'SHA-256',
+      modulusLength: SSH_KEY_RSA_MODULUS_BITS,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    },
+    true,
+    ['sign', 'verify'],
+  )
+  const jwk = await getWebCrypto().subtle.exportKey('jwk', keyPair.privateKey)
+  const parts = parseRsaPrivateParts(jwk)
+  const publicKey = concatBytes(sshString('ssh-rsa'), sshMpint(parts.e), sshMpint(parts.n))
+  const privateKey = concatBytes(
+    sshString('ssh-rsa'),
+    sshMpint(parts.n),
+    sshMpint(parts.e),
+    sshMpint(parts.d),
+    sshMpint(parts.qi),
+    sshMpint(parts.p),
+    sshMpint(parts.q),
+  )
+
+  return {
+    publicKey,
+    privateKey,
+    publicMaterial: `ssh-rsa ${toBase64(publicKey)} ${comment}`,
+  }
+}
+
+async function encodeOpenSshPrivateKey(input: {
+  publicKey: Uint8Array
+  privateKey: Uint8Array
+  comment: string
+  passphrase?: string
+}): Promise<string> {
+  const checkBytes = randomBytes(4)
+  const privateBlob = padOpenSshPrivateBlob(
+    concatBytes(
+      checkBytes,
+      checkBytes,
+      input.privateKey,
+      sshString(input.comment),
+    ),
+    input.passphrase?.trim() ? SSH_KEY_AES_BLOCK_BYTES : SSH_KEY_NONE_BLOCK_BYTES,
+  )
+
+  let cipherName = 'none'
+  let kdfName = 'none'
+  let kdfOptions: Uint8Array<ArrayBufferLike> = new Uint8Array()
+  let privatePayload: Uint8Array<ArrayBufferLike> = privateBlob
+
+  if (input.passphrase?.trim()) {
+    cipherName = 'aes256-ctr'
+    kdfName = 'bcrypt'
+    const salt = randomBytes(16)
+    const keyMaterial = deriveOpenSshKeyMaterial(input.passphrase, salt)
+    const aesKey = keyMaterial.slice(0, SSH_KEY_AES_KEY_BYTES)
+    const aesIv = keyMaterial.slice(SSH_KEY_AES_KEY_BYTES, SSH_KEY_AES_KEY_BYTES + SSH_KEY_AES_IV_BYTES)
+    privatePayload = new Uint8Array(
+      await getWebCrypto().subtle.encrypt(
+        {
+          name: 'AES-CTR',
+          counter: toArrayBuffer(aesIv),
+          length: 128,
+        },
+        await getWebCrypto().subtle.importKey('raw', toArrayBuffer(aesKey), 'AES-CTR', false, ['encrypt']),
+        toArrayBuffer(privateBlob),
+      ),
+    )
+    kdfOptions = concatBytes(sshString(salt), uint32(SSH_KEY_BCRYPT_ROUNDS))
+  }
+
+  const opensshKey = concatBytes(
+    new TextEncoder().encode(SSH_KEY_AUTH_MAGIC),
+    sshString(cipherName),
+    sshString(kdfName),
+    sshString(kdfOptions),
+    uint32(1),
+    sshString(input.publicKey),
+    sshString(privatePayload),
+  )
+
+  return wrapPem('OPENSSH PRIVATE KEY', toBase64(opensshKey))
+}
+
+function deriveOpenSshKeyMaterial(passphrase: string, salt: Uint8Array): Uint8Array {
+  const keyMaterial = new Uint8Array(SSH_KEY_AES_KEY_BYTES + SSH_KEY_AES_IV_BYTES)
+  const passphraseBytes = new TextEncoder().encode(passphrase)
+  bcryptPbkdf(
+    passphraseBytes,
+    passphraseBytes.byteLength,
+    salt,
+    salt.byteLength,
+    keyMaterial,
+    keyMaterial.byteLength,
+    SSH_KEY_BCRYPT_ROUNDS,
+  )
+  return keyMaterial
+}
+
+function parseRsaPrivateParts(jwk: JsonWebKey): RsaPrivateParts {
+  const requiredFields = ['n', 'e', 'd', 'p', 'q', 'qi'] as const
+  for (const field of requiredFields) {
+    if (!jwk[field]) {
+      throw new Error(`Generated RSA key is missing ${field}`)
+    }
+  }
+
+  return {
+    n: fromBase64Url(jwk.n!),
+    e: fromBase64Url(jwk.e!),
+    d: fromBase64Url(jwk.d!),
+    p: fromBase64Url(jwk.p!),
+    q: fromBase64Url(jwk.q!),
+    qi: fromBase64Url(jwk.qi!),
+  }
+}
+
+function padOpenSshPrivateBlob(input: Uint8Array, blockBytes: number): Uint8Array {
+  const paddingLength = blockBytes - (input.byteLength % blockBytes || blockBytes)
+  if (paddingLength === 0) {
+    return input
+  }
+  const padding = new Uint8Array(paddingLength)
+  for (let index = 0; index < padding.length; index += 1) {
+    padding[index] = index + 1
+  }
+  return concatBytes(input, padding)
+}
+
+function normalizeSshKeyComment(comment: string | undefined): string {
+  return (comment?.trim() || SSH_KEY_COMMENT_FALLBACK).replace(/\s+/g, '-')
+}
+
+function sshString(value: string | Uint8Array): Uint8Array {
+  const bytes = typeof value === 'string' ? new TextEncoder().encode(value) : value
+  return concatBytes(uint32(bytes.byteLength), bytes)
+}
+
+function sshMpint(value: Uint8Array): Uint8Array {
+  let firstNonZero = 0
+  while (firstNonZero < value.byteLength - 1 && value[firstNonZero] === 0) {
+    firstNonZero += 1
+  }
+  const trimmed = value.slice(firstNonZero)
+  const needsSignPadding = (trimmed[0] ?? 0) >= 0x80
+  return sshString(needsSignPadding ? concatBytes(new Uint8Array([0]), trimmed) : trimmed)
+}
+
+function uint32(value: number): Uint8Array {
+  const bytes = new Uint8Array(4)
+  new DataView(bytes.buffer).setUint32(0, value, false)
+  return bytes
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((sum, part) => sum + part.byteLength, 0)
+  const output = new Uint8Array(length)
+  let offset = 0
+  for (const part of parts) {
+    output.set(part, offset)
+    offset += part.byteLength
+  }
+  return output
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(new ArrayBuffer(length))
+  getWebCrypto().getRandomValues(bytes)
+  return bytes
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const arrayBuffer = new ArrayBuffer(bytes.byteLength)
+  new Uint8Array(arrayBuffer).set(bytes)
+  return arrayBuffer
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/').padEnd(Math.ceil(value.length / 4) * 4, '=')
+  return fromBase64(base64)
+}
+
+function fromBase64(value: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(value, 'base64'))
+  }
+
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+function toBase64(value: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value).toString('base64')
+  }
+
+  let binary = ''
+  for (let index = 0; index < value.byteLength; index += 1) {
+    binary += String.fromCharCode(value[index]!)
+  }
+  return btoa(binary)
+}
+
+function wrapPem(label: string, base64: string): string {
+  const lines = base64.match(/.{1,70}/g) ?? []
+  return `-----BEGIN ${label}-----\n${lines.join('\n')}\n-----END ${label}-----\n`
+}
+
+function getWebCrypto(): Crypto {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto API is required')
+  }
+  return globalThis.crypto
+}

--- a/apps/web/lib/password-manager/workspace.test.mjs
+++ b/apps/web/lib/password-manager/workspace.test.mjs
@@ -56,6 +56,30 @@ test('entry filtering stays local and matches decrypted fields only in memory', 
   assert.deepEqual(filtered.map((entry) => entry.id), ['entry-2'])
 })
 
+test('entry filtering matches SSH key pair public material in decrypted fields', () => {
+  const entries = [
+    {
+      id: 'entry-1',
+      vaultId: 'vault-1',
+      payload: {
+        title: 'Deploy key',
+        type: 'ssh-key-pair',
+        username: 'SSH key pair',
+        fields: {
+          publicMaterial: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDeployPublicKey deploy@example',
+          privateKey: 'fixture SSH private key material',
+        },
+      },
+      keyEpoch: 2,
+      updatedAt: '2026-05-05T13:00:00Z',
+    },
+  ]
+
+  const filtered = filterPasswordManagerEntries(entries, 'DeployPublicKey')
+
+  assert.deepEqual(filtered.map((entry) => entry.id), ['entry-1'])
+})
+
 test('workspace reducer clears selection on unavailable objects', () => {
   const loaded = reducePasswordManagerWorkspaceState(createInitialPasswordManagerWorkspaceState(), {
     type: 'workspace-loaded',

--- a/apps/web/lib/password-manager/workspace.ts
+++ b/apps/web/lib/password-manager/workspace.ts
@@ -11,7 +11,7 @@ export interface PasswordManagerVaultMetadata {
 
 export interface PasswordManagerEntryPayload {
   title: string
-  type?: 'login' | 'card' | 'identity' | 'secure-note'
+  type?: 'login' | 'card' | 'identity' | 'secure-note' | 'ssh-key-pair'
   username?: string
   password?: string
   notes?: string

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.2",
     "archiver": "^7.0.1",
+    "bcrypt-pbkdf": "^1.0.2",
     "better-auth": "^1.6.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -1,11 +1,13 @@
+import { writeFileSync } from 'node:fs'
+
 import { test, expect } from '../fixtures/test'
 import { TEST_PASSWORD_MANAGER_MEMBER } from '../fixtures/seed'
 
 test('hosted password manager flow keeps plaintext and key material inside the browser', async ({
   authenticatedPage: page,
   passwordManagerMock,
-}) => {
-  test.setTimeout(60_000)
+}, testInfo) => {
+  test.setTimeout(120_000)
 
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
 
@@ -15,6 +17,19 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   const updatedEntryPassword = 'RotatedPassword!100'
   const entryNotes = 'Recovery codes and production notes'
   const cardNumber = '4111111111111111'
+  const pastedSshPublicMaterial = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPastedDeployPublicKey deploy@example.test'
+  const pastedSshPrivateKey = 'pasted SSH private key fixture material'
+  const uploadedSshPublicMaterial = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQUploadedDeployPublicKey uploaded@example.test'
+  const uploadedSshPrivateKey = 'uploaded SSH private key fixture material'
+  const generatedSshPassphrase = 'GeneratedSshPassphrase!42'
+  let generatedEd25519PublicMaterial = ''
+  let generatedEd25519PrivateKey = ''
+  let generatedRsaPublicMaterial = ''
+  let generatedRsaPrivateKey = ''
+  const uploadedSshPublicPath = testInfo.outputPath('uploaded-ssh-key.pub')
+  const uploadedSshPrivatePath = testInfo.outputPath('uploaded-ssh-key')
+  writeFileSync(uploadedSshPublicPath, uploadedSshPublicMaterial)
+  writeFileSync(uploadedSshPrivatePath, uploadedSshPrivateKey)
 
   const consoleMessages: string[] = []
   const pageErrors: string[] = []
@@ -84,6 +99,58 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   const entryCard = page.getByTestId('password-manager-entry-entry-2')
   await expect(entryCard).toContainText('Grafana admin')
   await expect(entryCard).toContainText('ops-admin')
+
+  await page.getByTestId('password-manager-entry-template-menu').click()
+  await page.getByRole('menuitemradio', { name: /SSH Key Pair/ }).click()
+  await page.getByRole('button', { name: 'New entry' }).click()
+  await expect(page.getByRole('dialog', { name: 'New SSH key pair' })).toBeVisible()
+  await page.getByLabel('Title').fill('Pasted deploy key')
+  await page.getByLabel('Public key or certificate').fill(pastedSshPublicMaterial)
+  await page.getByLabel('Private key').fill(pastedSshPrivateKey)
+  await page.getByRole('button', { name: 'Create encrypted entry' }).click()
+  const pastedSshEntry = page.getByTestId('password-manager-entry-entry-3')
+  await expect(pastedSshEntry).toContainText('Pasted deploy key')
+  await expect(pastedSshEntry).toContainText('SSH key pair')
+  await expect(pastedSshEntry.getByRole('button', { name: 'Reveal password' })).toHaveCount(0)
+  await expect(pastedSshEntry.getByRole('button', { name: 'Copy password' })).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'New entry' }).click()
+  await expect(page.getByRole('dialog', { name: 'New SSH key pair' })).toBeVisible()
+  await page.getByLabel('Title').fill('Uploaded deploy key')
+  await page.locator('#password-manager-entry-publicMaterial-file').setInputFiles(uploadedSshPublicPath)
+  await page.locator('#password-manager-entry-privateKey-file').setInputFiles(uploadedSshPrivatePath)
+  await expect(page.getByLabel('Public key or certificate')).toHaveValue(uploadedSshPublicMaterial)
+  await expect(page.getByLabel('Private key')).toHaveValue(uploadedSshPrivateKey)
+  await page.getByRole('button', { name: 'Create encrypted entry' }).click()
+  await expect(page.getByTestId('password-manager-entry-entry-4')).toContainText('Uploaded deploy key')
+
+  await page.getByRole('button', { name: 'New entry' }).click()
+  await expect(page.getByRole('dialog', { name: 'New SSH key pair' })).toBeVisible()
+  await page.getByLabel('Title').fill('Generated Ed25519 deploy key')
+  await page.getByLabel('Password protect generated private key').check()
+  await page.getByLabel('Key passphrase').fill(generatedSshPassphrase)
+  await page.getByLabel('Confirm key passphrase').fill(generatedSshPassphrase)
+  await page.getByRole('button', { name: 'Generate key pair' }).click()
+  await expect(page.getByLabel('Public key or certificate')).toHaveValue(/^ssh-ed25519 /)
+  await expect(page.getByLabel('Private key')).toHaveValue(/BEGIN OPENSSH PRIVATE KEY/)
+  generatedEd25519PublicMaterial = await page.getByLabel('Public key or certificate').inputValue()
+  generatedEd25519PrivateKey = await page.getByLabel('Private key').inputValue()
+  expect(generatedEd25519PrivateKey).not.toContain(generatedSshPassphrase)
+  await page.getByRole('button', { name: 'Create encrypted entry' }).click()
+  await expect(page.getByTestId('password-manager-entry-entry-5')).toContainText('Generated Ed25519 deploy key')
+
+  await page.getByRole('button', { name: 'New entry' }).click()
+  await expect(page.getByRole('dialog', { name: 'New SSH key pair' })).toBeVisible()
+  await page.getByLabel('Title').fill('Generated RSA deploy key')
+  await page.getByLabel('Algorithm').click()
+  await page.getByRole('option', { name: 'RSA 4096' }).click()
+  await page.getByRole('button', { name: 'Generate key pair' }).click()
+  await expect(page.getByLabel('Public key or certificate')).toHaveValue(/^ssh-rsa /)
+  await expect(page.getByLabel('Private key')).toHaveValue(/BEGIN OPENSSH PRIVATE KEY/)
+  generatedRsaPublicMaterial = await page.getByLabel('Public key or certificate').inputValue()
+  generatedRsaPrivateKey = await page.getByLabel('Private key').inputValue()
+  await page.getByRole('button', { name: 'Create encrypted entry' }).click()
+  await expect(page.getByTestId('password-manager-entry-entry-6')).toContainText('Generated RSA deploy key')
 
   await entryCard.getByRole('button', { name: 'Reveal password' }).click()
   await expect(entryCard.getByText(entryPassword)).toBeVisible()
@@ -209,6 +276,15 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(request.rawBody).not.toContain(entryPassword)
     expect(request.rawBody).not.toContain(updatedEntryPassword)
     expect(request.rawBody).not.toContain(entryNotes)
+    expect(request.rawBody).not.toContain(pastedSshPublicMaterial)
+    expect(request.rawBody).not.toContain(pastedSshPrivateKey)
+    expect(request.rawBody).not.toContain(uploadedSshPublicMaterial)
+    expect(request.rawBody).not.toContain(uploadedSshPrivateKey)
+    expect(request.rawBody).not.toContain(generatedSshPassphrase)
+    expect(request.rawBody).not.toContain(generatedEd25519PublicMaterial)
+    expect(request.rawBody).not.toContain(generatedEd25519PrivateKey)
+    expect(request.rawBody).not.toContain(generatedRsaPublicMaterial)
+    expect(request.rawBody).not.toContain(generatedRsaPrivateKey)
   }
 
   expect(passwordManagerMock.detectPlaintextLeak()).toBeNull()
@@ -220,6 +296,15 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(message).not.toContain(entryPassword)
     expect(message).not.toContain(updatedEntryPassword)
     expect(message).not.toContain(entryNotes)
+    expect(message).not.toContain(pastedSshPublicMaterial)
+    expect(message).not.toContain(pastedSshPrivateKey)
+    expect(message).not.toContain(uploadedSshPublicMaterial)
+    expect(message).not.toContain(uploadedSshPrivateKey)
+    expect(message).not.toContain(generatedSshPassphrase)
+    expect(message).not.toContain(generatedEd25519PublicMaterial)
+    expect(message).not.toContain(generatedEd25519PrivateKey)
+    expect(message).not.toContain(generatedRsaPublicMaterial)
+    expect(message).not.toContain(generatedRsaPrivateKey)
   }
 
   expect(pageErrors).toEqual([])
@@ -231,5 +316,14 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(request.body).not.toContain(entryPassword)
     expect(request.body).not.toContain(updatedEntryPassword)
     expect(request.body).not.toContain(entryNotes)
+    expect(request.body).not.toContain(pastedSshPublicMaterial)
+    expect(request.body).not.toContain(pastedSshPrivateKey)
+    expect(request.body).not.toContain(uploadedSshPublicMaterial)
+    expect(request.body).not.toContain(uploadedSshPrivateKey)
+    expect(request.body).not.toContain(generatedSshPassphrase)
+    expect(request.body).not.toContain(generatedEd25519PublicMaterial)
+    expect(request.body).not.toContain(generatedEd25519PrivateKey)
+    expect(request.body).not.toContain(generatedRsaPublicMaterial)
+    expect(request.body).not.toContain(generatedRsaPrivateKey)
   }
 })

--- a/apps/web/types/bcrypt-pbkdf.d.ts
+++ b/apps/web/types/bcrypt-pbkdf.d.ts
@@ -1,0 +1,11 @@
+declare module 'bcrypt-pbkdf' {
+  export function pbkdf(
+    pass: Uint8Array,
+    passlen: number,
+    salt: Uint8Array,
+    saltlen: number,
+    key: Uint8Array,
+    keylen: number,
+    rounds: number,
+  ): void
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       archiver:
         specifier: ^7.0.1
         version: 7.0.1
+      bcrypt-pbkdf:
+        specifier: ^1.0.2
+        version: 1.0.2
       better-auth:
         specifier: ^1.6.9
         version: 1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vue@3.5.33(typescript@5.9.3))


### PR DESCRIPTION
## Summary

- add an `SSH Key Pair` Password Manager entry template with public/certificate material, private key, upload controls, and generation controls
- generate OpenSSH-compatible Ed25519 and RSA 4096 keys in the browser, including optional passphrase-encrypted private keys
- include SSH fields in local search/export behavior while keeping password reveal/copy actions limited to entries with password payloads
- cover SSH entry filtering/export, key generation, and E2E creation/leak assertions

## Validation

- `git diff --check`
- `pnpm --dir apps/web exec node --experimental-strip-types --test lib/password-manager/ssh-keys.test.mjs lib/password-manager/workspace.test.mjs lib/password-manager/export.test.mjs`
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings outside this change)
- `ssh-keygen -y` compatibility check for generated Ed25519, RSA, and passphrase-protected Ed25519 private keys

## Known unrelated validation blockers

- `pnpm --filter web test:unit` still fails only in `apps/web/lib/agent/binary-integrity.test.mjs`; existing issue: #1109
- `E2E_PORT=3200 pnpm --filter web test:e2e -- tests/e2e/tooling/password-manager.spec.ts` fails before the target spec runs because shared `auth.setup.ts` times out warming `/reports/patch-status`; filed #1154
