### PR TITLE
fix(calendar): restore time grid slot layout

### DIFF
--- a/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
+++ b/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
@@ -630,9 +630,12 @@ export function OperationsCalendarClient({
             },
             dayGridMonth: {
               dayHeaderFormat: { weekday: 'short' },
+              dayCellContent: renderDayCellContent,
+              expandRows: true,
             },
             multiMonthYear: {
               dayHeaderFormat: { weekday: 'short' },
+              dayCellContent: renderDayCellContent,
             },
           }}
           firstDay={1}
@@ -650,7 +653,6 @@ export function OperationsCalendarClient({
           slotLabelFormat={{ hour: 'numeric', minute: '2-digit', omitZeroMinute: true, meridiem: 'short' }}
           scrollTime="09:00:00"
           expandRows={false}
-          dayCellContent={renderDayCellContent}
           dayMaxEvents={4}
           fixedWeekCount
           showNonCurrentDates

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -193,6 +193,7 @@
   --fc-today-bg-color: color-mix(in oklch, var(--primary) 8%, transparent);
   --fc-now-indicator-color: oklch(0.62 0.19 27);
   --fc-small-font-size: 0.75rem;
+  --ct-ops-calendar-workday-slot-height: max(2rem, calc((100svh - 18rem) / 16));
   height: calc(100svh - 12rem);
   min-height: 560px;
   position: relative;
@@ -233,7 +234,11 @@
 }
 
 .ct-ops-calendar .fc-timegrid-slot {
-  height: 2rem;
+  height: var(--ct-ops-calendar-workday-slot-height);
+}
+
+.ct-ops-calendar .fc-timegrid-slots tr {
+  height: var(--ct-ops-calendar-workday-slot-height);
 }
 
 .ct-ops-calendar .fc-timegrid-slot-minor {
@@ -250,16 +255,8 @@
   width: 100% !important;
 }
 
-.ct-ops-calendar .fc-daygrid-day-frame {
-  min-height: 7.5rem;
-}
-
 .ct-ops-calendar .fc-dayGridMonth-view .fc-scrollgrid-sync-table {
   height: 100% !important;
-}
-
-.ct-ops-calendar .fc-dayGridMonth-view .fc-daygrid-day-frame {
-  min-height: 6.5rem;
 }
 
 .ct-ops-calendar .fc-multimonth {

--- a/apps/web/tests/e2e/calendar/calendar.spec.ts
+++ b/apps/web/tests/e2e/calendar/calendar.spec.ts
@@ -52,6 +52,18 @@ test('engineer can create a host-linked calendar event with participant roles ac
   await page.getByTestId('calendar-event-submit').click()
 
   await expect(page.getByText('Kernel patch planning')).toBeVisible()
+  const timedEvent = page.locator('.fc-timegrid-event').filter({ hasText: 'Kernel patch planning' }).first()
+  await expect(timedEvent).toBeVisible()
+  await expect(page.locator('.fc-daygrid-event').filter({ hasText: 'Kernel patch planning' })).toHaveCount(0)
+  const [timedEventBox, timeGridBox] = await Promise.all([
+    timedEvent.boundingBox(),
+    page.locator('.fc-timegrid-body').first().boundingBox(),
+  ])
+  expect(timedEventBox).not.toBeNull()
+  expect(timeGridBox).not.toBeNull()
+  expect(timedEventBox!.height).toBeGreaterThan(40)
+  expect(timedEventBox!.y).toBeGreaterThanOrEqual(timeGridBox!.y)
+  expect(timedEventBox!.y + timedEventBox!.height).toBeLessThanOrEqual(timeGridBox!.y + timeGridBox!.height + 1)
 
   for (const view of ['day', 'work-week', 'full-week', 'month', 'year']) {
     await page.getByTestId(`calendar-view-${view}`).click()
@@ -176,10 +188,21 @@ test('calendar views use operational calendar labels and grid structure', async 
   await expect(page.locator('.fc-timegrid-slot-label').filter({ hasText: '9:30 AM' }).first()).toBeVisible()
   await expect(page.locator('.fc-timegrid-slot-label').filter({ hasText: '5 PM' }).first()).toBeVisible()
   await expect(page.locator('.fc-col-header-cell').filter({ hasText: 'Sun' })).toHaveCount(0)
+  await expect(page.locator('.fc-timegrid .fc-daygrid-day-number')).toHaveCount(0)
+  expect(await page.locator('.fc-timegrid-slots .fc-timegrid-slot').count()).toBeGreaterThanOrEqual(48)
+  const timeSlotHeights = await page.locator('.fc-timegrid-slots tr').evaluateAll((slots) =>
+    slots.map((slot) => slot.getBoundingClientRect().height),
+  )
+  expect(timeSlotHeights.length).toBeGreaterThanOrEqual(48)
+  expect(Math.min(...timeSlotHeights)).toBeGreaterThanOrEqual(28)
+  const visibleSlotHeight = timeSlotHeights[0]!
+  const scrollerHeight = await page.locator('.fc-timegrid-body').first().evaluate((body) => body.getBoundingClientRect().height)
+  expect(visibleSlotHeight * 16).toBeGreaterThanOrEqual(scrollerHeight * 0.85)
 
   await page.getByTestId('calendar-view-full-week').click()
   await expect(page.locator('.fc-col-header-cell').filter({ hasText: /Mon \d{1,2} [A-Z][a-z]{2}/ }).first()).toBeVisible()
   await expect(page.locator('.fc-col-header-cell').filter({ hasText: /Sun \d{1,2} [A-Z][a-z]{2}/ }).first()).toBeVisible()
+  await expect(page.locator('.fc-timegrid .fc-daygrid-day-number')).toHaveCount(0)
 
   await page.getByTestId('calendar-view-month').click()
   await expect(page.getByTestId('calendar-period-title')).toContainText(/^[A-Z][a-z]{2} \d{4}$/)


### PR DESCRIPTION
## Summary
- scope 3-letter month day-cell rendering to month/year views so timed views do not get duplicate all-day date headers
- remove the global daygrid minimum height that was inflating the time-grid all-day row and squeezing timed slots
- size every time-grid 30-minute row from the viewport so the 9 AM to 5 PM window fills the calendar body with earlier/later hours scrollable
- strengthen calendar E2E coverage to assert timed event geometry and every empty 30-minute slot row height

## Validation
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing unrelated warnings)
- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret DATABASE_URL=postgres://test:test@localhost:5432/ctops_test pnpm --filter web build` (passes with expected placeholder-secret warnings and existing Turbopack NFT warning)
- `pnpm --filter web test:e2e tests/e2e/calendar/calendar.spec.ts` (blocked locally: Testcontainers could not find a working container runtime strategy)