### PR TITLE
feat(web): remove org scope from host groups and networks

### DIFF
--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -539,7 +539,7 @@ This slice owns per-host metadata editing and access-control flows.
 
 ## Task 9 - Web Host Groups And Networks Inventory Conversion
 
-Status: Not started
+Status: In progress
 
 Completed by:
 

--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -539,19 +539,38 @@ This slice owns per-host metadata editing and access-control flows.
 
 ## Task 9 - Web Host Groups And Networks Inventory Conversion
 
-Status: In progress
+Status: Complete
 
-Completed by:
+Completed by: Codex automation
 
-PR:
+PR: [#1229](https://github.com/carrtech-dev/ct-ops/pull/1229)
 
-Summary:
+Summary: Removed caller-supplied organisation identity from the host groups
+inventory, networks inventory/detail, and network membership picker flows by
+switching those pages to session-derived instance scope, dropping org-scoped
+React Query keys, and trimming unused organisation payload fields from the
+network graph helpers.
 
-Files changed:
+Files changed: `ORGANISATION_REMOVAL_TASKS.md`,
+`apps/web/app/(dashboard)/hosts/groups/{page.tsx,groups-client.tsx}`,
+`apps/web/app/(dashboard)/hosts/networks/{page.tsx,networks-client.tsx,all-networks-graph.tsx,components/network-flow-nodes.tsx}`,
+`apps/web/app/(dashboard)/hosts/networks/[id]/{page.tsx,network-detail-client.tsx,network-graph.tsx}`,
+`apps/web/lib/actions/{host-groups,networks}.ts`
 
-Validation:
+Validation: `pnpm install --frozen-lockfile`; `pnpm --dir apps/web type-check`
+(passes); `pnpm --dir apps/web lint` (passes with pre-existing warnings only);
+`pnpm --dir apps/web test:unit` (fails only `lib/db/rls.test.mjs` and
+`lib/integrations/ct-cve/db-nonce-store.test.mjs`); `pnpm --dir apps/web exec
+playwright test --list` (passes);
+`BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=test-secret pnpm --dir apps/web exec playwright test tests/e2e/hosts/groups.spec.ts --project=chromium --grep "create, edit, and delete a host group"`
+(fails before execution because Next instrumentation cannot import
+`./lib/agent/cache-prewarm` in this checkout);
+`rg -n "orgId|organisationId|organisation_id|org_id|organisations|tenant" 'apps/web/app/(dashboard)/hosts/groups/page.tsx' 'apps/web/app/(dashboard)/hosts/groups/groups-client.tsx' 'apps/web/app/(dashboard)/hosts/networks' apps/web/lib/actions/{host-groups,networks}.ts`
+(no matches)
 
-Follow-up:
+Follow-up: Start Task 10 next. If you need local browser smoke coverage in
+this worktree, fix the missing `apps/web/lib/agent/cache-prewarm` import path
+or use an environment where the instrumentation hook resolves correctly.
 
 ### Required work
 

--- a/apps/web/app/(dashboard)/hosts/groups/groups-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/groups-client.tsx
@@ -51,7 +51,6 @@ const groupSchema = z.object({
 type GroupFormValues = z.infer<typeof groupSchema>
 
 interface Props {
-  orgId: string
   initialGroups: HostGroupWithCount[]
 }
 
@@ -133,42 +132,42 @@ function GroupForm({
   )
 }
 
-export function GroupsClient({ orgId, initialGroups }: Props) {
+export function GroupsClient({ initialGroups }: Props) {
   const queryClient = useQueryClient()
   const [createOpen, setCreateOpen] = useState(false)
   const [editGroup, setEditGroup] = useState<HostGroupWithCount | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<HostGroupWithCount | null>(null)
 
   const { data: groups = initialGroups } = useQuery({
-    queryKey: ['host-groups', orgId],
-    queryFn: () => listGroups(orgId),
+    queryKey: ['host-groups'],
+    queryFn: () => listGroups(),
     initialData: initialGroups,
   })
 
   const { mutate: doCreate, isPending: isCreating } = useMutation({
     mutationFn: (data: GroupFormValues) =>
-      createGroup(orgId, { name: data.name, description: data.description || undefined }),
+      createGroup({ name: data.name, description: data.description || undefined }),
     onSuccess: (result) => {
       if ('error' in result) return
-      queryClient.invalidateQueries({ queryKey: ['host-groups', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['host-groups'] })
       setCreateOpen(false)
     },
   })
 
   const { mutate: doUpdate, isPending: isUpdating } = useMutation({
     mutationFn: (data: GroupFormValues) =>
-      updateGroup(orgId, editGroup!.id, { name: data.name, description: data.description || undefined }),
+      updateGroup(editGroup!.id, { name: data.name, description: data.description || undefined }),
     onSuccess: (result) => {
       if ('error' in result) return
-      queryClient.invalidateQueries({ queryKey: ['host-groups', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['host-groups'] })
       setEditGroup(null)
     },
   })
 
   const { mutate: doDelete, isPending: isDeleting } = useMutation({
-    mutationFn: (groupId: string) => deleteGroup(orgId, groupId),
+    mutationFn: (groupId: string) => deleteGroup(groupId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['host-groups', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['host-groups'] })
       setDeleteTarget(null)
     },
   })

--- a/apps/web/app/(dashboard)/hosts/groups/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { getRequiredSession } from '@/lib/auth/session'
 import { listGroups } from '@/lib/actions/host-groups'
 import { GroupsClient } from './groups-client'
 
@@ -8,10 +7,7 @@ export const metadata: Metadata = {
 }
 
 export default async function GroupsPage() {
-  const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const groups = await listGroups()
 
-  const groups = await listGroups(orgId)
-
-  return <GroupsClient orgId={orgId} initialGroups={groups} />
+  return <GroupsClient initialGroups={groups} />
 }

--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-detail-client.tsx
@@ -67,7 +67,6 @@ import type { Network as NetworkType, Host } from '@/lib/db/schema'
 type NetworkWithMembers = NetworkType & { members: Host[] }
 
 interface Props {
-  orgId: string
   initialNetwork: NetworkWithMembers
   initialAllHosts: HostWithAgent[]
 }
@@ -78,7 +77,7 @@ function HostStatusIcon({ status }: { status: string }) {
   return <AlertTriangle className="size-3.5 text-yellow-500" />
 }
 
-export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: Props) {
+export function NetworkDetailClient({ initialNetwork, initialAllHosts }: Props) {
   const queryClient = useQueryClient()
   const [viewMode, setViewMode] = useState<'table' | 'graph'>('table')
   const [addOpen, setAddOpen] = useState(false)
@@ -86,20 +85,20 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
   const [removeTarget, setRemoveTarget] = useState<Host | null>(null)
 
   const { data: network = initialNetwork } = useQuery({
-    queryKey: ['network', orgId, initialNetwork.id],
-    queryFn: () => getNetwork(orgId, initialNetwork.id),
+    queryKey: ['network', initialNetwork.id],
+    queryFn: () => getNetwork(initialNetwork.id),
     initialData: initialNetwork,
     select: (d) => d ?? initialNetwork,
   })
 
   const { data: memberships = [] } = useQuery({
-    queryKey: ['network-memberships', orgId, initialNetwork.id],
-    queryFn: () => listMembershipsForNetwork(orgId, initialNetwork.id),
+    queryKey: ['network-memberships', initialNetwork.id],
+    queryFn: () => listMembershipsForNetwork(initialNetwork.id),
   })
 
   const { data: allHosts = initialAllHosts } = useQuery({
-    queryKey: ['hosts', orgId],
-    queryFn: () => listHosts(orgId),
+    queryKey: ['hosts'],
+    queryFn: () => listHosts(),
     initialData: initialAllHosts,
     enabled: addOpen,
   })
@@ -114,14 +113,14 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
   )
 
   const { mutate: doAdd, isPending: isAdding } = useMutation({
-    mutationFn: (hostId: string) => addHostToNetwork(orgId, network.id, hostId),
+    mutationFn: (hostId: string) => addHostToNetwork(network.id, hostId),
     onSuccess: async (result) => {
       if ('error' in result) return
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['network', orgId, network.id] }),
-        queryClient.invalidateQueries({ queryKey: ['network-memberships', orgId, network.id] }),
-        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
-        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['network', network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['network-memberships', network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['networks'] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts'] }),
       ])
       setAddOpen(false)
       setSearch('')
@@ -129,14 +128,14 @@ export function NetworkDetailClient({ orgId, initialNetwork, initialAllHosts }: 
   })
 
   const { mutate: doRemove, isPending: isRemoving } = useMutation({
-    mutationFn: (hostId: string) => removeHostFromNetwork(orgId, network.id, hostId),
+    mutationFn: (hostId: string) => removeHostFromNetwork(network.id, hostId),
     onSuccess: async (result) => {
       if ('error' in result) return
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['network', orgId, network.id] }),
-        queryClient.invalidateQueries({ queryKey: ['network-memberships', orgId, network.id] }),
-        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
-        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['network', network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['network-memberships', network.id] }),
+        queryClient.invalidateQueries({ queryKey: ['networks'] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts'] }),
       ])
       setRemoveTarget(null)
     },

--- a/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/network-graph.tsx
@@ -89,7 +89,6 @@ function computeLayout(
         ipAddresses: (host.ipAddresses as string[] | null) ?? [],
         status: host.status ?? 'unknown',
         hostId: host.id,
-        orgId: host.organisationId,
       },
     })
 

--- a/apps/web/app/(dashboard)/hosts/networks/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/[id]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { getRequiredSession } from '@/lib/auth/session'
 import { getNetwork } from '@/lib/actions/networks'
 import { listHosts } from '@/lib/actions/agents'
 import { NetworkDetailClient } from './network-detail-client'
@@ -15,19 +14,16 @@ interface Props {
 
 export default async function NetworkDetailPage({ params }: Props) {
   const { id } = await params
-  const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
 
   const [network, allHosts] = await Promise.all([
-    getNetwork(orgId, id),
-    listHosts(orgId),
+    getNetwork(id),
+    listHosts(),
   ])
 
   if (!network) notFound()
 
   return (
     <NetworkDetailClient
-      orgId={orgId}
       initialNetwork={network}
       initialAllHosts={allHosts}
     />

--- a/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/all-networks-graph.tsx
@@ -95,7 +95,6 @@ function computeLayout(
             ipAddresses: (host.ipAddresses as string[] | null) ?? [],
             status: host.status ?? 'unknown',
             hostId: host.id,
-            orgId: host.organisationId,
           },
         })
       }

--- a/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/components/network-flow-nodes.tsx
@@ -40,7 +40,6 @@ export type HostNodeData = {
   ipAddresses: string[]
   status: string
   hostId: string
-  orgId: string
 }
 
 export type HostFlowNode = Node<HostNodeData, 'hostNode'>

--- a/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/networks-client.tsx
@@ -59,7 +59,6 @@ const networkSchema = z.object({
 type NetworkFormValues = z.infer<typeof networkSchema>
 
 interface Props {
-  orgId: string
   initialNetworks: NetworkWithCount[]
 }
 
@@ -134,7 +133,7 @@ function NetworkForm({
   )
 }
 
-export function NetworksClient({ orgId, initialNetworks }: Props) {
+export function NetworksClient({ initialNetworks }: Props) {
   const queryClient = useQueryClient()
   const [viewMode, setViewMode] = useState<'table' | 'graph'>('table')
   const [createOpen, setCreateOpen] = useState(false)
@@ -142,20 +141,20 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
   const [deleteTarget, setDeleteTarget] = useState<NetworkWithCount | null>(null)
 
   const { data: networkList = initialNetworks } = useQuery({
-    queryKey: ['networks', orgId],
-    queryFn: () => listNetworks(orgId),
+    queryKey: ['networks'],
+    queryFn: () => listNetworks(),
     initialData: initialNetworks,
   })
 
   const { data: networksWithHosts = [] } = useQuery({
-    queryKey: ['networks-with-hosts', orgId],
-    queryFn: () => listNetworksWithHosts(orgId),
+    queryKey: ['networks-with-hosts'],
+    queryFn: () => listNetworksWithHosts(),
     enabled: viewMode === 'graph',
   })
 
   const { mutate: doCreate, isPending: isCreating } = useMutation({
     mutationFn: (data: NetworkFormValues) =>
-      createNetwork(orgId, {
+      createNetwork({
         name: data.name,
         cidr: data.cidr,
         description: data.description || undefined,
@@ -163,8 +162,8 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
     onSuccess: async (result) => {
       if ('error' in result) return
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
-        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks'] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts'] }),
       ])
       setCreateOpen(false)
     },
@@ -172,7 +171,7 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
 
   const { mutate: doUpdate, isPending: isUpdating } = useMutation({
     mutationFn: (data: NetworkFormValues) =>
-      updateNetwork(orgId, editNetwork!.id, {
+      updateNetwork(editNetwork!.id, {
         name: data.name,
         cidr: data.cidr,
         description: data.description || undefined,
@@ -180,20 +179,20 @@ export function NetworksClient({ orgId, initialNetworks }: Props) {
     onSuccess: async (result) => {
       if ('error' in result) return
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
-        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks'] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts'] }),
       ])
       setEditNetwork(null)
     },
   })
 
   const { mutate: doDelete, isPending: isDeleting } = useMutation({
-    mutationFn: (networkId: string) => deleteNetwork(orgId, networkId),
+    mutationFn: (networkId: string) => deleteNetwork(networkId),
     onSuccess: async (result) => {
       if ('error' in result) return
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['networks', orgId] }),
-        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts', orgId] }),
+        queryClient.invalidateQueries({ queryKey: ['networks'] }),
+        queryClient.invalidateQueries({ queryKey: ['networks-with-hosts'] }),
       ])
       setDeleteTarget(null)
     },

--- a/apps/web/app/(dashboard)/hosts/networks/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/networks/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { getRequiredSession } from '@/lib/auth/session'
 import { listNetworks } from '@/lib/actions/networks'
 import { NetworksClient } from './networks-client'
 
@@ -8,10 +7,7 @@ export const metadata: Metadata = {
 }
 
 export default async function NetworksPage() {
-  const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const networks = await listNetworks()
 
-  const networks = await listNetworks(orgId)
-
-  return <NetworksClient orgId={orgId} initialNetworks={networks} />
+  return <NetworksClient initialNetworks={networks} />
 }

--- a/apps/web/lib/actions/host-groups.ts
+++ b/apps/web/lib/actions/host-groups.ts
@@ -19,25 +19,30 @@ import {
 export type { HostGroupWithCount, HostGroupWithMembers } from './host-groups-core'
 
 export async function createGroup(
-  scopeId: string,
-  input: unknown,
+  ...args: [unknown] | [string, unknown]
 ): Promise<{ success: true; group: import('@/lib/db/schema').HostGroup } | { error: string }> {
-  return createGroupCore(scopeId, input)
+  const session = await getRequiredSession()
+  const [currentScope, input] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return createGroupCore(currentScope, input)
 }
 
 export async function updateGroup(
-  scopeId: string,
-  groupId: string,
-  input: unknown,
+  ...args: [string, unknown] | [string, string, unknown]
 ): Promise<{ success: true } | { error: string }> {
-  return updateGroupCore(scopeId, groupId, input)
+  const session = await getRequiredSession()
+  const [currentScope, groupId, input] =
+    args.length === 3 ? args : [resolveCurrentActionScope(session), args[0], args[1]]
+  return updateGroupCore(currentScope, groupId, input)
 }
 
 export async function deleteGroup(
-  scopeId: string,
-  groupId: string,
+  ...args: [string] | [string, string]
 ): Promise<{ success: true } | { error: string }> {
-  return deleteGroupCore(scopeId, groupId)
+  const session = await getRequiredSession()
+  const [currentScope, groupId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return deleteGroupCore(currentScope, groupId)
 }
 
 export async function listGroups(
@@ -49,10 +54,12 @@ export async function listGroups(
 }
 
 export async function getGroup(
-  scopeId: string,
-  groupId: string,
+  ...args: [string] | [string, string]
 ): Promise<HostGroupWithMembers | null> {
-  return getGroupCore(scopeId, groupId)
+  const session = await getRequiredSession()
+  const [currentScope, groupId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return getGroupCore(currentScope, groupId)
 }
 
 export async function addHostToGroup(
@@ -74,10 +81,12 @@ export async function removeHostFromGroup(
 }
 
 export async function listHostsInGroup(
-  scopeId: string,
-  groupId: string,
+  ...args: [string] | [string, string]
 ): Promise<import('@/lib/db/schema').Host[]> {
-  return listHostsInGroupCore(scopeId, groupId)
+  const session = await getRequiredSession()
+  const [currentScope, groupId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return listHostsInGroupCore(currentScope, groupId)
 }
 
 export async function listGroupsForHost(

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -36,32 +36,43 @@ export async function listNetworks(
 }
 
 export async function getNetwork(
-  scopeId: string,
-  networkId: string,
+  ...args: [string] | [string, string]
 ): Promise<(import('@/lib/db/schema').Network & { members: import('@/lib/db/schema').Host[] }) | null> {
-  return getNetworkCore(scopeId, networkId)
+  const session = await getRequiredSession()
+  const [currentScope, networkId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return getNetworkCore(currentScope, networkId)
 }
 
 export async function createNetwork(
-  scopeId: string,
-  data: { name: string; cidr: string; description?: string },
+  ...args:
+    | [{ name: string; cidr: string; description?: string }]
+    | [string, { name: string; cidr: string; description?: string }]
 ): Promise<{ success: true; network: import('@/lib/db/schema').Network } | { error: string }> {
-  return createNetworkCore(scopeId, data)
+  const session = await getRequiredSession()
+  const [currentScope, data] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return createNetworkCore(currentScope, data)
 }
 
 export async function updateNetwork(
-  scopeId: string,
-  networkId: string,
-  data: { name: string; cidr: string; description?: string },
+  ...args:
+    | [string, { name: string; cidr: string; description?: string }]
+    | [string, string, { name: string; cidr: string; description?: string }]
 ): Promise<{ success: true } | { error: string }> {
-  return updateNetworkCore(scopeId, networkId, data)
+  const session = await getRequiredSession()
+  const [currentScope, networkId, data] =
+    args.length === 3 ? args : [resolveCurrentActionScope(session), args[0], args[1]]
+  return updateNetworkCore(currentScope, networkId, data)
 }
 
 export async function deleteNetwork(
-  scopeId: string,
-  networkId: string,
+  ...args: [string] | [string, string]
 ): Promise<{ success: true } | { error: string }> {
-  return deleteNetworkCore(scopeId, networkId)
+  const session = await getRequiredSession()
+  const [currentScope, networkId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return deleteNetworkCore(currentScope, networkId)
 }
 
 export async function addHostToNetwork(
@@ -83,23 +94,29 @@ export async function removeHostFromNetwork(
 }
 
 export async function listHostsInNetwork(
-  scopeId: string,
-  networkId: string,
+  ...args: [string] | [string, string]
 ): Promise<import('@/lib/db/schema').Host[]> {
-  return listHostsInNetworkCore(scopeId, networkId)
+  const session = await getRequiredSession()
+  const [currentScope, networkId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return listHostsInNetworkCore(currentScope, networkId)
 }
 
 export async function listMembershipsForNetwork(
-  scopeId: string,
-  networkId: string,
+  ...args: [string] | [string, string]
 ): Promise<NetworkMembershipEntry[]> {
-  return listMembershipsForNetworkCore(scopeId, networkId)
+  const session = await getRequiredSession()
+  const [currentScope, networkId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return listMembershipsForNetworkCore(currentScope, networkId)
 }
 
 export async function listNetworksWithHosts(
-  scopeId: string,
+  ...args: [] | [string]
 ): Promise<NetworkWithHosts[]> {
-  return listNetworksWithHostsCore(scopeId)
+  const session = await getRequiredSession()
+  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  return listNetworksWithHostsCore(currentScope)
 }
 
 export async function listNetworksForHost(


### PR DESCRIPTION
## Summary
- remove caller-supplied org scope from host groups and networks inventory/detail pages
- switch slice-owned host-group and network action wrappers to derive instance scope from the session by default
- drop org-scoped React Query keys and unused organisation payload fields from the network graph helpers

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint` (pre-existing warnings only)
- `pnpm --dir apps/web test:unit` (fails only `lib/db/rls.test.mjs` and `lib/integrations/ct-cve/db-nonce-store.test.mjs`)
- `pnpm --dir apps/web exec playwright test --list`
- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=test-secret pnpm --dir apps/web exec playwright test tests/e2e/hosts/groups.spec.ts --project=chromium --grep "create, edit, and delete a host group"` (fails before execution because Next instrumentation cannot import `./lib/agent/cache-prewarm` in this checkout)
- `rg -n "orgId|organisationId|organisation_id|org_id|organisations|tenant" 'apps/web/app/(dashboard)/hosts/groups/page.tsx' 'apps/web/app/(dashboard)/hosts/groups/groups-client.tsx' 'apps/web/app/(dashboard)/hosts/networks' apps/web/lib/actions/{host-groups,networks}.ts`
