### PR TITLE
fix(notifications): await bell mark-read before navigation

### DIFF
--- a/apps/web/components/shared/notification-bell.tsx
+++ b/apps/web/components/shared/notification-bell.tsx
@@ -73,6 +73,11 @@ export function NotificationBell({ orgId }: NotificationBellProps) {
     window.location.assign(path)
   }
 
+  async function handleNotificationSelect(notification: Notification) {
+    await markReadMutation.mutateAsync(notification.id)
+    navigateTo(getResourceUrl(notification.resourceType, notification.resourceId))
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -121,8 +126,7 @@ export function NotificationBell({ orgId }: NotificationBellProps) {
                 data-testid={`notification-bell-item-${n.id}`}
                 onSelect={(event) => {
                   event.preventDefault()
-                  markReadMutation.mutate(n.id)
-                  navigateTo(getResourceUrl(n.resourceType, n.resourceId))
+                  void handleNotificationSelect(n)
                 }}
               >
                   {severityDot(n.severity)}

--- a/apps/web/lib/notifications/notification-bell.test.mjs
+++ b/apps/web/lib/notifications/notification-bell.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+
+const here = path.dirname(new URL(import.meta.url).pathname)
+const source = readFileSync(path.join(here, '..', '..', 'components', 'shared', 'notification-bell.tsx'), 'utf8')
+
+test('notification bell awaits mark-as-read before navigating to a resource', () => {
+  assert.match(
+    source,
+    /async function handleNotificationSelect\([^)]*Notification[^)]*\)[\s\S]*await markReadMutation\.mutateAsync\(notification\.id\)[\s\S]*navigateTo\(getResourceUrl\(notification\.resourceType, notification\.resourceId\)\)/,
+    'notification selection must wait for markAsRead to finish before changing location',
+  )
+})


### PR DESCRIPTION
## Summary
- await the notification bell mark-as-read mutation before navigating to the linked resource
- add a unit regression guard for the topbar bell selection flow

Fixes #997

## Validation
- node --experimental-strip-types --test lib/notifications/notification-bell.test.mjs
- pnpm exec tsc --noEmit --pretty false

## Notes
- pnpm test:e2e --project=chromium tests/e2e/notifications/bell.spec.ts:21 could not run locally because Testcontainers could not find a working container runtime strategy.
- A broader pnpm test:unit invocation also hit unrelated/pre-existing failures: binary integrity cache revalidation and container-runtime-dependent DB tests.