### PR TITLE
test(web): isolate LDAP empty-state e2e

### DIFF
--- a/apps/web/tests/e2e/directory-lookup/empty-state.spec.ts
+++ b/apps/web/tests/e2e/directory-lookup/empty-state.spec.ts
@@ -14,6 +14,14 @@ async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
 }
 
 test('authenticated user sees the LDAP setup empty state when no directory is configured', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const orgId = await getOrgId(sql)
+
+  await sql`
+    DELETE FROM ldap_configurations
+    WHERE organisation_id = ${orgId}
+  `
+
   await page.goto('/directory-lookup')
 
   await expect(page.getByTestId('directory-lookup-heading')).toContainText('Directory User Lookup')


### PR DESCRIPTION
## Summary
- make the directory lookup empty-state E2E arrange its own no-LDAP-config precondition
- prevents prior LDAP/settings batch state from affecting the empty-state assertion

Fixes #994

## Tests
- pnpm exec eslint tests/e2e/directory-lookup/empty-state.spec.ts
- pnpm test:e2e --project=chromium tests/e2e/directory-lookup/empty-state.spec.ts:16 (blocked locally: Testcontainers could not find a working container runtime strategy)