### PR TITLE
fix(notifications): await inbox mutation refreshes

### DIFF
--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -275,49 +275,61 @@ export function NotificationsClient({
 
   const markReadMutation = useMutation({
     mutationFn: (id: string) => markAsRead(orgId, id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] }),
+      ])
     },
   })
 
   const markAllMutation = useMutation({
     mutationFn: () => markAllAsRead(orgId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] }),
+      ])
     },
   })
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteNotification(orgId, id),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-stats', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId] }),
+      ])
     },
   })
 
   const bulkDeleteMutation = useMutation({
     mutationFn: (ids: string[]) => deleteNotifications(orgId, ids),
-    onSuccess: () => {
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-stats', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId] }),
+      ])
       setSelectedIds(new Set())
-      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-stats', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId] })
     },
   })
 
   const bulkMarkReadMutation = useMutation({
     mutationFn: ({ ids, read }: { ids: string[]; read: boolean }) =>
       markBatchReadStatus(orgId, ids, read),
-    onSuccess: () => {
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] }),
+      ])
       setSelectedIds(new Set())
-      qc.invalidateQueries({ queryKey: ['notifications', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
     },
   })
 

--- a/apps/web/lib/notifications/notification-inbox.test.mjs
+++ b/apps/web/lib/notifications/notification-inbox.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+
+const here = path.dirname(new URL(import.meta.url).pathname)
+const source = readFileSync(path.join(here, '..', '..', 'app', '(dashboard)', 'notifications', 'notifications-client.tsx'), 'utf8')
+
+test('notification inbox waits for bulk delete refetches before clearing selection', () => {
+  assert.match(
+    source,
+    /const bulkDeleteMutation = useMutation\(\{[\s\S]*onSuccess: async \(\) => \{[\s\S]*await Promise\.all\(\[[\s\S]*queryKey: \['notifications', orgId\][\s\S]*queryKey: \['notifications-unread', orgId\][\s\S]*queryKey: \['notifications-stats', orgId\][\s\S]*queryKey: \['notifications-time-series', orgId\][\s\S]*\]\)[\s\S]*setSelectedIds\(new Set\(\)\)/,
+    'bulk delete must wait for notification list/count/chart refetches before clearing selected state',
+  )
+})


### PR DESCRIPTION
## Summary\n- await notification inbox mutation invalidations so stale unread rows are not shown after bulk/delete/read actions\n- add a focused regression test for the bulk-delete refresh ordering\n\nFixes #998\n\n## Tests\n- node --test apps/web/lib/notifications/notification-inbox.test.mjs apps/web/lib/notifications/notification-bell.test.mjs apps/web/lib/actions/notifications-authz.test.mjs\n- pnpm --filter web type-check\n- pnpm --filter web lint -- app/(dashboard)/notifications/notifications-client.tsx lib/notifications/notification-inbox.test.mjs\n\n## Not run\n- pnpm --filter web test:e2e --project=chromium tests/e2e/notifications/inbox.spec.ts:21 (local Testcontainers could not find a working container runtime strategy)