### PR TITLE
fix(web): improve password manager generator layout

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,25 @@
 
 ## What Has Been Built
 
+### Session 123 — Password Manager generator integration layout
+
+**Password Generator embedded layout** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/tests/e2e/password-generator/password-generator.spec.ts`)
+- Widened the Password Manager entry dialog so template forms have room for
+  inline password-generation controls.
+- Made template password fields span the full form width when generation is
+  available, preventing the label action from compressing the password input.
+- Widened the embedded shared Password Generator dialog used from Password
+  Manager entries while leaving the standalone generator features unchanged.
+- Added E2E layout assertions covering the Password Manager entry dialog,
+  generated-password field wrapper, and embedded generator dialog sizing.
+
+**Validation**
+- `pnpm install --frozen-lockfile`
+- `pnpm --filter web type-check`
+- `pnpm --filter web lint -- 'app/(dashboard)/password-manager/password-manager-client.tsx' tests/e2e/password-generator/password-generator.spec.ts`
+- `pnpm --filter web exec playwright test --list tests/e2e/password-generator/password-generator.spec.ts`
+- `git diff --check`
+
 ### Session 122 — Patch Status history chart semantics
 
 **Patch Status check history chart** (`apps/web/app/(dashboard)/hosts/[id]/checks-tab.tsx`, `apps/web/lib/checks/history-chart.ts`)

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -3267,7 +3267,10 @@ function PasswordManagerWorkspace({
           </Card>
 
           <Dialog open={entryDialogOpen} onOpenChange={setEntryDialogOpen}>
-            <DialogContent>
+            <DialogContent
+              className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-xl"
+              data-testid="password-manager-entry-dialog"
+            >
               <DialogHeader>
                 <DialogTitle>
                   {isViewingEntry ? 'View' : editingEntryId ? 'Edit' : 'New'} {activeEntryTemplate.dialogLabel}
@@ -3394,9 +3397,15 @@ function PasswordManagerWorkspace({
                     const canCopySshField =
                       isViewingEntry && activeEntryTemplate.id === 'ssh-key-pair' && !!editingEntryId && !!selectedEntry && !!value
                     const canGeneratePassword = field.id === 'password' && !isViewingEntry
+                    const fieldContainerClassName =
+                      field.multiline || canGeneratePassword ? 'grid gap-2 sm:col-span-2' : 'grid gap-2'
 
                     return (
-                      <div key={field.id} className={field.multiline ? 'grid gap-2 sm:col-span-2' : 'grid gap-2'}>
+                      <div
+                        key={field.id}
+                        className={fieldContainerClassName}
+                        data-testid={`password-manager-entry-field-${field.id}`}
+                      >
                         <div className="flex items-center justify-between gap-2">
                           <Label htmlFor={fieldId}>{field.label}</Label>
                           {canGeneratePassword ? (
@@ -3499,7 +3508,10 @@ function PasswordManagerWorkspace({
             </DialogContent>
           </Dialog>
           <Dialog open={passwordGeneratorDialogOpen} onOpenChange={setPasswordGeneratorDialogOpen}>
-            <DialogContent className="max-h-[calc(100vh-2rem)] max-w-4xl overflow-y-auto">
+            <DialogContent
+              className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] overflow-y-auto sm:max-w-5xl"
+              data-testid="password-manager-generator-dialog"
+            >
               <DialogHeader>
                 <DialogTitle>Password Generator</DialogTitle>
                 <DialogDescription>

--- a/apps/web/tests/e2e/password-generator/password-generator.spec.ts
+++ b/apps/web/tests/e2e/password-generator/password-generator.spec.ts
@@ -40,8 +40,12 @@ test('password manager uses the shared generator to populate a login password fi
 
   await page.getByRole('button', { name: 'New entry' }).click()
   await expect(page.getByRole('dialog', { name: 'New login' })).toBeVisible()
+  await expect(page.getByTestId('password-manager-entry-dialog')).toHaveClass(/sm:max-w-xl/)
+  await expect(page.getByTestId('password-manager-entry-field-password')).toHaveClass(/sm:col-span-2/)
+
   await page.getByRole('button', { name: 'Generate password' }).click()
   await expect(page.getByRole('dialog', { name: 'Password Generator' })).toBeVisible()
+  await expect(page.getByTestId('password-manager-generator-dialog')).toHaveClass(/sm:max-w-5xl/)
 
   await page.getByLabel('Password length', { exact: true }).fill('28')
   await page.getByRole('button', { name: 'Use password' }).click()


### PR DESCRIPTION
## Summary
- widen the Password Manager entry modal so password-generation controls do not compress the password input
- make generated password fields span the modal form width
- widen the embedded shared Password Generator dialog while leaving the standalone generator features unchanged
- add E2E layout assertions for the Password Manager integration

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter web type-check
- pnpm --filter web lint -- 'app/(dashboard)/password-manager/password-manager-client.tsx' tests/e2e/password-generator/password-generator.spec.ts\n- pnpm --filter web exec playwright test --list tests/e2e/password-generator/password-generator.spec.ts\n- git diff --check