### PR TITLE
fix(web): resolve latest agent download release

### DIFF
--- a/apps/web/lib/agent/binary-integrity.test.mjs
+++ b/apps/web/lib/agent/binary-integrity.test.mjs
@@ -23,24 +23,13 @@ test('resolveAgentBinary rejects GitHub assets that do not match release checksu
 
   globalThis.fetch = async (url) => {
     const href = String(url)
+    if (href.includes('/releases?')) {
+      return jsonResponse([
+        releasePayload('agent/v0.33.0', trusted, trustedSha256, sidecar),
+      ])
+    }
     if (href.includes('/releases/tags/')) {
-      return jsonResponse({
-        tag_name: 'agent/v0.33.0',
-        assets: [
-          {
-            name: 'ct-ops-agent-linux-amd64',
-            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64',
-            digest: `sha256:${trustedSha256}`,
-            size: trusted.byteLength,
-          },
-          {
-            name: 'ct-ops-agent-linux-amd64.sha256',
-            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64.sha256',
-            digest: `sha256:${sha256(Buffer.from(sidecar))}`,
-            size: Buffer.byteLength(sidecar),
-          },
-        ],
-      })
+      return jsonResponse(releasePayload('agent/v0.33.0', trusted, trustedSha256, sidecar))
     }
     if (href.endsWith('.sha256')) {
       return textResponse(sidecar)
@@ -70,24 +59,13 @@ test('resolveAgentBinary revalidates cached bytes before serving them', async ()
 
   globalThis.fetch = async (url) => {
     const href = String(url)
+    if (href.includes('/releases?')) {
+      return jsonResponse([
+        releasePayload('agent/v0.33.0', trusted, trustedSha256, sidecar),
+      ])
+    }
     if (href.includes('/releases/tags/')) {
-      return jsonResponse({
-        tag_name: 'agent/v0.33.0',
-        assets: [
-          {
-            name: 'ct-ops-agent-linux-amd64',
-            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64',
-            digest: `sha256:${trustedSha256}`,
-            size: trusted.byteLength,
-          },
-          {
-            name: 'ct-ops-agent-linux-amd64.sha256',
-            browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64.sha256',
-            digest: `sha256:${sha256(Buffer.from(sidecar))}`,
-            size: Buffer.byteLength(sidecar),
-          },
-        ],
-      })
+      return jsonResponse(releasePayload('agent/v0.33.0', trusted, trustedSha256, sidecar))
     }
     if (href.endsWith('.sha256')) {
       return textResponse(sidecar)
@@ -103,6 +81,45 @@ test('resolveAgentBinary revalidates cached bytes before serving them', async ()
   const binary = await resolveAgentBinary('linux', 'amd64')
 
   assert.equal(binary?.bytes.toString(), 'trusted-agent-binary')
+})
+
+test('resolveAgentBinary prefers the latest agent release over the baked manifest version', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ct-ops-agent-binary-'))
+  process.env.AGENT_DIST_DIR = tempDir
+
+  const latest = Buffer.from('latest-agent-binary')
+  const latestSha256 = sha256(latest)
+  const sidecar = `${latestSha256}  ct-ops-agent-linux-amd64\n`
+  let requiredTagRequests = 0
+
+  globalThis.fetch = async (url) => {
+    const href = String(url)
+    if (href.includes('/releases?')) {
+      return jsonResponse([
+        releasePayload('agent/v9.9.9', latest, latestSha256, sidecar),
+      ])
+    }
+    if (href.includes('/releases/tags/')) {
+      requiredTagRequests += 1
+      return new Response('not found', { status: 404 })
+    }
+    if (href.endsWith('.sha256')) {
+      return textResponse(sidecar)
+    }
+    return new Response(latest, {
+      status: 200,
+      headers: { 'content-length': String(latest.byteLength) },
+    })
+  }
+
+  const { resolveAgentBinary } = await import(`./binary.ts?latest=${Date.now()}`)
+
+  const binary = await resolveAgentBinary('linux', 'amd64')
+  const cached = await fs.readFile(path.join(tempDir, 'ct-ops-agent-linux-amd64-v9.9.9'))
+
+  assert.equal(binary?.bytes.toString(), 'latest-agent-binary')
+  assert.equal(cached.toString(), 'latest-agent-binary')
+  assert.equal(requiredTagRequests, 0)
 })
 
 function sha256(data) {
@@ -121,4 +138,24 @@ function textResponse(body) {
     status: 200,
     headers: { 'content-type': 'text/plain' },
   })
+}
+
+function releasePayload(tagName, binary, binarySha256, sidecar) {
+  return {
+    tag_name: tagName,
+    assets: [
+      {
+        name: 'ct-ops-agent-linux-amd64',
+        browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64',
+        digest: `sha256:${binarySha256}`,
+        size: binary.byteLength,
+      },
+      {
+        name: 'ct-ops-agent-linux-amd64.sha256',
+        browser_download_url: 'https://downloads.example.com/ct-ops-agent-linux-amd64.sha256',
+        digest: `sha256:${sha256(Buffer.from(sidecar))}`,
+        size: Buffer.byteLength(sidecar),
+      },
+    ],
+  }
 }

--- a/apps/web/lib/agent/binary.ts
+++ b/apps/web/lib/agent/binary.ts
@@ -24,6 +24,9 @@ interface GitHubRelease {
   assets: GitHubAsset[]
 }
 
+const LATEST_RELEASE_CACHE_TTL_MS = 5 * 60 * 1000
+let latestReleaseCache: { release: GitHubRelease | null; expiresAt: number } | null = null
+
 export function binaryBaseName(os: AgentOS, arch: AgentArch): string {
   const suffix = os === 'windows' ? '.exe' : ''
   return `ct-ops-agent-${os}-${arch}${suffix}`
@@ -42,26 +45,26 @@ export async function resolveAgentBinary(
 ): Promise<{ bytes: Buffer; fileName: string } | null> {
   const baseName = binaryBaseName(os, arch)
   const suffix = os === 'windows' ? '.exe' : ''
-  const versionedName = `ct-ops-agent-${os}-${arch}-${REQUIRED_AGENT_VERSION}${suffix}`
-  const versionedPath = path.join(AGENT_DIST_DIR, versionedName)
 
-  const cachedVersioned = await readVerifiedLocalBinary(versionedPath, baseName)
-  if (cachedVersioned) {
-    return { bytes: cachedVersioned, fileName: baseName }
+  const latestRelease = await fetchLatestAgentRelease()
+  const latestVersion = versionFromAgentTag(latestRelease?.tag_name)
+  if (latestRelease && latestVersion) {
+    const latest = await resolveFromRelease(latestRelease, latestVersion, os, arch, baseName, suffix)
+    if (latest) return latest
   }
 
   const tag = `agent/${REQUIRED_AGENT_VERSION}`
-  const release = await fetchRelease(tag)
-  if (release?.tag_name === tag) {
-    const asset = release.assets.find((a) => a.name === baseName)
-    const checksumAsset = release.assets.find((a) => a.name === `${baseName}.sha256`)
-    if (asset && checksumAsset) {
-      const verified = await fetchVerifiedBinaryFromGitHub(asset, checksumAsset, baseName)
-      if (verified) {
-        await cacheLocally(versionedPath, verified.bytes, verified.checksumLine)
-        return { bytes: Buffer.from(verified.bytes), fileName: baseName }
-      }
-    }
+  const requiredRelease = latestRelease?.tag_name === tag ? latestRelease : await fetchRelease(tag)
+  if (requiredRelease?.tag_name === tag) {
+    const required = await resolveFromRelease(
+      requiredRelease,
+      REQUIRED_AGENT_VERSION,
+      os,
+      arch,
+      baseName,
+      suffix,
+    )
+    if (required) return required
   }
 
   const unversionedPath = path.join(AGENT_DIST_DIR, baseName)
@@ -84,9 +87,9 @@ export async function resolveAgentBinary(
 
 export function binaryUnavailableMessage(os: AgentOS, arch: AgentArch): string {
   return (
-    `No binary available for ${os}/${arch} (required version: ${REQUIRED_AGENT_VERSION}). ` +
+    `No binary available for ${os}/${arch} (latest agent release or required version: ${REQUIRED_AGENT_VERSION}). ` +
     `Either place a binary plus matching .sha256 sidecar in AGENT_DIST_DIR (${AGENT_DIST_DIR}) ` +
-    `or ensure a GitHub release exists for tag "agent/${REQUIRED_AGENT_VERSION}" in ` +
+    `or ensure a GitHub agent release exists in ` +
     `${AGENT_REPO_OWNER}/${AGENT_REPO_NAME} with verified binary and checksum assets.`
   )
 }
@@ -97,6 +100,58 @@ const ghHeaders: Record<string, string> = {
   ...(process.env.GITHUB_TOKEN
     ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
     : {}),
+}
+
+async function resolveFromRelease(
+  release: GitHubRelease,
+  version: string,
+  os: AgentOS,
+  arch: AgentArch,
+  baseName: string,
+  suffix: string,
+): Promise<{ bytes: Buffer; fileName: string } | null> {
+  const versionedName = `ct-ops-agent-${os}-${arch}-${version}${suffix}`
+  const versionedPath = path.join(AGENT_DIST_DIR, versionedName)
+
+  const cachedVersioned = await readVerifiedLocalBinary(versionedPath, baseName)
+  if (cachedVersioned) {
+    return { bytes: cachedVersioned, fileName: baseName }
+  }
+
+  const asset = release.assets.find((a) => a.name === baseName)
+  const checksumAsset = release.assets.find((a) => a.name === `${baseName}.sha256`)
+  if (!asset || !checksumAsset) return null
+
+  const verified = await fetchVerifiedBinaryFromGitHub(asset, checksumAsset, baseName)
+  if (!verified) return null
+
+  await cacheLocally(versionedPath, verified.bytes, verified.checksumLine)
+  return { bytes: Buffer.from(verified.bytes), fileName: baseName }
+}
+
+async function fetchLatestAgentRelease(): Promise<GitHubRelease | null> {
+  const now = Date.now()
+  if (latestReleaseCache && latestReleaseCache.expiresAt > now) {
+    return latestReleaseCache.release
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${AGENT_REPO_OWNER}/${AGENT_REPO_NAME}/releases?per_page=20`,
+      { headers: ghHeaders },
+    )
+    if (!res.ok) {
+      latestReleaseCache = { release: null, expiresAt: now + LATEST_RELEASE_CACHE_TTL_MS }
+      return null
+    }
+    const releases = (await res.json()) as GitHubRelease[]
+    const release = releases.find((r) => versionFromAgentTag(r.tag_name)) ?? null
+    latestReleaseCache = { release, expiresAt: now + LATEST_RELEASE_CACHE_TTL_MS }
+    return release
+  } catch {
+    latestReleaseCache = { release: null, expiresAt: now + LATEST_RELEASE_CACHE_TTL_MS }
+    return null
+  }
 }
 
 async function fetchRelease(tag: string): Promise<GitHubRelease | null> {
@@ -110,6 +165,11 @@ async function fetchRelease(tag: string): Promise<GitHubRelease | null> {
   } catch {
     return null
   }
+}
+
+function versionFromAgentTag(tag: string | undefined): string | null {
+  const match = tag?.match(/^agent\/(v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/)
+  return match?.[1] ?? null
 }
 
 async function fetchVerifiedBinaryFromGitHub(


### PR DESCRIPTION
## Summary
- make web agent binary resolution prefer the newest published `agent/v*` GitHub release before falling back to the baked manifest version
- keep verified local cache, checksum validation, and baked/offline fallback behavior intact
- add regression coverage proving stale baked manifests no longer force older agent downloads

## Validation
- `pnpm --dir apps/web exec node --experimental-strip-types --test lib/agent/binary-integrity.test.mjs`
- `pnpm --filter web type-check`
- `pnpm --filter web lint -- lib/agent/binary.ts lib/agent/binary-integrity.test.mjs`
- `pnpm --filter web test:unit` (fails locally only for Testcontainers-backed tests because this environment has no working container runtime strategy: `lib/db/rls.test.mjs`, `lib/integrations/ct-cve/db-nonce-store.test.mjs`)

## Operational note
This should produce a web/customer release with the current manifest values (`agent` 0.34.2 and `apps/ingest` 0.9.5), and future web installs can discover newer agent releases even when the web image was built before an agent-only release.