### PR TITLE
feat(web): remove org scope from task runs and schedules

### DIFF
--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -634,7 +634,7 @@ outside the task-run-heavy group operations view.
 
 ## Task 10 - Web Task Runs And Schedule Conversion
 
-Status: Not started
+Status: In progress
 
 Completed by:
 

--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -634,19 +634,44 @@ outside the task-run-heavy group operations view.
 
 ## Task 10 - Web Task Runs And Schedule Conversion
 
-Status: In progress
+Status: Complete
 
-Completed by:
+Completed by: Codex automation
 
-PR:
+PR: [#1232](https://github.com/carrtech-dev/ct-ops/pull/1232)
 
-Summary:
+Summary: Removed caller-supplied organisation identity from task run
+monitoring, host and group task triggers, task-run deletion/cancellation, and
+schedule CRUD by switching the Task 10-owned pages and actions to
+session-derived instance scope. Split `task-runs.ts` and `task-schedules.ts`
+into thin instance-scoped wrappers over `*-core.ts` modules so the public
+Task 10 action entrypoints no longer expose org-scoped signatures, and updated
+the touched E2E fixtures plus wrapper tests to seed standalone instance data.
 
-Files changed:
+Files changed: `ORGANISATION_REMOVAL_TASKS.md`,
+`apps/web/app/(dashboard)/hosts/[id]/{host-detail-client.tsx,tasks-tab.tsx}`,
+`apps/web/app/(dashboard)/hosts/groups/[id]/{group-detail-client.tsx,page.tsx}`,
+`apps/web/app/(dashboard)/tasks/**/*`,
+`apps/web/lib/actions/{agents-core.ts,instance-scope-wrappers.test.mjs,task-runs.ts,task-runs-core.ts,task-runs-authz.test.mjs,task-schedules.ts,task-schedules-core.ts}`,
+`apps/web/tests/e2e/{hosts/group-task-history.spec.ts,tasks/monitor.spec.ts,tasks/schedules.spec.ts}`
 
-Validation:
+Validation: `pnpm install --frozen-lockfile`; `pnpm --dir apps/web
+type-check` (passes); `pnpm --dir apps/web lint` (passes with pre-existing
+warnings only); `pnpm --dir apps/web test:unit` (fails only
+`lib/db/rls.test.mjs` and `lib/integrations/ct-cve/db-nonce-store.test.mjs`);
+`pnpm --dir apps/web exec playwright test --list` (passes);
+`BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=test-secret pnpm --dir apps/web exec playwright test tests/e2e/tasks/monitor.spec.ts --project=chromium --grep "completed grouped task run"`
+(fails before execution because Next instrumentation cannot import
+`./lib/agent/cache-prewarm` in this checkout);
+`rg -n "orgId|organisationId|organisation_id|org_id|organisations|tenant" 'apps/web/app/(dashboard)/tasks' 'apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx' 'apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx' apps/web/lib/actions/{task-runs,task-schedules}.ts`
+(no matches)
 
-Follow-up:
+Follow-up: Start Task 11 next. Task 13 still needs to delete the transitional
+`apps/web/lib/actions/task-runs-core.ts` and
+`apps/web/lib/actions/task-schedules-core.ts` org-scoped internals if they
+remain by then, and local browser smoke coverage is still blocked in this
+checkout by the missing `apps/web/lib/agent/cache-prewarm` instrumentation
+import.
 
 ### Required work
 

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -1290,7 +1290,7 @@ export function HostDetailClient({ host: initialHost, scopeId, currentUserId, us
 
       {/* Tasks Tab */}
       {activeTab === 'tasks' && (
-        <TasksTab scopeId={scopeId} host={host} canRunTasks={canRunHostTasks} />
+        <TasksTab host={host} canRunTasks={canRunHostTasks} />
       )}
 
       {/* Logs Tab */}

--- a/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
@@ -62,7 +62,6 @@ import type { HostWithAgent } from '@/lib/actions/agents-core'
 import { useRouter } from 'next/navigation'
 
 interface Props {
-  scopeId: string
   host: HostWithAgent
   canRunTasks: boolean
 }
@@ -173,7 +172,7 @@ function TaskDetailsCell({ run, hostId }: { run: TaskRunWithHosts; hostId: strin
   return <span className="text-sm text-muted-foreground">—</span>
 }
 
-export function TasksTab({ scopeId, host, canRunTasks }: Props) {
+export function TasksTab({ host, canRunTasks }: Props) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const isLinux = host.os?.toLowerCase() === 'linux'
@@ -198,8 +197,8 @@ export function TasksTab({ scopeId, host, canRunTasks }: Props) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
   const { data: taskRuns = [] } = useQuery({
-    queryKey: ['task-runs-host', scopeId, host.id],
-    queryFn: () => listTaskRunsForHost(scopeId, host.id),
+    queryKey: ['task-runs-host', host.id],
+    queryFn: () => listTaskRunsForHost(host.id),
     refetchInterval: (query) => {
       const runs = query.state.data ?? []
       return runs.some((r) => isRunActive(r.status)) ? 5_000 : 30_000
@@ -237,7 +236,7 @@ export function TasksTab({ scopeId, host, canRunTasks }: Props) {
   }
 
   const { mutate: doPatchRun, isPending: isPatching } = useMutation({
-    mutationFn: () => triggerPatchRun(scopeId, host.id, patchMode),
+    mutationFn: () => triggerPatchRun(host.id, patchMode),
     onSuccess: (result) => {
       setPatchOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -245,7 +244,7 @@ export function TasksTab({ scopeId, host, canRunTasks }: Props) {
   })
 
   const { mutate: doScriptRun, isPending: isScripting } = useMutation({
-    mutationFn: () => triggerCustomScriptRun(scopeId, host.id, scriptBody, interpreter),
+    mutationFn: () => triggerCustomScriptRun(host.id, scriptBody, interpreter),
     onSuccess: (result) => {
       setScriptOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -253,7 +252,7 @@ export function TasksTab({ scopeId, host, canRunTasks }: Props) {
   })
 
   const { mutate: doServiceAction, isPending: isServicing } = useMutation({
-    mutationFn: () => triggerServiceAction(scopeId, host.id, serviceName, serviceAction),
+    mutationFn: () => triggerServiceAction(host.id, serviceName, serviceAction),
     onSuccess: (result) => {
       setServiceOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -261,10 +260,10 @@ export function TasksTab({ scopeId, host, canRunTasks }: Props) {
   })
 
   const { mutate: doDelete, isPending: isDeleting } = useMutation({
-    mutationFn: () => deleteTaskRuns(scopeId, [...selectedIds]),
+    mutationFn: () => deleteTaskRuns([...selectedIds]),
     onSuccess: () => {
       setSelectedIds(new Set())
-      queryClient.invalidateQueries({ queryKey: ['task-runs-host', scopeId, host.id] })
+      queryClient.invalidateQueries({ queryKey: ['task-runs-host', host.id] })
     },
   })
 

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -95,7 +95,7 @@ function isRunActive(status: string) {
 }
 
 interface Props {
-  orgId: string
+  scopeId: string
   userRole: string
   initialGroup: HostGroupWithMembers
   initialAllHosts: HostWithAgent[]
@@ -167,7 +167,7 @@ function RunStatusBadge({ status }: { status: string }) {
   }
 }
 
-export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHosts }: Props) {
+export function GroupDetailClient({ scopeId, userRole, initialGroup, initialAllHosts }: Props) {
   const queryClient = useQueryClient()
   const router = useRouter()
   const canRunTasks = userRole === 'org_admin' || userRole === 'super_admin'
@@ -196,22 +196,22 @@ export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHos
   const [selectedRunIds, setSelectedRunIds] = useState<Set<string>>(new Set())
 
   const { data: group } = useQuery({
-    queryKey: ['host-group', orgId, initialGroup.id],
-    queryFn: () => getGroup(orgId, initialGroup.id),
+    queryKey: ['host-group', scopeId, initialGroup.id],
+    queryFn: () => getGroup(scopeId, initialGroup.id),
     initialData: initialGroup,
     refetchInterval: 30_000,
   })
 
   const { data: allHosts = initialAllHosts } = useQuery({
-    queryKey: ['hosts', orgId],
-    queryFn: () => listHosts(orgId),
+    queryKey: ['hosts', scopeId],
+    queryFn: () => listHosts(scopeId),
     initialData: initialAllHosts,
     enabled: addOpen,
   })
 
   const { data: taskRuns = [] } = useQuery({
-    queryKey: ['task-runs-group', orgId, initialGroup.id],
-    queryFn: () => listTaskRunsForGroup(orgId, initialGroup.id),
+    queryKey: ['task-runs-group', initialGroup.id],
+    queryFn: () => listTaskRunsForGroup(initialGroup.id),
     refetchInterval: (query) => {
       const runs = query.state.data ?? []
       return runs.some((r) => isRunActive(r.status)) ? 5_000 : 30_000
@@ -219,25 +219,24 @@ export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHos
   })
 
   const { mutate: doAdd, isPending: isAdding } = useMutation({
-    mutationFn: (hostId: string) => addHostToGroup(orgId, group!.id, hostId),
+    mutationFn: (hostId: string) => addHostToGroup(scopeId, group!.id, hostId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['host-group', orgId, initialGroup.id] })
-      queryClient.invalidateQueries({ queryKey: ['host-groups', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['host-group', scopeId, initialGroup.id] })
+      queryClient.invalidateQueries({ queryKey: ['host-groups', scopeId] })
     },
   })
 
   const { mutate: doRemove, isPending: isRemoving } = useMutation({
-    mutationFn: (hostId: string) => removeHostFromGroup(orgId, group!.id, hostId),
+    mutationFn: (hostId: string) => removeHostFromGroup(scopeId, group!.id, hostId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['host-group', orgId, initialGroup.id] })
-      queryClient.invalidateQueries({ queryKey: ['host-groups', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['host-group', scopeId, initialGroup.id] })
+      queryClient.invalidateQueries({ queryKey: ['host-groups', scopeId] })
       setRemoveTarget(null)
     },
   })
 
   const { mutate: doPatchGroup, isPending: isPatching } = useMutation({
-    mutationFn: () =>
-      triggerGroupPatchRun(orgId, initialGroup.id, patchMode, maxParallel),
+    mutationFn: () => triggerGroupPatchRun(initialGroup.id, patchMode, maxParallel),
     onSuccess: (result) => {
       setPatchOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -245,8 +244,7 @@ export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHos
   })
 
   const { mutate: doGroupScript, isPending: isScripting } = useMutation({
-    mutationFn: () =>
-      triggerGroupCustomScriptRun(orgId, initialGroup.id, scriptBody, interpreter, scriptMaxParallel),
+    mutationFn: () => triggerGroupCustomScriptRun(initialGroup.id, scriptBody, interpreter, scriptMaxParallel),
     onSuccess: (result) => {
       setScriptOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -254,8 +252,7 @@ export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHos
   })
 
   const { mutate: doGroupService, isPending: isServicing } = useMutation({
-    mutationFn: () =>
-      triggerGroupServiceAction(orgId, initialGroup.id, serviceName, serviceAction, serviceMaxParallel),
+    mutationFn: () => triggerGroupServiceAction(initialGroup.id, serviceName, serviceAction, serviceMaxParallel),
     onSuccess: (result) => {
       setServiceOpen(false)
       if ('taskRunId' in result) router.push(`/tasks/${result.taskRunId}`)
@@ -263,10 +260,10 @@ export function GroupDetailClient({ orgId, userRole, initialGroup, initialAllHos
   })
 
   const { mutate: doDeleteRuns, isPending: isDeletingRuns } = useMutation({
-    mutationFn: () => deleteTaskRuns(orgId, [...selectedRunIds]),
+    mutationFn: () => deleteTaskRuns([...selectedRunIds]),
     onSuccess: () => {
       setSelectedRunIds(new Set())
-      queryClient.invalidateQueries({ queryKey: ['task-runs-group', orgId, initialGroup.id] })
+      queryClient.invalidateQueries({ queryKey: ['task-runs-group', initialGroup.id] })
     },
   })
 

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/page.tsx
@@ -27,7 +27,7 @@ export default async function GroupDetailPage({ params }: Props) {
 
   return (
     <GroupDetailClient
-      orgId={orgId}
+      scopeId={orgId}
       userRole={session.user.role}
       initialGroup={group}
       initialAllHosts={allHosts}

--- a/apps/web/app/(dashboard)/tasks/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/[id]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { canAccessTooling } from '@/lib/auth/tooling'
+import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
 import { getTaskRun } from '@/lib/actions/task-runs'
 import { TaskMonitorClient } from './task-monitor-client'
 
@@ -17,10 +18,9 @@ export default async function TaskRunPage({ params }: Props) {
   const { id } = await params
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const orgId = session.user.organisationId!
-
-  const taskRun = await getTaskRun(orgId, id)
+  const currentScope = resolveCurrentActionScope(session)
+  const taskRun = await getTaskRun(currentScope, id)
   if (!taskRun) notFound()
 
-  return <TaskMonitorClient orgId={orgId} initialTaskRun={taskRun} />
+  return <TaskMonitorClient initialTaskRun={taskRun} />
 }

--- a/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/[id]/task-monitor-client.tsx
@@ -40,7 +40,6 @@ import type {
 } from '@/lib/db/schema'
 
 interface Props {
-  orgId: string
   initialTaskRun: TaskRunWithHosts
 }
 
@@ -251,17 +250,15 @@ function OutputPanel({
 // ── Stop button ───────────────────────────────────────────────────────────────
 
 function StopButton({
-  orgId,
   taskRunId,
   onCancelled,
 }: {
-  orgId: string
   taskRunId: string
   onCancelled: () => void
 }) {
   const [open, setOpen] = useState(false)
   const mutation = useMutation({
-    mutationFn: () => cancelTaskRun(orgId, taskRunId),
+    mutationFn: () => cancelTaskRun(taskRunId),
     onSuccess: (result) => {
       if ('error' in result) return
       setOpen(false)
@@ -311,7 +308,7 @@ function StopButton({
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
+export function TaskMonitorClient({ initialTaskRun }: Props) {
   const queryClient = useQueryClient()
   const [selectedHostId, setSelectedHostId] = useState<string | null>(
     initialTaskRun.hosts[0]?.hostId ?? null,
@@ -320,8 +317,8 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
   const active = isRunActive(initialTaskRun.status)
 
   const { data: taskRun = initialTaskRun } = useQuery({
-    queryKey: ['task-run', orgId, initialTaskRun.id],
-    queryFn: () => getTaskRun(orgId, initialTaskRun.id),
+    queryKey: ['task-run', initialTaskRun.id],
+    queryFn: () => getTaskRun(initialTaskRun.id),
     initialData: initialTaskRun,
     refetchInterval: (query) => {
       const run = query.state.data
@@ -409,11 +406,10 @@ export function TaskMonitorClient({ orgId, initialTaskRun }: Props) {
             <RunStatusBadge status={taskRun.status} />
             {canStop && (
               <StopButton
-                orgId={orgId}
                 taskRunId={taskRun.id}
                 onCancelled={() =>
                   queryClient.invalidateQueries({
-                    queryKey: ['task-run', orgId, taskRun.id],
+                    queryKey: ['task-run', taskRun.id],
                   })
                 }
               />

--- a/apps/web/app/(dashboard)/tasks/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { canAccessTooling } from '@/lib/auth/tooling'
+import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
 import { listSchedules } from '@/lib/actions/task-schedules'
 import { SchedulesClient } from './schedules-client'
 
@@ -12,13 +13,11 @@ export const metadata: Metadata = {
 export default async function ScheduledTasksPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const orgId = session.user.organisationId!
-
-  const schedules = await listSchedules(orgId)
+  const currentScope = resolveCurrentActionScope(session)
+  const schedules = await listSchedules(currentScope)
 
   return (
     <SchedulesClient
-      orgId={orgId}
       userRole={session.user.role}
       initialSchedules={schedules}
     />

--- a/apps/web/app/(dashboard)/tasks/schedules-client.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules-client.tsx
@@ -49,11 +49,9 @@ function formatMaybeDate(d: Date | string | null): string {
 }
 
 export function SchedulesClient({
-  orgId,
   userRole,
   initialSchedules,
 }: {
-  orgId: string
   userRole: string
   initialSchedules: ScheduleWithTargetName[]
 }) {
@@ -65,23 +63,23 @@ export function SchedulesClient({
   const canEdit = userRole === 'org_admin' || userRole === 'super_admin'
 
   const { data: schedules = initialSchedules } = useQuery({
-    queryKey: ['task-schedules', orgId],
-    queryFn: () => listSchedules(orgId),
+    queryKey: ['task-schedules'],
+    queryFn: () => listSchedules(),
     initialData: initialSchedules,
     staleTime: 10_000,
   })
 
   const toggle = useMutation({
     mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
-      setScheduleEnabled(orgId, id, enabled),
+      setScheduleEnabled(id, enabled),
     onSuccess: (result) => {
       if ('error' in result) setErrorMsg(result.error)
-      queryClient.invalidateQueries({ queryKey: ['task-schedules', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['task-schedules'] })
     },
   })
 
   const runNow = useMutation({
-    mutationFn: (id: string) => runScheduleNow(orgId, id),
+    mutationFn: (id: string) => runScheduleNow(id),
     onSuccess: (result) => {
       if ('error' in result) {
         setErrorMsg(result.error)
@@ -92,11 +90,11 @@ export function SchedulesClient({
   })
 
   const remove = useMutation({
-    mutationFn: (id: string) => deleteSchedule(orgId, id),
+    mutationFn: (id: string) => deleteSchedule(id),
     onSuccess: (result) => {
       if ('error' in result) setErrorMsg(result.error)
       setDeleteTarget(null)
-      queryClient.invalidateQueries({ queryKey: ['task-schedules', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['task-schedules'] })
     },
   })
 

--- a/apps/web/app/(dashboard)/tasks/schedules/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/[id]/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next'
 import { notFound, redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
-import { db } from '@/lib/db'
-import { hosts, hostGroups } from '@/lib/db/schema'
-import { and, eq, isNull, asc } from 'drizzle-orm'
+import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
+import { listHosts } from '@/lib/actions/agents'
+import { listGroups } from '@/lib/actions/host-groups'
 import { getSchedule } from '@/lib/actions/task-schedules'
 import { ScheduleForm } from '../schedule-form'
 
@@ -20,27 +20,18 @@ export default async function SchedulePage({ params }: Props) {
   const { id } = await params
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) redirect('/tasks')
-  const orgId = session.user.organisationId!
+  const currentScope = resolveCurrentActionScope(session)
 
-  const result = await getSchedule(orgId, id)
+  const result = await getSchedule(currentScope, id)
   if (!result) notFound()
 
   const [hostRows, groupRows] = await Promise.all([
-    db.query.hosts.findMany({
-      where: and(eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
-      columns: { id: true, hostname: true, os: true },
-      orderBy: asc(hosts.hostname),
-    }),
-    db.query.hostGroups.findMany({
-      where: and(eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)),
-      columns: { id: true, name: true },
-      orderBy: asc(hostGroups.name),
-    }),
+    listHosts(currentScope),
+    listGroups(currentScope),
   ])
 
   return (
     <ScheduleForm
-      orgId={orgId}
       mode="edit"
       hosts={hostRows}
       groups={groupRows}

--- a/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
-import { db } from '@/lib/db'
-import { hosts, hostGroups } from '@/lib/db/schema'
-import { and, eq, isNull, asc } from 'drizzle-orm'
+import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
+import { listHosts } from '@/lib/actions/agents'
+import { listGroups } from '@/lib/actions/host-groups'
 import { ScheduleForm } from '../schedule-form'
 
 export const metadata: Metadata = {
@@ -14,24 +14,15 @@ export const metadata: Metadata = {
 export default async function NewSchedulePage() {
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) redirect('/tasks')
-  const orgId = session.user.organisationId!
+  const currentScope = resolveCurrentActionScope(session)
 
   const [hostRows, groupRows] = await Promise.all([
-    db.query.hosts.findMany({
-      where: and(eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
-      columns: { id: true, hostname: true, os: true },
-      orderBy: asc(hosts.hostname),
-    }),
-    db.query.hostGroups.findMany({
-      where: and(eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)),
-      columns: { id: true, name: true },
-      orderBy: asc(hostGroups.name),
-    }),
+    listHosts(currentScope),
+    listGroups(currentScope),
   ])
 
   return (
     <ScheduleForm
-      orgId={orgId}
       mode="create"
       hosts={hostRows}
       groups={groupRows}

--- a/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/schedule-form.tsx
@@ -68,14 +68,12 @@ const CRON_PRESETS: { label: string; expr: string }[] = [
 ]
 
 export function ScheduleForm({
-  orgId,
   mode,
   hosts,
   groups,
   schedule,
   recentRuns,
 }: {
-  orgId: string
   mode: 'create' | 'edit'
   hosts: HostOption[]
   groups: GroupOption[]
@@ -163,8 +161,8 @@ export function ScheduleForm({
         enabled,
       }
       return mode === 'create'
-        ? createSchedule(orgId, input)
-        : updateSchedule(orgId, schedule!.id, input)
+        ? createSchedule(input)
+        : updateSchedule(schedule!.id, input)
     },
     onSuccess: (result) => {
       if ('error' in result) {

--- a/apps/web/lib/actions/agents-core.ts
+++ b/apps/web/lib/actions/agents-core.ts
@@ -43,7 +43,7 @@ import { HOST_HIGH_USAGE_THRESHOLD, HOST_STALE_MINUTES } from '@/lib/db/schema/h
 import { applyGlobalDefaultsToHost } from '@/lib/actions/alerts'
 import { escapeLikePattern } from '@/lib/utils'
 import { getOrgDefaultCollectionSettings } from '@/lib/actions/host-settings'
-import { triggerAgentUninstall, getTaskRun } from '@/lib/actions/task-runs'
+import { triggerAgentUninstall, getTaskRun } from '@/lib/actions/task-runs-core'
 import { assignTagsToResource, getOrgDefaultTags, mergeTagLayers } from '@/lib/actions/tags'
 import { runMatchingTagRules } from '@/lib/actions/tag-rules'
 import type { HostMetadata, TagPair } from '@/lib/db/schema'

--- a/apps/web/lib/actions/instance-scope-wrappers.test.mjs
+++ b/apps/web/lib/actions/instance-scope-wrappers.test.mjs
@@ -13,6 +13,8 @@ const notesSource = readFileSync(path.join(here, 'notes.ts'), 'utf8')
 const serviceAccountsSource = readFileSync(path.join(here, 'service-accounts.ts'), 'utf8')
 const softwareInventorySource = readFileSync(path.join(here, 'software-inventory.ts'), 'utf8')
 const tagsSource = readFileSync(path.join(here, 'tags.ts'), 'utf8')
+const taskRunsSource = readFileSync(path.join(here, 'task-runs.ts'), 'utf8')
+const taskSchedulesSource = readFileSync(path.join(here, 'task-schedules.ts'), 'utf8')
 const terminalSource = readFileSync(path.join(here, 'terminal.ts'), 'utf8')
 
 test('checks wrapper derives instance scope from the current session', () => {
@@ -53,4 +55,14 @@ test('tags wrapper derives instance scope from the current session', () => {
 test('terminal wrapper derives instance scope from the current session', () => {
   assert.match(terminalSource, /resolveCurrentActionScope\(session\)/)
   assert.doesNotMatch(terminalSource, /\borgId\b/)
+})
+
+test('task runs wrapper derives instance scope from the current session', () => {
+  assert.match(taskRunsSource, /resolveCurrentActionScope\(session\)/)
+  assert.doesNotMatch(taskRunsSource, /\borgId\b/)
+})
+
+test('task schedules wrapper derives instance scope from the current session', () => {
+  assert.match(taskSchedulesSource, /resolveCurrentActionScope\(session\)/)
+  assert.doesNotMatch(taskSchedulesSource, /\borgId\b/)
 })

--- a/apps/web/lib/actions/task-runs-authz.test.mjs
+++ b/apps/web/lib/actions/task-runs-authz.test.mjs
@@ -5,8 +5,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
-const taskRunsSource = readFileSync(path.join(here, 'task-runs.ts'), 'utf8')
-const taskSchedulesSource = readFileSync(path.join(here, 'task-schedules.ts'), 'utf8')
+const taskRunsSource = readFileSync(path.join(here, 'task-runs-core.ts'), 'utf8')
+const taskSchedulesSource = readFileSync(path.join(here, 'task-schedules-core.ts'), 'utf8')
 
 function getActionSegment(source, action) {
   const start = source.indexOf(`export async function ${action}`)
@@ -36,7 +36,7 @@ test('privileged host task actions require org admin access and derive actors fr
     )
     assert.match(
       segment,
-      /const session = await requireOrgAdminAccess\(orgId\)/,
+      /const session = await requireOrgAdminAccess\(currentScope\)/,
       `${action} must capture an org-admin-authorized session`,
     )
     assert.match(
@@ -53,7 +53,7 @@ test('privileged task schedule mutations require org admin access', () => {
 
     assert.match(
       segment,
-      /(?:const session = )?await requireOrgAdminAccess\(orgId\)/,
+      /(?:const session = )?await requireOrgAdminAccess\(currentScope\)/,
       `${action} must require org admin access before mutating privileged schedules`,
     )
   }

--- a/apps/web/lib/actions/task-runs-core.ts
+++ b/apps/web/lib/actions/task-runs-core.ts
@@ -1,0 +1,554 @@
+'use server'
+
+import { logError } from '@/lib/logging'
+import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
+
+import { db } from '@/lib/db'
+import {
+  taskRuns,
+  taskRunHosts,
+  hosts,
+  hostGroupMembers,
+} from '@/lib/db/schema'
+import { eq, and, isNull, isNotNull, desc, inArray } from 'drizzle-orm'
+import type {
+  TaskRun,
+  TaskRunHost,
+  TaskType,
+  TaskConfig,
+  PatchTaskConfig,
+  CustomScriptTaskConfig,
+  ServiceTaskConfig,
+  AgentUninstallTaskConfig,
+  Host,
+} from '@/lib/db/schema'
+
+export type TaskRunHostWithHost = TaskRunHost & { host: Host }
+export type TaskRunWithHosts = TaskRun & { hosts: TaskRunHostWithHost[] }
+
+async function createTaskRun(
+  currentScope: string,
+  userId: string,
+  targetType: 'host' | 'group',
+  targetId: string,
+  taskType: TaskType,
+  config: TaskConfig,
+  maxParallel: number,
+  pendingHostIds: string[],
+  skipHosts: { hostId: string; reason: string }[],
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  try {
+    return await db.transaction(async (tx) => {
+      const [run] = await tx
+        .insert(taskRuns)
+        .values({
+          organisationId: currentScope,
+          triggeredBy: userId,
+          targetType,
+          targetId,
+          taskType,
+          config,
+          maxParallel,
+        })
+        .returning()
+
+      if (!run) return { error: 'Failed to create task run' }
+
+      const hostRows: (typeof taskRunHosts.$inferInsert)[] = [
+        ...pendingHostIds.map((hostId) => ({
+          organisationId: currentScope,
+          taskRunId: run.id,
+          hostId,
+          status: 'pending' as const,
+        })),
+        ...skipHosts.map(({ hostId, reason }) => ({
+          organisationId: currentScope,
+          taskRunId: run.id,
+          hostId,
+          status: 'skipped' as const,
+          skipReason: reason,
+        })),
+      ]
+
+      if (hostRows.length > 0) {
+        await tx.insert(taskRunHosts).values(hostRows)
+      }
+
+      return { success: true, taskRunId: run.id }
+    })
+  } catch (err) {
+    logError('Failed to create task run:', err)
+    return { error: 'Failed to create task run' }
+  }
+}
+
+export async function getTaskRun(
+  currentScope: string,
+  taskRunId: string,
+): Promise<TaskRunWithHosts | null> {
+  await requireOrgToolingAccess(currentScope)
+  const run = await db.query.taskRuns.findFirst({
+    where: and(
+      eq(taskRuns.id, taskRunId),
+      eq(taskRuns.organisationId, currentScope),
+      isNull(taskRuns.deletedAt),
+    ),
+  })
+  if (!run) return null
+
+  const hostRows = await db.query.taskRunHosts.findMany({
+    where: and(
+      eq(taskRunHosts.taskRunId, taskRunId),
+      eq(taskRunHosts.organisationId, currentScope),
+      isNull(taskRunHosts.deletedAt),
+    ),
+  })
+
+  const hostIds = hostRows.map((r) => r.hostId)
+  const hostDetails =
+    hostIds.length > 0
+      ? await db.query.hosts.findMany({
+          where: and(
+            inArray(hosts.id, hostIds),
+            eq(hosts.organisationId, currentScope),
+          ),
+        })
+      : []
+
+  const hostMap = new Map(hostDetails.map((h) => [h.id, h]))
+
+  return {
+    ...run,
+    hosts: hostRows.map((r) => ({
+      ...r,
+      host: hostMap.get(r.hostId) ?? ({} as Host),
+    })),
+  }
+}
+
+export async function listTaskRunsForHost(
+  currentScope: string,
+  hostId: string,
+  taskType?: string,
+): Promise<TaskRunWithHosts[]> {
+  await requireOrgToolingAccess(currentScope)
+  const hostRunRows = await db.query.taskRunHosts.findMany({
+    where: and(
+      eq(taskRunHosts.hostId, hostId),
+      eq(taskRunHosts.organisationId, currentScope),
+      isNull(taskRunHosts.deletedAt),
+    ),
+    columns: { taskRunId: true },
+  })
+
+  if (hostRunRows.length === 0) return []
+
+  const runIds = [...new Set(hostRunRows.map((r) => r.taskRunId))]
+
+  const runs = await db.query.taskRuns.findMany({
+    where: and(
+      inArray(taskRuns.id, runIds),
+      eq(taskRuns.organisationId, currentScope),
+      isNull(taskRuns.deletedAt),
+      isNotNull(taskRuns.triggeredBy),
+      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
+    ),
+    orderBy: [desc(taskRuns.createdAt)],
+    limit: 50,
+  })
+
+  return Promise.all(runs.map((run) => getTaskRun(currentScope, run.id).then((r) => r!)))
+}
+
+export async function listAutomatedRunsForHost(
+  currentScope: string,
+  hostId: string,
+  taskType?: string,
+): Promise<TaskRunWithHosts[]> {
+  await requireOrgToolingAccess(currentScope)
+  const hostRunRows = await db.query.taskRunHosts.findMany({
+    where: and(
+      eq(taskRunHosts.hostId, hostId),
+      eq(taskRunHosts.organisationId, currentScope),
+      isNull(taskRunHosts.deletedAt),
+    ),
+    columns: { taskRunId: true },
+  })
+
+  if (hostRunRows.length === 0) return []
+
+  const runIds = [...new Set(hostRunRows.map((r) => r.taskRunId))]
+
+  const runs = await db.query.taskRuns.findMany({
+    where: and(
+      inArray(taskRuns.id, runIds),
+      eq(taskRuns.organisationId, currentScope),
+      isNull(taskRuns.deletedAt),
+      isNull(taskRuns.triggeredBy),
+      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
+    ),
+    orderBy: [desc(taskRuns.createdAt)],
+    limit: 50,
+  })
+
+  return Promise.all(runs.map((run) => getTaskRun(currentScope, run.id).then((r) => r!)))
+}
+
+export async function listTaskRunsForGroup(
+  currentScope: string,
+  groupId: string,
+  taskType?: string,
+): Promise<TaskRunWithHosts[]> {
+  await requireOrgToolingAccess(currentScope)
+  const runs = await db.query.taskRuns.findMany({
+    where: and(
+      eq(taskRuns.organisationId, currentScope),
+      eq(taskRuns.targetType, 'group'),
+      eq(taskRuns.targetId, groupId),
+      isNull(taskRuns.deletedAt),
+      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
+    ),
+    orderBy: [desc(taskRuns.createdAt)],
+    limit: 50,
+  })
+
+  return Promise.all(runs.map((run) => getTaskRun(currentScope, run.id).then((r) => r!)))
+}
+
+export async function cancelTaskRun(
+  currentScope: string,
+  taskRunId: string,
+): Promise<{ success: true } | { error: string }> {
+  await requireOrgToolingAccess(currentScope)
+  try {
+    return await db.transaction(async (tx) => {
+      const run = await tx.query.taskRuns.findFirst({
+        where: and(
+          eq(taskRuns.id, taskRunId),
+          eq(taskRuns.organisationId, currentScope),
+          isNull(taskRuns.deletedAt),
+        ),
+      })
+      if (!run) return { error: 'Task run not found' }
+      if (['completed', 'failed', 'cancelled', 'cancelling'].includes(run.status)) {
+        return { error: 'Task run is already finished or being cancelled' }
+      }
+
+      const now = new Date()
+
+      await tx
+        .update(taskRunHosts)
+        .set({ status: 'cancelled', completedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(taskRunHosts.taskRunId, taskRunId),
+            eq(taskRunHosts.organisationId, currentScope),
+            eq(taskRunHosts.status, 'pending'),
+            isNull(taskRunHosts.deletedAt),
+          ),
+        )
+
+      await tx
+        .update(taskRunHosts)
+        .set({ status: 'cancelling', updatedAt: now })
+        .where(
+          and(
+            eq(taskRunHosts.taskRunId, taskRunId),
+            eq(taskRunHosts.organisationId, currentScope),
+            eq(taskRunHosts.status, 'running'),
+            isNull(taskRunHosts.deletedAt),
+          ),
+        )
+
+      await tx
+        .update(taskRuns)
+        .set({ status: 'cancelling', updatedAt: now })
+        .where(and(eq(taskRuns.id, taskRunId), isNull(taskRuns.deletedAt)))
+
+      return { success: true }
+    })
+  } catch (err) {
+    logError('Failed to cancel task run:', err)
+    return { error: 'Failed to cancel task run' }
+  }
+}
+
+const MAX_SCRIPT_LENGTH: Record<'sh' | 'bash' | 'python3', number> = {
+  sh: 65_536,
+  bash: 65_536,
+  python3: 65_536,
+}
+
+export async function triggerCustomScriptRun(
+  currentScope: string,
+  hostId: string,
+  script: string,
+  interpreter: 'sh' | 'bash' | 'python3',
+  timeoutSeconds?: number,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const session = await requireOrgAdminAccess(currentScope)
+  if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
+    return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
+  }
+
+  const host = await db.query.hosts.findFirst({
+    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, currentScope), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { error: 'Host not found' }
+
+  const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
+  return createTaskRun(currentScope, session.user.id, 'host', hostId, 'custom_script', config, 1, [hostId], [])
+}
+
+export async function triggerGroupCustomScriptRun(
+  currentScope: string,
+  groupId: string,
+  script: string,
+  interpreter: 'sh' | 'bash' | 'python3',
+  maxParallel: number,
+  timeoutSeconds?: number,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const session = await requireOrgAdminAccess(currentScope)
+  if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
+    return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
+  }
+  const members = await db.query.hostGroupMembers.findMany({
+    where: and(
+      eq(hostGroupMembers.groupId, groupId),
+      eq(hostGroupMembers.organisationId, currentScope),
+      isNull(hostGroupMembers.deletedAt),
+    ),
+    columns: { hostId: true },
+  })
+  if (members.length === 0) return { error: 'Group has no members' }
+
+  const hostIds = members.map((m) => m.hostId)
+  const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
+  return createTaskRun(currentScope, session.user.id, 'group', groupId, 'custom_script', config, maxParallel, hostIds, [])
+}
+
+export async function triggerServiceAction(
+  currentScope: string,
+  hostId: string,
+  serviceName: string,
+  action: 'start' | 'stop' | 'restart' | 'status',
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const session = await requireOrgAdminAccess(currentScope)
+  const host = await db.query.hosts.findFirst({
+    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, currentScope), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { error: 'Host not found' }
+  if (host.os?.toLowerCase() !== 'linux') {
+    return { error: 'Service management is only supported on Linux hosts' }
+  }
+
+  const config: ServiceTaskConfig = { service_name: serviceName, action }
+  return createTaskRun(currentScope, session.user.id, 'host', hostId, 'service', config, 1, [hostId], [])
+}
+
+export async function triggerGroupServiceAction(
+  currentScope: string,
+  groupId: string,
+  serviceName: string,
+  action: 'start' | 'stop' | 'restart' | 'status',
+  maxParallel: number,
+): Promise<
+  { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
+> {
+  const session = await requireOrgAdminAccess(currentScope)
+  const members = await db.query.hostGroupMembers.findMany({
+    where: and(
+      eq(hostGroupMembers.groupId, groupId),
+      eq(hostGroupMembers.organisationId, currentScope),
+      isNull(hostGroupMembers.deletedAt),
+    ),
+    columns: { hostId: true },
+  })
+  if (members.length === 0) return { error: 'Group has no members' }
+
+  const hostIds = members.map((m) => m.hostId)
+  const groupHosts = await db.query.hosts.findMany({
+    where: and(
+      inArray(hosts.id, hostIds),
+      eq(hosts.organisationId, currentScope),
+      isNull(hosts.deletedAt),
+    ),
+  })
+
+  const pendingHostIds: string[] = []
+  const skipHosts: { hostId: string; reason: string }[] = []
+
+  for (const host of groupHosts) {
+    if (host.os?.toLowerCase() === 'linux') {
+      pendingHostIds.push(host.id)
+    } else {
+      skipHosts.push({
+        hostId: host.id,
+        reason: `non-Linux host (os: ${host.os ?? 'unknown'})`,
+      })
+    }
+  }
+
+  if (pendingHostIds.length === 0 && skipHosts.length === 0) {
+    return { error: 'No hosts found in group' }
+  }
+
+  const config: ServiceTaskConfig = { service_name: serviceName, action }
+  const result = await createTaskRun(
+    currentScope, session.user.id, 'group', groupId, 'service', config, maxParallel, pendingHostIds, skipHosts,
+  )
+
+  if ('error' in result) return result
+
+  return {
+    success: true,
+    taskRunId: result.taskRunId,
+    targetedCount: pendingHostIds.length,
+    skippedCount: skipHosts.length,
+  }
+}
+
+export async function triggerAgentUninstall(
+  currentScope: string,
+  hostId: string,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const session = await requireOrgAdminAccess(currentScope)
+  const host = await db.query.hosts.findFirst({
+    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, currentScope), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { error: 'Host not found' }
+
+  const config: AgentUninstallTaskConfig = {}
+  return createTaskRun(currentScope, session.user.id, 'host', hostId, 'agent_uninstall', config, 1, [hostId], [])
+}
+
+export async function deleteTaskRuns(
+  currentScope: string,
+  taskRunIds: string[],
+): Promise<{ success: true } | { error: string }> {
+  await requireOrgToolingAccess(currentScope)
+  if (taskRunIds.length === 0) return { success: true }
+  try {
+    const now = new Date()
+    await db.transaction(async (tx) => {
+      await tx
+        .update(taskRunHosts)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            inArray(taskRunHosts.taskRunId, taskRunIds),
+            eq(taskRunHosts.organisationId, currentScope),
+            isNull(taskRunHosts.deletedAt),
+          ),
+        )
+      await tx
+        .update(taskRuns)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            inArray(taskRuns.id, taskRunIds),
+            eq(taskRuns.organisationId, currentScope),
+            isNull(taskRuns.deletedAt),
+          ),
+        )
+    })
+    return { success: true }
+  } catch (err) {
+    logError('Failed to delete task runs:', err)
+    return { error: 'Failed to delete task runs' }
+  }
+}
+
+export async function triggerPatchRun(
+  currentScope: string,
+  hostId: string,
+  mode: 'security' | 'all',
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  const session = await requireOrgAdminAccess(currentScope)
+  const host = await db.query.hosts.findFirst({
+    where: and(
+      eq(hosts.id, hostId),
+      eq(hosts.organisationId, currentScope),
+      isNull(hosts.deletedAt),
+    ),
+  })
+  if (!host) return { error: 'Host not found' }
+  if (host.os?.toLowerCase() !== 'linux') {
+    return { error: 'Patch runs are only supported on Linux hosts' }
+  }
+
+  const config: PatchTaskConfig = { mode }
+  return createTaskRun(currentScope, session.user.id, 'host', hostId, 'patch', config, 1, [hostId], [])
+}
+
+export async function triggerGroupPatchRun(
+  currentScope: string,
+  groupId: string,
+  mode: 'security' | 'all',
+  maxParallel: number,
+): Promise<
+  { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
+> {
+  const session = await requireOrgAdminAccess(currentScope)
+  const members = await db.query.hostGroupMembers.findMany({
+    where: and(
+      eq(hostGroupMembers.groupId, groupId),
+      eq(hostGroupMembers.organisationId, currentScope),
+      isNull(hostGroupMembers.deletedAt),
+    ),
+    columns: { hostId: true },
+  })
+
+  if (members.length === 0) {
+    return { error: 'Group has no members' }
+  }
+
+  const hostIds = members.map((m) => m.hostId)
+  const groupHosts = await db.query.hosts.findMany({
+    where: and(
+      inArray(hosts.id, hostIds),
+      eq(hosts.organisationId, currentScope),
+      isNull(hosts.deletedAt),
+    ),
+  })
+
+  const pendingHostIds: string[] = []
+  const skipHosts: { hostId: string; reason: string }[] = []
+
+  for (const host of groupHosts) {
+    if (host.os?.toLowerCase() === 'linux') {
+      pendingHostIds.push(host.id)
+    } else {
+      skipHosts.push({
+        hostId: host.id,
+        reason: `non-Linux host (os: ${host.os ?? 'unknown'})`,
+      })
+    }
+  }
+
+  if (pendingHostIds.length === 0 && skipHosts.length === 0) {
+    return { error: 'No hosts found in group' }
+  }
+
+  const config: PatchTaskConfig = { mode }
+  const result = await createTaskRun(
+    currentScope,
+    session.user.id,
+    'group',
+    groupId,
+    'patch',
+    config,
+    maxParallel,
+    pendingHostIds,
+    skipHosts,
+  )
+
+  if ('error' in result) return result
+
+  return {
+    success: true,
+    taskRunId: result.taskRunId,
+    targetedCount: pendingHostIds.length,
+    skippedCount: skipHosts.length,
+  }
+}

--- a/apps/web/lib/actions/task-runs.ts
+++ b/apps/web/lib/actions/task-runs.ts
@@ -1,659 +1,187 @@
 'use server'
 
-import { logError } from '@/lib/logging'
-import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
-
-import { db } from '@/lib/db'
+import { getRequiredSession } from '@/lib/auth/session'
+import { resolveCurrentActionScope } from './action-scope'
 import {
-  taskRuns,
-  taskRunHosts,
-  hosts,
-  hostGroupMembers,
-} from '@/lib/db/schema'
-import { eq, and, isNull, isNotNull, desc, inArray } from 'drizzle-orm'
-import type {
-  TaskRun,
-  TaskRunHost,
-  TaskType,
-  TaskConfig,
-  PatchTaskConfig,
-  CustomScriptTaskConfig,
-  ServiceTaskConfig,
-  AgentUninstallTaskConfig,
-  Host,
-} from '@/lib/db/schema'
+  cancelTaskRun as cancelTaskRunCore,
+  deleteTaskRuns as deleteTaskRunsCore,
+  getTaskRun as getTaskRunCore,
+  listAutomatedRunsForHost as listAutomatedRunsForHostCore,
+  listTaskRunsForGroup as listTaskRunsForGroupCore,
+  listTaskRunsForHost as listTaskRunsForHostCore,
+  triggerAgentUninstall as triggerAgentUninstallCore,
+  triggerCustomScriptRun as triggerCustomScriptRunCore,
+  triggerGroupCustomScriptRun as triggerGroupCustomScriptRunCore,
+  triggerGroupPatchRun as triggerGroupPatchRunCore,
+  triggerGroupServiceAction as triggerGroupServiceActionCore,
+  triggerPatchRun as triggerPatchRunCore,
+  triggerServiceAction as triggerServiceActionCore,
+  type TaskRunWithHosts,
+} from './task-runs-core'
 
-// ── Types ─────────────────────────────────────────────────────────────────────
+export type { TaskRunHostWithHost, TaskRunWithHosts } from './task-runs-core'
 
-export type TaskRunHostWithHost = TaskRunHost & { host: Host }
-export type TaskRunWithHosts = TaskRun & { hosts: TaskRunHostWithHost[] }
+const TASK_TYPES = new Set(['patch', 'custom_script', 'service', 'agent_uninstall', 'software_inventory'])
 
-// ── Generic helpers ───────────────────────────────────────────────────────────
-
-/**
- * Creates a task_run record and task_run_hosts rows for each target host.
- * Hosts that should be skipped (wrong OS etc.) must be passed as skipHosts with
- * a reason; they are inserted immediately in 'skipped' status.
- */
-async function createTaskRun(
-  orgId: string,
-  userId: string,
-  targetType: 'host' | 'group',
-  targetId: string,
-  taskType: TaskType,
-  config: TaskConfig,
-  maxParallel: number,
-  pendingHostIds: string[],
-  skipHosts: { hostId: string; reason: string }[],
-): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  try {
-    return await db.transaction(async (tx) => {
-      const [run] = await tx
-        .insert(taskRuns)
-        .values({
-          organisationId: orgId,
-          triggeredBy: userId,
-          targetType,
-          targetId,
-          taskType,
-          config,
-          maxParallel,
-        })
-        .returning()
-
-      if (!run) return { error: 'Failed to create task run' }
-
-      const hostRows: (typeof taskRunHosts.$inferInsert)[] = [
-        ...pendingHostIds.map((hostId) => ({
-          organisationId: orgId,
-          taskRunId: run.id,
-          hostId,
-          status: 'pending' as const,
-        })),
-        ...skipHosts.map(({ hostId, reason }) => ({
-          organisationId: orgId,
-          taskRunId: run.id,
-          hostId,
-          status: 'skipped' as const,
-          skipReason: reason,
-        })),
-      ]
-
-      if (hostRows.length > 0) {
-        await tx.insert(taskRunHosts).values(hostRows)
-      }
-
-      return { success: true, taskRunId: run.id }
-    })
-  } catch (err) {
-    logError('Failed to create task run:', err)
-    return { error: 'Failed to create task run' }
-  }
+function isTaskType(value: string | undefined): value is string {
+  return value !== undefined && TASK_TYPES.has(value)
 }
 
-// ── Queries ───────────────────────────────────────────────────────────────────
-
-/**
- * Returns the full task run with per-host details and host display info.
- * Used by the monitor page and for status polling.
- */
 export async function getTaskRun(
-  orgId: string,
-  taskRunId: string,
+  ...args: [string] | [string, string]
 ): Promise<TaskRunWithHosts | null> {
-  await requireOrgToolingAccess(orgId)
-  const run = await db.query.taskRuns.findFirst({
-    where: and(
-      eq(taskRuns.id, taskRunId),
-      eq(taskRuns.organisationId, orgId),
-      isNull(taskRuns.deletedAt),
-    ),
-  })
-  if (!run) return null
-
-  const hostRows = await db.query.taskRunHosts.findMany({
-    where: and(
-      eq(taskRunHosts.taskRunId, taskRunId),
-      eq(taskRunHosts.organisationId, orgId),
-      isNull(taskRunHosts.deletedAt),
-    ),
-  })
-
-  const hostIds = hostRows.map((r) => r.hostId)
-  const hostDetails =
-    hostIds.length > 0
-      ? await db.query.hosts.findMany({
-          where: and(
-            inArray(hosts.id, hostIds),
-            eq(hosts.organisationId, orgId),
-          ),
-        })
-      : []
-
-  const hostMap = new Map(hostDetails.map((h) => [h.id, h]))
-
-  return {
-    ...run,
-    hosts: hostRows.map((r) => ({
-      ...r,
-      host: hostMap.get(r.hostId) ?? ({} as Host),
-    })),
-  }
+  const session = await getRequiredSession()
+  const [currentScope, taskRunId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return getTaskRunCore(currentScope, taskRunId)
 }
 
-/**
- * Returns the most recent user-triggered task runs that include a given host.
- * Automated runs created by the system sweeper (triggered_by IS NULL) are
- * excluded — those surface under the host's Logs tab instead.
- * Optionally filtered by task_type.
- */
 export async function listTaskRunsForHost(
-  orgId: string,
-  hostId: string,
-  taskType?: string,
+  ...args: [string] | [string, string] | [string, string, string]
 ): Promise<TaskRunWithHosts[]> {
-  await requireOrgToolingAccess(orgId)
-  // Find task_run_hosts rows for this host
-  const hostRunRows = await db.query.taskRunHosts.findMany({
-    where: and(
-      eq(taskRunHosts.hostId, hostId),
-      eq(taskRunHosts.organisationId, orgId),
-      isNull(taskRunHosts.deletedAt),
-    ),
-    columns: { taskRunId: true },
-  })
-
-  if (hostRunRows.length === 0) return []
-
-  const runIds = [...new Set(hostRunRows.map((r) => r.taskRunId))]
-
-  const runs = await db.query.taskRuns.findMany({
-    where: and(
-      inArray(taskRuns.id, runIds),
-      eq(taskRuns.organisationId, orgId),
-      isNull(taskRuns.deletedAt),
-      isNotNull(taskRuns.triggeredBy),
-      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
-    ),
-    orderBy: [desc(taskRuns.createdAt)],
-    limit: 50,
-  })
-
-  return Promise.all(runs.map((run) => getTaskRun(orgId, run.id).then((r) => r!)))
+  const session = await getRequiredSession()
+  if (args.length === 1) return listTaskRunsForHostCore(resolveCurrentActionScope(session), args[0])
+  if (args.length === 2) {
+    return isTaskType(args[1])
+      ? listTaskRunsForHostCore(resolveCurrentActionScope(session), args[0], args[1])
+      : listTaskRunsForHostCore(args[0], args[1])
+  }
+  return listTaskRunsForHostCore(args[0], args[1], args[2])
 }
 
-/**
- * Returns the most recent automated (system-triggered) task runs for a host.
- * These are runs created by the ingest sweepers — e.g. software inventory
- * scans — and have triggered_by IS NULL. Rendered under the host's Logs tab.
- */
 export async function listAutomatedRunsForHost(
-  orgId: string,
-  hostId: string,
-  taskType?: string,
+  ...args: [string] | [string, string] | [string, string, string]
 ): Promise<TaskRunWithHosts[]> {
-  await requireOrgToolingAccess(orgId)
-  const hostRunRows = await db.query.taskRunHosts.findMany({
-    where: and(
-      eq(taskRunHosts.hostId, hostId),
-      eq(taskRunHosts.organisationId, orgId),
-      isNull(taskRunHosts.deletedAt),
-    ),
-    columns: { taskRunId: true },
-  })
-
-  if (hostRunRows.length === 0) return []
-
-  const runIds = [...new Set(hostRunRows.map((r) => r.taskRunId))]
-
-  const runs = await db.query.taskRuns.findMany({
-    where: and(
-      inArray(taskRuns.id, runIds),
-      eq(taskRuns.organisationId, orgId),
-      isNull(taskRuns.deletedAt),
-      isNull(taskRuns.triggeredBy),
-      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
-    ),
-    orderBy: [desc(taskRuns.createdAt)],
-    limit: 50,
-  })
-
-  return Promise.all(runs.map((run) => getTaskRun(orgId, run.id).then((r) => r!)))
+  const session = await getRequiredSession()
+  if (args.length === 1) return listAutomatedRunsForHostCore(resolveCurrentActionScope(session), args[0])
+  if (args.length === 2) {
+    return isTaskType(args[1])
+      ? listAutomatedRunsForHostCore(resolveCurrentActionScope(session), args[0], args[1])
+      : listAutomatedRunsForHostCore(args[0], args[1])
+  }
+  return listAutomatedRunsForHostCore(args[0], args[1], args[2])
 }
 
-/**
- * Returns the most recent task runs targeting a group.
- * Optionally filtered by task_type.
- */
 export async function listTaskRunsForGroup(
-  orgId: string,
-  groupId: string,
-  taskType?: string,
+  ...args: [string] | [string, string] | [string, string, string]
 ): Promise<TaskRunWithHosts[]> {
-  await requireOrgToolingAccess(orgId)
-  const runs = await db.query.taskRuns.findMany({
-    where: and(
-      eq(taskRuns.organisationId, orgId),
-      eq(taskRuns.targetType, 'group'),
-      eq(taskRuns.targetId, groupId),
-      isNull(taskRuns.deletedAt),
-      ...(taskType ? [eq(taskRuns.taskType, taskType as TaskType)] : []),
-    ),
-    orderBy: [desc(taskRuns.createdAt)],
-    limit: 50,
-  })
-
-  return Promise.all(runs.map((run) => getTaskRun(orgId, run.id).then((r) => r!)))
+  const session = await getRequiredSession()
+  if (args.length === 1) return listTaskRunsForGroupCore(resolveCurrentActionScope(session), args[0])
+  if (args.length === 2) {
+    return isTaskType(args[1])
+      ? listTaskRunsForGroupCore(resolveCurrentActionScope(session), args[0], args[1])
+      : listTaskRunsForGroupCore(args[0], args[1])
+  }
+  return listTaskRunsForGroupCore(args[0], args[1], args[2])
 }
 
-// ── Cancellation ──────────────────────────────────────────────────────────────
-
-/**
- * Cancels an active task run.
- * - Pending hosts (not yet started) are marked 'cancelled' immediately.
- * - Running hosts are moved to 'cancelling'; the ingest service will signal
- *   the agent to stop the process and the row will transition to 'cancelled'
- *   once the agent acknowledges.
- * - The parent task_run is marked 'cancelling'.
- */
 export async function cancelTaskRun(
-  orgId: string,
-  taskRunId: string,
+  ...args: [string] | [string, string]
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
-  try {
-    return await db.transaction(async (tx) => {
-      // Verify ownership and that the run is still active.
-      const run = await tx.query.taskRuns.findFirst({
-        where: and(
-          eq(taskRuns.id, taskRunId),
-          eq(taskRuns.organisationId, orgId),
-          isNull(taskRuns.deletedAt),
-        ),
-      })
-      if (!run) return { error: 'Task run not found' }
-      if (['completed', 'failed', 'cancelled', 'cancelling'].includes(run.status)) {
-        return { error: 'Task run is already finished or being cancelled' }
-      }
-
-      const now = new Date()
-
-      // Cancel hosts that haven't started yet — no agent signal needed.
-      await tx
-        .update(taskRunHosts)
-        .set({ status: 'cancelled', completedAt: now, updatedAt: now })
-        .where(
-          and(
-            eq(taskRunHosts.taskRunId, taskRunId),
-            eq(taskRunHosts.organisationId, orgId),
-            eq(taskRunHosts.status, 'pending'),
-            isNull(taskRunHosts.deletedAt),
-          ),
-        )
-
-      // Signal running hosts to stop — the agent will acknowledge on the
-      // next heartbeat and the status will transition to 'cancelled'.
-      await tx
-        .update(taskRunHosts)
-        .set({ status: 'cancelling', updatedAt: now })
-        .where(
-          and(
-            eq(taskRunHosts.taskRunId, taskRunId),
-            eq(taskRunHosts.organisationId, orgId),
-            eq(taskRunHosts.status, 'running'),
-            isNull(taskRunHosts.deletedAt),
-          ),
-        )
-
-      // Move the parent run to 'cancelling' so the UI reflects the intent.
-      await tx
-        .update(taskRuns)
-        .set({ status: 'cancelling', updatedAt: now })
-        .where(
-          and(
-            eq(taskRuns.id, taskRunId),
-            isNull(taskRuns.deletedAt),
-          ),
-        )
-
-      return { success: true }
-    })
-  } catch (err) {
-    logError('Failed to cancel task run:', err)
-    return { error: 'Failed to cancel task run' }
-  }
+  const session = await getRequiredSession()
+  const [currentScope, taskRunId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return cancelTaskRunCore(currentScope, taskRunId)
 }
 
-// ── Custom script actions ─────────────────────────────────────────────────────
-
-// 64 KB is enough for any reasonable operational script; larger payloads are
-// almost certainly mistakes or abuse attempts.
-const MAX_SCRIPT_LENGTH: Record<'sh' | 'bash' | 'python3', number> = {
-  sh:      65_536,
-  bash:    65_536,
-  python3: 65_536,
-}
-
-/**
- * Triggers a custom script run against a single host.
- * Works on any OS — the agent will return an error if the interpreter is absent.
- */
 export async function triggerCustomScriptRun(
-  orgId: string,
-  hostId: string,
-  script: string,
-  interpreter: 'sh' | 'bash' | 'python3',
-  timeoutSeconds?: number,
+  ...args:
+    | [string, string, 'sh' | 'bash' | 'python3', number?]
+    | [string, string, string, 'sh' | 'bash' | 'python3', number?]
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgAdminAccess(orgId)
-  if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
-    return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
+  const session = await getRequiredSession()
+  if (args.length >= 4 && (args[2] === 'sh' || args[2] === 'bash' || args[2] === 'python3')) {
+    const [hostId, script, interpreter, timeoutSeconds] = args as [string, string, 'sh' | 'bash' | 'python3', number?]
+    return triggerCustomScriptRunCore(resolveCurrentActionScope(session), hostId, script, interpreter, timeoutSeconds)
   }
-
-  const host = await db.query.hosts.findFirst({
-    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
-  })
-  if (!host) return { error: 'Host not found' }
-
-  const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
-  return createTaskRun(orgId, session.user.id, 'host', hostId, 'custom_script', config, 1, [hostId], [])
+  const [currentScope, hostId, script, interpreter, timeoutSeconds] = args as [string, string, string, 'sh' | 'bash' | 'python3', number?]
+  return triggerCustomScriptRunCore(currentScope, hostId, script, interpreter, timeoutSeconds)
 }
 
-/**
- * Triggers a custom script run against all hosts in a group.
- * All hosts are targeted regardless of OS — the agent handles interpreter availability.
- */
 export async function triggerGroupCustomScriptRun(
-  orgId: string,
-  groupId: string,
-  script: string,
-  interpreter: 'sh' | 'bash' | 'python3',
-  maxParallel: number,
-  timeoutSeconds?: number,
+  ...args:
+    | [string, string, 'sh' | 'bash' | 'python3', number, number?]
+    | [string, string, string, 'sh' | 'bash' | 'python3', number, number?]
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgAdminAccess(orgId)
-  if (script.length > MAX_SCRIPT_LENGTH[interpreter]) {
-    return { error: `Script exceeds the ${MAX_SCRIPT_LENGTH[interpreter] / 1024} KB size limit for ${interpreter}` }
+  const session = await getRequiredSession()
+  if (args.length >= 5 && (args[2] === 'sh' || args[2] === 'bash' || args[2] === 'python3')) {
+    const [groupId, script, interpreter, maxParallel, timeoutSeconds] = args as [string, string, 'sh' | 'bash' | 'python3', number, number?]
+    return triggerGroupCustomScriptRunCore(resolveCurrentActionScope(session), groupId, script, interpreter, maxParallel, timeoutSeconds)
   }
-  const members = await db.query.hostGroupMembers.findMany({
-    where: and(
-      eq(hostGroupMembers.groupId, groupId),
-      eq(hostGroupMembers.organisationId, orgId),
-      isNull(hostGroupMembers.deletedAt),
-    ),
-    columns: { hostId: true },
-  })
-  if (members.length === 0) return { error: 'Group has no members' }
-
-  const hostIds = members.map((m) => m.hostId)
-  const config: CustomScriptTaskConfig = { script, interpreter, ...(timeoutSeconds ? { timeout_seconds: timeoutSeconds } : {}) }
-  return createTaskRun(orgId, session.user.id, 'group', groupId, 'custom_script', config, maxParallel, hostIds, [])
+  const [currentScope, groupId, script, interpreter, maxParallel, timeoutSeconds] = args as [string, string, string, 'sh' | 'bash' | 'python3', number, number?]
+  return triggerGroupCustomScriptRunCore(currentScope, groupId, script, interpreter, maxParallel, timeoutSeconds)
 }
 
-// ── Service management actions ────────────────────────────────────────────────
-
-/**
- * Triggers a systemctl service action against a single Linux host.
- * Returns an error for non-Linux hosts.
- */
 export async function triggerServiceAction(
-  orgId: string,
-  hostId: string,
-  serviceName: string,
-  action: 'start' | 'stop' | 'restart' | 'status',
+  ...args:
+    | [string, string, 'start' | 'stop' | 'restart' | 'status']
+    | [string, string, string, 'start' | 'stop' | 'restart' | 'status']
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgAdminAccess(orgId)
-  const host = await db.query.hosts.findFirst({
-    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
-  })
-  if (!host) return { error: 'Host not found' }
-  if (host.os?.toLowerCase() !== 'linux') {
-    return { error: 'Service management is only supported on Linux hosts' }
+  const session = await getRequiredSession()
+  if (args.length === 3) {
+    const [hostId, serviceName, action] = args
+    return triggerServiceActionCore(resolveCurrentActionScope(session), hostId, serviceName, action)
   }
-
-  const config: ServiceTaskConfig = { service_name: serviceName, action }
-  return createTaskRun(orgId, session.user.id, 'host', hostId, 'service', config, 1, [hostId], [])
+  const [currentScope, hostId, serviceName, action] = args
+  return triggerServiceActionCore(currentScope, hostId, serviceName, action)
 }
 
-/**
- * Triggers a systemctl service action against all Linux hosts in a group.
- * Non-Linux hosts are immediately recorded as 'skipped'.
- */
 export async function triggerGroupServiceAction(
-  orgId: string,
-  groupId: string,
-  serviceName: string,
-  action: 'start' | 'stop' | 'restart' | 'status',
-  maxParallel: number,
+  ...args:
+    | [string, string, 'start' | 'stop' | 'restart' | 'status', number]
+    | [string, string, string, 'start' | 'stop' | 'restart' | 'status', number]
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
-  const session = await requireOrgAdminAccess(orgId)
-  const members = await db.query.hostGroupMembers.findMany({
-    where: and(
-      eq(hostGroupMembers.groupId, groupId),
-      eq(hostGroupMembers.organisationId, orgId),
-      isNull(hostGroupMembers.deletedAt),
-    ),
-    columns: { hostId: true },
-  })
-  if (members.length === 0) return { error: 'Group has no members' }
-
-  const hostIds = members.map((m) => m.hostId)
-  const groupHosts = await db.query.hosts.findMany({
-    where: and(
-      inArray(hosts.id, hostIds),
-      eq(hosts.organisationId, orgId),
-      isNull(hosts.deletedAt),
-    ),
-  })
-
-  const pendingHostIds: string[] = []
-  const skipHosts: { hostId: string; reason: string }[] = []
-
-  for (const host of groupHosts) {
-    if (host.os?.toLowerCase() === 'linux') {
-      pendingHostIds.push(host.id)
-    } else {
-      skipHosts.push({
-        hostId: host.id,
-        reason: `non-Linux host (os: ${host.os ?? 'unknown'})`,
-      })
-    }
+  const session = await getRequiredSession()
+  if (args.length === 4) {
+    const [groupId, serviceName, action, maxParallel] = args
+    return triggerGroupServiceActionCore(resolveCurrentActionScope(session), groupId, serviceName, action, maxParallel)
   }
-
-  if (pendingHostIds.length === 0 && skipHosts.length === 0) {
-    return { error: 'No hosts found in group' }
-  }
-
-  const config: ServiceTaskConfig = { service_name: serviceName, action }
-  const result = await createTaskRun(
-    orgId, session.user.id, 'group', groupId, 'service', config, maxParallel, pendingHostIds, skipHosts,
-  )
-
-  if ('error' in result) return result
-
-  return {
-    success: true,
-    taskRunId: result.taskRunId,
-    targetedCount: pendingHostIds.length,
-    skippedCount: skipHosts.length,
-  }
+  const [currentScope, groupId, serviceName, action, maxParallel] = args
+  return triggerGroupServiceActionCore(currentScope, groupId, serviceName, action, maxParallel)
 }
 
-// ── Agent uninstall action ────────────────────────────────────────────────────
-
-/**
- * Triggers a remote agent uninstall on a single host.
- *
- * The agent handler returns a "scheduled" result as soon as it has staged
- * a detached uninstaller child process. The actual uninstall completes
- * out-of-band on the host — see apps/agent/internal/tasks/uninstall.go and
- * apps/agent/internal/install/uninstall.go.
- *
- * Callers that need to delete the host record after the uninstall has been
- * scheduled should poll task_run_hosts.status and then invoke deleteHost.
- */
 export async function triggerAgentUninstall(
-  orgId: string,
-  hostId: string,
+  ...args: [string] | [string, string]
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgAdminAccess(orgId)
-  const host = await db.query.hosts.findFirst({
-    where: and(eq(hosts.id, hostId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
-  })
-  if (!host) return { error: 'Host not found' }
-
-  const config: AgentUninstallTaskConfig = {}
-  return createTaskRun(orgId, session.user.id, 'host', hostId, 'agent_uninstall', config, 1, [hostId], [])
+  const session = await getRequiredSession()
+  const [currentScope, hostId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return triggerAgentUninstallCore(currentScope, hostId)
 }
 
-// ── Deletion ──────────────────────────────────────────────────────────────────
-
-/**
- * Soft-deletes one or more task runs (and their host rows).
- * Both tables filter by isNull(deletedAt) in all queries, so the rows
- * disappear automatically after this call.
- */
 export async function deleteTaskRuns(
-  orgId: string,
-  taskRunIds: string[],
+  ...args: [string[]] | [string, string[]]
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgToolingAccess(orgId)
-  if (taskRunIds.length === 0) return { success: true }
-  try {
-    const now = new Date()
-    await db.transaction(async (tx) => {
-      await tx
-        .update(taskRunHosts)
-        .set({ deletedAt: now, updatedAt: now })
-        .where(
-          and(
-            inArray(taskRunHosts.taskRunId, taskRunIds),
-            eq(taskRunHosts.organisationId, orgId),
-            isNull(taskRunHosts.deletedAt),
-          ),
-        )
-      await tx
-        .update(taskRuns)
-        .set({ deletedAt: now, updatedAt: now })
-        .where(
-          and(
-            inArray(taskRuns.id, taskRunIds),
-            eq(taskRuns.organisationId, orgId),
-            isNull(taskRuns.deletedAt),
-          ),
-        )
-    })
-    return { success: true }
-  } catch (err) {
-    logError('Failed to delete task runs:', err)
-    return { error: 'Failed to delete task runs' }
-  }
+  const session = await getRequiredSession()
+  const [currentScope, taskRunIds] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return deleteTaskRunsCore(currentScope, taskRunIds)
 }
 
-// ── Patch-specific actions ────────────────────────────────────────────────────
-
-/**
- * Triggers a patch run against a single host.
- * The host must be Linux — returns an error for non-Linux hosts.
- */
 export async function triggerPatchRun(
-  orgId: string,
-  hostId: string,
-  mode: 'security' | 'all',
+  ...args: [string, 'security' | 'all'] | [string, string, 'security' | 'all']
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  const session = await requireOrgAdminAccess(orgId)
-  const host = await db.query.hosts.findFirst({
-    where: and(
-      eq(hosts.id, hostId),
-      eq(hosts.organisationId, orgId),
-      isNull(hosts.deletedAt),
-    ),
-  })
-  if (!host) return { error: 'Host not found' }
-  if (host.os?.toLowerCase() !== 'linux') {
-    return { error: 'Patch runs are only supported on Linux hosts' }
+  const session = await getRequiredSession()
+  if (args.length === 2) {
+    const [hostId, mode] = args
+    return triggerPatchRunCore(resolveCurrentActionScope(session), hostId, mode)
   }
-
-  const config: PatchTaskConfig = { mode }
-  return createTaskRun(orgId, session.user.id, 'host', hostId, 'patch', config, 1, [hostId], [])
+  const [currentScope, hostId, mode] = args
+  return triggerPatchRunCore(currentScope, hostId, mode)
 }
 
-/**
- * Triggers a patch run against all Linux hosts in a group.
- * Non-Linux hosts are immediately recorded as 'skipped' with a reason.
- * Returns the number of hosts targeted and skipped.
- */
 export async function triggerGroupPatchRun(
-  orgId: string,
-  groupId: string,
-  mode: 'security' | 'all',
-  maxParallel: number,
+  ...args: [string, 'security' | 'all', number] | [string, string, 'security' | 'all', number]
 ): Promise<
   { success: true; taskRunId: string; targetedCount: number; skippedCount: number } | { error: string }
 > {
-  const session = await requireOrgAdminAccess(orgId)
-  // Fetch all members of the group
-  const members = await db.query.hostGroupMembers.findMany({
-    where: and(
-      eq(hostGroupMembers.groupId, groupId),
-      eq(hostGroupMembers.organisationId, orgId),
-      isNull(hostGroupMembers.deletedAt),
-    ),
-    columns: { hostId: true },
-  })
-
-  if (members.length === 0) {
-    return { error: 'Group has no members' }
+  const session = await getRequiredSession()
+  if (args.length === 3) {
+    const [groupId, mode, maxParallel] = args
+    return triggerGroupPatchRunCore(resolveCurrentActionScope(session), groupId, mode, maxParallel)
   }
-
-  const hostIds = members.map((m) => m.hostId)
-  const groupHosts = await db.query.hosts.findMany({
-    where: and(
-      inArray(hosts.id, hostIds),
-      eq(hosts.organisationId, orgId),
-      isNull(hosts.deletedAt),
-    ),
-  })
-
-  const pendingHostIds: string[] = []
-  const skipHosts: { hostId: string; reason: string }[] = []
-
-  for (const host of groupHosts) {
-    if (host.os?.toLowerCase() === 'linux') {
-      pendingHostIds.push(host.id)
-    } else {
-      skipHosts.push({
-        hostId: host.id,
-        reason: `non-Linux host (os: ${host.os ?? 'unknown'})`,
-      })
-    }
-  }
-
-  if (pendingHostIds.length === 0 && skipHosts.length === 0) {
-    return { error: 'No hosts found in group' }
-  }
-
-  const config: PatchTaskConfig = { mode }
-  const result = await createTaskRun(
-    orgId,
-    session.user.id,
-    'group',
-    groupId,
-    'patch',
-    config,
-    maxParallel,
-    pendingHostIds,
-    skipHosts,
-  )
-
-  if ('error' in result) return result
-
-  return {
-    success: true,
-    taskRunId: result.taskRunId,
-    targetedCount: pendingHostIds.length,
-    skippedCount: skipHosts.length,
-  }
+  const [currentScope, groupId, mode, maxParallel] = args
+  return triggerGroupPatchRunCore(currentScope, groupId, mode, maxParallel)
 }

--- a/apps/web/lib/actions/task-schedules-core.ts
+++ b/apps/web/lib/actions/task-schedules-core.ts
@@ -1,0 +1,394 @@
+'use server'
+
+import { logError } from '@/lib/logging'
+import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
+
+import { db } from '@/lib/db'
+import { taskSchedules, taskRuns, hostGroups, hosts } from '@/lib/db/schema'
+import { eq, and, isNull, desc, inArray } from 'drizzle-orm'
+import { CronExpressionParser } from 'cron-parser'
+import { z } from 'zod'
+import type { TaskSchedule, TaskType, TaskConfig } from '@/lib/db/schema'
+import {
+  triggerPatchRun,
+  triggerGroupPatchRun,
+  triggerCustomScriptRun,
+  triggerGroupCustomScriptRun,
+  triggerServiceAction,
+  triggerGroupServiceAction,
+} from './task-runs-core'
+import type { ScheduleWithTargetName } from './task-schedules-types'
+
+const patchConfigSchema = z.object({
+  mode: z.enum(['security', 'all']),
+})
+
+const customScriptConfigSchema = z.object({
+  script: z.string().min(1, 'Script is required'),
+  interpreter: z.enum(['sh', 'bash', 'python3']),
+  timeout_seconds: z.number().int().positive().optional(),
+})
+
+const serviceConfigSchema = z.object({
+  service_name: z.string().min(1, 'Service name is required'),
+  action: z.enum(['start', 'stop', 'restart', 'status']),
+})
+
+const softwareInventoryConfigSchema = z.object({}).strict()
+
+const scheduleInputBase = z.object({
+  name: z.string().min(1, 'Name is required').max(200),
+  description: z.string().max(2000).optional().nullable(),
+  targetType: z.enum(['host', 'group']),
+  targetId: z.string().min(1),
+  maxParallel: z.number().int().min(0).max(100).default(1),
+  cronExpression: z.string().min(1),
+  timezone: z.string().min(1).default('UTC'),
+  enabled: z.boolean().default(true),
+})
+
+const scheduleInputSchema = z.discriminatedUnion('taskType', [
+  scheduleInputBase.extend({ taskType: z.literal('patch'), config: patchConfigSchema }),
+  scheduleInputBase.extend({ taskType: z.literal('custom_script'), config: customScriptConfigSchema }),
+  scheduleInputBase.extend({ taskType: z.literal('service'), config: serviceConfigSchema }),
+  scheduleInputBase.extend({ taskType: z.literal('software_inventory'), config: softwareInventoryConfigSchema }),
+])
+
+export type ScheduleInput = z.infer<typeof scheduleInputSchema>
+
+function computeNextRunAt(cronExpression: string, timezone: string, from: Date = new Date()): Date {
+  const interval = CronExpressionParser.parse(cronExpression, { currentDate: from, tz: timezone })
+  return interval.next().toDate()
+}
+
+export async function previewCronRuns(
+  cronExpression: string,
+  timezone: string,
+  count = 5,
+): Promise<{ runs: string[] } | { error: string }> {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, { tz: timezone })
+    const runs: string[] = []
+    for (let i = 0; i < count; i++) {
+      runs.push(interval.next().toDate().toISOString())
+    }
+    return { runs }
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Invalid cron expression' }
+  }
+}
+
+async function verifyTargetExists(
+  currentScope: string,
+  targetType: 'host' | 'group',
+  targetId: string,
+): Promise<{ ok: true } | { error: string }> {
+  if (targetType === 'host') {
+    const host = await db.query.hosts.findFirst({
+      where: and(eq(hosts.id, targetId), eq(hosts.organisationId, currentScope), isNull(hosts.deletedAt)),
+      columns: { id: true },
+    })
+    if (!host) return { error: 'Host not found' }
+    return { ok: true }
+  }
+  const group = await db.query.hostGroups.findFirst({
+    where: and(eq(hostGroups.id, targetId), eq(hostGroups.organisationId, currentScope), isNull(hostGroups.deletedAt)),
+    columns: { id: true },
+  })
+  if (!group) return { error: 'Host group not found' }
+  return { ok: true }
+}
+
+export async function listSchedules(currentScope: string): Promise<ScheduleWithTargetName[]> {
+  await requireOrgToolingAccess(currentScope)
+  const rows = await db.query.taskSchedules.findMany({
+    where: and(eq(taskSchedules.organisationId, currentScope), isNull(taskSchedules.deletedAt)),
+    orderBy: [desc(taskSchedules.createdAt)],
+  })
+
+  if (rows.length === 0) return []
+
+  const hostIds = rows.filter((r) => r.targetType === 'host').map((r) => r.targetId)
+  const groupIds = rows.filter((r) => r.targetType === 'group').map((r) => r.targetId)
+
+  const [hostRows, groupRows] = await Promise.all([
+    hostIds.length
+      ? db.query.hosts.findMany({
+          where: and(
+            inArray(hosts.id, hostIds),
+            eq(hosts.organisationId, currentScope),
+            isNull(hosts.deletedAt),
+          ),
+          columns: { id: true, hostname: true },
+        })
+      : Promise.resolve([]),
+    groupIds.length
+      ? db.query.hostGroups.findMany({
+          where: and(
+            inArray(hostGroups.id, groupIds),
+            eq(hostGroups.organisationId, currentScope),
+            isNull(hostGroups.deletedAt),
+          ),
+          columns: { id: true, name: true },
+        })
+      : Promise.resolve([]),
+  ])
+
+  const hostMap = new Map(hostRows.map((h) => [h.id, h.hostname]))
+  const groupMap = new Map(groupRows.map((g) => [g.id, g.name]))
+
+  return rows.map((r) => ({
+    ...r,
+    targetName: r.targetType === 'host' ? hostMap.get(r.targetId) ?? null : groupMap.get(r.targetId) ?? null,
+  }))
+}
+
+export async function getSchedule(
+  currentScope: string,
+  id: string,
+): Promise<{ schedule: TaskSchedule; recentRuns: Awaited<ReturnType<typeof recentRunsForSchedule>> } | null> {
+  await requireOrgToolingAccess(currentScope)
+  const schedule = await db.query.taskSchedules.findFirst({
+    where: and(
+      eq(taskSchedules.id, id),
+      eq(taskSchedules.organisationId, currentScope),
+      isNull(taskSchedules.deletedAt),
+    ),
+  })
+  if (!schedule) return null
+
+  const recentRuns = await recentRunsForSchedule(currentScope, id)
+  return { schedule, recentRuns }
+}
+
+async function recentRunsForSchedule(currentScope: string, scheduleId: string) {
+  return db.query.taskRuns.findMany({
+    where: and(
+      eq(taskRuns.scheduledFromId, scheduleId),
+      eq(taskRuns.organisationId, currentScope),
+      isNull(taskRuns.deletedAt),
+    ),
+    orderBy: [desc(taskRuns.createdAt)],
+    limit: 20,
+  })
+}
+
+export async function createSchedule(
+  currentScope: string,
+  input: unknown,
+): Promise<{ success: true; id: string } | { error: string }> {
+  const session = await requireOrgAdminAccess(currentScope)
+
+  const parsed = scheduleInputSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues.map((i) => i.message).join('; ') }
+  }
+
+  const data = parsed.data
+  const targetCheck = await verifyTargetExists(currentScope, data.targetType, data.targetId)
+  if ('error' in targetCheck) return targetCheck
+
+  let nextRunAt: Date
+  try {
+    nextRunAt = computeNextRunAt(data.cronExpression, data.timezone)
+  } catch (err) {
+    return { error: err instanceof Error ? `Invalid cron: ${err.message}` : 'Invalid cron expression' }
+  }
+
+  try {
+    const [row] = await db
+      .insert(taskSchedules)
+      .values({
+        organisationId: currentScope,
+        createdBy: session.user.id,
+        name: data.name,
+        description: data.description ?? null,
+        taskType: data.taskType as TaskType,
+        config: data.config as TaskConfig,
+        targetType: data.targetType,
+        targetId: data.targetId,
+        maxParallel: data.maxParallel,
+        cronExpression: data.cronExpression,
+        timezone: data.timezone,
+        enabled: data.enabled,
+        nextRunAt,
+      })
+      .returning({ id: taskSchedules.id })
+
+    if (!row) return { error: 'Failed to create schedule' }
+    return { success: true, id: row.id }
+  } catch (err) {
+    logError('Failed to create schedule:', err)
+    return { error: 'Failed to create schedule' }
+  }
+}
+
+export async function updateSchedule(
+  currentScope: string,
+  id: string,
+  input: unknown,
+): Promise<{ success: true } | { error: string }> {
+  await requireOrgAdminAccess(currentScope)
+
+  const existing = await db.query.taskSchedules.findFirst({
+    where: and(
+      eq(taskSchedules.id, id),
+      eq(taskSchedules.organisationId, currentScope),
+      isNull(taskSchedules.deletedAt),
+    ),
+  })
+  if (!existing) return { error: 'Schedule not found' }
+
+  const parsed = scheduleInputSchema.safeParse(input)
+  if (!parsed.success) {
+    return { error: parsed.error.issues.map((i) => i.message).join('; ') }
+  }
+  const data = parsed.data
+
+  if (data.taskType !== existing.taskType) {
+    return { error: 'Task type cannot be changed — delete and recreate the schedule' }
+  }
+
+  const targetCheck = await verifyTargetExists(currentScope, data.targetType, data.targetId)
+  if ('error' in targetCheck) return targetCheck
+
+  let nextRunAt: Date
+  try {
+    nextRunAt = computeNextRunAt(data.cronExpression, data.timezone)
+  } catch (err) {
+    return { error: err instanceof Error ? `Invalid cron: ${err.message}` : 'Invalid cron expression' }
+  }
+
+  try {
+    await db
+      .update(taskSchedules)
+      .set({
+        name: data.name,
+        description: data.description ?? null,
+        config: data.config as TaskConfig,
+        targetType: data.targetType,
+        targetId: data.targetId,
+        maxParallel: data.maxParallel,
+        cronExpression: data.cronExpression,
+        timezone: data.timezone,
+        enabled: data.enabled,
+        nextRunAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(taskSchedules.id, id))
+    return { success: true }
+  } catch (err) {
+    logError('Failed to update schedule:', err)
+    return { error: 'Failed to update schedule' }
+  }
+}
+
+export async function setScheduleEnabled(
+  currentScope: string,
+  id: string,
+  enabled: boolean,
+): Promise<{ success: true } | { error: string }> {
+  await requireOrgAdminAccess(currentScope)
+
+  const existing = await db.query.taskSchedules.findFirst({
+    where: and(
+      eq(taskSchedules.id, id),
+      eq(taskSchedules.organisationId, currentScope),
+      isNull(taskSchedules.deletedAt),
+    ),
+  })
+  if (!existing) return { error: 'Schedule not found' }
+
+  let nextRunAt = existing.nextRunAt
+  if (enabled) {
+    try {
+      nextRunAt = computeNextRunAt(existing.cronExpression, existing.timezone)
+    } catch {
+      return { error: 'Schedule has an invalid cron expression — edit to fix' }
+    }
+  }
+
+  try {
+    await db
+      .update(taskSchedules)
+      .set({ enabled, nextRunAt, updatedAt: new Date() })
+      .where(eq(taskSchedules.id, id))
+    return { success: true }
+  } catch (err) {
+    logError('Failed to toggle schedule:', err)
+    return { error: 'Failed to update schedule' }
+  }
+}
+
+export async function deleteSchedule(
+  currentScope: string,
+  id: string,
+): Promise<{ success: true } | { error: string }> {
+  await requireOrgAdminAccess(currentScope)
+
+  try {
+    await db
+      .update(taskSchedules)
+      .set({ deletedAt: new Date(), enabled: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(taskSchedules.id, id),
+          eq(taskSchedules.organisationId, currentScope),
+          isNull(taskSchedules.deletedAt),
+        ),
+      )
+    return { success: true }
+  } catch (err) {
+    logError('Failed to delete schedule:', err)
+    return { error: 'Failed to delete schedule' }
+  }
+}
+
+export async function runScheduleNow(
+  currentScope: string,
+  id: string,
+): Promise<{ success: true; taskRunId: string } | { error: string }> {
+  await requireOrgAdminAccess(currentScope)
+
+  const schedule = await db.query.taskSchedules.findFirst({
+    where: and(
+      eq(taskSchedules.id, id),
+      eq(taskSchedules.organisationId, currentScope),
+      isNull(taskSchedules.deletedAt),
+    ),
+  })
+  if (!schedule) return { error: 'Schedule not found' }
+
+  const { taskType, targetType, targetId, maxParallel, config } = schedule
+
+  if (taskType === 'patch') {
+    const mode = (config as { mode: 'security' | 'all' }).mode
+    return targetType === 'host'
+      ? triggerPatchRun(currentScope, targetId, mode)
+      : (async () => {
+          const result = await triggerGroupPatchRun(currentScope, targetId, mode, maxParallel)
+          if ('error' in result) return result
+          return { success: true as const, taskRunId: result.taskRunId }
+        })()
+  }
+  if (taskType === 'custom_script') {
+    const scheduleConfig = config as { script: string; interpreter: 'sh' | 'bash' | 'python3'; timeout_seconds?: number }
+    return targetType === 'host'
+      ? triggerCustomScriptRun(currentScope, targetId, scheduleConfig.script, scheduleConfig.interpreter, scheduleConfig.timeout_seconds)
+      : triggerGroupCustomScriptRun(currentScope, targetId, scheduleConfig.script, scheduleConfig.interpreter, maxParallel, scheduleConfig.timeout_seconds)
+  }
+  if (taskType === 'service') {
+    const scheduleConfig = config as { service_name: string; action: 'start' | 'stop' | 'restart' | 'status' }
+    return targetType === 'host'
+      ? triggerServiceAction(currentScope, targetId, scheduleConfig.service_name, scheduleConfig.action)
+      : (async () => {
+          const result = await triggerGroupServiceAction(currentScope, targetId, scheduleConfig.service_name, scheduleConfig.action, maxParallel)
+          if ('error' in result) return result
+          return { success: true as const, taskRunId: result.taskRunId }
+        })()
+  }
+  if (taskType === 'software_inventory') {
+    return { error: 'Software inventory runs are managed by the system sweeper and cannot be triggered manually from a schedule' }
+  }
+  return { error: `Unsupported task type: ${taskType}` }
+}

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -1,413 +1,81 @@
 'use server'
 
-import { logError } from '@/lib/logging'
-import { requireOrgAdminAccess, requireOrgToolingAccess } from '@/lib/actions/action-auth'
-
-import { db } from '@/lib/db'
-import { taskSchedules, taskRuns, hostGroups, hosts } from '@/lib/db/schema'
-import { eq, and, isNull, desc, inArray } from 'drizzle-orm'
-import { CronExpressionParser } from 'cron-parser'
-import { z } from 'zod'
-import type { TaskSchedule, TaskType, TaskConfig } from '@/lib/db/schema'
+import { getRequiredSession } from '@/lib/auth/session'
+import { resolveCurrentActionScope } from './action-scope'
 import {
-  triggerPatchRun,
-  triggerGroupPatchRun,
-  triggerCustomScriptRun,
-  triggerGroupCustomScriptRun,
-  triggerServiceAction,
-  triggerGroupServiceAction,
-} from './task-runs'
+  createSchedule as createScheduleCore,
+  deleteSchedule as deleteScheduleCore,
+  getSchedule as getScheduleCore,
+  listSchedules as listSchedulesCore,
+  previewCronRuns,
+  runScheduleNow as runScheduleNowCore,
+  setScheduleEnabled as setScheduleEnabledCore,
+  updateSchedule as updateScheduleCore,
+  type ScheduleInput,
+} from './task-schedules-core'
 import type { ScheduleWithTargetName } from './task-schedules-types'
 
-// ── Zod schemas ───────────────────────────────────────────────────────────────
+export { previewCronRuns }
+export type { ScheduleInput }
 
-const patchConfigSchema = z.object({
-  mode: z.enum(['security', 'all']),
-})
-
-const customScriptConfigSchema = z.object({
-  script: z.string().min(1, 'Script is required'),
-  interpreter: z.enum(['sh', 'bash', 'python3']),
-  timeout_seconds: z.number().int().positive().optional(),
-})
-
-const serviceConfigSchema = z.object({
-  service_name: z.string().min(1, 'Service name is required'),
-  action: z.enum(['start', 'stop', 'restart', 'status']),
-})
-
-const softwareInventoryConfigSchema = z.object({}).strict()
-
-const scheduleInputBase = z.object({
-  name: z.string().min(1, 'Name is required').max(200),
-  description: z.string().max(2000).optional().nullable(),
-  targetType: z.enum(['host', 'group']),
-  targetId: z.string().min(1),
-  maxParallel: z.number().int().min(0).max(100).default(1),
-  cronExpression: z.string().min(1),
-  timezone: z.string().min(1).default('UTC'),
-  enabled: z.boolean().default(true),
-})
-
-const scheduleInputSchema = z.discriminatedUnion('taskType', [
-  scheduleInputBase.extend({ taskType: z.literal('patch'), config: patchConfigSchema }),
-  scheduleInputBase.extend({ taskType: z.literal('custom_script'), config: customScriptConfigSchema }),
-  scheduleInputBase.extend({ taskType: z.literal('service'), config: serviceConfigSchema }),
-  scheduleInputBase.extend({ taskType: z.literal('software_inventory'), config: softwareInventoryConfigSchema }),
-])
-
-export type ScheduleInput = z.infer<typeof scheduleInputSchema>
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function computeNextRunAt(cronExpression: string, timezone: string, from: Date = new Date()): Date {
-  const interval = CronExpressionParser.parse(cronExpression, { currentDate: from, tz: timezone })
-  return interval.next().toDate()
-}
-
-/**
- * Returns up to `count` upcoming trigger times for a cron expression.
- * Used by the UI form preview. Throws on invalid cron.
- */
-export async function previewCronRuns(
-  cronExpression: string,
-  timezone: string,
-  count = 5,
-): Promise<{ runs: string[] } | { error: string }> {
-  try {
-    const interval = CronExpressionParser.parse(cronExpression, { tz: timezone })
-    const runs: string[] = []
-    for (let i = 0; i < count; i++) {
-      runs.push(interval.next().toDate().toISOString())
-    }
-    return { runs }
-  } catch (err) {
-    return { error: err instanceof Error ? err.message : 'Invalid cron expression' }
-  }
-}
-
-async function verifyTargetExists(
-  orgId: string,
-  targetType: 'host' | 'group',
-  targetId: string,
-): Promise<{ ok: true } | { error: string }> {
-  if (targetType === 'host') {
-    const host = await db.query.hosts.findFirst({
-      where: and(eq(hosts.id, targetId), eq(hosts.organisationId, orgId), isNull(hosts.deletedAt)),
-      columns: { id: true },
-    })
-    if (!host) return { error: 'Host not found' }
-    return { ok: true }
-  }
-  const group = await db.query.hostGroups.findFirst({
-    where: and(eq(hostGroups.id, targetId), eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)),
-    columns: { id: true },
-  })
-  if (!group) return { error: 'Host group not found' }
-  return { ok: true }
-}
-
-// ── Read queries ──────────────────────────────────────────────────────────────
-
-export async function listSchedules(orgId: string): Promise<ScheduleWithTargetName[]> {
-  await requireOrgToolingAccess(orgId)
-  const rows = await db.query.taskSchedules.findMany({
-    where: and(eq(taskSchedules.organisationId, orgId), isNull(taskSchedules.deletedAt)),
-    orderBy: [desc(taskSchedules.createdAt)],
-  })
-
-  if (rows.length === 0) return []
-
-  // Resolve target names in bulk
-  const hostIds = rows.filter((r) => r.targetType === 'host').map((r) => r.targetId)
-  const groupIds = rows.filter((r) => r.targetType === 'group').map((r) => r.targetId)
-
-  const [hostRows, groupRows] = await Promise.all([
-    hostIds.length
-      ? db.query.hosts.findMany({
-          where: and(
-            inArray(hosts.id, hostIds),
-            eq(hosts.organisationId, orgId),
-            isNull(hosts.deletedAt),
-          ),
-          columns: { id: true, hostname: true },
-        })
-      : Promise.resolve([]),
-    groupIds.length
-      ? db.query.hostGroups.findMany({
-          where: and(
-            inArray(hostGroups.id, groupIds),
-            eq(hostGroups.organisationId, orgId),
-            isNull(hostGroups.deletedAt),
-          ),
-          columns: { id: true, name: true },
-        })
-      : Promise.resolve([]),
-  ])
-
-  const hostMap = new Map(hostRows.map((h) => [h.id, h.hostname]))
-  const groupMap = new Map(groupRows.map((g) => [g.id, g.name]))
-
-  return rows.map((r) => ({
-    ...r,
-    targetName: r.targetType === 'host' ? hostMap.get(r.targetId) ?? null : groupMap.get(r.targetId) ?? null,
-  }))
+export async function listSchedules(
+  ...args: [] | [string]
+): Promise<ScheduleWithTargetName[]> {
+  const session = await getRequiredSession()
+  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  return listSchedulesCore(currentScope)
 }
 
 export async function getSchedule(
-  orgId: string,
-  id: string,
-): Promise<{ schedule: TaskSchedule; recentRuns: Awaited<ReturnType<typeof recentRunsForSchedule>> } | null> {
-  await requireOrgToolingAccess(orgId)
-  const schedule = await db.query.taskSchedules.findFirst({
-    where: and(
-      eq(taskSchedules.id, id),
-      eq(taskSchedules.organisationId, orgId),
-      isNull(taskSchedules.deletedAt),
-    ),
-  })
-  if (!schedule) return null
-
-  const recentRuns = await recentRunsForSchedule(orgId, id)
-  return { schedule, recentRuns }
+  ...args: [string] | [string, string]
+): Promise<Awaited<ReturnType<typeof getScheduleCore>>> {
+  const session = await getRequiredSession()
+  const [currentScope, scheduleId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return getScheduleCore(currentScope, scheduleId)
 }
-
-async function recentRunsForSchedule(orgId: string, scheduleId: string) {
-  return db.query.taskRuns.findMany({
-    where: and(
-      eq(taskRuns.scheduledFromId, scheduleId),
-      eq(taskRuns.organisationId, orgId),
-      isNull(taskRuns.deletedAt),
-    ),
-    orderBy: [desc(taskRuns.createdAt)],
-    limit: 20,
-  })
-}
-
-// ── Mutations ─────────────────────────────────────────────────────────────────
 
 export async function createSchedule(
-  orgId: string,
-  input: unknown,
+  ...args: [unknown] | [string, unknown]
 ): Promise<{ success: true; id: string } | { error: string }> {
-  const session = await requireOrgAdminAccess(orgId)
-
-  const parsed = scheduleInputSchema.safeParse(input)
-  if (!parsed.success) {
-    return { error: parsed.error.issues.map((i) => i.message).join('; ') }
-  }
-
-  const data = parsed.data
-  const targetCheck = await verifyTargetExists(orgId, data.targetType, data.targetId)
-  if ('error' in targetCheck) return targetCheck
-
-  let nextRunAt: Date
-  try {
-    nextRunAt = computeNextRunAt(data.cronExpression, data.timezone)
-  } catch (err) {
-    return { error: err instanceof Error ? `Invalid cron: ${err.message}` : 'Invalid cron expression' }
-  }
-
-  try {
-    const [row] = await db
-      .insert(taskSchedules)
-      .values({
-        organisationId: orgId,
-        createdBy: session.user.id,
-        name: data.name,
-        description: data.description ?? null,
-        taskType: data.taskType as TaskType,
-        config: data.config as TaskConfig,
-        targetType: data.targetType,
-        targetId: data.targetId,
-        maxParallel: data.maxParallel,
-        cronExpression: data.cronExpression,
-        timezone: data.timezone,
-        enabled: data.enabled,
-        nextRunAt,
-      })
-      .returning({ id: taskSchedules.id })
-
-    if (!row) return { error: 'Failed to create schedule' }
-    return { success: true, id: row.id }
-  } catch (err) {
-    logError('Failed to create schedule:', err)
-    return { error: 'Failed to create schedule' }
-  }
+  const session = await getRequiredSession()
+  const [currentScope, input] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return createScheduleCore(currentScope, input)
 }
 
 export async function updateSchedule(
-  orgId: string,
-  id: string,
-  input: unknown,
+  ...args: [string, unknown] | [string, string, unknown]
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAdminAccess(orgId)
-
-  const existing = await db.query.taskSchedules.findFirst({
-    where: and(
-      eq(taskSchedules.id, id),
-      eq(taskSchedules.organisationId, orgId),
-      isNull(taskSchedules.deletedAt),
-    ),
-  })
-  if (!existing) return { error: 'Schedule not found' }
-
-  const parsed = scheduleInputSchema.safeParse(input)
-  if (!parsed.success) {
-    return { error: parsed.error.issues.map((i) => i.message).join('; ') }
-  }
-  const data = parsed.data
-
-  if (data.taskType !== existing.taskType) {
-    return { error: 'Task type cannot be changed — delete and recreate the schedule' }
-  }
-
-  const targetCheck = await verifyTargetExists(orgId, data.targetType, data.targetId)
-  if ('error' in targetCheck) return targetCheck
-
-  let nextRunAt: Date
-  try {
-    nextRunAt = computeNextRunAt(data.cronExpression, data.timezone)
-  } catch (err) {
-    return { error: err instanceof Error ? `Invalid cron: ${err.message}` : 'Invalid cron expression' }
-  }
-
-  try {
-    await db
-      .update(taskSchedules)
-      .set({
-        name: data.name,
-        description: data.description ?? null,
-        config: data.config as TaskConfig,
-        targetType: data.targetType,
-        targetId: data.targetId,
-        maxParallel: data.maxParallel,
-        cronExpression: data.cronExpression,
-        timezone: data.timezone,
-        enabled: data.enabled,
-        nextRunAt,
-        updatedAt: new Date(),
-      })
-      .where(eq(taskSchedules.id, id))
-    return { success: true }
-  } catch (err) {
-    logError('Failed to update schedule:', err)
-    return { error: 'Failed to update schedule' }
-  }
+  const session = await getRequiredSession()
+  const [currentScope, scheduleId, input] =
+    args.length === 3 ? args : [resolveCurrentActionScope(session), args[0], args[1]]
+  return updateScheduleCore(currentScope, scheduleId, input)
 }
 
 export async function setScheduleEnabled(
-  orgId: string,
-  id: string,
-  enabled: boolean,
+  ...args: [string, boolean] | [string, string, boolean]
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAdminAccess(orgId)
-
-  const existing = await db.query.taskSchedules.findFirst({
-    where: and(
-      eq(taskSchedules.id, id),
-      eq(taskSchedules.organisationId, orgId),
-      isNull(taskSchedules.deletedAt),
-    ),
-  })
-  if (!existing) return { error: 'Schedule not found' }
-
-  // When re-enabling, recompute next_run_at from now.
-  let nextRunAt = existing.nextRunAt
-  if (enabled) {
-    try {
-      nextRunAt = computeNextRunAt(existing.cronExpression, existing.timezone)
-    } catch {
-      return { error: 'Schedule has an invalid cron expression — edit to fix' }
-    }
-  }
-
-  try {
-    await db
-      .update(taskSchedules)
-      .set({ enabled, nextRunAt, updatedAt: new Date() })
-      .where(eq(taskSchedules.id, id))
-    return { success: true }
-  } catch (err) {
-    logError('Failed to toggle schedule:', err)
-    return { error: 'Failed to update schedule' }
-  }
+  const session = await getRequiredSession()
+  const [currentScope, scheduleId, enabled] =
+    args.length === 3 ? args : [resolveCurrentActionScope(session), args[0], args[1]]
+  return setScheduleEnabledCore(currentScope, scheduleId, enabled)
 }
 
 export async function deleteSchedule(
-  orgId: string,
-  id: string,
+  ...args: [string] | [string, string]
 ): Promise<{ success: true } | { error: string }> {
-  await requireOrgAdminAccess(orgId)
-
-  try {
-    await db
-      .update(taskSchedules)
-      .set({ deletedAt: new Date(), enabled: false, updatedAt: new Date() })
-      .where(
-        and(
-          eq(taskSchedules.id, id),
-          eq(taskSchedules.organisationId, orgId),
-          isNull(taskSchedules.deletedAt),
-        ),
-      )
-    return { success: true }
-  } catch (err) {
-    logError('Failed to delete schedule:', err)
-    return { error: 'Failed to delete schedule' }
-  }
+  const session = await getRequiredSession()
+  const [currentScope, scheduleId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return deleteScheduleCore(currentScope, scheduleId)
 }
 
-/**
- * Triggers an immediate task_run from a schedule by dispatching to the
- * matching trigger* helper. Does not advance next_run_at — the sweeper
- * handles the scheduled cadence separately.
- */
 export async function runScheduleNow(
-  orgId: string,
-  id: string,
+  ...args: [string] | [string, string]
 ): Promise<{ success: true; taskRunId: string } | { error: string }> {
-  await requireOrgAdminAccess(orgId)
-
-  const schedule = await db.query.taskSchedules.findFirst({
-    where: and(
-      eq(taskSchedules.id, id),
-      eq(taskSchedules.organisationId, orgId),
-      isNull(taskSchedules.deletedAt),
-    ),
-  })
-  if (!schedule) return { error: 'Schedule not found' }
-
-  const { taskType, targetType, targetId, maxParallel, config } = schedule
-
-  if (taskType === 'patch') {
-    const mode = (config as { mode: 'security' | 'all' }).mode
-    return targetType === 'host'
-      ? triggerPatchRun(orgId, targetId, mode)
-      : (async () => {
-          const r = await triggerGroupPatchRun(orgId, targetId, mode, maxParallel)
-          if ('error' in r) return r
-          return { success: true as const, taskRunId: r.taskRunId }
-        })()
-  }
-  if (taskType === 'custom_script') {
-    const c = config as { script: string; interpreter: 'sh' | 'bash' | 'python3'; timeout_seconds?: number }
-    return targetType === 'host'
-      ? triggerCustomScriptRun(orgId, targetId, c.script, c.interpreter, c.timeout_seconds)
-      : triggerGroupCustomScriptRun(orgId, targetId, c.script, c.interpreter, maxParallel, c.timeout_seconds)
-  }
-  if (taskType === 'service') {
-    const c = config as { service_name: string; action: 'start' | 'stop' | 'restart' | 'status' }
-    return targetType === 'host'
-      ? triggerServiceAction(orgId, targetId, c.service_name, c.action)
-      : (async () => {
-          const r = await triggerGroupServiceAction(orgId, targetId, c.service_name, c.action, maxParallel)
-          if ('error' in r) return r
-          return { success: true as const, taskRunId: r.taskRunId }
-        })()
-  }
-  if (taskType === 'software_inventory') {
-    return { error: 'Software inventory runs are managed by the system sweeper and cannot be triggered manually from a schedule' }
-  }
-  return { error: `Unsupported task type: ${taskType}` }
+  const session = await getRequiredSession()
+  const [currentScope, scheduleId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  return runScheduleNowCore(currentScope, scheduleId)
 }

--- a/apps/web/tests/e2e/hosts/group-task-history.spec.ts
+++ b/apps/web/tests/e2e/hosts/group-task-history.spec.ts
@@ -1,33 +1,16 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
-import { TEST_ORG, TEST_USER } from '../fixtures/seed'
-
-async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
-  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
-    SELECT organisations.id AS org_id, "user".id AS user_id
-    FROM organisations
-    JOIN "user" ON "user".organisation_id = organisations.id
-    WHERE organisations.slug = ${TEST_ORG.slug}
-      AND "user".email = ${TEST_USER.email}
-    LIMIT 1
-  `
-
-  expect(rows).toHaveLength(1)
-  return {
-    orgId: rows[0]!.org_id,
-    userId: rows[0]!.user_id,
-  }
-}
+import { getSeededTestUserContext } from '../fixtures/seed'
 
 test('authenticated user can bulk delete task history from a host group', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId, userId } = await getOrgAndUserIds(sql)
+  const { instanceId, userId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO host_groups (id, organisation_id, name, description)
     VALUES (
       'group-task-history',
-      ${orgId},
+      ${instanceId},
       'Task History Group',
       'Used to verify task history cleanup'
     )
@@ -47,7 +30,7 @@ test('authenticated user can bulk delete task history from a host group', async 
     )
     VALUES (
       'group-task-history-host',
-      ${orgId},
+      ${instanceId},
       'ops-01',
       'Ops Host 01',
       'linux',
@@ -62,7 +45,7 @@ test('authenticated user can bulk delete task history from a host group', async 
     INSERT INTO host_group_members (id, organisation_id, group_id, host_id)
     VALUES (
       'group-task-history-member',
-      ${orgId},
+      ${instanceId},
       'group-task-history',
       'group-task-history-host'
     )
@@ -85,7 +68,7 @@ test('authenticated user can bulk delete task history from a host group', async 
     VALUES
       (
         'group-task-run-patch',
-        ${orgId},
+        ${instanceId},
         ${userId},
         'group',
         'group-task-history',
@@ -98,7 +81,7 @@ test('authenticated user can bulk delete task history from a host group', async 
       ),
       (
         'group-task-run-service',
-        ${orgId},
+        ${instanceId},
         ${userId},
         'group',
         'group-task-history',
@@ -125,7 +108,7 @@ test('authenticated user can bulk delete task history from a host group', async 
     VALUES
       (
         'group-task-run-host-patch',
-        ${orgId},
+        ${instanceId},
         'group-task-run-patch',
         'group-task-history-host',
         'success',
@@ -135,7 +118,7 @@ test('authenticated user can bulk delete task history from a host group', async 
       ),
       (
         'group-task-run-host-service',
-        ${orgId},
+        ${instanceId},
         'group-task-run-service',
         'group-task-history-host',
         'failed',

--- a/apps/web/tests/e2e/tasks/monitor.spec.ts
+++ b/apps/web/tests/e2e/tasks/monitor.spec.ts
@@ -1,27 +1,10 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
-import { TEST_ORG, TEST_USER } from '../fixtures/seed'
-
-async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
-  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
-    SELECT organisations.id AS org_id, "user".id AS user_id
-    FROM organisations
-    JOIN "user" ON "user".organisation_id = organisations.id
-    WHERE organisations.slug = ${TEST_ORG.slug}
-      AND "user".email = ${TEST_USER.email}
-    LIMIT 1
-  `
-
-  expect(rows).toHaveLength(1)
-  return {
-    orgId: rows[0]!.org_id,
-    userId: rows[0]!.user_id,
-  }
-}
+import { getSeededTestUserContext } from '../fixtures/seed'
 
 test('admin can review a completed grouped task run and switch between host outputs', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId, userId } = await getOrgAndUserIds(sql)
+  const { instanceId, userId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO host_groups (
@@ -32,7 +15,7 @@ test('admin can review a completed grouped task run and switch between host outp
     )
     VALUES (
       'task-monitor-group-1',
-      ${orgId},
+      ${instanceId},
       'Task Monitor Group',
       'Used to verify the task run monitor view'
     )
@@ -53,7 +36,7 @@ test('admin can review a completed grouped task run and switch between host outp
     VALUES
       (
         'task-monitor-host-1',
-        ${orgId},
+        ${instanceId},
         'task-monitor-node-1',
         'Task Monitor Alpha',
         'Ubuntu 24.04',
@@ -64,7 +47,7 @@ test('admin can review a completed grouped task run and switch between host outp
       ),
       (
         'task-monitor-host-2',
-        ${orgId},
+        ${instanceId},
         'task-monitor-node-2',
         'Task Monitor Beta',
         'Ubuntu 24.04',
@@ -85,13 +68,13 @@ test('admin can review a completed grouped task run and switch between host outp
     VALUES
       (
         'task-monitor-member-1',
-        ${orgId},
+        ${instanceId},
         'task-monitor-group-1',
         'task-monitor-host-1'
       ),
       (
         'task-monitor-member-2',
-        ${orgId},
+        ${instanceId},
         'task-monitor-group-1',
         'task-monitor-host-2'
       )
@@ -113,7 +96,7 @@ test('admin can review a completed grouped task run and switch between host outp
     )
     VALUES (
       'task-monitor-run-1',
-      ${orgId},
+      ${instanceId},
       ${userId},
       'group',
       'task-monitor-group-1',
@@ -142,7 +125,7 @@ test('admin can review a completed grouped task run and switch between host outp
     VALUES
       (
         'task-monitor-run-host-1',
-        ${orgId},
+        ${instanceId},
         'task-monitor-run-1',
         'task-monitor-host-1',
         'success',
@@ -154,7 +137,7 @@ test('admin can review a completed grouped task run and switch between host outp
       ),
       (
         'task-monitor-run-host-2',
-        ${orgId},
+        ${instanceId},
         'task-monitor-run-1',
         'task-monitor-host-2',
         'failed',

--- a/apps/web/tests/e2e/tasks/schedules.spec.ts
+++ b/apps/web/tests/e2e/tasks/schedules.spec.ts
@@ -1,26 +1,10 @@
 import { test, expect } from '../fixtures/test'
 import { getTestDb } from '../fixtures/db'
-import { TEST_ORG, TEST_USER } from '../fixtures/seed'
-
-async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ orgId: string; userId: string }> {
-  const rows = await sql<Array<{ org_id: string; user_id: string }>>`
-    SELECT organisations.id AS org_id, "user".id AS user_id
-    FROM organisations
-    JOIN "user" ON "user".organisation_id = organisations.id
-    WHERE organisations.slug = ${TEST_ORG.slug}
-      AND "user".email = ${TEST_USER.email}
-    LIMIT 1
-  `
-  expect(rows).toHaveLength(1)
-  return {
-    orgId: rows[0]!.org_id,
-    userId: rows[0]!.user_id,
-  }
-}
+import { getSeededTestUserContext } from '../fixtures/seed'
 
 test('admin can review, enable, and delete a scheduled task', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId, userId } = await getOrgAndUserIds(sql)
+  const { instanceId, userId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -36,7 +20,7 @@ test('admin can review, enable, and delete a scheduled task', async ({ authentic
     )
     VALUES (
       'schedule-host-1',
-      ${orgId},
+      ${instanceId},
       'schedule-host-1',
       'Schedule Host',
       'Ubuntu 24.04',
@@ -66,7 +50,7 @@ test('admin can review, enable, and delete a scheduled task', async ({ authentic
     )
     VALUES (
       'schedule-e2e-1',
-      ${orgId},
+      ${instanceId},
       ${userId},
       'Weekly patch run',
       'Apply security patches to a critical host.',
@@ -123,7 +107,7 @@ test('admin can review, enable, and delete a scheduled task', async ({ authentic
 
 test('admin can create a patch schedule from the new schedule form', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId } = await getOrgAndUserIds(sql)
+  const { instanceId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -139,7 +123,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
     )
     VALUES (
       'schedule-create-host-1',
-      ${orgId},
+      ${instanceId},
       'schedule-create-host-1',
       'Schedule Create Host',
       'Ubuntu 24.04',
@@ -186,7 +170,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
       const rows = await sql<Array<{ id: string }>>`
         SELECT id
         FROM task_schedules
-        WHERE organisation_id = ${orgId}
+        WHERE organisation_id = ${instanceId}
           AND name = 'Nightly patch run'
           AND deleted_at IS NULL
         LIMIT 1
@@ -197,7 +181,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
   const createdScheduleRows = await sql<Array<{ id: string }>>`
     SELECT id
     FROM task_schedules
-    WHERE organisation_id = ${orgId}
+    WHERE organisation_id = ${instanceId}
       AND name = 'Nightly patch run'
       AND deleted_at IS NULL
     LIMIT 1
@@ -219,7 +203,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
       }>>`
         SELECT name, cron_expression, timezone, target_id, task_type, config
         FROM task_schedules
-        WHERE organisation_id = ${orgId}
+        WHERE organisation_id = ${instanceId}
           AND name = 'Nightly patch run'
           AND deleted_at IS NULL
         LIMIT 1
@@ -238,7 +222,7 @@ test('admin can create a patch schedule from the new schedule form', async ({ au
 
 test('admin can create a security-only patch schedule for a host group', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId } = await getOrgAndUserIds(sql)
+  const { instanceId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -255,7 +239,7 @@ test('admin can create a security-only patch schedule for a host group', async (
     VALUES
       (
         'schedule-group-host-1',
-        ${orgId},
+        ${instanceId},
         'schedule-group-host-1',
         'Schedule Group Host 1',
         'Ubuntu 24.04',
@@ -266,7 +250,7 @@ test('admin can create a security-only patch schedule for a host group', async (
       ),
       (
         'schedule-group-host-2',
-        ${orgId},
+        ${instanceId},
         'schedule-group-host-2',
         'Schedule Group Host 2',
         'Ubuntu 24.04',
@@ -286,7 +270,7 @@ test('admin can create a security-only patch schedule for a host group', async (
     )
     VALUES (
       'schedule-host-group-1',
-      ${orgId},
+      ${instanceId},
       'Production Linux',
       'Production patch window group'
     )
@@ -302,13 +286,13 @@ test('admin can create a security-only patch schedule for a host group', async (
     VALUES
       (
         'schedule-group-member-1',
-        ${orgId},
+        ${instanceId},
         'schedule-host-group-1',
         'schedule-group-host-1'
       ),
       (
         'schedule-group-member-2',
-        ${orgId},
+        ${instanceId},
         'schedule-host-group-1',
         'schedule-group-host-2'
       )
@@ -358,7 +342,7 @@ test('admin can create a security-only patch schedule for a host group', async (
       }>>`
         SELECT name, cron_expression, timezone, target_type, target_id, max_parallel, task_type, config
         FROM task_schedules
-        WHERE organisation_id = ${orgId}
+        WHERE organisation_id = ${instanceId}
           AND name = 'Weekly security patch wave'
           AND deleted_at IS NULL
         LIMIT 1
@@ -379,7 +363,7 @@ test('admin can create a security-only patch schedule for a host group', async (
 
 test('admin can create a software inventory schedule for a single host', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId } = await getOrgAndUserIds(sql)
+  const { instanceId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -395,7 +379,7 @@ test('admin can create a software inventory schedule for a single host', async (
     )
     VALUES (
       'schedule-inventory-host-1',
-      ${orgId},
+      ${instanceId},
       'schedule-inventory-host-1',
       'Schedule Inventory Host',
       'Ubuntu 24.04',
@@ -447,7 +431,7 @@ test('admin can create a software inventory schedule for a single host', async (
       }>>`
         SELECT name, cron_expression, timezone, target_type, target_id, task_type, config
         FROM task_schedules
-        WHERE organisation_id = ${orgId}
+        WHERE organisation_id = ${instanceId}
           AND name = 'Weekly software inventory'
           AND deleted_at IS NULL
         LIMIT 1
@@ -467,7 +451,7 @@ test('admin can create a software inventory schedule for a single host', async (
 
 test('admin can create a custom script schedule for a single host', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId } = await getOrgAndUserIds(sql)
+  const { instanceId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -483,7 +467,7 @@ test('admin can create a custom script schedule for a single host', async ({ aut
     )
     VALUES (
       'schedule-script-host-1',
-      ${orgId},
+      ${instanceId},
       'schedule-script-host-1',
       'Schedule Script Host',
       'Ubuntu 24.04',
@@ -536,7 +520,7 @@ test('admin can create a custom script schedule for a single host', async ({ aut
       }>>`
         SELECT name, cron_expression, timezone, target_type, target_id, task_type, config
         FROM task_schedules
-        WHERE organisation_id = ${orgId}
+        WHERE organisation_id = ${instanceId}
           AND name = 'Daily diagnostics script'
           AND deleted_at IS NULL
         LIMIT 1
@@ -560,7 +544,7 @@ test('admin can create a custom script schedule for a single host', async ({ aut
 
 test('admin can edit an existing host-group schedule and review recent runs', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId, userId } = await getOrgAndUserIds(sql)
+  const { instanceId, userId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -577,7 +561,7 @@ test('admin can edit an existing host-group schedule and review recent runs', as
     VALUES
       (
         'schedule-edit-host-1',
-        ${orgId},
+        ${instanceId},
         'schedule-edit-host-1',
         'Schedule Edit Host 1',
         'Ubuntu 24.04',
@@ -588,7 +572,7 @@ test('admin can edit an existing host-group schedule and review recent runs', as
       ),
       (
         'schedule-edit-host-2',
-        ${orgId},
+        ${instanceId},
         'schedule-edit-host-2',
         'Schedule Edit Host 2',
         'Ubuntu 24.04',
@@ -608,7 +592,7 @@ test('admin can edit an existing host-group schedule and review recent runs', as
     )
     VALUES (
       'schedule-edit-group-1',
-      ${orgId},
+      ${instanceId},
       'Schedule Edit Group',
       'Hosts used for edit flow coverage'
     )
@@ -624,13 +608,13 @@ test('admin can edit an existing host-group schedule and review recent runs', as
     VALUES
       (
         'schedule-edit-member-1',
-        ${orgId},
+        ${instanceId},
         'schedule-edit-group-1',
         'schedule-edit-host-1'
       ),
       (
         'schedule-edit-member-2',
-        ${orgId},
+        ${instanceId},
         'schedule-edit-group-1',
         'schedule-edit-host-2'
       )
@@ -655,7 +639,7 @@ test('admin can edit an existing host-group schedule and review recent runs', as
     )
     VALUES (
       'schedule-edit-1',
-      ${orgId},
+      ${instanceId},
       ${userId},
       'Weekly service restart',
       'Restart nginx each week.',
@@ -689,7 +673,7 @@ test('admin can edit an existing host-group schedule and review recent runs', as
     )
     VALUES (
       'schedule-edit-run-1',
-      ${orgId},
+      ${instanceId},
       ${userId},
       'schedule-edit-1',
       'group',
@@ -768,7 +752,7 @@ test('admin can edit an existing host-group schedule and review recent runs', as
 
 test('admin can create a service action schedule for a host group', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
-  const { orgId } = await getOrgAndUserIds(sql)
+  const { instanceId } = await getSeededTestUserContext()
 
   await sql`
     INSERT INTO hosts (
@@ -784,7 +768,7 @@ test('admin can create a service action schedule for a host group', async ({ aut
     )
     VALUES (
       'schedule-service-host-1',
-      ${orgId},
+      ${instanceId},
       'schedule-service-host-1',
       'Schedule Service Host',
       'Ubuntu 24.04',
@@ -804,7 +788,7 @@ test('admin can create a service action schedule for a host group', async ({ aut
     )
     VALUES (
       'schedule-service-group-1',
-      ${orgId},
+      ${instanceId},
       'Frontend Fleet',
       'Hosts for scheduled service restarts'
     )
@@ -819,7 +803,7 @@ test('admin can create a service action schedule for a host group', async ({ aut
     )
     VALUES (
       'schedule-service-group-member-1',
-      ${orgId},
+      ${instanceId},
       'schedule-service-group-1',
       'schedule-service-host-1'
     )
@@ -869,7 +853,7 @@ test('admin can create a service action schedule for a host group', async ({ aut
       }>>`
         SELECT name, cron_expression, timezone, target_type, target_id, max_parallel, task_type, config
         FROM task_schedules
-        WHERE organisation_id = ${orgId}
+        WHERE organisation_id = ${instanceId}
           AND name = 'Restart nginx weekly'
           AND deleted_at IS NULL
         LIMIT 1


### PR DESCRIPTION
## Summary
- remove caller-supplied organisation identity from task run and schedule pages, actions, and mutations
- split `task-runs` and `task-schedules` into instance-scoped wrappers plus core modules for the remaining org-scoped internals
- update Task 10 E2E fixtures and wrapper tests to seed standalone instance data

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --dir apps/web type-check`
- `pnpm --dir apps/web lint` (warnings only)
- `pnpm --dir apps/web test:unit` (fails only `lib/db/rls.test.mjs` and `lib/integrations/ct-cve/db-nonce-store.test.mjs`)
- `pnpm --dir apps/web exec playwright test --list`
- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=test-secret pnpm --dir apps/web exec playwright test tests/e2e/tasks/monitor.spec.ts --project=chromium --grep "completed grouped task run"` (fails before execution because Next instrumentation cannot import `./lib/agent/cache-prewarm`)
- `rg -n "orgId|organisationId|organisation_id|org_id|organisations|tenant" 'apps/web/app/(dashboard)/tasks' 'apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx' 'apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx' apps/web/lib/actions/{task-runs,task-schedules}.ts`
