### PR TITLE
fix(release): bake latest agent manifest into ct-ops images

### DIFF
--- a/apps/ingest/internal/config/config_test.go
+++ b/apps/ingest/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"net/url"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -43,5 +45,23 @@ func TestLoadBuildsEncodedDatabaseURLFromPostgresEnv(t *testing.T) {
 	want := "postgresql://ctops:Pyth%29n2475%23%23@db:5432/ctops"
 	if cfg.DatabaseURL != want {
 		t.Fatalf("cfg.DatabaseURL = %q, want %q", cfg.DatabaseURL, want)
+	}
+}
+
+func TestLoadSeedsAgentVersionFromConfiguredReleaseManifest(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, ".release-please-manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"agent":"9.9.9"}`), 0o644); err != nil {
+		t.Fatalf("writing release manifest: %v", err)
+	}
+	t.Setenv("INGEST_RELEASE_MANIFEST_PATH", manifestPath)
+
+	cfg, err := Load("/tmp/does-not-exist.yaml")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.Agent.LatestVersion != "v9.9.9" {
+		t.Fatalf("cfg.Agent.LatestVersion = %q, want %q", cfg.Agent.LatestVersion, "v9.9.9")
 	}
 }

--- a/apps/web/lib/agent/version.test.mjs
+++ b/apps/web/lib/agent/version.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+import { REQUIRED_AGENT_VERSION } from './version.ts'
+
+test('required agent version follows the release manifest baked into the web image', () => {
+  const candidates = [
+    path.resolve(process.cwd(), '.release-please-manifest.json'),
+    path.resolve(process.cwd(), '../../.release-please-manifest.json'),
+  ]
+  const manifestPath = candidates.find((candidate) => fs.existsSync(candidate))
+  assert.ok(manifestPath, 'expected release manifest to exist')
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+  assert.equal(REQUIRED_AGENT_VERSION, `v${manifest.agent}`)
+})


### PR DESCRIPTION
## Summary
- add ingest coverage for loading the baked release manifest as the latest agent fallback
- add web coverage that the required agent version follows the baked release manifest
- intentionally touches both web and ingest packages so release-please rebuilds the CT-Ops bundle with agent v0.34.3 baked into both images

## Validation
- go test ./apps/ingest/internal/config
- node --experimental-strip-types --test apps/web/lib/agent/version.test.mjs

## Why
The agent v0.34.3 release exists, but current CT-Ops installs built before that release still carry a baked manifest with agent v0.34.2. Releasing both CT-Ops images lets offline/bundled installs test automatic self-update against the new bundled required agent version.