### PR TITLE
fix(web): await network mutation refreshes

### DIFF
--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
@@ -115,11 +115,14 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
 
   const { mutate: doAdd, isPending: isAdding } = useMutation({
     mutationFn: (hostId: string) => addHostToNetwork(orgId, network.id, hostId),
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       if ('error' in result) return
-      queryClient.invalidateQueries({ queryKey: ['network', orgId, network.id] })
-      queryClient.invalidateQueries({ queryKey: ['network-memberships', orgId, network.id] })
-      queryClient.invalidateQueries({ queryKey: ['networks', orgId] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['network', orgId, network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['network-memberships', orgId, network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+      ])
       setAddOpen(false)
       setSearch('')
     },
@@ -127,10 +130,14 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
 
   const { mutate: doRemove, isPending: isRemoving } = useMutation({
     mutationFn: (hostId: string) => removeHostFromNetwork(orgId, network.id, hostId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['network', orgId, network.id] })
-      queryClient.invalidateQueries({ queryKey: ['network-memberships', orgId, network.id] })
-      queryClient.invalidateQueries({ queryKey: ['networks', orgId] })
+    onSuccess: async (result) => {
+      if ('error' in result) return
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['network', orgId, network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['network-memberships', orgId, network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+      ])
       setRemoveTarget(null)
     },
   })

--- a/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
@@ -160,9 +160,12 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
         cidr: data.cidr,
         description: data.description || undefined,
       }),
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       if ('error' in result) return
-      queryClient.invalidateQueries({ queryKey: ['networks', orgId] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+      ])
       setCreateOpen(false)
     },
   })
@@ -174,17 +177,24 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
         cidr: data.cidr,
         description: data.description || undefined,
       }),
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       if ('error' in result) return
-      queryClient.invalidateQueries({ queryKey: ['networks', orgId] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+      ])
       setEditNetwork(null)
     },
   })
 
   const { mutate: doDelete, isPending: isDeleting } = useMutation({
     mutationFn: (networkId: string) => deleteNetwork(orgId, networkId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['networks', orgId] })
+    onSuccess: async (result) => {
+      if ('error' in result) return
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+      ])
       setDeleteTarget(null)
     },
   })


### PR DESCRIPTION
## Summary
- wait for network list/detail React Query invalidations before closing mutation dialogs
- refresh graph caches after create/update/delete and membership mutations
- keep mutation dialogs open when server actions return errors so stale UI is not treated as success

Fixes #996

## Tests
- pnpm type-check
- pnpm lint -- app/(dashboard)/hosts/networks/networks-client.tsx app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx

## Not run
- pnpm test:e2e --project=chromium tests/e2e/hosts/networks.spec.ts:16 (blocked locally: Docker daemon is not running, so Testcontainers cannot start TimescaleDB)