### PR TITLE
test(web): harden local user host e2e

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/local-users-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/local-users-tab.tsx
@@ -63,10 +63,11 @@ export function LocalUsersTab({ orgId, hostId }: LocalUsersTabProps) {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"
+            data-testid="local-users-search"
           />
         </div>
         <Select value={typeFilter} onValueChange={(v) => setTypeFilter(v as ServiceAccountType | 'all')}>
-          <SelectTrigger className="w-36">
+          <SelectTrigger className="w-36" data-testid="local-users-type-filter">
             <SelectValue placeholder="Type" />
           </SelectTrigger>
           <SelectContent>
@@ -77,7 +78,7 @@ export function LocalUsersTab({ orgId, hostId }: LocalUsersTabProps) {
           </SelectContent>
         </Select>
         <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as ServiceAccountStatus | 'all')}>
-          <SelectTrigger className="w-36">
+          <SelectTrigger className="w-36" data-testid="local-users-status-filter">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -126,6 +127,7 @@ export function LocalUsersTab({ orgId, hostId }: LocalUsersTabProps) {
                   <TableRow
                     key={account.id}
                     className="cursor-pointer hover:bg-muted/50"
+                    data-testid={`local-user-row-${account.id}`}
                     onClick={() => router.push(`/hosts/${hostId}/users/${account.id}`)}
                   >
                     <TableCell className="font-medium font-mono text-sm">

--- a/apps/web/app/(dashboard)/hosts/[id]/users/[accountId]/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/users/[accountId]/page.tsx
@@ -17,7 +17,7 @@ export default async function LocalUserDetailPage({
   const orgId = session.user.organisationId!
   const { id: hostId, accountId } = await params
 
-  const result = await getServiceAccount(orgId, accountId)
+  const result = await getServiceAccount(orgId, accountId, hostId)
   if (!result) notFound()
 
   return (

--- a/apps/web/lib/actions/service-accounts.ts
+++ b/apps/web/lib/actions/service-accounts.ts
@@ -130,6 +130,7 @@ export async function getServiceAccounts(
 export async function getServiceAccount(
   orgId: string,
   accountId: string,
+  hostId?: string,
 ): Promise<{
   account: ServiceAccount
   keys: SshKey[]
@@ -142,6 +143,7 @@ export async function getServiceAccount(
       eq(serviceAccounts.id, accountId),
       eq(serviceAccounts.organisationId, orgId),
       isNull(serviceAccounts.deletedAt),
+      ...(hostId != null && hostId !== '' ? [eq(serviceAccounts.hostId, hostId)] : []),
     ),
   })
   if (!account) return null

--- a/apps/web/tests/e2e/hosts/local-users.spec.ts
+++ b/apps/web/tests/e2e/hosts/local-users.spec.ts
@@ -190,23 +190,23 @@ test('authenticated user can review host local users and open a user detail page
   await expect(page.getByRole('row', { name: /backup-svc/i })).toBeVisible()
   await expect(page.getByRole('row', { name: /legacy-daemon/i })).toBeVisible()
 
-  await page.getByPlaceholder('Search by username...').fill('backup')
-  await expect(page.getByRole('row', { name: /backup-svc/i })).toBeVisible()
-  await expect(page.getByRole('row', { name: /alice-admin/i })).toHaveCount(0)
+  await page.getByTestId('local-users-search').fill('backup')
+  await expect(page.getByTestId('local-user-row-local-user-backup')).toBeVisible()
+  await expect(page.getByTestId('local-user-row-local-user-alice')).toHaveCount(0)
 
-  await page.getByPlaceholder('Search by username...').fill('')
+  await page.getByTestId('local-users-search').fill('')
 
-  await page.getByRole('combobox').nth(0).click()
+  await page.getByTestId('local-users-type-filter').click()
   await page.getByRole('option', { name: 'Human' }).click()
-  await expect(page.getByRole('row', { name: /alice-admin/i })).toBeVisible()
-  await expect(page.getByRole('row', { name: /backup-svc/i })).toHaveCount(0)
+  await expect(page.getByTestId('local-user-row-local-user-alice')).toBeVisible()
+  await expect(page.getByTestId('local-user-row-local-user-backup')).toHaveCount(0)
 
-  await page.getByRole('combobox').nth(1).click()
+  await page.getByTestId('local-users-status-filter').click()
   await page.getByRole('option', { name: 'Active' }).click()
-  await expect(page.getByRole('row', { name: /alice-admin/i })).toBeVisible()
-  await expect(page.getByRole('row', { name: /legacy-daemon/i })).toHaveCount(0)
+  await expect(page.getByTestId('local-user-row-local-user-alice')).toBeVisible()
+  await expect(page.getByTestId('local-user-row-local-user-daemon')).toHaveCount(0)
 
-  await page.getByRole('row', { name: /alice-admin/i }).click()
+  await page.getByTestId('local-user-row-local-user-alice').click()
 
   await expect(page).toHaveURL(/\/hosts\/local-users-host\/users\/local-user-alice$/)
   await expect(page.getByRole('heading', { name: 'alice-admin' })).toBeVisible()


### PR DESCRIPTION
## Summary\n- add stable local-users selectors for the host local users E2E flow\n- route the local user detail lookup through the host ID so stale/cross-host account IDs 404\n- update the reported E2E to use deterministic row/filter selectors\n\nFixes #995\n\n## Tests\n- pnpm --filter web type-check\n- pnpm --filter web lint (passes with existing warnings)\n- pnpm --filter web test:e2e --project=chromium tests/e2e/hosts/local-users.spec.ts:16 (blocked locally: Testcontainers could not find a working container runtime strategy)