### PR TITLE
fix(hosts): hard-delete pending certificate signing rows

### DIFF
--- a/apps/web/lib/actions/agents-delete-hard.test.mjs
+++ b/apps/web/lib/actions/agents-delete-hard.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const agentsSource = readFileSync(path.join(here, 'agents.ts'), 'utf8')
+
+function actionSegment(action) {
+  const start = agentsSource.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist in agents.ts`)
+  const next = agentsSource.indexOf('\nexport async function ', start + 1)
+  return agentsSource.slice(start, next === -1 ? undefined : next)
+}
+
+test('deleteHost performs a hard delete and clears agent dependants before deleting the agent', () => {
+  const segment = actionSegment('deleteHost')
+
+  assert.match(
+    segment,
+    /\.delete\(hosts\)[\s\S]*\.where\(and\(eq\(hosts\.id, hostId\), eq\(hosts\.organisationId, orgId\)\)\)/,
+    'deleteHost must physically delete the host row',
+  )
+  assert.doesNotMatch(
+    segment,
+    /\.update\(hosts\)[\s\S]*deletedAt/,
+    'deleteHost must not soft-delete hosts',
+  )
+
+  const pendingDelete = segment.indexOf('.delete(pendingCertSignings)')
+  const agentDelete = segment.indexOf('.delete(agents)')
+  assert.notEqual(pendingDelete, -1, 'deleteHost must delete pending CSR rows for the agent')
+  assert.notEqual(agentDelete, -1, 'deleteHost must delete the agent row')
+  assert.ok(
+    pendingDelete < agentDelete,
+    'pending CSR rows must be deleted before the agent row to avoid FK rollback',
+  )
+})

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -35,6 +35,7 @@ import {
   hostNetworkMemberships,
   hostPatchStatuses,
   hostPackageUpdates,
+  pendingCertSignings,
 } from '@/lib/db/schema'
 import { eq, and, isNull, gt, gte, lte, asc, desc, sql, inArray, ilike, or, count } from 'drizzle-orm'
 import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
@@ -1262,6 +1263,9 @@ export async function deleteHost(
             .onConflictDoNothing()
         }
 
+        await tx
+          .delete(pendingCertSignings)
+          .where(eq(pendingCertSignings.agentId, host.agentId))
         await tx
           .delete(agentStatusHistory)
           .where(eq(agentStatusHistory.agentId, host.agentId))


### PR DESCRIPTION
## Summary
- clear pending certificate signing rows before deleting an agent during host deletion
- add a regression test that asserts host deletion remains a hard delete and removes agent dependants before the agent row

## Validation
- pnpm install --offline
- pnpm --dir apps/web exec node --test lib/actions/agents-delete-hard.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint -- lib/actions/agents.ts lib/actions/agents-delete-hard.test.mjs (passes with existing warning in agents.ts:617)
- pnpm --filter web test:unit (fails: existing tracked binary-integrity test issue #1109; local container runtime unavailable for RLS and CT-CVE nonce-store tests)