### PR TITLE
fix(agent): round patch age partial days up

### DIFF
--- a/agent/internal/checks/patch_status.go
+++ b/agent/internal/checks/patch_status.go
@@ -146,14 +146,20 @@ func buildPatchStatusReport(input patchStatusInput) patchStatusReport {
 	}
 	report.UpdatesCount = len(input.Updates)
 	report.LastPatchedAt = input.LastPatchedAt.UTC().Format(time.RFC3339)
-	report.PatchAgeDays = int(input.Now.UTC().Sub(input.LastPatchedAt.UTC()).Hours() / 24)
-	if report.PatchAgeDays < 0 {
-		report.PatchAgeDays = 0
-	}
+	report.PatchAgeDays = patchAgeDays(input.Now, input.LastPatchedAt)
 	if report.PatchAgeDays > maxAge {
 		report.Status = "fail"
 	}
 	return report
+}
+
+func patchAgeDays(now, lastPatchedAt time.Time) int {
+	elapsed := now.UTC().Sub(lastPatchedAt.UTC())
+	if elapsed <= 0 {
+		return 0
+	}
+	const day = 24 * time.Hour
+	return int((elapsed + day - time.Nanosecond) / day)
 }
 
 func detectPatchPackageManager() (string, error) {

--- a/agent/internal/checks/patch_status_test.go
+++ b/agent/internal/checks/patch_status_test.go
@@ -75,3 +75,19 @@ func TestEvaluatePatchStatusUsesPatchAgeOnly(t *testing.T) {
 		t.Fatalf("UpdatesCount = %d, want 1", report.UpdatesCount)
 	}
 }
+
+func TestPatchStatusRoundsPartialDayAgeUp(t *testing.T) {
+	t.Parallel()
+
+	report := buildPatchStatusReport(patchStatusInput{
+		Now:              time.Date(2026, 5, 8, 9, 30, 0, 0, time.UTC),
+		MaxAgeDays:       30,
+		LastPatchedAt:    time.Date(2026, 5, 8, 6, 28, 24, 0, time.UTC),
+		PackageManager:   "apt",
+		UpdatesSupported: true,
+	})
+
+	if report.PatchAgeDays != 1 {
+		t.Fatalf("PatchAgeDays = %d, want 1", report.PatchAgeDays)
+	}
+}


### PR DESCRIPTION
## Summary
- round positive partial-day patch age values up instead of reporting 0 days
- add regression coverage for same-day apt patch log timing like 2026-05-08 06:28 -> 2026-05-08 09:30

## Tests
- go test ./internal/checks
- go test ./...