### PR TITLE
fix(agent): cover self-update HTTP client defaults

### DIFF
--- a/agent/internal/updater/updater_test.go
+++ b/agent/internal/updater/updater_test.go
@@ -1,0 +1,32 @@
+package updater
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestBuildHTTPClientUsesPinnedTrustAndTimeout(t *testing.T) {
+	client, err := buildHTTPClient(nil)
+	if err != nil {
+		t.Fatalf("buildHTTPClient returned error: %v", err)
+	}
+	if client.Timeout != 10*time.Minute {
+		t.Fatalf("expected 10 minute timeout, got %s", client.Timeout)
+	}
+
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("expected TLS config")
+	}
+	if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected TLS 1.2 minimum, got %x", tr.TLSClientConfig.MinVersion)
+	}
+	if tr.TLSClientConfig.RootCAs == nil {
+		t.Fatal("expected non-nil RootCAs")
+	}
+}


### PR DESCRIPTION
## Summary
- add regression coverage for the agent self-update HTTP client timeout and TLS defaults
- intentionally touches the agent package to produce an agent patch release for self-update validation

## Validation
- go test ./internal/updater (from agent/)
- go test ./... (from agent/)

## Test plan after release
Once the agent release is published, enrolled test hosts should observe the new latest agent version via heartbeat and self-update from the CT-Ops server.