### PR TITLE
feat(web): add shared password generator tool

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,28 @@
 
 ## What Has Been Built
 
+### Session 121 — Shared Password Generator tool
+
+**Reusable password generator** (`apps/web/lib/password-generator.ts`, `apps/web/components/password-generator/password-generator-tool.tsx`, `apps/web/app/(dashboard)/password-generator/page.tsx`)
+- Added a tooling-protected Password Generator page with browser-local password
+  and passphrase generation, presets, length and character-class controls,
+  ambiguous-character exclusion, custom symbols, copy support, and strength
+  feedback.
+- Added Password Generator entries to the sidebar and command palette using
+  shared navigation metadata.
+- Reused the same generator component inside the Password Manager login entry
+  modal, so template password fields can open the generator and populate the
+  selected encrypted-entry password field without creating a second generator.
+
+**Validation**
+- `pnpm install --frozen-lockfile`
+- `node --experimental-strip-types --test lib/password-generator.test.mjs lib/password-generator/navigation.test.mjs`
+- `pnpm --filter web type-check`
+- `pnpm --filter web lint` (passes with existing unrelated warnings)
+- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret DATABASE_URL=postgres://test:test@localhost:5432/ctops_test pnpm --filter web build` (passes; local placeholder secret emits expected Better Auth warnings)
+- `pnpm --filter web test:e2e tests/e2e/password-generator/password-generator.spec.ts` (blocked locally: `testcontainers` could not find a working container runtime)
+- `pnpm --filter web test:unit` (new generator tests pass; full suite still has unrelated failures from missing container runtime plus existing issue https://github.com/carrtech-dev/ct-ops/issues/1109)
+
 ### Session 120 — Profile 2FA QR setup
 
 **Authenticator setup QR code** (`apps/web/app/(dashboard)/profile/profile-client.tsx`, `apps/web/tests/e2e/profile/profile.spec.ts`)

--- a/apps/web/app/(dashboard)/password-generator/page.tsx
+++ b/apps/web/app/(dashboard)/password-generator/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { PasswordGeneratorTool } from '@/components/password-generator/password-generator-tool'
+import { getRequiredSession } from '@/lib/auth/session'
+import { canAccessTooling } from '@/lib/auth/tooling'
+
+export const metadata: Metadata = {
+  title: 'Password Generator',
+}
+
+export default async function PasswordGeneratorPage() {
+  const session = await getRequiredSession()
+  if (!canAccessTooling(session.user)) redirect('/dashboard')
+
+  return (
+    <div className="max-w-5xl">
+      <PasswordGeneratorTool />
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -50,6 +50,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PasswordGeneratorTool } from '@/components/password-generator/password-generator-tool'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import {
@@ -2776,6 +2777,7 @@ function PasswordManagerWorkspace({
   const [createVaultDialogOpen, setCreateVaultDialogOpen] = useState(false)
   const [entryDialogOpen, setEntryDialogOpen] = useState(false)
   const [entryDialogMode, setEntryDialogMode] = useState<PasswordManagerEntryDialogMode>('create')
+  const [passwordGeneratorDialogOpen, setPasswordGeneratorDialogOpen] = useState(false)
   const [deleteVaultDialogOpen, setDeleteVaultDialogOpen] = useState(false)
   const [deleteVaultUnlockPassword, setDeleteVaultUnlockPassword] = useState('')
   const [deleteVaultNameConfirmation, setDeleteVaultNameConfirmation] = useState('')
@@ -2806,6 +2808,7 @@ function PasswordManagerWorkspace({
     onStartCreateEntry()
     setEntryDialogMode('create')
     resetSshKeyGenerationControls()
+    setPasswordGeneratorDialogOpen(false)
     setEntryDialogOpen(true)
   }
 
@@ -2814,6 +2817,7 @@ function PasswordManagerWorkspace({
     onStartEditEntry(entry)
     setEntryDialogMode('edit')
     resetSshKeyGenerationControls()
+    setPasswordGeneratorDialogOpen(false)
     setEntryDialogOpen(true)
   }
 
@@ -2822,6 +2826,7 @@ function PasswordManagerWorkspace({
     onStartEditEntry(entry)
     setEntryDialogMode('view')
     resetSshKeyGenerationControls()
+    setPasswordGeneratorDialogOpen(false)
     setEntryDialogOpen(true)
   }
 
@@ -3388,12 +3393,24 @@ function PasswordManagerWorkspace({
                           : `Copy ${field.label.toLowerCase()}`
                     const canCopySshField =
                       isViewingEntry && activeEntryTemplate.id === 'ssh-key-pair' && !!editingEntryId && !!selectedEntry && !!value
+                    const canGeneratePassword = field.id === 'password' && !isViewingEntry
 
                     return (
                       <div key={field.id} className={field.multiline ? 'grid gap-2 sm:col-span-2' : 'grid gap-2'}>
                         <div className="flex items-center justify-between gap-2">
                           <Label htmlFor={fieldId}>{field.label}</Label>
-                          {canCopySshField ? (
+                          {canGeneratePassword ? (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setPasswordGeneratorDialogOpen(true)}
+                              disabled={!selectedVault}
+                            >
+                              <KeyRound className="size-4" />
+                              Generate password
+                            </Button>
+                          ) : canCopySshField ? (
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <Button
@@ -3479,6 +3496,23 @@ function PasswordManagerWorkspace({
                   </Button>
                 ) : null}
               </DialogFooter>
+            </DialogContent>
+          </Dialog>
+          <Dialog open={passwordGeneratorDialogOpen} onOpenChange={setPasswordGeneratorDialogOpen}>
+            <DialogContent className="max-h-[calc(100vh-2rem)] max-w-4xl overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>Password Generator</DialogTitle>
+                <DialogDescription>
+                  Generate a password locally, then insert it into this entry.
+                </DialogDescription>
+              </DialogHeader>
+              <PasswordGeneratorTool
+                showHeading={false}
+                onUsePassword={(generatedPassword) => {
+                  onEntryPasswordChange(generatedPassword)
+                  setPasswordGeneratorDialogOpen(false)
+                }}
+              />
             </DialogContent>
           </Dialog>
         </TabsContent>

--- a/apps/web/components/password-generator/password-generator-tool.tsx
+++ b/apps/web/components/password-generator/password-generator-tool.tsx
@@ -1,0 +1,368 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Check, Copy, Dices, KeyRound, RefreshCcw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+  estimatePasswordStrength,
+  generatePassword,
+  normalisePasswordGeneratorOptions,
+  type PasswordGeneratorMode,
+  type PasswordGeneratorOptions,
+} from '@/lib/password-generator'
+import { cn } from '@/lib/utils'
+
+type PasswordGeneratorToolProps = {
+  className?: string
+  onUsePassword?: (password: string) => void
+  showHeading?: boolean
+}
+
+const PRESETS: Array<{
+  id: string
+  label: string
+  options: Partial<PasswordGeneratorOptions>
+}> = [
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    options: DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+  },
+  {
+    id: 'maximum',
+    label: 'Maximum',
+    options: {
+      mode: 'password',
+      length: 32,
+      includeLowercase: true,
+      includeUppercase: true,
+      includeNumbers: true,
+      includeSymbols: true,
+      excludeAmbiguous: false,
+    },
+  },
+  {
+    id: 'memorable',
+    label: 'Memorable',
+    options: {
+      mode: 'passphrase',
+      wordCount: 5,
+      separator: '-',
+      capitalizeWords: false,
+      includePassphraseNumber: true,
+    },
+  },
+  {
+    id: 'legacy',
+    label: 'Legacy safe',
+    options: {
+      mode: 'password',
+      length: 18,
+      includeLowercase: true,
+      includeUppercase: true,
+      includeNumbers: true,
+      includeSymbols: false,
+      excludeAmbiguous: true,
+    },
+  },
+]
+
+function SwitchRow({
+  checked,
+  disabled,
+  label,
+  onCheckedChange,
+}: {
+  checked: boolean
+  disabled?: boolean
+  label: string
+  onCheckedChange: (checked: boolean) => void
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2 text-sm">
+      <span>{label}</span>
+      <Switch checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} aria-label={label} />
+    </label>
+  )
+}
+
+export function PasswordGeneratorTool({
+  className,
+  onUsePassword,
+  showHeading = true,
+}: PasswordGeneratorToolProps) {
+  const [options, setOptions] = useState<PasswordGeneratorOptions>(DEFAULT_PASSWORD_GENERATOR_OPTIONS)
+  const [password, setPassword] = useState('')
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const strength = useMemo(() => estimatePasswordStrength(password), [password])
+
+  function updateOptions(nextOptions: Partial<PasswordGeneratorOptions>) {
+    setOptions((current) => normalisePasswordGeneratorOptions({ ...current, ...nextOptions }))
+    setError(null)
+  }
+
+  function regenerate(nextOptions: PasswordGeneratorOptions = options) {
+    try {
+      setPassword(generatePassword(nextOptions))
+      setCopied(false)
+      setError(null)
+    } catch (generateError) {
+      setError(generateError instanceof Error ? generateError.message : 'Password could not be generated.')
+    }
+  }
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      try {
+        setPassword(generatePassword(DEFAULT_PASSWORD_GENERATOR_OPTIONS))
+        setError(null)
+      } catch (generateError) {
+        setError(generateError instanceof Error ? generateError.message : 'Password could not be generated.')
+      }
+    }, 0)
+
+    return () => window.clearTimeout(timeout)
+  }, [])
+
+  async function copyPassword() {
+    if (!password) {
+      return
+    }
+    await navigator.clipboard.writeText(password)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+
+  function applyPreset(preset: (typeof PRESETS)[number]) {
+    const nextOptions = normalisePasswordGeneratorOptions({
+      ...DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+      ...preset.options,
+    })
+    setOptions(nextOptions)
+    regenerate(nextOptions)
+  }
+
+  const canDisableCharacterType = [
+    options.includeLowercase,
+    options.includeUppercase,
+    options.includeNumbers,
+    options.includeSymbols,
+  ].filter(Boolean).length > 1
+
+  return (
+    <div className={cn('space-y-5', className)}>
+      {showHeading ? (
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold text-foreground" data-testid="password-generator-heading">
+            <KeyRound className="size-6 text-primary" />
+            Password Generator
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Generate passwords and passphrases locally in this browser.
+          </p>
+        </div>
+      ) : null}
+
+      <Card className="border-border/60 shadow-xs">
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle>Generated secret</CardTitle>
+              <CardDescription>Nothing is sent to the server while generating or copying.</CardDescription>
+            </div>
+            <Badge
+              variant={strength.score >= 2 ? 'default' : strength.score === 1 ? 'secondary' : 'destructive'}
+              data-testid="password-generator-strength"
+            >
+              {strength.label} · {strength.entropyBits} bits
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              value={password}
+              readOnly
+              className="font-mono"
+              data-testid="password-generator-output"
+              aria-label="Generated password"
+            />
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={() => regenerate()} aria-label="Generate password">
+                <RefreshCcw className="size-4" />
+                Generate
+              </Button>
+              <Button type="button" variant="outline" onClick={() => void copyPassword()} aria-label="Copy password">
+                {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+              {onUsePassword ? (
+                <Button type="button" onClick={() => onUsePassword(password)} disabled={!password}>
+                  Use password
+                </Button>
+              ) : null}
+            </div>
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-5 lg:grid-cols-[1fr_1.2fr]">
+        <Card className="border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle>Presets</CardTitle>
+            <CardDescription>Start from a policy-friendly default, then tune it.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-2">
+            {PRESETS.map((preset) => (
+              <Button
+                key={preset.id}
+                type="button"
+                variant="outline"
+                className="justify-start"
+                onClick={() => applyPreset(preset)}
+              >
+                <Dices className="size-4" />
+                {preset.label}
+              </Button>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60 shadow-xs">
+          <CardHeader>
+            <CardTitle>Options</CardTitle>
+            <CardDescription>Use character passwords for systems, passphrases for humans.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <Tabs value={options.mode} onValueChange={(value) => updateOptions({ mode: value as PasswordGeneratorMode })}>
+              <TabsList>
+                <TabsTrigger value="password">Password</TabsTrigger>
+                <TabsTrigger value="passphrase">Passphrase</TabsTrigger>
+              </TabsList>
+            </Tabs>
+
+            {options.mode === 'password' ? (
+              <div className="space-y-5">
+                <div className="grid gap-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label htmlFor="password-generator-length">Password length</Label>
+                    <Input
+                      id="password-generator-length"
+                      type="number"
+                      min={8}
+                      max={128}
+                      value={options.length}
+                      onChange={(event) => updateOptions({ length: Number.parseInt(event.target.value, 10) })}
+                      className="w-24"
+                    />
+                  </div>
+                  <input
+                    type="range"
+                    min={8}
+                    max={128}
+                    value={options.length}
+                    onChange={(event) => updateOptions({ length: Number.parseInt(event.target.value, 10) })}
+                    aria-label="Password length slider"
+                  />
+                </div>
+
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <SwitchRow
+                    label="Lowercase"
+                    checked={options.includeLowercase}
+                    disabled={options.includeLowercase && !canDisableCharacterType}
+                    onCheckedChange={(checked) => updateOptions({ includeLowercase: checked })}
+                  />
+                  <SwitchRow
+                    label="Uppercase"
+                    checked={options.includeUppercase}
+                    disabled={options.includeUppercase && !canDisableCharacterType}
+                    onCheckedChange={(checked) => updateOptions({ includeUppercase: checked })}
+                  />
+                  <SwitchRow
+                    label="Numbers"
+                    checked={options.includeNumbers}
+                    disabled={options.includeNumbers && !canDisableCharacterType}
+                    onCheckedChange={(checked) => updateOptions({ includeNumbers: checked })}
+                  />
+                  <SwitchRow
+                    label="Symbols"
+                    checked={options.includeSymbols}
+                    disabled={options.includeSymbols && !canDisableCharacterType}
+                    onCheckedChange={(checked) => updateOptions({ includeSymbols: checked })}
+                  />
+                  <SwitchRow
+                    label="Avoid ambiguous characters"
+                    checked={options.excludeAmbiguous}
+                    onCheckedChange={(checked) => updateOptions({ excludeAmbiguous: checked })}
+                  />
+                </div>
+
+                {options.includeSymbols ? (
+                  <div className="grid gap-2">
+                    <Label htmlFor="password-generator-symbols">Allowed symbols</Label>
+                    <Input
+                      id="password-generator-symbols"
+                      value={options.customSymbols}
+                      onChange={(event) => updateOptions({ customSymbols: event.target.value })}
+                      className="font-mono"
+                    />
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="space-y-5">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-2">
+                    <Label htmlFor="password-generator-word-count">Word count</Label>
+                    <Input
+                      id="password-generator-word-count"
+                      type="number"
+                      min={3}
+                      max={10}
+                      value={options.wordCount}
+                      onChange={(event) => updateOptions({ wordCount: Number.parseInt(event.target.value, 10) })}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="password-generator-separator">Separator</Label>
+                    <Input
+                      id="password-generator-separator"
+                      value={options.separator}
+                      maxLength={3}
+                      onChange={(event) => updateOptions({ separator: event.target.value })}
+                    />
+                  </div>
+                </div>
+                <Separator />
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <SwitchRow
+                    label="Capitalize words"
+                    checked={options.capitalizeWords}
+                    onCheckedChange={(checked) => updateOptions({ capitalizeWords: checked })}
+                  />
+                  <SwitchRow
+                    label="Append number"
+                    checked={options.includePassphraseNumber}
+                    onCheckedChange={(checked) => updateOptions({ includePassphraseNumber: checked })}
+                  />
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/shared/command-palette/providers.tsx
+++ b/apps/web/components/shared/command-palette/providers.tsx
@@ -26,6 +26,7 @@ import {
 import { listHosts } from '@/lib/actions/agents'
 import { canAccessTooling } from '@/lib/auth/tooling'
 import { PASSWORD_MANAGER_COMMAND_ITEM } from '@/lib/password-manager/navigation'
+import { PASSWORD_GENERATOR_COMMAND_ITEM } from '@/lib/password-generator/navigation'
 import type { CommandPaletteItem } from './types'
 
 const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
@@ -42,6 +43,7 @@ const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
   { id: 'nav-reports-patch-status', label: 'Patch Status Report', icon: ShieldCheck, href: '/reports/patch-status' },
   { id: 'nav-reports-vulnerabilities', label: 'Vulnerability Report', icon: ShieldAlert, href: '/reports/vulnerabilities' },
   PASSWORD_MANAGER_COMMAND_ITEM,
+  PASSWORD_GENERATOR_COMMAND_ITEM,
   { id: 'nav-cert-checker', label: 'SSL Certificate Checker', icon: ScanSearch, href: '/certificate-checker' },
   { id: 'nav-dir-lookup', label: 'Directory User Lookup', icon: FolderSearch, href: '/directory-lookup' },
   { id: 'nav-bundlers', label: 'Air-gap Bundlers', icon: Package, href: '/bundlers' },
@@ -58,6 +60,7 @@ const NAV_ITEMS: ReadonlyArray<Omit<CommandPaletteItem, 'group'>> = [
 
 const TOOLING_ITEM_IDS = new Set([
   'nav-password-manager',
+  'nav-password-generator',
   'nav-cert-checker',
   'nav-dir-lookup',
   'nav-bundlers',

--- a/apps/web/components/shared/sidebar.tsx
+++ b/apps/web/components/shared/sidebar.tsx
@@ -45,6 +45,7 @@ import { TerminalPanelTrigger } from '@/components/terminal'
 import type { LicenceTier } from '@/lib/features'
 import { canAccessTooling } from '@/lib/auth/tooling'
 import { PASSWORD_MANAGER_NAV_ITEM } from '@/lib/password-manager/navigation'
+import { PASSWORD_GENERATOR_NAV_ITEM } from '@/lib/password-generator/navigation'
 import pkg from '../../package.json'
 
 const WEB_VERSION = `v${pkg.version}`
@@ -100,6 +101,7 @@ const reportingNav: NavItem[] = [
 
 const toolingNav: NavItem[] = [
   PASSWORD_MANAGER_NAV_ITEM,
+  PASSWORD_GENERATOR_NAV_ITEM,
   { title: 'SSL Certificate Checker', href: '/certificate-checker', icon: ScanSearch },
   { title: 'Directory User Lookup', href: '/directory-lookup', icon: FolderSearch },
   { title: 'Air-gap Bundlers', href: '/bundlers', icon: Package },

--- a/apps/web/lib/password-generator.test.mjs
+++ b/apps/web/lib/password-generator.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+  estimatePasswordStrength,
+  generatePassword,
+  normalisePasswordGeneratorOptions,
+} from './password-generator.ts'
+
+function createCyclingRandomInt() {
+  let current = 0
+  return (max) => {
+    const next = current % max
+    current += 1
+    return next
+  }
+}
+
+test('generatePassword creates a bounded password with every selected character class', () => {
+  const password = generatePassword(
+    {
+      ...DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+      length: 20,
+      includeLowercase: true,
+      includeUppercase: true,
+      includeNumbers: true,
+      includeSymbols: true,
+      excludeAmbiguous: false,
+    },
+    createCyclingRandomInt(),
+  )
+
+  assert.equal(password.length, 20)
+  assert.match(password, /[a-z]/)
+  assert.match(password, /[A-Z]/)
+  assert.match(password, /[0-9]/)
+  assert.match(password, /[^A-Za-z0-9]/)
+})
+
+test('generatePassword excludes ambiguous characters when requested', () => {
+  const password = generatePassword(
+    {
+      ...DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+      length: 64,
+      includeLowercase: true,
+      includeUppercase: true,
+      includeNumbers: true,
+      includeSymbols: false,
+      excludeAmbiguous: true,
+    },
+    createCyclingRandomInt(),
+  )
+
+  assert.doesNotMatch(password, /[O0oIl1]/)
+})
+
+test('normalisePasswordGeneratorOptions clamps risky option values', () => {
+  const options = normalisePasswordGeneratorOptions({
+    length: 500,
+    wordCount: 99,
+    separator: 'too-long',
+    customSymbols: '',
+  })
+
+  assert.equal(options.length, 128)
+  assert.equal(options.wordCount, 10)
+  assert.equal(options.separator, '-')
+  assert.equal(options.customSymbols, DEFAULT_PASSWORD_GENERATOR_OPTIONS.customSymbols)
+})
+
+test('generatePassword creates memorable passphrases from the shared generator', () => {
+  const passphrase = generatePassword(
+    {
+      ...DEFAULT_PASSWORD_GENERATOR_OPTIONS,
+      mode: 'passphrase',
+      wordCount: 4,
+      separator: '.',
+      capitalizeWords: true,
+      includePassphraseNumber: true,
+    },
+    createCyclingRandomInt(),
+  )
+
+  assert.match(passphrase, /^[A-Z][a-z]+(\.[A-Z][a-z]+){3}\.[0-9]{2}$/)
+})
+
+test('estimatePasswordStrength reports stronger entropy for longer generated secrets', () => {
+  const weak = estimatePasswordStrength('abc123')
+  const strong = estimatePasswordStrength('aB3!aB3!aB3!aB3!aB3!')
+
+  assert.equal(weak.label, 'Weak')
+  assert.ok(strong.entropyBits > weak.entropyBits)
+  assert.ok(strong.score > weak.score)
+})

--- a/apps/web/lib/password-generator.ts
+++ b/apps/web/lib/password-generator.ts
@@ -1,0 +1,288 @@
+export type PasswordGeneratorMode = 'password' | 'passphrase'
+
+export interface PasswordGeneratorOptions {
+  mode: PasswordGeneratorMode
+  length: number
+  includeLowercase: boolean
+  includeUppercase: boolean
+  includeNumbers: boolean
+  includeSymbols: boolean
+  excludeAmbiguous: boolean
+  customSymbols: string
+  wordCount: number
+  separator: string
+  capitalizeWords: boolean
+  includePassphraseNumber: boolean
+}
+
+export interface PasswordStrengthEstimate {
+  entropyBits: number
+  label: 'Weak' | 'Fair' | 'Strong' | 'Excellent'
+  score: 0 | 1 | 2 | 3
+}
+
+export type PasswordGeneratorRandomInt = (maxExclusive: number) => number
+
+const LOWERCASE = 'abcdefghijklmnopqrstuvwxyz'
+const UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const NUMBERS = '0123456789'
+const DEFAULT_SYMBOLS = '!@#$%^&*()-_=+[]{};:,.<>?'
+const AMBIGUOUS_CHARACTERS = new Set('O0oIl1'.split(''))
+const MIN_PASSWORD_LENGTH = 8
+const MAX_PASSWORD_LENGTH = 128
+const MIN_WORD_COUNT = 3
+const MAX_WORD_COUNT = 10
+
+const PASSPHRASE_WORDS = [
+  'anchor',
+  'atlas',
+  'beacon',
+  'binary',
+  'brisk',
+  'canyon',
+  'cedar',
+  'cipher',
+  'cobalt',
+  'comet',
+  'coral',
+  'delta',
+  'ember',
+  'falcon',
+  'fathom',
+  'fibre',
+  'forge',
+  'harbor',
+  'hazel',
+  'helium',
+  'indigo',
+  'ion',
+  'jade',
+  'kepler',
+  'lagoon',
+  'lattice',
+  'lumen',
+  'matrix',
+  'meridian',
+  'nebula',
+  'nickel',
+  'nova',
+  'onyx',
+  'orbit',
+  'parity',
+  'pixel',
+  'plasma',
+  'quartz',
+  'radar',
+  'raven',
+  'relay',
+  'ripple',
+  'signal',
+  'silicon',
+  'summit',
+  'tango',
+  'tidal',
+  'vector',
+  'velvet',
+  'vertex',
+  'violet',
+  'zenith',
+]
+
+export const DEFAULT_PASSWORD_GENERATOR_OPTIONS: PasswordGeneratorOptions = {
+  mode: 'password',
+  length: 20,
+  includeLowercase: true,
+  includeUppercase: true,
+  includeNumbers: true,
+  includeSymbols: true,
+  excludeAmbiguous: true,
+  customSymbols: DEFAULT_SYMBOLS,
+  wordCount: 4,
+  separator: '-',
+  capitalizeWords: false,
+  includePassphraseNumber: true,
+}
+
+function clampInteger(value: unknown, minimum: number, maximum: number, fallback: number): number {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value), 10)
+  if (!Number.isFinite(parsed)) {
+    return fallback
+  }
+  return Math.min(maximum, Math.max(minimum, Math.trunc(parsed)))
+}
+
+function normaliseSymbols(value: unknown): string {
+  if (typeof value !== 'string') {
+    return DEFAULT_SYMBOLS
+  }
+  const unique = Array.from(new Set(value.trim().split(''))).join('')
+  return unique || DEFAULT_SYMBOLS
+}
+
+function normaliseSeparator(value: unknown): string {
+  if (typeof value !== 'string') {
+    return DEFAULT_PASSWORD_GENERATOR_OPTIONS.separator
+  }
+  const trimmed = value.trim()
+  return trimmed.length >= 1 && trimmed.length <= 3 ? trimmed : DEFAULT_PASSWORD_GENERATOR_OPTIONS.separator
+}
+
+export function normalisePasswordGeneratorOptions(
+  input: Partial<PasswordGeneratorOptions> = {},
+): PasswordGeneratorOptions {
+  return {
+    mode: input.mode === 'passphrase' ? 'passphrase' : 'password',
+    length: clampInteger(
+      input.length,
+      MIN_PASSWORD_LENGTH,
+      MAX_PASSWORD_LENGTH,
+      DEFAULT_PASSWORD_GENERATOR_OPTIONS.length,
+    ),
+    includeLowercase: input.includeLowercase ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.includeLowercase,
+    includeUppercase: input.includeUppercase ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.includeUppercase,
+    includeNumbers: input.includeNumbers ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.includeNumbers,
+    includeSymbols: input.includeSymbols ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.includeSymbols,
+    excludeAmbiguous: input.excludeAmbiguous ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.excludeAmbiguous,
+    customSymbols: normaliseSymbols(input.customSymbols),
+    wordCount: clampInteger(
+      input.wordCount,
+      MIN_WORD_COUNT,
+      MAX_WORD_COUNT,
+      DEFAULT_PASSWORD_GENERATOR_OPTIONS.wordCount,
+    ),
+    separator: normaliseSeparator(input.separator),
+    capitalizeWords: input.capitalizeWords ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.capitalizeWords,
+    includePassphraseNumber:
+      input.includePassphraseNumber ?? DEFAULT_PASSWORD_GENERATOR_OPTIONS.includePassphraseNumber,
+  }
+}
+
+function removeAmbiguousCharacters(characters: string): string {
+  return characters
+    .split('')
+    .filter((character) => !AMBIGUOUS_CHARACTERS.has(character))
+    .join('')
+}
+
+function getSelectedCharacterSets(options: PasswordGeneratorOptions): string[] {
+  const sets = [
+    options.includeLowercase ? LOWERCASE : '',
+    options.includeUppercase ? UPPERCASE : '',
+    options.includeNumbers ? NUMBERS : '',
+    options.includeSymbols ? options.customSymbols : '',
+  ]
+    .map((characters) => (options.excludeAmbiguous ? removeAmbiguousCharacters(characters) : characters))
+    .filter(Boolean)
+
+  if (sets.length === 0) {
+    throw new Error('Select at least one character type before generating a password.')
+  }
+  return sets
+}
+
+function secureRandomInt(maxExclusive: number): number {
+  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
+    throw new Error('Random range must be a positive integer.')
+  }
+  const cryptoApi = globalThis.crypto
+  if (!cryptoApi?.getRandomValues) {
+    throw new Error('Secure browser crypto is required to generate passwords.')
+  }
+
+  const maximumUint32 = 0xffffffff
+  const limit = maximumUint32 - (maximumUint32 % maxExclusive)
+  const buffer = new Uint32Array(1)
+  let value = 0
+  do {
+    cryptoApi.getRandomValues(buffer)
+    value = buffer[0] ?? 0
+  } while (value >= limit)
+
+  return value % maxExclusive
+}
+
+function randomCharacter(characters: string, randomInt: PasswordGeneratorRandomInt): string {
+  return characters[randomInt(characters.length)]!
+}
+
+function shuffleCharacters(characters: string[], randomInt: PasswordGeneratorRandomInt): string[] {
+  const shuffled = [...characters]
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = randomInt(index + 1)
+    ;[shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex]!, shuffled[index]!]
+  }
+  return shuffled
+}
+
+function capitalizeWord(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
+function generateCharacterPassword(
+  options: PasswordGeneratorOptions,
+  randomInt: PasswordGeneratorRandomInt,
+): string {
+  const sets = getSelectedCharacterSets(options)
+  if (options.length < sets.length) {
+    throw new Error('Password length is too short for the selected character types.')
+  }
+
+  const allCharacters = sets.join('')
+  const characters = sets.map((set) => randomCharacter(set, randomInt))
+  while (characters.length < options.length) {
+    characters.push(randomCharacter(allCharacters, randomInt))
+  }
+
+  return shuffleCharacters(characters, randomInt).join('')
+}
+
+function generatePassphrase(options: PasswordGeneratorOptions, randomInt: PasswordGeneratorRandomInt): string {
+  const words = Array.from({ length: options.wordCount }, () => {
+    const word = PASSPHRASE_WORDS[randomInt(PASSPHRASE_WORDS.length)]!
+    return options.capitalizeWords ? capitalizeWord(word) : word
+  })
+
+  if (options.includePassphraseNumber) {
+    words.push(String(randomInt(90) + 10))
+  }
+
+  return words.join(options.separator)
+}
+
+export function generatePassword(
+  input: Partial<PasswordGeneratorOptions> = {},
+  randomInt: PasswordGeneratorRandomInt = secureRandomInt,
+): string {
+  const options = normalisePasswordGeneratorOptions(input)
+  return options.mode === 'passphrase'
+    ? generatePassphrase(options, randomInt)
+    : generateCharacterPassword(options, randomInt)
+}
+
+export function estimatePasswordStrength(password: string): PasswordStrengthEstimate {
+  const uniqueCharacters = new Set(password.split('')).size
+  const hasLowercase = /[a-z]/.test(password)
+  const hasUppercase = /[A-Z]/.test(password)
+  const hasNumber = /[0-9]/.test(password)
+  const hasSymbol = /[^A-Za-z0-9]/.test(password)
+  const poolSize =
+    (hasLowercase ? 26 : 0) +
+    (hasUppercase ? 26 : 0) +
+    (hasNumber ? 10 : 0) +
+    (hasSymbol ? DEFAULT_SYMBOLS.length : 0)
+  const repetitionPenalty = uniqueCharacters <= 2 && password.length > 4 ? 0.5 : 1
+  const entropyBits = password.length && poolSize
+    ? Math.round(password.length * Math.log2(poolSize) * repetitionPenalty)
+    : 0
+
+  if (entropyBits >= 100) {
+    return { entropyBits, label: 'Excellent', score: 3 }
+  }
+  if (entropyBits >= 70) {
+    return { entropyBits, label: 'Strong', score: 2 }
+  }
+  if (entropyBits >= 45) {
+    return { entropyBits, label: 'Fair', score: 1 }
+  }
+  return { entropyBits, label: 'Weak', score: 0 }
+}

--- a/apps/web/lib/password-generator/navigation.test.mjs
+++ b/apps/web/lib/password-generator/navigation.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  PASSWORD_GENERATOR_COMMAND_ITEM,
+  PASSWORD_GENERATOR_NAV_ITEM,
+} from './navigation.ts'
+
+test('Password Generator sidebar navigation targets the tooling route', () => {
+  assert.equal(PASSWORD_GENERATOR_NAV_ITEM.title, 'Password Generator')
+  assert.equal(PASSWORD_GENERATOR_NAV_ITEM.href, '/password-generator')
+  assert.equal(PASSWORD_GENERATOR_NAV_ITEM.testId, 'sidebar-password-generator')
+})
+
+test('Password Generator command palette item exposes route and search keywords', () => {
+  assert.equal(PASSWORD_GENERATOR_COMMAND_ITEM.id, 'nav-password-generator')
+  assert.equal(PASSWORD_GENERATOR_COMMAND_ITEM.label, 'Password Generator')
+  assert.equal(PASSWORD_GENERATOR_COMMAND_ITEM.href, '/password-generator')
+  assert.deepEqual(
+    PASSWORD_GENERATOR_COMMAND_ITEM.keywords,
+    ['password', 'generator', 'secrets', 'credentials', 'tooling'],
+  )
+})

--- a/apps/web/lib/password-generator/navigation.ts
+++ b/apps/web/lib/password-generator/navigation.ts
@@ -1,0 +1,16 @@
+import { KeyRound } from 'lucide-react'
+
+export const PASSWORD_GENERATOR_NAV_ITEM = {
+  title: 'Password Generator',
+  href: '/password-generator',
+  icon: KeyRound,
+  testId: 'sidebar-password-generator',
+} as const
+
+export const PASSWORD_GENERATOR_COMMAND_ITEM = {
+  id: 'nav-password-generator',
+  label: 'Password Generator',
+  icon: KeyRound,
+  href: '/password-generator',
+  keywords: ['password', 'generator', 'secrets', 'credentials', 'tooling'] as string[],
+} as const

--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -33,6 +33,7 @@ const authenticatedRoutes = [
   '/hosts/networks',
   '/legal-notice',
   '/notifications',
+  '/password-generator',
   '/password-manager',
   '/reports/patch-status',
   '/reports/software',

--- a/apps/web/tests/e2e/password-generator/password-generator.spec.ts
+++ b/apps/web/tests/e2e/password-generator/password-generator.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '../fixtures/test'
+
+test('standalone password generator creates, tunes, and copies a password locally', async ({
+  authenticatedPage: page,
+}) => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+
+  await page.goto('/password-generator')
+  await expect(page.getByTestId('password-generator-heading')).toContainText('Password Generator')
+
+  await page.getByLabel('Password length', { exact: true }).fill('24')
+  await page.getByRole('switch', { name: 'Symbols' }).click()
+  await page.getByRole('switch', { name: 'Avoid ambiguous characters' }).click()
+  await page.getByRole('button', { name: 'Generate password' }).click()
+
+  const generated = page.getByTestId('password-generator-output')
+  await expect(generated).toHaveValue(/^[^!@#$%^&*()_\-+=[\]{};:,.<>/?~`|\\'"]{24}$/)
+  await expect(page.getByTestId('password-generator-strength')).toContainText(/Strong|Excellent/)
+
+  await page.getByRole('button', { name: 'Copy password' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toHaveLength(24)
+})
+
+test('password manager uses the shared generator to populate a login password field', async ({
+  authenticatedPage: page,
+}) => {
+  const setupPassword = 'LocalUnlockPassword!42'
+
+  await page.goto('/password-manager')
+  await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()
+
+  await page.getByLabel('Unlock password', { exact: true }).fill(setupPassword)
+  await page.getByLabel('Confirm unlock password', { exact: true }).fill(setupPassword)
+  await page.getByRole('button', { name: 'Create unlock profile' }).click()
+  await expect(page.getByTestId('password-manager-workspace')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Create vault' }).click()
+  await page.getByLabel('Vault name').fill('Shared production')
+  await page.getByRole('button', { name: 'Create encrypted vault' }).click()
+
+  await page.getByRole('button', { name: 'New entry' }).click()
+  await expect(page.getByRole('dialog', { name: 'New login' })).toBeVisible()
+  await page.getByRole('button', { name: 'Generate password' }).click()
+  await expect(page.getByRole('dialog', { name: 'Password Generator' })).toBeVisible()
+
+  await page.getByLabel('Password length', { exact: true }).fill('28')
+  await page.getByRole('button', { name: 'Use password' }).click()
+
+  await expect(page.getByRole('dialog', { name: 'New login' })).toBeVisible()
+  await expect(page.getByLabel('Password', { exact: true })).toHaveValue(/.{28}/)
+})

--- a/apps/web/tests/e2e/tooling/access-control.spec.ts
+++ b/apps/web/tests/e2e/tooling/access-control.spec.ts
@@ -23,9 +23,10 @@ test('read-only users cannot access tooling pages or certificate checker API', a
     await page.goto('/dashboard')
     await expect(page.getByText('Tooling')).toHaveCount(0)
     await expect(page.getByRole('link', { name: 'Password Manager' })).toHaveCount(0)
+    await expect(page.getByRole('link', { name: 'Password Generator' })).toHaveCount(0)
     await expect(page.getByRole('link', { name: 'SSL Certificate Checker' })).toHaveCount(0)
 
-    for (const path of ['/password-manager', '/certificate-checker', '/directory-lookup', '/tasks', '/build-docs']) {
+    for (const path of ['/password-manager', '/password-generator', '/certificate-checker', '/directory-lookup', '/tasks', '/build-docs']) {
       await page.goto(path)
       await expect(page).toHaveURL(/\/dashboard$/)
     }


### PR DESCRIPTION
## Summary
- add a tooling-protected Password Generator page with password/passphrase modes, presets, local generation, copy support, and strength feedback
- register Password Generator in the sidebar and command palette
- reuse the same generator component from Password Manager login password fields so generated values populate the encrypted entry form

## Validation
- pnpm install --frozen-lockfile
- node --experimental-strip-types --test lib/password-generator.test.mjs lib/password-generator/navigation.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing unrelated warnings)
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret DATABASE_URL=postgres://test:test@localhost:5432/ctops_test pnpm --filter web build (passes; local placeholder secret emits expected Better Auth warnings)
- pnpm --filter web test:e2e tests/e2e/password-generator/password-generator.spec.ts (blocked locally: testcontainers could not find a working container runtime)
- pnpm --filter web test:unit (new generator tests pass; full suite still has unrelated failures from missing container runtime plus existing issue #1109)