### PR TITLE
fix(deploy): include ct-ops in generated TLS cert SANs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ dev-tls:
 		-days 365 \
 		-nodes \
 		-subj "/CN=localhost" \
-		-addext "subjectAltName=DNS:localhost,DNS:ingest,IP:127.0.0.1" \
+		-addext "subjectAltName=DNS:localhost,DNS:ingest,DNS:ct-ops,IP:127.0.0.1" \
 		2>/dev/null
 	@echo "Generated deploy/dev-tls/server.crt and deploy/dev-tls/server.key"
 

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -569,7 +569,7 @@ gen_cert() {
   elif command -v ifconfig >/dev/null 2>&1; then
     local_ips=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//' || true)
   fi
-  local san="DNS:ingest,DNS:localhost,IP:127.0.0.1"
+  local san="DNS:ingest,DNS:localhost,DNS:ct-ops,IP:127.0.0.1"
   [ -n "$local_ips" ] && san="${san},${local_ips}"
 
   local openssl_err

--- a/deploy/scripts/gen-server-cert.sh
+++ b/deploy/scripts/gen-server-cert.sh
@@ -15,7 +15,8 @@
 # Behaviour:
 #   - Idempotent: exits 0 if OUT_DIR/server.crt and server.key both exist
 #     unless FORCE=1.
-#   - Always includes DNS:localhost, DNS:ingest, IP:127.0.0.1 in the SAN list.
+#   - Always includes DNS:localhost, DNS:ingest, DNS:ct-ops, IP:127.0.0.1
+#     in the SAN list.
 #   - Appends every non-loopback IPv4 address on the host (so remote agents
 #     can verify by IP against a cert generated on the server).
 #   - Writes the key with mode 600 and the cert with mode 644.
@@ -50,7 +51,7 @@ elif command -v ifconfig >/dev/null 2>&1; then
   LOCAL_IPS=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//' || true)
 fi
 
-SAN="DNS:localhost,DNS:ingest,IP:127.0.0.1"
+SAN="DNS:localhost,DNS:ingest,DNS:ct-ops,IP:127.0.0.1"
 [ -n "$LOCAL_IPS" ] && SAN="${SAN},${LOCAL_IPS}"
 [ -n "$EXTRA_SANS" ] && SAN="${SAN},${EXTRA_SANS}"
 

--- a/deploy/scripts/test-gen-server-cert.sh
+++ b/deploy/scripts/test-gen-server-cert.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+main() {
+  local tmpdir cert_text
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '$tmpdir'" EXIT
+
+  OUT_DIR="$tmpdir" "${SCRIPT_DIR}/gen-server-cert.sh" >/dev/null
+
+  cert_text="$(openssl x509 -in "$tmpdir/server.crt" -noout -text)"
+
+  if [[ "$cert_text" != *"DNS:ct-ops"* ]]; then
+    echo "expected generated cert SANs to include DNS:ct-ops" >&2
+    echo "$cert_text" >&2
+    exit 1
+  fi
+  if [[ "$cert_text" != *"DNS:localhost"* ]]; then
+    echo "expected generated cert SANs to include DNS:localhost" >&2
+    echo "$cert_text" >&2
+    exit 1
+  fi
+  if [[ "$cert_text" != *"DNS:ingest"* ]]; then
+    echo "expected generated cert SANs to include DNS:ingest" >&2
+    echo "$cert_text" >&2
+    exit 1
+  fi
+
+  echo "gen-server-cert SAN test passed"
+}
+
+main "$@"

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -274,7 +274,7 @@ services:
           -keyout /tls/server.key \
           -out /tls/server.crt \
           -subj "/CN=ct-ops" \
-          -addext "subjectAltName=DNS:localhost,DNS:ingest,IP:127.0.0.1" 2>/dev/null
+          -addext "subjectAltName=DNS:localhost,DNS:ingest,DNS:ct-ops,IP:127.0.0.1" 2>/dev/null
         chmod 600 /tls/server.key
         chmod 644 /tls/server.crt
         echo "tls-init: wrote /tls/server.{crt,key}. Replace with your own cert"

--- a/start.sh
+++ b/start.sh
@@ -452,7 +452,7 @@ if [ ! -f "$CERT_DIR/server.crt" ] || [ ! -f "$CERT_DIR/server.key" ]; then
   else
     LOCAL_IPS=$(ifconfig 2>/dev/null | awk '/inet / && !/127\.0\.0\.1/ {print "IP:" $2}' | tr '\n' ',' | sed 's/,$//')
   fi
-  SAN="DNS:ingest,DNS:localhost,IP:127.0.0.1"
+  SAN="DNS:ingest,DNS:localhost,DNS:ct-ops,IP:127.0.0.1"
   if [ -n "$LOCAL_IPS" ]; then
     SAN="${SAN},${LOCAL_IPS}"
   fi


### PR DESCRIPTION
## Summary
- include DNS:ct-ops in bundled self-signed cert generation paths
- add a shell regression test for generated server certificate SANs

## Root cause
Agents were being told to download updates from https://ct-ops, but the bundled generated nginx/browser TLS certificate only covered localhost, ingest, and loopback/IP SANs. The agent correctly rejected the update download with x509 hostname verification because ct-ops was missing from the certificate SANs.

## Validation
- bash deploy/scripts/test-gen-server-cert.sh
- bash deploy/scripts/test-start.sh
- git diff --check