### PR TITLE
fix(calendar): lay out overlapping timed events

### DIFF
--- a/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
+++ b/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
@@ -36,6 +36,7 @@ import {
   type CalendarHostOption,
   type CalendarUserOption,
 } from '@/lib/actions/calendar'
+import { getTimedEventLayouts } from '@/lib/calendar/timed-layout'
 import {
   CALENDAR_EVENT_CATEGORIES,
   CALENDAR_EVENT_STATUSES,
@@ -661,6 +662,7 @@ export function OperationsCalendarClient({
             {days.map((day) => {
               const dayKey = localDateKey(day)
               const timedEvents = eventsForDay(calendarEvents, day).filter((event) => !event.allDay)
+              const eventLayouts = getTimedEventLayouts(timedEvents)
               return (
                 <div key={dayKey} className="ct-ops-calendar-time-day-stack" data-testid={`calendar-time-day-${dayKey}`}>
                   {TIME_SLOTS.map((minutes, index) => {
@@ -681,6 +683,10 @@ export function OperationsCalendarClient({
                     )
                   })}
                   {timedEvents.map((event) => {
+                    const layout = eventLayouts[event.id] ?? {
+                      leftPercent: 0,
+                      widthPercent: 100,
+                    }
                     const dayStart = startOfDay(day)
                     const startsAt = new Date(event.startsAt)
                     const endsAt = new Date(event.endsAt)
@@ -694,6 +700,8 @@ export function OperationsCalendarClient({
                         event={event}
                         onOpen={openEdit}
                         style={{
+                          left: `calc(${layout.leftPercent}% + 0.25rem)`,
+                          width: `calc(${layout.widthPercent}% - 0.5rem)`,
                           top: `calc(${topSlots} * var(--ct-ops-calendar-time-slot-height) + 2px)`,
                           height: `max(1.5rem, calc(${heightSlots} * var(--ct-ops-calendar-time-slot-height) - 4px))`,
                         }}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -311,7 +311,7 @@
 .ct-ops-calendar-time-day-stack > .ct-ops-calendar-event {
   position: absolute;
   left: 0.25rem;
-  right: 0.25rem;
+  width: calc(100% - 0.5rem);
   z-index: 2;
 }
 

--- a/apps/web/lib/calendar/timed-layout.test.mjs
+++ b/apps/web/lib/calendar/timed-layout.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getTimedEventLayouts } from './timed-layout.ts'
+
+test('places same-time timed events side by side with equal width', () => {
+  const layouts = getTimedEventLayouts([
+    {
+      id: 'first',
+      startsAt: '2026-05-08T10:00:00.000Z',
+      endsAt: '2026-05-08T11:00:00.000Z',
+    },
+    {
+      id: 'second',
+      startsAt: '2026-05-08T10:00:00.000Z',
+      endsAt: '2026-05-08T11:00:00.000Z',
+    },
+  ])
+
+  assert.deepEqual(layouts.first, { column: 0, columns: 2, leftPercent: 0, widthPercent: 50 })
+  assert.deepEqual(layouts.second, { column: 1, columns: 2, leftPercent: 50, widthPercent: 50 })
+})
+
+test('uses the same column count for a connected overlap group', () => {
+  const layouts = getTimedEventLayouts([
+    {
+      id: 'early',
+      startsAt: '2026-05-08T09:00:00.000Z',
+      endsAt: '2026-05-08T10:00:00.000Z',
+    },
+    {
+      id: 'middle',
+      startsAt: '2026-05-08T09:30:00.000Z',
+      endsAt: '2026-05-08T10:30:00.000Z',
+    },
+    {
+      id: 'late',
+      startsAt: '2026-05-08T10:00:00.000Z',
+      endsAt: '2026-05-08T11:00:00.000Z',
+    },
+    {
+      id: 'separate',
+      startsAt: '2026-05-08T12:00:00.000Z',
+      endsAt: '2026-05-08T13:00:00.000Z',
+    },
+  ])
+
+  assert.equal(layouts.early.columns, 2)
+  assert.equal(layouts.middle.columns, 2)
+  assert.equal(layouts.late.columns, 2)
+  assert.deepEqual(layouts.separate, { column: 0, columns: 1, leftPercent: 0, widthPercent: 100 })
+})

--- a/apps/web/lib/calendar/timed-layout.ts
+++ b/apps/web/lib/calendar/timed-layout.ts
@@ -1,0 +1,97 @@
+export interface TimedEventLayoutInput {
+  id: string
+  startsAt: string
+  endsAt: string
+}
+
+export interface TimedEventLayout {
+  column: number
+  columns: number
+  leftPercent: number
+  widthPercent: number
+}
+
+interface TimedEventLayoutItem extends TimedEventLayoutInput {
+  startMs: number
+  endMs: number
+  order: number
+}
+
+interface AssignedTimedEventLayout {
+  id: string
+  column: number
+}
+
+function overlaps(left: TimedEventLayoutItem, right: TimedEventLayoutItem): boolean {
+  return left.startMs < right.endMs && right.startMs < left.endMs
+}
+
+function sortTimedLayoutItems(left: TimedEventLayoutItem, right: TimedEventLayoutItem): number {
+  return left.startMs - right.startMs || left.endMs - right.endMs || left.order - right.order
+}
+
+function assignGroupLayouts(group: TimedEventLayoutItem[]): Record<string, TimedEventLayout> {
+  const activeColumns: Array<{ column: number; endMs: number }> = []
+  const assigned: AssignedTimedEventLayout[] = []
+  let columns = 0
+
+  for (const item of group) {
+    for (let index = activeColumns.length - 1; index >= 0; index -= 1) {
+      if (activeColumns[index]!.endMs <= item.startMs) {
+        activeColumns.splice(index, 1)
+      }
+    }
+
+    const unavailableColumns = new Set(activeColumns.map((column) => column.column))
+    let column = 0
+    while (unavailableColumns.has(column)) column += 1
+
+    activeColumns.push({ column, endMs: item.endMs })
+    assigned.push({ id: item.id, column })
+    columns = Math.max(columns, column + 1)
+  }
+
+  const widthPercent = 100 / Math.max(1, columns)
+  return Object.fromEntries(
+    assigned.map(({ id, column }) => [
+      id,
+      {
+        column,
+        columns,
+        leftPercent: column * widthPercent,
+        widthPercent,
+      },
+    ]),
+  )
+}
+
+export function getTimedEventLayouts(events: TimedEventLayoutInput[]): Record<string, TimedEventLayout> {
+  const items = events
+    .map((event, order) => ({
+      ...event,
+      startMs: Date.parse(event.startsAt),
+      endMs: Date.parse(event.endsAt),
+      order,
+    }))
+    .filter((event) => Number.isFinite(event.startMs) && Number.isFinite(event.endMs) && event.endMs > event.startMs)
+    .sort(sortTimedLayoutItems)
+
+  const layouts: Record<string, TimedEventLayout> = {}
+  let group: TimedEventLayoutItem[] = []
+
+  function flushGroup() {
+    Object.assign(layouts, assignGroupLayouts(group))
+    group = []
+  }
+
+  for (const item of items) {
+    if (group.length > 0 && !group.some((groupItem) => overlaps(groupItem, item))) {
+      flushGroup()
+    }
+    group.push(item)
+  }
+
+  if (group.length > 0) flushGroup()
+
+  return layouts
+}

--- a/apps/web/tests/e2e/calendar/calendar.spec.ts
+++ b/apps/web/tests/e2e/calendar/calendar.spec.ts
@@ -165,6 +165,41 @@ test('dragging one recurring occurrence creates an exception without moving the 
   expect(rows[1]!.starts_at).toContain('2026-05-12 11:00:00')
 })
 
+test('overlapping timed calendar events render side by side', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { orgId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO calendar_events (id, organisation_id, created_by, title, starts_at, ends_at, all_day, timezone, status, category)
+    VALUES
+      ('calendar-overlap-1', ${orgId}, ${userId}, 'First overlapping maintenance', '2026-05-08T10:00:00Z', '2026-05-08T11:00:00Z', false, 'UTC', 'planned', 'maintenance'),
+      ('calendar-overlap-2', ${orgId}, ${userId}, 'Second overlapping maintenance', '2026-05-08T10:00:00Z', '2026-05-08T11:00:00Z', false, 'UTC', 'planned', 'patching')
+  `
+
+  await page.clock.setFixedTime(CALENDAR_TEST_NOW)
+  await page.goto('/calendar')
+
+  const firstEvent = page.getByTestId('calendar-rendered-event-calendar-overlap-1')
+  const secondEvent = page.getByTestId('calendar-rendered-event-calendar-overlap-2')
+  await expect(firstEvent).toBeVisible()
+  await expect(secondEvent).toBeVisible()
+
+  const [firstBox, secondBox, dayBox] = await Promise.all([
+    firstEvent.boundingBox(),
+    secondEvent.boundingBox(),
+    page.getByTestId('calendar-time-day-2026-05-08').boundingBox(),
+  ])
+
+  expect(firstBox).not.toBeNull()
+  expect(secondBox).not.toBeNull()
+  expect(dayBox).not.toBeNull()
+  expect(Math.abs(firstBox!.y - secondBox!.y)).toBeLessThanOrEqual(1)
+  expect(Math.abs(firstBox!.width - secondBox!.width)).toBeLessThanOrEqual(1)
+  expect(firstBox!.x + firstBox!.width).toBeLessThanOrEqual(secondBox!.x + 1)
+  expect(firstBox!.width).toBeLessThan(dayBox!.width * 0.6)
+  expect(secondBox!.width).toBeLessThan(dayBox!.width * 0.6)
+})
+
 test('read-only users can view calendar events but cannot create them', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const { orgId, userId } = await getOrgAndUserIds(sql)


### PR DESCRIPTION
## Summary
- add a timed-event overlap layout helper that assigns equal-width columns within overlap groups
- apply those widths in the Operations Calendar time grid so simultaneous events render side by side
- add unit and E2E coverage for overlapping timed events

## Validation
- node --experimental-strip-types --test lib/calendar/timed-layout.test.mjs
- pnpm --dir apps/web lint 'app/(dashboard)/calendar/operations-calendar-client.tsx' lib/calendar/timed-layout.ts lib/calendar/timed-layout.test.mjs tests/e2e/calendar/calendar.spec.ts
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec playwright test --list tests/e2e/calendar/calendar.spec.ts

## Local blockers
- pnpm --dir apps/web test:e2e tests/e2e/calendar/calendar.spec.ts: blocked locally because testcontainers could not find a working container runtime strategy
- pnpm --dir apps/web test:unit: blocked locally by DB-backed tests that require testcontainers/container runtime; non-container tests including lib/calendar/timed-layout.test.mjs passed