### PR TITLE
fix(web): cover generated ct-ops TLS certificate SAN

### DIFF
--- a/apps/web/lib/agent/server-cert-generation.test.mjs
+++ b/apps/web/lib/agent/server-cert-generation.test.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../../../..')
+
+test('generated server certificates include the bundled ct-ops hostname', () => {
+  execFileSync('bash', [resolve(repoRoot, 'deploy/scripts/test-gen-server-cert.sh')], {
+    cwd: repoRoot,
+    stdio: 'pipe',
+  })
+})


### PR DESCRIPTION
## Summary
- add a web-package unit test that runs the generated server certificate SAN regression
- ensure release-please sees this self-update TLS fix in the web/customer-bundle release path

## Validation
- node --experimental-strip-types --test apps/web/lib/agent/server-cert-generation.test.mjs
- bash deploy/scripts/test-gen-server-cert.sh

Note: running pnpm --dir apps/web test:unit attempted the whole web suite and failed because this local worktree has no node_modules installed; the new targeted test passed both in that run and directly.