### PR TITLE
fix(hosts): ignore virtual bridge IPs for host dedupe

### DIFF
--- a/agent/internal/registration/registrar.go
+++ b/agent/internal/registration/registrar.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
@@ -156,7 +157,8 @@ func (r *Registrar) Register(ctx context.Context, existingAgentID string) (*iden
 
 // localIPs returns the non-loopback IP addresses currently bound on this host,
 // so the server can detect duplicate-host registrations by IP overlap.
-// Mirrors the filtering used by the heartbeat's network interface reporter.
+// Container and host-local bridge interfaces are intentionally ignored because
+// their gateway addresses are commonly duplicated across unrelated hosts.
 func localIPs() []string {
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -164,10 +166,7 @@ func localIPs() []string {
 	}
 	var ips []string
 	for _, iface := range ifaces {
-		if iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-		if iface.Flags&net.FlagUp == 0 {
+		if !isRegistrationIdentityInterface(iface) {
 			continue
 		}
 		addrs, err := iface.Addrs()
@@ -179,8 +178,50 @@ func localIPs() []string {
 			if err != nil {
 				continue
 			}
+			if !isRegistrationIdentityIP(ip) {
+				continue
+			}
 			ips = append(ips, ip.String())
 		}
 	}
 	return ips
+}
+
+func isRegistrationIdentityInterface(iface net.Interface) bool {
+	if iface.Flags&net.FlagLoopback != 0 {
+		return false
+	}
+	if iface.Flags&net.FlagUp == 0 {
+		return false
+	}
+
+	name := strings.ToLower(iface.Name)
+	virtualPrefixes := []string{
+		"br-",
+		"cali",
+		"cni",
+		"docker",
+		"flannel",
+		"lxcbr",
+		"podman",
+		"veth",
+		"virbr",
+	}
+	for _, prefix := range virtualPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+func isRegistrationIdentityIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return !ip.IsLoopback() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsLinkLocalMulticast() &&
+		!ip.IsMulticast() &&
+		!ip.IsUnspecified()
 }

--- a/agent/internal/registration/registrar_test.go
+++ b/agent/internal/registration/registrar_test.go
@@ -1,0 +1,70 @@
+package registration
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsRegistrationIdentityInterfaceSkipsContainerBridgeInterfaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "ens5", want: true},
+		{name: "eth0", want: true},
+		{name: "docker0", want: false},
+		{name: "br-36a3ae6d4ea9", want: false},
+		{name: "vethd3ba27c", want: false},
+		{name: "virbr0", want: false},
+		{name: "cni0", want: false},
+		{name: "flannel.1", want: false},
+		{name: "cali123456", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isRegistrationIdentityInterface(net.Interface{
+				Name:  tt.name,
+				Flags: net.FlagUp,
+			}); got != tt.want {
+				t.Fatalf("isRegistrationIdentityInterface(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRegistrationIdentityIPSkipsWeakAddresses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{ip: "192.168.8.191", want: true},
+		{ip: "fd6b:46a:a53d:4e78:5054:8ff:fe00:812", want: true},
+		{ip: "127.0.0.1", want: false},
+		{ip: "::1", want: false},
+		{ip: "169.254.10.20", want: false},
+		{ip: "fe80::1", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.ip, func(t *testing.T) {
+			t.Parallel()
+
+			parsed := net.ParseIP(tt.ip)
+			if parsed == nil {
+				t.Fatalf("test IP %q did not parse", tt.ip)
+			}
+			if got := isRegistrationIdentityIP(parsed); got != tt.want {
+				t.Fatalf("isRegistrationIdentityIP(%q) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/ingest/internal/db/queries/hosts.sql.go
+++ b/apps/ingest/internal/db/queries/hosts.sql.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -48,6 +49,7 @@ func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname 
 	if ips == nil {
 		ips = []string{}
 	}
+	ips = FilterHostIdentityIPs(ips)
 	row := pool.QueryRow(ctx, q, orgID, hostname, ips)
 	var c HostCollision
 	if err := row.Scan(&c.HostID, &c.AgentID, &c.Hostname, &c.HostStatus, &c.AgentStatus); err != nil {
@@ -57,6 +59,46 @@ func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname 
 		return nil, err
 	}
 	return &c, nil
+}
+
+// FilterHostIdentityIPs returns only IPs that are useful for host identity
+// collision checks. Linux hosts commonly expose host-local bridge gateway
+// addresses such as docker0's 172.17.0.1; those addresses are duplicated on
+// unrelated machines and must not block fresh registrations.
+func FilterHostIdentityIPs(ips []string) []string {
+	filtered := make([]string, 0, len(ips))
+	seen := make(map[string]struct{}, len(ips))
+	for _, raw := range ips {
+		addr, err := netip.ParseAddr(raw)
+		if err != nil || isWeakHostIdentityIP(addr) {
+			continue
+		}
+		normalized := addr.String()
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		filtered = append(filtered, normalized)
+	}
+	return filtered
+}
+
+func isWeakHostIdentityIP(addr netip.Addr) bool {
+	if !addr.IsValid() ||
+		addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsMulticast() ||
+		addr.IsUnspecified() {
+		return true
+	}
+
+	if addr.Is4() {
+		octets := addr.As4()
+		if octets[3] == 1 && addr.IsPrivate() {
+			return true
+		}
+	}
+	return false
 }
 
 // RotateAgentPublicKey replaces the public key on an existing agent row.

--- a/apps/ingest/internal/db/queries/hosts_test.go
+++ b/apps/ingest/internal/db/queries/hosts_test.go
@@ -1,0 +1,49 @@
+package queries
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFilterHostIdentityIPsDropsHostLocalAndVirtualBridgeAddresses(t *testing.T) {
+	t.Parallel()
+
+	input := []string{
+		"10.20.30.40",
+		"172.17.0.1",
+		"172.18.0.1",
+		"172.20.5.1",
+		"192.168.122.1",
+		"192.168.8.1",
+		"10.88.0.1",
+		"10.20.30.1",
+		"127.0.0.1",
+		"::1",
+		"169.254.10.20",
+		"fe80::1",
+		"10.20.30.40",
+		"not-an-ip",
+		"2001:4860:4860::8888",
+	}
+
+	got := FilterHostIdentityIPs(input)
+	want := []string{"10.20.30.40", "2001:4860:4860::8888"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FilterHostIdentityIPs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFilterHostIdentityIPsKeepsNormalPrivateLANAddresses(t *testing.T) {
+	t.Parallel()
+
+	input := []string{
+		"10.0.0.23",
+		"172.20.5.23",
+		"192.168.1.23",
+	}
+
+	got := FilterHostIdentityIPs(input)
+	if !reflect.DeepEqual(got, input) {
+		t.Fatalf("FilterHostIdentityIPs() = %#v, want %#v", got, input)
+	}
+}


### PR DESCRIPTION
## Summary
- filter weak host-identity IPs before ingest registration dedupe checks for already-installed agents
- ignore private gateway-style addresses like Docker's 172.17.0.1 instead of chasing individual Docker subnets
- update the agent registration IP collector so future agents do not send container/bridge/veth interface addresses as host identity
- keep normal LAN private addresses eligible for dedupe

## Validation
- go test ./apps/ingest/internal/db/queries
- go test ./apps/ingest/internal/db/queries ./apps/ingest/internal/handlers
- go test ./apps/ingest/internal/...
- go test ./agent/internal/... ./apps/ingest/internal/...