### PR TITLE
fix(web): update patch status chart semantics

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,27 @@
 
 ## What Has Been Built
 
+### Session 122 — Patch Status history chart semantics
+
+**Patch Status check history chart** (`apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx`, `apps/web/lib/checks/history-chart.ts`)
+- Changed Patch Status history bars so their height is based on
+  `updates_count` instead of check response duration.
+- Changed Patch Status history bar colour to reflect patch age against the
+  configured policy threshold: green before five-sixths of the threshold, amber
+  from five-sixths through the threshold, and red after the threshold.
+- Kept non-Patch Status checks on the existing response-duration chart
+  semantics, and added tooltip copy for available updates, patch age, and the
+  policy threshold.
+
+**Validation**
+- `pnpm install --frozen-lockfile`
+- `node --experimental-strip-types --test apps/web/lib/checks/history-chart.test.mjs`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web lint` (passes with existing unrelated warnings)
+- `pnpm --dir apps/web test:unit` (new tests pass; full suite still has
+  unrelated failures from missing local container runtime plus existing issue
+  https://github.com/carrtech-dev/ct-ops/issues/1109)
+
 ### Session 121 — Shared Password Generator tool
 
 **Reusable password generator** (`apps/web/lib/password-generator.ts`, `apps/web/components/password-generator/password-generator-tool.tsx`, `apps/web/app/(dashboard)/password-generator/page.tsx`)

--- a/apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx
@@ -63,6 +63,12 @@ import {
   deleteCheck,
   deleteCheckHistory,
 } from '@/lib/actions/checks'
+import {
+  CHECK_STATUS_COLOURS,
+  getPatchStatusChartColour,
+  getPatchStatusChartValue,
+  parsePatchStatusOutput,
+} from '@/lib/checks/history-chart'
 import type { CheckWithHistory } from '@/lib/actions/checks'
 import type {
   CheckResultRow,
@@ -89,11 +95,7 @@ interface Props {
   hostId: string
 }
 
-const STATUS_COLOUR: Record<string, string> = {
-  pass: '#22c55e',
-  fail: '#ef4444',
-  error: '#f59e0b',
-}
+const STATUS_COLOUR: Record<string, string> = CHECK_STATUS_COLOURS
 
 function formatCheckOutput(checkType: string, output: string): string {
   if (checkType === 'service_account') {
@@ -252,16 +254,35 @@ function StatusWeather({ results }: { results: CheckResultRow[] }) {
   return <span title={label}><CloudLightning className="size-4 text-red-500" aria-label="Mostly failing" /></span>
 }
 
-function CheckHistoryChart({ results, checkType }: { results: CheckResultRow[]; checkType: string }) {
+function CheckHistoryChart({
+  results,
+  checkType,
+  patchConfig,
+}: {
+  results: CheckResultRow[]
+  checkType: string
+  patchConfig?: PatchStatusCheckConfig
+}) {
+  const maxPatchAgeDays = patchConfig?.max_age_days
   const data = [...results]
     .reverse()
-    .map((r) => ({
-      id: r.id,
-      time: new Date(r.ranAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      duration: Math.max(1, r.durationMs ?? 1),
-      status: r.status,
-      output: r.output ? formatCheckOutput(checkType, r.output) : r.output,
-    }))
+    .map((r) => {
+      const patchPayload = checkType === 'patch_status' ? parsePatchStatusOutput(r.output) : null
+      const patchMaxAgeDays = typeof patchPayload?.max_age_days === 'number' ? patchPayload.max_age_days : maxPatchAgeDays
+      return {
+        id: r.id,
+        time: new Date(r.ranAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        duration: Math.max(1, r.durationMs ?? 1),
+        status: r.status,
+        output: r.output ? formatCheckOutput(checkType, r.output) : r.output,
+        value: checkType === 'patch_status' ? getPatchStatusChartValue(r.output) : Math.max(1, r.durationMs ?? 1),
+        fill: checkType === 'patch_status'
+          ? getPatchStatusChartColour(r.output, maxPatchAgeDays)
+          : STATUS_COLOUR[r.status] ?? STATUS_COLOUR.unknown,
+        patchAgeDays: typeof patchPayload?.patch_age_days === 'number' ? patchPayload.patch_age_days : null,
+        patchMaxAgeDays,
+      }
+    })
 
   return (
     <ResponsiveContainer width="100%" height={72}>
@@ -288,19 +309,38 @@ function CheckHistoryChart({ results, checkType }: { results: CheckResultRow[]; 
                 </p>
                 {d.output && <p className="text-muted-foreground truncate max-w-48">{d.output}</p>}
                 <p className="text-muted-foreground">{d.time}</p>
-                <p className="text-muted-foreground">
-                  Response time:{' '}
-                  <span className="text-foreground font-medium">{d.duration}ms</span>
-                </p>
+                {checkType === 'patch_status' ? (
+                  <>
+                    <p className="text-muted-foreground">
+                      Available updates:{' '}
+                      <span className="text-foreground font-medium">{d.value}</span>
+                    </p>
+                    <p className="text-muted-foreground">
+                      Patch age:{' '}
+                      <span className="text-foreground font-medium">
+                        {d.patchAgeDays ?? 'unknown'}
+                        {d.patchAgeDays == null ? '' : 'd'}
+                      </span>
+                      {typeof d.patchMaxAgeDays === 'number' && (
+                        <> / {d.patchMaxAgeDays}d policy</>
+                      )}
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-muted-foreground">
+                    Response time:{' '}
+                    <span className="text-foreground font-medium">{d.duration}ms</span>
+                  </p>
+                )}
               </div>
             )
           }}
         />
-        <Bar dataKey="duration" minPointSize={6} radius={[2, 2, 0, 0]}>
+        <Bar dataKey="value" minPointSize={checkType === 'patch_status' ? 3 : 6} radius={[2, 2, 0, 0]}>
           {data.map((entry) => (
             <Cell
               key={entry.id}
-              fill={STATUS_COLOUR[entry.status] ?? '#9ca3af'}
+              fill={entry.fill}
               fillOpacity={0.85}
             />
           ))}
@@ -1309,7 +1349,11 @@ function CheckRow({
                   <> · <span className="text-foreground">{formatCheckOutput(check.checkType, check.latestResult.output)}</span></>
                 )}
               </p>
-              <CheckHistoryChart results={check.results} checkType={check.checkType} />
+              <CheckHistoryChart
+                results={check.results}
+                checkType={check.checkType}
+                patchConfig={check.checkType === 'patch_status' ? check.config as PatchStatusCheckConfig : undefined}
+              />
             </>
           ) : (
             <p className="text-sm text-muted-foreground py-2">No results yet.</p>

--- a/apps/web/lib/checks/history-chart.test.mjs
+++ b/apps/web/lib/checks/history-chart.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  getPatchStatusChartColour,
+  getPatchStatusChartValue,
+} from './history-chart.ts'
+
+test('patch status chart height follows available update count', () => {
+  assert.equal(getPatchStatusChartValue('{"patch_age_days":12,"updates_count":0}'), 0)
+  assert.equal(getPatchStatusChartValue('{"patch_age_days":12,"updates_count":7}'), 7)
+  assert.equal(getPatchStatusChartValue('not json'), 0)
+})
+
+test('patch status chart colour follows patch age policy threshold', () => {
+  assert.equal(getPatchStatusChartColour('{"patch_age_days":24,"updates_count":4}', 30), '#22c55e')
+  assert.equal(getPatchStatusChartColour('{"patch_age_days":25,"updates_count":4}', 30), '#f59e0b')
+  assert.equal(getPatchStatusChartColour('{"patch_age_days":31,"updates_count":4}', 30), '#ef4444')
+})

--- a/apps/web/lib/checks/history-chart.ts
+++ b/apps/web/lib/checks/history-chart.ts
@@ -1,0 +1,57 @@
+export const CHECK_STATUS_COLOURS = {
+  pass: '#22c55e',
+  fail: '#ef4444',
+  error: '#f59e0b',
+  unknown: '#9ca3af',
+} as const
+
+const PATCH_STATUS_AMBER_RATIO = 5 / 6
+
+type PatchStatusPayload = {
+  patch_age_days?: unknown
+  max_age_days?: unknown
+  updates_count?: unknown
+}
+
+export function parsePatchStatusOutput(output: string | null | undefined): PatchStatusPayload | null {
+  if (!output) return null
+  try {
+    const parsed = JSON.parse(output) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    return parsed as PatchStatusPayload
+  } catch {
+    return null
+  }
+}
+
+function finiteNonNegativeNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return Math.max(0, value)
+}
+
+export function getPatchStatusChartValue(output: string | null | undefined): number {
+  return finiteNonNegativeNumber(parsePatchStatusOutput(output)?.updates_count) ?? 0
+}
+
+export function getPatchStatusChartColour(
+  output: string | null | undefined,
+  configuredMaxAgeDays?: number,
+): string {
+  const payload = parsePatchStatusOutput(output)
+  const patchAgeDays = finiteNonNegativeNumber(payload?.patch_age_days)
+  const maxAgeDays = finiteNonNegativeNumber(payload?.max_age_days) ?? finiteNonNegativeNumber(configuredMaxAgeDays)
+
+  if (patchAgeDays === null || maxAgeDays === null || maxAgeDays <= 0) {
+    return CHECK_STATUS_COLOURS.unknown
+  }
+
+  if (patchAgeDays > maxAgeDays) {
+    return CHECK_STATUS_COLOURS.fail
+  }
+
+  if (patchAgeDays >= maxAgeDays * PATCH_STATUS_AMBER_RATIO) {
+    return CHECK_STATUS_COLOURS.error
+  }
+
+  return CHECK_STATUS_COLOURS.pass
+}


### PR DESCRIPTION
## Summary
- make Patch Status history bar height follow available update count instead of response duration
- colour Patch Status history bars by patch age against the policy threshold, with amber at five-sixths of the threshold and red after the threshold
- add focused helper coverage and update progress tracking

## Validation
- pnpm install --frozen-lockfile
- node --experimental-strip-types --test apps/web/lib/checks/history-chart.test.mjs
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing unrelated warnings)
- pnpm --dir apps/web test:unit (new tests pass; full suite still has unrelated failures from missing local container runtime plus existing issue #1109)