### PR TITLE
fix(install): avoid GitHub API for latest bundle lookup

### DIFF
--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 REPO_OWNER="carrtech-dev"
 REPO_NAME="ct-ops"
+RELEASE_MANIFEST_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/.release-please-manifest.json"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -104,58 +105,27 @@ require_docker() {
 }
 
 latest_web_tag() {
-  local page releases_tmp tags_tmp tag
-  tags_tmp="$(mktemp -t ct-ops.XXXXXX.release-tags)"
-  page=1
+  local manifest_tmp version
+  manifest_tmp="$(mktemp -t ct-ops.XXXXXX.release-manifest.json)"
+  if ! curl -fsSL -o "$manifest_tmp" "$RELEASE_MANIFEST_URL"; then
+    rm -f "$manifest_tmp"
+    echo "ERROR: could not download the CT-Ops release manifest." >&2
+    echo "Try pinning the current release explicitly:" >&2
+    echo "  CT_OPS_VERSION=v0.124.5 ./upgrade.sh" >&2
+    return 1
+  fi
 
-  while :; do
-    releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
-    if ! curl -fsSL \
-      -o "$releases_tmp" \
-      "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100&page=${page}"; then
-      rm -f "$releases_tmp" "$tags_tmp"
-      return 1
-    fi
+  version="$(
+    awk -F '"' '$2 == "apps/web" { print $4; exit }' "$manifest_tmp"
+  )"
+  rm -f "$manifest_tmp"
 
-    awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9]+[.][0-9]+[.][0-9]+"/ { print $4 }' "$releases_tmp" >> "$tags_tmp"
-    if ! grep -q '"tag_name":[[:space:]]*"' "$releases_tmp"; then
-      rm -f "$releases_tmp"
-      break
-    fi
-
-    rm -f "$releases_tmp"
-    page=$((page + 1))
-  done
-
-  tag="$(awk -F '"' '
-    {
-      tag = $0
-      version = tag
-      sub(/^web\/v/, "", version)
-      if (version !~ /^[0-9]+[.][0-9]+[.][0-9]+$/) {
-        next
-      }
-      split(version, parts, ".")
-      key = sprintf("%010d.%010d.%010d", parts[1], parts[2], parts[3])
-      if (key > best_key) {
-        best_key = key
-        best_tag = tag
-      }
-    }
-    END {
-      if (best_tag != "") {
-        print best_tag
-      }
-    }
-  ' "$tags_tmp")"
-  rm -f "$tags_tmp"
-
-  if [ -z "$tag" ]; then
-    echo "ERROR: could not find a published web release for ${REPO_OWNER}/${REPO_NAME}." >&2
+  if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    echo "ERROR: could not read the latest web release from ${RELEASE_MANIFEST_URL}." >&2
     exit 1
   fi
 
-  printf '%s\n' "$tag"
+  printf 'web/v%s\n' "$version"
 }
 
 download_bundle() {

--- a/deploy/scripts/test-install.sh
+++ b/deploy/scripts/test-install.sh
@@ -44,13 +44,8 @@ if [[ -n "${MOCK_CURL_LOG:-}" ]]; then
   printf '%s\n' "$url" >> "$MOCK_CURL_LOG"
 fi
 
-if [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100" \
-  || "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=1" ]]; then
-  printf '%s' "${MOCK_RELEASES_JSON}" > "$out"
-elif [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=2" ]]; then
-  printf '%s' "${MOCK_RELEASES_JSON_PAGE_2:-[]}" > "$out"
-elif [[ "$url" == https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100\&page=* ]]; then
-  printf '[]' > "$out"
+if [[ "$url" == "https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/.release-please-manifest.json" ]]; then
+  printf '%s' "${MOCK_RELEASE_MANIFEST_JSON}" > "$out"
 elif [[ "$url" == *.sha256 ]]; then
   printf '%s  ct-ops-single.zip\n' "${MOCK_CHECKSUM}" > "$out"
 else
@@ -81,14 +76,11 @@ run_match_case() {
   make_mock_bin "$mockbin"
 
   export MOCK_PAYLOAD="verified bundle payload"
-  export MOCK_RELEASES_JSON='[
-    { "tag_name": "ingest/v9.9.9" },
-    { "tag_name": "web/v0.99.0" },
-    { "tag_name": "web/v0.98.0" }
-  ]'
-  export MOCK_RELEASES_JSON_PAGE_2='[
-    { "tag_name": "web/v0.100.0" }
-  ]'
+  export MOCK_RELEASE_MANIFEST_JSON='{
+    "agent": "9.9.9",
+    "apps/ingest": "9.9.9",
+    "apps/web": "0.100.0"
+  }'
   export MOCK_CURL_LOG="${workspace}/curl.log"
   export MOCK_CHECKSUM
   MOCK_CHECKSUM="$(printf '%s' "$MOCK_PAYLOAD" | openssl dgst -sha256 | awk '{print $NF}')"
@@ -106,7 +98,7 @@ run_match_case() {
     exit 1
   fi
   unset MOCK_CURL_LOG
-  unset MOCK_RELEASES_JSON_PAGE_2
+  unset MOCK_RELEASE_MANIFEST_JSON
 }
 
 run_mismatch_case() {
@@ -116,7 +108,7 @@ run_mismatch_case() {
   make_mock_bin "$mockbin"
 
   export MOCK_PAYLOAD="tampered bundle payload"
-  export MOCK_RELEASES_JSON='[{ "tag_name": "web/v1.2.3" }]'
+  export MOCK_RELEASE_MANIFEST_JSON='{ "apps/web": "1.2.3" }'
   export MOCK_CHECKSUM="deadbeef"
   export UNZIP_SHOULD_FAIL="1"
 
@@ -151,7 +143,7 @@ run_pinned_case() {
   make_mock_bin "$mockbin"
 
   export MOCK_PAYLOAD="verified pinned bundle payload"
-  export MOCK_RELEASES_JSON='[{ "tag_name": "ingest/v9.9.9" }]'
+  export MOCK_RELEASE_MANIFEST_JSON='{ "apps/web": "9.9.9" }'
   export MOCK_CURL_LOG="${workspace}/curl.log"
   export MOCK_CHECKSUM
   MOCK_CHECKSUM="$(printf '%s' "$MOCK_PAYLOAD" | openssl dgst -sha256 | awk '{print $NF}')"
@@ -163,8 +155,8 @@ run_pinned_case() {
 
   test -d "${workspace}/ct-ops"
   grep -Fxq "https://github.com/carrtech-dev/ct-ops/releases/download/web/v4.5.6/ct-ops-single-v4.5.6.zip" "$MOCK_CURL_LOG"
-  if grep -Fq "api.github.com" "$MOCK_CURL_LOG"; then
-    echo "pinned installs should not query the releases API" >&2
+  if grep -Fq ".release-please-manifest.json" "$MOCK_CURL_LOG"; then
+    echo "pinned installs should not query the release manifest" >&2
     exit 1
   fi
   unset MOCK_CURL_LOG

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -81,13 +81,8 @@ if [[ -n "${MOCK_CURL_LOG:-}" ]]; then
   printf '%s\n' "$url" >> "$MOCK_CURL_LOG"
 fi
 
-if [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100" \
-  || "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=1" ]]; then
-  printf '%s' "${MOCK_RELEASES_JSON}" > "$out"
-elif [[ "$url" == "https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100&page=2" ]]; then
-  printf '%s' "${MOCK_RELEASES_JSON_PAGE_2:-[]}" > "$out"
-elif [[ "$url" == https://api.github.com/repos/carrtech-dev/ct-ops/releases?per_page=100\&page=* ]]; then
-  printf '[]' > "$out"
+if [[ "$url" == "https://raw.githubusercontent.com/carrtech-dev/ct-ops/main/.release-please-manifest.json" ]]; then
+  printf '%s' "${MOCK_RELEASE_MANIFEST_JSON}" > "$out"
 elif [[ "$url" == *.sha256 ]]; then
   printf '%s  ct-ops-single.zip\n' "${MOCK_CHECKSUM}" > "$out"
 else
@@ -249,14 +244,11 @@ main() {
   rm -f "$bundle_zip"
   (cd "$new_src" && zip -qr "$bundle_zip" ct-ops)
 
-  export MOCK_RELEASES_JSON='[
-    { "tag_name": "ingest/v9.9.9" },
-    { "tag_name": "web/v0.99.0" },
-    { "tag_name": "web/v0.98.0" }
-  ]'
-  export MOCK_RELEASES_JSON_PAGE_2='[
-    { "tag_name": "web/v0.100.0" }
-  ]'
+  export MOCK_RELEASE_MANIFEST_JSON='{
+    "agent": "9.9.9",
+    "apps/ingest": "9.9.9",
+    "apps/web": "0.100.0"
+  }'
   export MOCK_BUNDLE_ZIP="$bundle_zip"
   export MOCK_CURL_LOG="${tmpdir}/curl.log"
   export MOCK_CHECKSUM
@@ -275,7 +267,7 @@ main() {
   grep -q 'example/web:v0.100.0' "${old_install}/docker-compose.yml"
   ! grep -q '^PASSWORD_MANAGER_API_IMAGE=' "${old_install}/.env"
   grep -q '"git_tag":"api/v0.100.0"' "${old_install}/password-manager-release.json"
-  unset MOCK_CURL_LOG MOCK_RELEASES_JSON_PAGE_2
+  unset MOCK_CURL_LOG MOCK_RELEASE_MANIFEST_JSON
 
   echo "upgrade.sh local bundle tests passed"
 }

--- a/install.sh
+++ b/install.sh
@@ -15,60 +15,30 @@ set -euo pipefail
 
 REPO_OWNER="carrtech-dev"
 REPO_NAME="ct-ops"
+RELEASE_MANIFEST_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/.release-please-manifest.json"
 
 latest_web_tag() {
-  local page releases_tmp tags_tmp tag
-  tags_tmp="$(mktemp -t ct-ops.XXXXXX.release-tags)"
-  page=1
+  local manifest_tmp version
+  manifest_tmp="$(mktemp -t ct-ops.XXXXXX.release-manifest.json)"
+  if ! curl -fsSL -o "$manifest_tmp" "$RELEASE_MANIFEST_URL"; then
+    rm -f "$manifest_tmp"
+    echo "ERROR: could not download the CT-Ops release manifest." >&2
+    echo "Try pinning the current release explicitly:" >&2
+    echo "  CT_OPS_VERSION=v0.124.5 bash install.sh" >&2
+    return 1
+  fi
 
-  while :; do
-    releases_tmp="$(mktemp -t ct-ops.XXXXXX.releases.json)"
-    if ! curl -fsSL \
-      -o "$releases_tmp" \
-      "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=100&page=${page}"; then
-      rm -f "$releases_tmp" "$tags_tmp"
-      return 1
-    fi
+  version="$(
+    awk -F '"' '$2 == "apps/web" { print $4; exit }' "$manifest_tmp"
+  )"
+  rm -f "$manifest_tmp"
 
-    awk -F '"' '/"tag_name":[[:space:]]*"web\/v[0-9]+[.][0-9]+[.][0-9]+"/ { print $4 }' "$releases_tmp" >> "$tags_tmp"
-    if ! grep -q '"tag_name":[[:space:]]*"' "$releases_tmp"; then
-      rm -f "$releases_tmp"
-      break
-    fi
-
-    rm -f "$releases_tmp"
-    page=$((page + 1))
-  done
-
-  tag="$(awk -F '"' '
-    {
-      tag = $0
-      version = tag
-      sub(/^web\/v/, "", version)
-      if (version !~ /^[0-9]+[.][0-9]+[.][0-9]+$/) {
-        next
-      }
-      split(version, parts, ".")
-      key = sprintf("%010d.%010d.%010d", parts[1], parts[2], parts[3])
-      if (key > best_key) {
-        best_key = key
-        best_tag = tag
-      }
-    }
-    END {
-      if (best_tag != "") {
-        print best_tag
-      }
-    }
-  ' "$tags_tmp")"
-  rm -f "$tags_tmp"
-
-  if [ -z "$tag" ]; then
-    echo "ERROR: could not find a published web release for ${REPO_OWNER}/${REPO_NAME}." >&2
+  if [[ ! "$version" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    echo "ERROR: could not read the latest web release from ${RELEASE_MANIFEST_URL}." >&2
     exit 1
   fi
 
-  printf '%s\n' "$tag"
+  printf 'web/v%s\n' "$version"
 }
 
 if [ "$(id -u)" = "0" ]; then


### PR DESCRIPTION
## Summary
- Resolve the latest CT-Ops web bundle from the raw release-please manifest instead of the unauthenticated GitHub Releases API
- Apply the same lookup to upgrade.sh
- Update install and upgrade tests for the manifest-based lookup

## Tests
- bash deploy/scripts/test-install.sh
- bash deploy/scripts/test-upgrade.sh
- bash -n install.sh deploy/customer-bundle/upgrade.sh
- git diff --check