### PR TITLE
feat(web): remove org ids from task 11 surfaces

### DIFF
--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -391,7 +391,7 @@ Status: Complete
 
 Completed by: Codex automation
 
-PR:
+PR: [#1234](https://github.com/carrtech-dev/ct-ops/pull/1234)
 
 Summary: Replaced the mixed host-detail metadata slice after auditing the
 remaining org-scoped surface and finding the previous task still spans host

--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -706,19 +706,50 @@ This slice owns task execution and scheduling workflows.
 
 ## Task 11 - Web Alerts, Notifications, Team, And Agent Management Conversion
 
-Status: Not started
+Status: Complete
 
-Completed by:
+Completed by: Codex automation
 
 PR:
 
-Summary:
+Summary: Removed caller-supplied organisation identity from the Task 11-owned
+alerts, notifications, team management, and agent-enrolment surfaces by
+switching those pages, shared topbar notification UI, and public actions to
+derive instance scope from the authenticated session. Also updated the
+monitoring and agent settings pages touched by this slice to load their org
+backing record through session-derived helpers instead of reading an
+organisation id in the route layer.
 
-Files changed:
+Files changed: `ORGANISATION_REMOVAL_TASKS.md`,
+`apps/web/app/(dashboard)/{alerts,notifications,team}`,
+`apps/web/app/(dashboard)/settings/{agents,monitoring,alerts,tag-rules}`,
+`apps/web/app/(dashboard)/hosts/{[id],bulk-tag}`,
+`apps/web/app/(dashboard)/layout.tsx`,
+`apps/web/components/shared/{notification-bell,topbar}.tsx`,
+`apps/web/lib/actions/{agents,alerts,notifications,settings,tag-rules,users}.ts`,
+`apps/web/lib/actions/notifications-authz.test.mjs`,
+`apps/web/lib/notifications/notification-inbox.test.mjs`
 
-Validation:
+Validation: `pnpm install --frozen-lockfile`; `pnpm --dir apps/web type-check`
+(passes); `pnpm --dir apps/web lint` (passes with pre-existing warnings only,
+including a few newly-exposed unused vars in Task 11-adjacent host alert UI);
+`pnpm --dir apps/web test:unit` (fails only `lib/db/rls.test.mjs` and
+`lib/integrations/ct-cve/db-nonce-store.test.mjs` because no working container
+runtime is available here); `pnpm --dir apps/web exec playwright test --list`
+(passes); `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=test-secret
+pnpm --dir apps/web exec playwright test tests/e2e/notifications/bell.spec.ts
+--project=chromium --grep "authenticated user can review topbar notifications
+and open the linked resource"` (fails before execution because Next
+instrumentation still cannot import `./lib/agent/cache-prewarm` in this
+checkout); targeted `rg` over the Task 11-owned pages/components shows the
+public UI no longer threads `orgId`, while the broad task grep still reports
+expected org-scoped internals and unrelated later-slice files.
 
-Follow-up:
+Follow-up: Start Task 12 next. Task 13 still needs to remove the remaining
+org-scoped internals left in `apps/web/lib/actions/alerts.ts` and the broader
+unrelated `apps/web/lib/actions/*` residue that the Task 11 validation grep
+still surfaces; local browser smoke coverage is still blocked in this checkout
+by the missing `apps/web/lib/agent/cache-prewarm` instrumentation import.
 
 ### Required work
 

--- a/apps/web/app/(dashboard)/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/alerts/alerts-client.tsx
@@ -143,12 +143,10 @@ const webhookFormSchema = z.object({
 type WebhookFormValues = z.infer<typeof webhookFormSchema>
 
 function AddWebhookDialog({
-  orgId,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
   onSuccess: SuccessHandler
@@ -161,7 +159,7 @@ function AddWebhookDialog({
   } = useForm<WebhookFormValues>({ resolver: zodResolver(webhookFormSchema) })
 
   async function onSubmit(values: WebhookFormValues) {
-    const result = await createNotificationChannel(orgId, {
+    const result = await createNotificationChannel({
       name: values.name,
       type: 'webhook',
       config: { url: values.url, secret: values.secret || undefined },
@@ -238,12 +236,10 @@ const smtpFormSchema = z.object({
 type SmtpFormValues = z.infer<typeof smtpFormSchema>
 
 function AddSmtpDialog({
-  orgId,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
   onSuccess: SuccessHandler
@@ -261,7 +257,7 @@ function AddSmtpDialog({
       .map((e) => e.trim())
       .filter(Boolean)
 
-    const result = await createNotificationChannel(orgId, {
+    const result = await createNotificationChannel({
       name: values.name,
       type: 'smtp',
       config: {
@@ -388,13 +384,11 @@ const editWebhookFormSchema = z.object({
 type EditWebhookFormValues = z.infer<typeof editWebhookFormSchema>
 
 function EditWebhookDialog({
-  orgId,
   channel,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   channel: NotificationChannelSafe & { type: 'webhook' }
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -412,7 +406,7 @@ function EditWebhookDialog({
   }, [open, channel, reset])
 
   async function onSubmit(values: EditWebhookFormValues) {
-    const result = await updateNotificationChannel(orgId, channel.id, {
+    const result = await updateNotificationChannel(channel.id, {
       name: values.name,
       url: values.url,
       secret: values.secret || undefined,
@@ -477,13 +471,11 @@ const editSmtpFormSchema = z.object({
 type EditSmtpFormValues = z.infer<typeof editSmtpFormSchema>
 
 function EditSmtpDialog({
-  orgId,
   channel,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   channel: NotificationChannelSafe & { type: 'smtp' }
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -507,7 +499,7 @@ function EditSmtpDialog({
       .map((e) => e.trim())
       .filter(Boolean)
 
-    const result = await updateNotificationChannel(orgId, channel.id, {
+    const result = await updateNotificationChannel(channel.id, {
       name: values.name,
       toAddresses,
     })
@@ -570,12 +562,10 @@ const editSlackFormSchema = z.object({
 type EditSlackFormValues = z.infer<typeof editSlackFormSchema>
 
 function AddSlackDialog({
-  orgId,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
   onSuccess: SuccessHandler
@@ -588,7 +578,7 @@ function AddSlackDialog({
   } = useForm<SlackFormValues>({ resolver: zodResolver(slackFormSchema) })
 
   async function onSubmit(values: SlackFormValues) {
-    const result = await createNotificationChannel(orgId, {
+    const result = await createNotificationChannel({
       name: values.name,
       type: 'slack',
       config: { webhookUrl: values.webhookUrl },
@@ -639,13 +629,11 @@ function AddSlackDialog({
 }
 
 function EditSlackDialog({
-  orgId,
   channel,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   channel: NotificationChannelSafe & { type: 'slack' }
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -663,7 +651,7 @@ function EditSlackDialog({
   }, [open, channel, reset])
 
   async function onSubmit(values: EditSlackFormValues) {
-    const result = await updateNotificationChannel(orgId, channel.id, {
+    const result = await updateNotificationChannel(channel.id, {
       name: values.name,
       webhookUrl: values.webhookUrl,
     })
@@ -719,12 +707,10 @@ const telegramFormSchema = z.object({
 type TelegramFormValues = z.infer<typeof telegramFormSchema>
 
 function AddTelegramDialog({
-  orgId,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
   onSuccess: SuccessHandler
@@ -737,7 +723,7 @@ function AddTelegramDialog({
   } = useForm<TelegramFormValues>({ resolver: zodResolver(telegramFormSchema) })
 
   async function onSubmit(values: TelegramFormValues) {
-    const result = await createNotificationChannel(orgId, {
+    const result = await createNotificationChannel({
       name: values.name,
       type: 'telegram',
       config: { botToken: values.botToken, chatId: values.chatId },
@@ -808,13 +794,11 @@ const editTelegramFormSchema = z.object({
 type EditTelegramFormValues = z.infer<typeof editTelegramFormSchema>
 
 function EditTelegramDialog({
-  orgId,
   channel,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   channel: NotificationChannelSafe & { type: 'telegram' }
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -832,7 +816,7 @@ function EditTelegramDialog({
   }, [open, channel, reset])
 
   async function onSubmit(values: EditTelegramFormValues) {
-    const result = await updateNotificationChannel(orgId, channel.id, {
+    const result = await updateNotificationChannel(channel.id, {
       name: values.name,
       botToken: values.botToken || undefined,
       chatId: values.chatId,
@@ -905,14 +889,12 @@ const silenceFormSchema = z.object({
 type SilenceFormValues = z.infer<typeof silenceFormSchema>
 
 function AddSilenceDialog({
-  orgId,
   hosts,
   open,
   onOpenChange,
   onSuccess,
   prefilledHostId,
 }: {
-  orgId: string
   hosts: HostWithAgent[]
   open: boolean
   onOpenChange: (v: boolean) => void
@@ -937,7 +919,7 @@ function AddSilenceDialog({
   })
 
   async function onSubmit(values: SilenceFormValues) {
-    const result = await createSilence(orgId, {
+    const result = await createSilence({
       hostId: values.hostId || null,
       reason: values.reason,
       startsAt: new Date(values.startsAt).toISOString(),
@@ -1009,7 +991,6 @@ function AddSilenceDialog({
 // ─── Main Component ────────────────────────────────────────────────────────────
 
 interface AlertsClientProps {
-  orgId: string
   initialActive: AlertInstanceWithRule[]
   initialChannels: NotificationChannelSafe[]
   initialSilences: AlertSilenceWithHost[]
@@ -1021,7 +1002,6 @@ type SeverityFilter = 'all' | AlertSeverity
 const HISTORY_PAGE_SIZE = 25
 
 export function AlertsClient({
-  orgId,
   initialActive,
   initialChannels,
   initialSilences,
@@ -1051,16 +1031,16 @@ export function AlertsClient({
   }
 
   const { data: activeAlerts = [] } = useQuery({
-    queryKey: ['alerts', orgId, 'firing'],
-    queryFn: () => getAlertInstances(orgId, { status: 'firing', limit: 100 }),
+    queryKey: ['alerts', 'firing'],
+    queryFn: () => getAlertInstances({ status: 'firing', limit: 100 }),
     initialData: initialActive,
     refetchInterval: 30_000,
   })
 
   const { data: historyAlerts = [], isFetching: historyFetching } = useQuery({
-    queryKey: ['alerts', orgId, 'history', historyPage, historyFilters],
+    queryKey: ['alerts', 'history', historyPage, historyFilters],
     queryFn: () =>
-      getAlertInstances(orgId, {
+      getAlertInstances({
         ...historyFilters,
         limit: HISTORY_PAGE_SIZE,
         offset: historyPage * HISTORY_PAGE_SIZE,
@@ -1069,48 +1049,48 @@ export function AlertsClient({
   })
 
   const { data: historyTotal = 0 } = useQuery({
-    queryKey: ['alerts', orgId, 'history-count', historyFilters],
-    queryFn: () => getAlertInstanceCount(orgId, historyFilters),
+    queryKey: ['alerts', 'history-count', historyFilters],
+    queryFn: () => getAlertInstanceCount(historyFilters),
   })
 
   const { data: channels = [] } = useQuery({
-    queryKey: ['notification-channels', orgId],
-    queryFn: () => getNotificationChannels(orgId),
+    queryKey: ['notification-channels'],
+    queryFn: () => getNotificationChannels(),
     initialData: initialChannels,
     refetchInterval: 60_000,
   })
 
   const { data: silences = [] } = useQuery({
-    queryKey: ['silences', orgId],
-    queryFn: () => getSilences(orgId),
+    queryKey: ['silences'],
+    queryFn: () => getSilences(),
     initialData: initialSilences,
     refetchInterval: 60_000,
   })
 
   const acknowledgeMutation = useMutation({
-    mutationFn: (instanceId: string) => acknowledgeAlert(orgId, instanceId),
+    mutationFn: (instanceId: string) => acknowledgeAlert(instanceId),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['alerts', orgId] })
+      qc.invalidateQueries({ queryKey: ['alerts'] })
     },
   })
 
   const deleteChannelMutation = useMutation({
-    mutationFn: (channelId: string) => deleteNotificationChannel(orgId, channelId),
+    mutationFn: (channelId: string) => deleteNotificationChannel(channelId),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+      qc.invalidateQueries({ queryKey: ['notification-channels'] })
     },
   })
 
   const deleteSilenceMutation = useMutation({
-    mutationFn: (silenceId: string) => deleteSilence(orgId, silenceId),
+    mutationFn: (silenceId: string) => deleteSilence(silenceId),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['silences', orgId] })
+      qc.invalidateQueries({ queryKey: ['silences'] })
     },
   })
 
   async function handleTestNotification(channel: NotificationChannelSafe) {
     setTestingChannelId(channel.id)
-    const result = await sendTestNotification(orgId, channel.id)
+    const result = await sendTestNotification(channel.id)
     setTestingChannelId(null)
     setTestLog({
       channelName: channel.name,
@@ -1619,84 +1599,75 @@ export function AlertsClient({
       </Card>
 
       <AddSilenceDialog
-        orgId={orgId}
         hosts={hosts}
         open={addSilenceOpen}
         onOpenChange={setAddSilenceOpen}
-        onSuccess={() => qc.invalidateQueries({ queryKey: ['silences', orgId] })}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['silences'] })}
       />
       <AddWebhookDialog
-        orgId={orgId}
         open={addWebhookOpen}
         onOpenChange={setAddWebhookOpen}
-        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels'] })}
       />
       <AddSmtpDialog
-        orgId={orgId}
         open={addSmtpOpen}
         onOpenChange={setAddSmtpOpen}
-        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels'] })}
       />
       <AddSlackDialog
-        orgId={orgId}
         open={addSlackOpen}
         onOpenChange={setAddSlackOpen}
-        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels'] })}
       />
       <AddTelegramDialog
-        orgId={orgId}
         open={addTelegramOpen}
         onOpenChange={setAddTelegramOpen}
-        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })}
+        onSuccess={() => qc.invalidateQueries({ queryKey: ['notification-channels'] })}
       />
       {testLog && (
         <TestLogDialog entry={testLog} onClose={() => setTestLog(null)} />
       )}
       {editingChannel?.type === 'webhook' && (
         <EditWebhookDialog
-          orgId={orgId}
           channel={editingChannel}
           open={true}
           onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
           onSuccess={() => {
             setEditingChannel(null)
-            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+            qc.invalidateQueries({ queryKey: ['notification-channels'] })
           }}
         />
       )}
       {editingChannel?.type === 'smtp' && (
         <EditSmtpDialog
-          orgId={orgId}
           channel={editingChannel}
           open={true}
           onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
           onSuccess={() => {
             setEditingChannel(null)
-            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+            qc.invalidateQueries({ queryKey: ['notification-channels'] })
           }}
         />
       )}
       {editingChannel?.type === 'slack' && (
         <EditSlackDialog
-          orgId={orgId}
           channel={editingChannel}
           open={true}
           onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
           onSuccess={() => {
             setEditingChannel(null)
-            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+            qc.invalidateQueries({ queryKey: ['notification-channels'] })
           }}
         />
       )}
       {editingChannel?.type === 'telegram' && (
         <EditTelegramDialog
-          orgId={orgId}
           channel={editingChannel}
           open={true}
           onOpenChange={(v) => { if (!v) setEditingChannel(null) }}
           onSuccess={() => {
             setEditingChannel(null)
-            qc.invalidateQueries({ queryKey: ['notification-channels', orgId] })
+            qc.invalidateQueries({ queryKey: ['notification-channels'] })
           }}
         />
       )}

--- a/apps/web/app/(dashboard)/alerts/page.tsx
+++ b/apps/web/app/(dashboard)/alerts/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { getRequiredSession } from '@/lib/auth/session'
 import { getAlertInstances, getNotificationChannels, getSilences } from '@/lib/actions/alerts'
 import { listHosts } from '@/lib/actions/agents'
 import { AlertsClient } from './alerts-client'
@@ -9,19 +8,15 @@ export const metadata: Metadata = {
 }
 
 export default async function AlertsPage() {
-  const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
-
   const [activeAlerts, channels, silences, hosts] = await Promise.all([
-    getAlertInstances(orgId, { status: 'firing', limit: 100 }),
-    getNotificationChannels(orgId),
-    getSilences(orgId),
-    listHosts(orgId),
+    getAlertInstances({ status: 'firing', limit: 100 }),
+    getNotificationChannels(),
+    getSilences(),
+    listHosts(),
   ])
 
   return (
     <AlertsClient
-      orgId={orgId}
       initialActive={activeAlerts}
       initialChannels={channels}
       initialSilences={silences}

--- a/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
@@ -145,7 +145,7 @@ function AddSilenceDialog({
   })
 
   async function onSubmit(values: SilenceFormValues) {
-    const result = await createSilence(scopeId, {
+    const result = await createSilence({
       hostId,
       reason: values.reason,
       startsAt: new Date(values.startsAt).toISOString(),
@@ -246,7 +246,7 @@ function AddRuleDialog({
   })
 
   async function onSubmit(values: RuleFormValues) {
-    let input: Parameters<typeof createAlertRule>[1]
+    let input: Parameters<typeof createAlertRule>[0]
 
     if (values.conditionType === 'check_status') {
       if (!values.checkId) return
@@ -281,7 +281,7 @@ function AddRuleDialog({
       }
     }
 
-    const result = await createAlertRule(scopeId, input)
+    const result = await createAlertRule(input)
     if ('error' in result) return
     reset()
     onSuccess()
@@ -539,25 +539,25 @@ export function AlertsTab({ scopeId, hostId }: Props) {
 
   const { data: allRules = [] } = useQuery({
     queryKey: ['alert-rules', scopeId, hostId],
-    queryFn: () => getAlertRules(scopeId, hostId),
+    queryFn: () => getAlertRules(hostId),
     refetchInterval: 30_000,
   })
 
   const { data: globalDefaults = [] } = useQuery({
     queryKey: ['alert-global-defaults', scopeId],
-    queryFn: () => getGlobalAlertDefaults(scopeId),
+    queryFn: () => getGlobalAlertDefaults(),
     refetchInterval: 60_000,
   })
 
   const { data: activeAlerts = [] } = useQuery({
     queryKey: ['alerts', scopeId, 'firing', hostId],
-    queryFn: () => getAlertInstances(scopeId, { status: 'firing', hostId }),
+    queryFn: () => getAlertInstances({ status: 'firing', hostId }),
     refetchInterval: 30_000,
   })
 
   const { data: activeSilences = [] } = useQuery({
     queryKey: ['silences-active', scopeId, hostId],
-    queryFn: () => getActiveSilencesForHost(scopeId, hostId),
+    queryFn: () => getActiveSilencesForHost(hostId),
     refetchInterval: 60_000,
   })
 
@@ -565,17 +565,17 @@ export function AlertsTab({ scopeId, hostId }: Props) {
 
   const toggleMutation = useMutation({
     mutationFn: ({ ruleId, enabled }: { ruleId: string; enabled: boolean }) =>
-      updateAlertRule(scopeId, ruleId, { enabled }),
+      updateAlertRule(ruleId, { enabled }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['alert-rules', scopeId, hostId] }),
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (ruleId: string) => deleteAlertRule(scopeId, ruleId),
+    mutationFn: (ruleId: string) => deleteAlertRule(ruleId),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['alert-rules', scopeId, hostId] }),
   })
 
   const deleteSilenceMutation = useMutation({
-    mutationFn: (silenceId: string) => deleteSilence(scopeId, silenceId),
+    mutationFn: (silenceId: string) => deleteSilence(silenceId),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['silences-active', scopeId, hostId] }),
   })
 

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -359,7 +359,7 @@ export function HostDetailClient({ host: initialHost, scopeId, currentUserId, us
 
   const { data: activeAlerts = [] } = useQuery({
     queryKey: ['alerts', scopeId, 'firing', initialHost.id],
-    queryFn: () => getAlertInstances(scopeId, { status: 'firing', hostId: initialHost.id }),
+    queryFn: () => getAlertInstances({ status: 'firing', hostId: initialHost.id }),
     refetchInterval: 30_000,
   })
   const activeAlertCount = activeAlerts.length
@@ -931,7 +931,6 @@ export function HostDetailClient({ host: initialHost, scopeId, currentUserId, us
               </Card>
 
               <HostNotificationCharts
-                scopeId={scopeId}
                 hostId={initialHost.id}
               />
             </>

--- a/apps/web/app/(dashboard)/hosts/[id]/host-notification-charts.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-notification-charts.tsx
@@ -55,22 +55,21 @@ function formatTrendDate(raw: string, range: TrendRange): string {
 }
 
 interface HostNotificationChartsProps {
-  scopeId: string
   hostId: string
 }
 
-export function HostNotificationCharts({ scopeId, hostId }: HostNotificationChartsProps) {
+export function HostNotificationCharts({ hostId }: HostNotificationChartsProps) {
   const [trendRange, setTrendRange] = useState<TrendRange>('30d')
 
   const { data: stats } = useQuery({
-    queryKey: ['notifications-stats', scopeId, hostId],
-    queryFn: () => getNotificationStats(scopeId, hostId),
+    queryKey: ['notifications-stats', hostId],
+    queryFn: () => getNotificationStats(hostId),
     refetchInterval: 60_000,
   })
 
   const { data: timeSeries } = useQuery({
-    queryKey: ['notifications-time-series', scopeId, hostId, trendRange],
-    queryFn: () => getNotificationsOverTime(scopeId, trendRange, hostId),
+    queryKey: ['notifications-time-series', hostId, trendRange],
+    queryFn: () => getNotificationsOverTime(trendRange, hostId),
     refetchInterval: 60_000,
   })
 

--- a/apps/web/app/(dashboard)/hosts/bulk-tag/bulk-tag-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/bulk-tag/bulk-tag-client.tsx
@@ -97,7 +97,7 @@ export function BulkTagClient({ orgId }: BulkTagClientProps) {
 
   const saveRuleMutation = useMutation({
     mutationFn: async () =>
-      createTagRule(orgId, {
+      createTagRule({
         name: ruleName.trim(),
         filter: buildFilter(),
         tags: tags.map((t) => ({ key: t.key, value: t.value })),

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -30,7 +30,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
         <SidebarProvider className="h-svh overflow-hidden">
           <AppSidebar tier={licence.tier} userRole={session.user.role} />
           <TerminalContentWrapper>
-            <Topbar orgId={orgId} />
+            <Topbar />
             <main className="flex-1 p-6 overflow-auto min-h-0">{children}</main>
           </TerminalContentWrapper>
         </SidebarProvider>

--- a/apps/web/app/(dashboard)/notifications/notifications-client.tsx
+++ b/apps/web/app/(dashboard)/notifications/notifications-client.tsx
@@ -73,7 +73,6 @@ const SEVERITY_COLORS: Record<string, string> = {
 }
 
 interface NotificationsClientProps {
-  orgId: string
   initialNotifications: Notification[]
   initialUnread: number
 }
@@ -101,18 +100,18 @@ function SeverityDot({ severity }: { severity: string }) {
   return <span className={`inline-block size-2.5 rounded-full shrink-0 mt-1 ${cls}`} />
 }
 
-function NotificationCharts({ orgId }: { orgId: string }) {
+function NotificationCharts() {
   const [trendRange, setTrendRange] = useState<TrendRange>('30d')
 
   const { data: stats } = useQuery({
-    queryKey: ['notifications-stats', orgId],
-    queryFn: () => getNotificationStats(orgId),
+    queryKey: ['notifications-stats'],
+    queryFn: () => getNotificationStats(),
     refetchInterval: 60_000,
   })
 
   const { data: timeSeries } = useQuery({
-    queryKey: ['notifications-time-series', orgId, trendRange],
-    queryFn: () => getNotificationsOverTime(orgId, trendRange),
+    queryKey: ['notifications-time-series', trendRange],
+    queryFn: () => getNotificationsOverTime(trendRange),
     refetchInterval: 60_000,
   })
 
@@ -248,7 +247,6 @@ function NotificationCharts({ orgId }: { orgId: string }) {
 }
 
 export function NotificationsClient({
-  orgId,
   initialNotifications,
   initialUnread,
 }: NotificationsClientProps) {
@@ -260,74 +258,73 @@ export function NotificationsClient({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
   const { data: unread = initialUnread } = useQuery({
-    queryKey: ['notifications-unread', orgId],
-    queryFn: () => getUnreadCount(orgId),
+    queryKey: ['notifications-unread'],
+    queryFn: () => getUnreadCount(),
     initialData: initialUnread,
     refetchInterval: 20_000,
   })
 
   const { data: notifications = initialNotifications } = useQuery({
-    queryKey: ['notifications', orgId, offset],
-    queryFn: () => getNotifications(orgId, PAGE_SIZE, offset),
+    queryKey: ['notifications', offset],
+    queryFn: () => getNotifications(PAGE_SIZE, offset),
     initialData: offset === 0 ? initialNotifications : undefined,
     refetchInterval: 30_000,
   })
 
   const markReadMutation = useMutation({
-    mutationFn: (id: string) => markAsRead(orgId, id),
+    mutationFn: (id: string) => markAsRead(id),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-recent'] }),
       ])
     },
   })
 
   const markAllMutation = useMutation({
-    mutationFn: () => markAllAsRead(orgId),
+    mutationFn: () => markAllAsRead(),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-recent'] }),
       ])
     },
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteNotification(orgId, id),
+    mutationFn: (id: string) => deleteNotification(id),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-stats', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-stats'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-time-series'] }),
       ])
     },
   })
 
   const bulkDeleteMutation = useMutation({
-    mutationFn: (ids: string[]) => deleteNotifications(orgId, ids),
+    mutationFn: (ids: string[]) => deleteNotifications(ids),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-stats', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-time-series', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-stats'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-time-series'] }),
       ])
       setSelectedIds(new Set())
     },
   })
 
   const bulkMarkReadMutation = useMutation({
-    mutationFn: ({ ids, read }: { ids: string[]; read: boolean }) =>
-      markBatchReadStatus(orgId, ids, read),
+    mutationFn: ({ ids, read }: { ids: string[]; read: boolean }) => markBatchReadStatus(ids, read),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ['notifications', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] }),
-        qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] }),
+        qc.invalidateQueries({ queryKey: ['notifications'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-unread'] }),
+        qc.invalidateQueries({ queryKey: ['notifications-recent'] }),
       ])
       setSelectedIds(new Set())
     },
@@ -384,7 +381,7 @@ export function NotificationsClient({
         </div>
       </div>
 
-      <NotificationCharts orgId={orgId} />
+      <NotificationCharts />
 
       {/* Filter tabs */}
       <div className="flex items-center gap-1 border-b">
@@ -570,10 +567,10 @@ export function NotificationsClient({
                         <Button
                           size="sm"
                           variant="ghost"
-                          onClick={() => markBatchReadStatus(orgId, [n.id], false).then(() => {
-                            qc.invalidateQueries({ queryKey: ['notifications', orgId] })
-                            qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-                            qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
+                          onClick={() => markBatchReadStatus([n.id], false).then(() => {
+                            qc.invalidateQueries({ queryKey: ['notifications'] })
+                            qc.invalidateQueries({ queryKey: ['notifications-unread'] })
+                            qc.invalidateQueries({ queryKey: ['notifications-recent'] })
                           })}
                           data-testid={`notification-mark-unread-${n.id}`}
                         >

--- a/apps/web/app/(dashboard)/notifications/page.tsx
+++ b/apps/web/app/(dashboard)/notifications/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next'
-import { getRequiredSession } from '@/lib/auth/session'
 import { getNotifications, getUnreadCount } from '@/lib/actions/notifications'
 import { NotificationsClient } from './notifications-client'
 
@@ -8,17 +7,13 @@ export const metadata: Metadata = {
 }
 
 export default async function NotificationsPage() {
-  const session = await getRequiredSession()
-  const orgId = session.user.organisationId ?? ''
-
   const [initialNotifications, initialUnread] = await Promise.all([
-    getNotifications(orgId, 25),
-    getUnreadCount(orgId),
+    getNotifications(25),
+    getUnreadCount(),
   ])
 
   return (
     <NotificationsClient
-      orgId={orgId}
       initialNotifications={initialNotifications}
       initialUnread={initialUnread}
     />

--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -60,7 +60,6 @@ const createTokenSchema = z.object({
 type CreateTokenForm = z.infer<typeof createTokenSchema>
 
 interface AgentsSettingsClientProps {
-  orgId: string
   initialTokens: EnrolmentTokenSafe[]
   appUrl: string
 }
@@ -99,7 +98,6 @@ function tokenStatus(token: EnrolmentTokenSafe): { label: string; className: str
 }
 
 export function AgentsSettingsClient({
-  orgId,
   initialTokens,
   appUrl,
 }: AgentsSettingsClientProps) {
@@ -112,8 +110,8 @@ export function AgentsSettingsClient({
   const [tokenTags, setTokenTags] = useState<EditorTag[]>([])
 
   const { data: tokens } = useQuery({
-    queryKey: ['enrolment-tokens', orgId],
-    queryFn: () => listEnrolmentTokens(orgId),
+    queryKey: ['enrolment-tokens'],
+    queryFn: () => listEnrolmentTokens(),
     initialData: initialTokens,
   })
 
@@ -140,7 +138,7 @@ export function AgentsSettingsClient({
 
   const createMutation = useMutation({
     mutationFn: (data: CreateTokenForm) =>
-      createEnrolmentToken(orgId, {
+      createEnrolmentToken({
         label: data.label,
         autoApprove: data.autoApprove,
         skipVerify: data.skipVerify,
@@ -151,7 +149,7 @@ export function AgentsSettingsClient({
       }),
     onSuccess: (result, variables) => {
       if ('error' in result) return
-      queryClient.invalidateQueries({ queryKey: ['enrolment-tokens', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['enrolment-tokens'] })
       setNewTokenValue(result.token)
       setNewInstallCommand(
         buildAgentInstallCommand(appUrl || window.location.origin, variables.skipVerify, result.token),
@@ -162,9 +160,9 @@ export function AgentsSettingsClient({
   })
 
   const revokeMutation = useMutation({
-    mutationFn: (tokenId: string) => revokeEnrolmentToken(orgId, tokenId),
+    mutationFn: (tokenId: string) => revokeEnrolmentToken(tokenId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['enrolment-tokens', orgId] })
+      queryClient.invalidateQueries({ queryKey: ['enrolment-tokens'] })
     },
   })
 

--- a/apps/web/app/(dashboard)/settings/agents/defaults/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/defaults/page.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
-import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
 
@@ -16,10 +14,7 @@ export default async function AgentDefaultsPage() {
   const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const org = await db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
-  })
+  const org = await getCurrentOrganisationSettingsRecord()
 
   if (!org) return null
 

--- a/apps/web/app/(dashboard)/settings/agents/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/page.tsx
@@ -16,8 +16,7 @@ export default async function AgentsSettingsPage() {
     session.user.role === 'super_admin' || session.user.role === 'org_admin'
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const tokens = await listEnrolmentTokens(orgId)
+  const tokens = await listEnrolmentTokens()
 
   const appUrl = process.env.AGENT_DOWNLOAD_BASE_URL ?? ''
 
@@ -32,7 +31,6 @@ export default async function AgentsSettingsPage() {
         ]}
       />
       <AgentsSettingsClient
-        orgId={orgId}
         initialTokens={tokens}
         appUrl={appUrl}
       />

--- a/apps/web/app/(dashboard)/settings/agents/software/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/software/page.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
-import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
 
@@ -16,10 +14,7 @@ export default async function SoftwareInventorySettingsPage() {
   const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const org = await db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
-  })
+  const org = await getCurrentOrganisationSettingsRecord()
 
   if (!org) return null
 

--- a/apps/web/app/(dashboard)/settings/agents/tags/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/tags/page.tsx
@@ -15,8 +15,7 @@ export default async function AgentTagRulesPage() {
     session.user.role === 'super_admin' || session.user.role === 'org_admin'
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const rules = await listTagRules(orgId)
+  const rules = await listTagRules()
 
   return (
     <div className="space-y-6">
@@ -28,7 +27,7 @@ export default async function AgentTagRulesPage() {
           { title: 'Software inventory', href: '/settings/agents/software' },
         ]}
       />
-      <TagRulesClient orgId={orgId} initialRules={rules} />
+      <TagRulesClient initialRules={rules} />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
+++ b/apps/web/app/(dashboard)/settings/alerts/alerts-client.tsx
@@ -75,12 +75,10 @@ function ruleSummary(rule: AlertRule): string {
 // ─── Add Default Dialog ───────────────────────────────────────────────────────
 
 function AddDefaultDialog({
-  orgId,
   open,
   onOpenChange,
   onSuccess,
 }: {
-  orgId: string
   open: boolean
   onOpenChange: (v: boolean) => void
   onSuccess: () => void
@@ -102,7 +100,7 @@ function AddDefaultDialog({
   })
 
   async function onSubmit(values: RuleFormValues) {
-    const result = await createGlobalAlertDefault(orgId, {
+    const result = await createGlobalAlertDefault({
       name: values.name,
       severity: values.severity,
       config: {
@@ -221,23 +219,22 @@ function AddDefaultDialog({
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 interface GlobalAlertsClientProps {
-  orgId: string
   initialDefaults: AlertRule[]
 }
 
-export function GlobalAlertsClient({ orgId, initialDefaults }: GlobalAlertsClientProps) {
+export function GlobalAlertsClient({ initialDefaults }: GlobalAlertsClientProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const queryClient = useQueryClient()
 
   const { data: defaults = initialDefaults } = useQuery({
-    queryKey: ['global-alert-defaults', orgId],
-    queryFn: () => getGlobalAlertDefaults(orgId),
+    queryKey: ['global-alert-defaults'],
+    queryFn: () => getGlobalAlertDefaults(),
     initialData: initialDefaults,
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (ruleId: string) => deleteGlobalAlertDefault(orgId, ruleId),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['global-alert-defaults', orgId] }),
+    mutationFn: (ruleId: string) => deleteGlobalAlertDefault(ruleId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['global-alert-defaults'] }),
   })
 
   return (
@@ -323,10 +320,9 @@ export function GlobalAlertsClient({ orgId, initialDefaults }: GlobalAlertsClien
       </div>
 
       <AddDefaultDialog
-        orgId={orgId}
         open={dialogOpen}
         onOpenChange={setDialogOpen}
-        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['global-alert-defaults', orgId] })}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['global-alert-defaults'] })}
       />
     </div>
   )

--- a/apps/web/app/(dashboard)/settings/monitoring/notifications/page.tsx
+++ b/apps/web/app/(dashboard)/settings/monitoring/notifications/page.tsx
@@ -1,11 +1,9 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
-import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
+import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
 
 export const metadata: Metadata = {
   title: 'Notification Policy Settings',
@@ -16,10 +14,7 @@ export default async function NotificationPolicyPage() {
   const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const org = await db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
-  })
+  const org = await getCurrentOrganisationSettingsRecord()
 
   if (!org) return null
 

--- a/apps/web/app/(dashboard)/settings/monitoring/page.tsx
+++ b/apps/web/app/(dashboard)/settings/monitoring/page.tsx
@@ -14,8 +14,7 @@ export default async function MonitoringSettingsPage() {
   const isAdmin = session.user.role === 'super_admin' || session.user.role === 'org_admin'
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const defaults = await getGlobalAlertDefaults(orgId)
+  const defaults = await getGlobalAlertDefaults()
 
   return (
     <div className="space-y-6">
@@ -26,7 +25,7 @@ export default async function MonitoringSettingsPage() {
           { title: 'Metric retention', href: '/settings/monitoring/retention' },
         ]}
       />
-      <GlobalAlertsClient orgId={orgId} initialDefaults={defaults} />
+      <GlobalAlertsClient initialDefaults={defaults} />
     </div>
   )
 }

--- a/apps/web/app/(dashboard)/settings/monitoring/retention/page.tsx
+++ b/apps/web/app/(dashboard)/settings/monitoring/retention/page.tsx
@@ -1,11 +1,9 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
-import { db } from '@/lib/db'
-import { organisations } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
+import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
 
 export const metadata: Metadata = {
   title: 'Metric Retention Settings',
@@ -16,10 +14,7 @@ export default async function MetricRetentionSettingsPage() {
   const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const org = await db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
-  })
+  const org = await getCurrentOrganisationSettingsRecord()
 
   if (!org) return null
 

--- a/apps/web/app/(dashboard)/settings/tag-rules/tag-rules-client.tsx
+++ b/apps/web/app/(dashboard)/settings/tag-rules/tag-rules-client.tsx
@@ -24,7 +24,6 @@ import {
 import type { TagRule } from '@/lib/db/schema'
 
 interface TagRulesClientProps {
-  orgId: string
   initialRules: TagRule[]
 }
 
@@ -43,20 +42,20 @@ function summariseFilter(filter: TagRule['filter']): string {
   return parts.join(' AND ') || '(empty filter — matches nothing)'
 }
 
-export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
+export function TagRulesClient({ initialRules }: TagRulesClientProps) {
   const qc = useQueryClient()
   const [message, setMessage] = useState<{ kind: 'info' | 'error'; text: string } | null>(null)
 
   const { data: rules = initialRules } = useQuery({
-    queryKey: ['tag-rules', orgId],
-    queryFn: () => listTagRules(orgId),
+    queryKey: ['tag-rules'],
+    queryFn: () => listTagRules(),
     initialData: initialRules,
   })
 
-  const invalidate = () => qc.invalidateQueries({ queryKey: ['tag-rules', orgId] })
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['tag-rules'] })
 
   const runMutation = useMutation({
-    mutationFn: (ruleId: string) => runTagRule(orgId, ruleId),
+    mutationFn: (ruleId: string) => runTagRule(ruleId),
     onSuccess: (result) => {
       if ('error' in result) setMessage({ kind: 'error', text: result.error })
       else setMessage({ kind: 'info', text: `Applied rule to ${result.applied} host(s).` })
@@ -65,7 +64,7 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
 
   const toggleMutation = useMutation({
     mutationFn: ({ ruleId, enabled }: { ruleId: string; enabled: boolean }) =>
-      updateTagRule(orgId, ruleId, { enabled }),
+      updateTagRule(ruleId, { enabled }),
     onSuccess: (result) => {
       if ('error' in result) setMessage({ kind: 'error', text: result.error })
       invalidate()
@@ -73,7 +72,7 @@ export function TagRulesClient({ orgId, initialRules }: TagRulesClientProps) {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (ruleId: string) => deleteTagRule(orgId, ruleId),
+    mutationFn: (ruleId: string) => deleteTagRule(ruleId),
     onSuccess: (result) => {
       if ('error' in result) setMessage({ kind: 'error', text: result.error })
       else setMessage({ kind: 'info', text: 'Rule deleted.' })

--- a/apps/web/app/(dashboard)/team/page.tsx
+++ b/apps/web/app/(dashboard)/team/page.tsx
@@ -9,12 +9,10 @@ export const metadata: Metadata = {
 
 export default async function TeamPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
-  const { members, pendingInvites } = await getOrgUsers(orgId)
+  const { members, pendingInvites } = await getOrgUsers()
 
   return (
     <TeamClient
-      orgId={orgId}
       currentUserId={session.user.id}
       currentUserRole={session.user.role}
       initialMembers={members}

--- a/apps/web/app/(dashboard)/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/team/team-client.tsx
@@ -49,7 +49,6 @@ const inviteSchema = z.object({
 type InviteValues = z.infer<typeof inviteSchema>
 
 interface TeamClientProps {
-  orgId: string
   currentUserId: string
   currentUserRole: string
   initialMembers: User[]
@@ -64,7 +63,6 @@ function getDisplayedRoles(entity: Pick<User | Invitation, 'role' | 'roles'>): s
 }
 
 export function TeamClient({
-  orgId,
   currentUserId,
   currentUserRole,
   initialMembers,
@@ -76,15 +74,15 @@ export function TeamClient({
   const [copiedLink, setCopiedLink] = useState(false)
 
   const { data } = useQuery({
-    queryKey: ['org-users', orgId],
-    queryFn: () => getOrgUsers(orgId),
+    queryKey: ['org-users'],
+    queryFn: () => getOrgUsers(),
     initialData: { members: initialMembers, pendingInvites: initialPendingInvites },
   })
 
   const members = data?.members ?? []
   const pendingInvites = data?.pendingInvites ?? []
 
-  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['org-users', orgId] })
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['org-users'] })
 
   const {
     handleSubmit,
@@ -103,7 +101,7 @@ export function TeamClient({
   const [inviteError, setInviteError] = useState<string | null>(null)
 
   const inviteMutation = useMutation({
-    mutationFn: (values: InviteValues) => inviteUser(orgId, values),
+    mutationFn: (values: InviteValues) => inviteUser(values),
     onSuccess: (result) => {
       if ('error' in result) {
         setInviteError(result.error)
@@ -122,7 +120,7 @@ export function TeamClient({
 
   const updateRoleMutation = useMutation({
     mutationFn: ({ userId, roles }: { userId: string; roles: string[] }) =>
-      updateUserRole(orgId, userId, roles),
+      updateUserRole(userId, roles),
     onSuccess: (result) => {
       if ('success' in result) {
         invalidate()
@@ -131,22 +129,22 @@ export function TeamClient({
   })
 
   const deactivateMutation = useMutation({
-    mutationFn: (targetId: string) => deactivateUser(orgId, targetId),
+    mutationFn: (targetId: string) => deactivateUser(targetId),
     onSuccess: invalidate,
   })
 
   const reactivateMutation = useMutation({
-    mutationFn: (targetId: string) => reactivateUser(orgId, targetId),
+    mutationFn: (targetId: string) => reactivateUser(targetId),
     onSuccess: invalidate,
   })
 
   const removeMutation = useMutation({
-    mutationFn: (targetId: string) => removeUser(orgId, targetId),
+    mutationFn: (targetId: string) => removeUser(targetId),
     onSuccess: invalidate,
   })
 
   const cancelInviteMutation = useMutation({
-    mutationFn: (inviteId: string) => cancelInvite(orgId, inviteId),
+    mutationFn: (inviteId: string) => cancelInvite(inviteId),
     onSuccess: invalidate,
   })
 

--- a/apps/web/components/shared/notification-bell.tsx
+++ b/apps/web/components/shared/notification-bell.tsx
@@ -15,10 +15,6 @@ import {
 import { getNotifications, getUnreadCount, markAsRead, markAllAsRead } from '@/lib/actions/notifications'
 import type { Notification } from '@/lib/db/schema'
 
-interface NotificationBellProps {
-  orgId: string
-}
-
 function getResourceUrl(resourceType: string, resourceId: string): string {
   switch (resourceType) {
     case 'host': return `/hosts/${resourceId}`
@@ -36,36 +32,36 @@ function severityDot(severity: string) {
   return <span className={`inline-block size-2 rounded-full shrink-0 mt-1.5 ${cls}`} />
 }
 
-export function NotificationBell({ orgId }: NotificationBellProps) {
+export function NotificationBell() {
   const qc = useQueryClient()
 
   const { data: unreadCount = 0 } = useQuery({
-    queryKey: ['notifications-unread', orgId],
-    queryFn: () => getUnreadCount(orgId),
+    queryKey: ['notifications-unread'],
+    queryFn: () => getUnreadCount(),
     refetchInterval: 20_000,
     staleTime: 10_000,
   })
 
   const { data: notifications = [] } = useQuery({
-    queryKey: ['notifications-recent', orgId],
-    queryFn: () => getNotifications(orgId, 10),
+    queryKey: ['notifications-recent'],
+    queryFn: () => getNotifications(10),
     refetchInterval: 20_000,
     staleTime: 10_000,
   })
 
   const markReadMutation = useMutation({
-    mutationFn: (id: string) => markAsRead(orgId, id),
+    mutationFn: (id: string) => markAsRead(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread'] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent'] })
     },
   })
 
   const markAllMutation = useMutation({
-    mutationFn: () => markAllAsRead(orgId),
+    mutationFn: () => markAllAsRead(),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['notifications-unread', orgId] })
-      qc.invalidateQueries({ queryKey: ['notifications-recent', orgId] })
+      qc.invalidateQueries({ queryKey: ['notifications-unread'] })
+      qc.invalidateQueries({ queryKey: ['notifications-recent'] })
     },
   })
 

--- a/apps/web/components/shared/topbar.tsx
+++ b/apps/web/components/shared/topbar.tsx
@@ -26,11 +26,7 @@ function getInitials(name: string): string {
     .slice(0, 2)
 }
 
-interface TopbarProps {
-  orgId: string
-}
-
-export function Topbar({ orgId }: TopbarProps) {
+export function Topbar() {
   const { data: session } = useSession()
   const router = useRouter()
 
@@ -45,8 +41,8 @@ export function Topbar({ orgId }: TopbarProps) {
       <SidebarTrigger />
       <div className="flex-1" />
       <CommandPaletteTrigger />
-      {session?.user?.id && orgId && (
-        <NotificationBell orgId={orgId} />
+      {session?.user?.id && (
+        <NotificationBell />
       )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -81,7 +81,6 @@ export async function listDistinctHostOses(...args: [] | [string]): Promise<stri
 }
 
 export async function createEnrolmentToken(
-  scopeId: string,
   input: {
     label: string
     autoApprove: boolean
@@ -91,18 +90,20 @@ export async function createEnrolmentToken(
     tags?: Array<{ key: string; value: string }>
   },
 ): Promise<{ token: string; id: string } | { error: string }> {
-  return createEnrolmentTokenCore(scopeId, input)
+  const session = await getRequiredSession()
+  return createEnrolmentTokenCore(resolveCurrentActionScope(session), input)
 }
 
-export async function listEnrolmentTokens(scopeId: string): Promise<EnrolmentTokenSafe[]> {
-  return listEnrolmentTokensCore(scopeId)
+export async function listEnrolmentTokens(): Promise<EnrolmentTokenSafe[]> {
+  const session = await getRequiredSession()
+  return listEnrolmentTokensCore(resolveCurrentActionScope(session))
 }
 
 export async function revokeEnrolmentToken(
-  scopeId: string,
   tokenId: string,
 ): Promise<{ success: true } | { error: string }> {
-  return revokeEnrolmentTokenCore(scopeId, tokenId)
+  const session = await getRequiredSession()
+  return revokeEnrolmentTokenCore(resolveCurrentActionScope(session), tokenId)
 }
 
 export async function getHostMetrics(

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -36,6 +36,12 @@ import type {
 import { organisations } from '@/lib/db/schema'
 import type { SmtpEncryption } from '@/lib/notifications/smtp-settings'
 import { getRequiredSession } from '@/lib/auth/session'
+import { resolveCurrentActionScope } from './action-scope'
+
+async function resolveCurrentAlertScope(): Promise<string> {
+  const session = await getRequiredSession()
+  return resolveCurrentActionScope(session)
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -119,7 +125,8 @@ const createNotificationChannelSchema = z.discriminatedUnion('type', [
 
 // ─── Alert Rules ──────────────────────────────────────────────────────────────
 
-export async function getAlertRules(orgId: string, hostId?: string): Promise<AlertRule[]> {
+export async function getAlertRules(hostId?: string): Promise<AlertRule[]> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   return db.query.alertRules.findMany({
     where: and(
@@ -132,7 +139,8 @@ export async function getAlertRules(orgId: string, hostId?: string): Promise<Ale
   })
 }
 
-export async function getGlobalAlertDefaults(orgId: string): Promise<AlertRule[]> {
+export async function getGlobalAlertDefaults(): Promise<AlertRule[]> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   return db.query.alertRules.findMany({
     where: and(
@@ -151,9 +159,9 @@ const createGlobalAlertDefaultSchema = z.object({
 })
 
 export async function createGlobalAlertDefault(
-  orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAdminAccess(orgId)
   const parsed = createGlobalAlertDefaultSchema.safeParse(input)
   if (!parsed.success) {
@@ -183,9 +191,9 @@ export async function createGlobalAlertDefault(
 }
 
 export async function deleteGlobalAlertDefault(
-  orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgAdminAccess(orgId)
   const existing = await db.query.alertRules.findFirst({
     where: and(
@@ -225,7 +233,14 @@ export async function applyGlobalDefaultsToHost(
   hostId: string,
 ): Promise<void> {
   await requireOrgAdminAccess(orgId)
-  const defaults = await getGlobalAlertDefaults(orgId)
+  const defaults = await db.query.alertRules.findMany({
+    where: and(
+      eq(alertRules.organisationId, orgId),
+      isNull(alertRules.deletedAt),
+      eq(alertRules.isGlobalDefault, true),
+    ),
+    orderBy: alertRules.createdAt,
+  })
   if (defaults.length === 0) return
 
   await db.insert(alertRules).values(
@@ -243,9 +258,9 @@ export async function applyGlobalDefaultsToHost(
 }
 
 export async function createAlertRule(
-  orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgWriteAccess(orgId)
   const parsed = createAlertRuleSchema.safeParse(input)
   if (!parsed.success) {
@@ -274,10 +289,10 @@ export async function createAlertRule(
 }
 
 export async function updateAlertRule(
-  orgId: string,
   ruleId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgWriteAccess(orgId)
   const parsed = updateAlertRuleSchema.safeParse(input)
   if (!parsed.success) {
@@ -309,9 +324,9 @@ export async function updateAlertRule(
 }
 
 export async function deleteAlertRule(
-  orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgWriteAccess(orgId)
   const existing = await db.query.alertRules.findFirst({
     where: and(
@@ -358,9 +373,9 @@ export type AlertHistoryFilters = {
 }
 
 export async function getAlertInstances(
-  orgId: string,
   filters: AlertHistoryFilters = {},
 ): Promise<AlertInstanceWithRule[]> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   const limit = filters.limit ?? 50
   const offset = filters.offset ?? 0
@@ -408,9 +423,9 @@ export async function getAlertInstances(
 }
 
 export async function getAlertInstanceCount(
-  orgId: string,
   filters: Omit<AlertHistoryFilters, 'limit' | 'offset'> = {},
 ): Promise<number> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   const rows = await db
     .select({ total: count() })
@@ -431,9 +446,9 @@ export async function getAlertInstanceCount(
 }
 
 export async function acknowledgeAlert(
-  orgId: string,
   instanceId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgWriteAccess(orgId)
   const existing = await db.query.alertInstances.findFirst({
     where: and(
@@ -458,24 +473,8 @@ export async function acknowledgeAlert(
 
 export async function getActiveAlertCountsForHosts(
   hostIds: string[],
-): Promise<Record<string, number>>
-export async function getActiveAlertCountsForHosts(
-  orgId: string,
-  hostIds: string[],
-): Promise<Record<string, number>>
-export async function getActiveAlertCountsForHosts(
-  orgIdOrHostIds: string | string[],
-  maybeHostIds?: string[],
 ): Promise<Record<string, number>> {
-  const currentScope = maybeHostIds
-    ? orgIdOrHostIds as string
-    : await (async () => {
-      const session = await getRequiredSession()
-      const orgId = session.user.organisationId
-      if (!orgId) throw new Error('Instance scope is not configured')
-      return orgId
-    })()
-  const hostIds = maybeHostIds ?? orgIdOrHostIds as string[]
+  const currentScope = await resolveCurrentAlertScope()
   await requireOrgAccess(currentScope)
   if (hostIds.length === 0) return {}
 
@@ -522,7 +521,8 @@ function normaliseSmtpConfig(raw: unknown): SmtpChannelConfig {
   return { ...rest, encryption } as unknown as SmtpChannelConfig
 }
 
-export async function getNotificationChannels(orgId: string): Promise<NotificationChannelSafe[]> {
+export async function getNotificationChannels(): Promise<NotificationChannelSafe[]> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   const rows = await db.query.notificationChannels.findMany({
     where: and(
@@ -572,9 +572,9 @@ export async function getNotificationChannels(orgId: string): Promise<Notificati
 }
 
 export async function createNotificationChannel(
-  orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgAdminAccess(orgId)
   const parsed = createNotificationChannelSchema.safeParse(input)
   if (!parsed.success) {
@@ -615,9 +615,9 @@ export async function createNotificationChannel(
 }
 
 export async function deleteNotificationChannel(
-  orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgAdminAccess(orgId)
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
@@ -677,10 +677,10 @@ const updateTelegramChannelSchema = z.object({
 })
 
 export async function updateNotificationChannel(
-  orgId: string,
   channelId: string,
   input: unknown,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgAdminAccess(orgId)
   const existing = await db.query.notificationChannels.findFirst({
     where: and(
@@ -772,9 +772,9 @@ export async function updateNotificationChannel(
 }
 
 export async function sendTestNotification(
-  orgId: string,
   channelId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAdminAccess(orgId)
   if (!await testNotificationLimiter.check(orgId)) {
     return { error: 'Too many requests — please wait before sending another test notification.' }
@@ -929,7 +929,8 @@ const createSilenceSchema = z.object({
   path: ['endsAt'],
 })
 
-export async function getSilences(orgId: string): Promise<AlertSilenceWithHost[]> {
+export async function getSilences(): Promise<AlertSilenceWithHost[]> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   const rows = await db
     .select({
@@ -961,9 +962,9 @@ export async function getSilences(orgId: string): Promise<AlertSilenceWithHost[]
 }
 
 export async function getActiveSilencesForHost(
-  orgId: string,
   hostId: string,
 ): Promise<AlertSilence[]> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgAccess(orgId)
   const now = new Date()
   return db.query.alertSilences.findMany({
@@ -980,9 +981,9 @@ export async function getActiveSilencesForHost(
 }
 
 export async function createSilence(
-  orgId: string,
   input: unknown,
 ): Promise<{ success: true; id: string } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   const session = await requireOrgWriteAccess(orgId)
   const parsed = createSilenceSchema.safeParse(input)
   if (!parsed.success) {
@@ -1027,9 +1028,9 @@ export async function createSilence(
 }
 
 export async function deleteSilence(
-  orgId: string,
   silenceId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const orgId = await resolveCurrentAlertScope()
   await requireOrgWriteAccess(orgId)
   const existing = await db.query.alertSilences.findFirst({
     where: and(

--- a/apps/web/lib/actions/notifications-authz.test.mjs
+++ b/apps/web/lib/actions/notifications-authz.test.mjs
@@ -37,8 +37,8 @@ test('notification actions derive the user scope from the authenticated session'
     )
     assert.match(
       segment,
-      /const session = await requireOrgAccess\(orgId\)/,
-      `${action} must load the authenticated session before querying notifications`,
+      /const authSession = await getRequiredSession\(\)[\s\S]*resolveCurrentActionScope\(authSession\)/,
+      `${action} must derive the authenticated session and instance scope before querying notifications`,
     )
     assert.match(
       segment,

--- a/apps/web/lib/actions/notifications.ts
+++ b/apps/web/lib/actions/notifications.ts
@@ -1,6 +1,8 @@
 'use server'
 
 import { requireOrgAccess } from '@/lib/actions/action-auth'
+import { getRequiredSession } from '@/lib/auth/session'
+import { resolveCurrentActionScope } from './action-scope'
 
 import { db } from '@/lib/db'
 import { notifications } from '@/lib/db/schema'
@@ -8,10 +10,11 @@ import { eq, and, desc, count, inArray, gte, sql, isNull } from 'drizzle-orm'
 import type { Notification } from '@/lib/db/schema'
 
 export async function getNotifications(
-  orgId: string,
   limit = 20,
   offset = 0,
 ): Promise<Notification[]> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   return db.query.notifications.findMany({
     where: and(
@@ -25,7 +28,9 @@ export async function getNotifications(
   })
 }
 
-export async function getUnreadCount(orgId: string): Promise<number> {
+export async function getUnreadCount(): Promise<number> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   const [result] = await db
     .select({ value: count() })
@@ -42,9 +47,10 @@ export async function getUnreadCount(orgId: string): Promise<number> {
 }
 
 export async function markAsRead(
-  orgId: string,
   notificationId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   try {
     await db
@@ -64,9 +70,9 @@ export async function markAsRead(
   }
 }
 
-export async function markAllAsRead(
-  orgId: string,
-): Promise<{ success: true } | { error: string }> {
+export async function markAllAsRead(): Promise<{ success: true } | { error: string }> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   try {
     await db
@@ -87,9 +93,10 @@ export async function markAllAsRead(
 }
 
 export async function deleteNotification(
-  orgId: string,
   notificationId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   try {
     await db
@@ -110,9 +117,10 @@ export async function deleteNotification(
 }
 
 export async function deleteNotifications(
-  orgId: string,
   ids: string[],
 ): Promise<{ success: true } | { error: string }> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   if (ids.length === 0) return { success: true }
   try {
@@ -134,10 +142,11 @@ export async function deleteNotifications(
 }
 
 export async function markBatchReadStatus(
-  orgId: string,
   ids: string[],
   read: boolean,
 ): Promise<{ success: true } | { error: string }> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   if (ids.length === 0) return { success: true }
   try {
@@ -164,9 +173,10 @@ export type NotificationSeverityStat = {
 }
 
 export async function getNotificationStats(
-  orgId: string,
   hostId?: string,
 ): Promise<NotificationSeverityStat[]> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   const results = await db
     .select({
@@ -207,10 +217,11 @@ export type NotificationTimeSeriesPoint = {
 }
 
 export async function getNotificationsOverTime(
-  orgId: string,
   range: TrendRange = '30d',
   hostId?: string,
 ): Promise<NotificationTimeSeriesPoint[]> {
+  const authSession = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(authSession)
   const session = await requireOrgAccess(orgId)
   // Intentionally does NOT filter on deletedAt so that deleting notifications
   // from the inbox does not affect the historical trend.

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -13,10 +13,20 @@ import { encodeActivationToken } from '@/lib/licence-activation-token'
 import { writeAuditEvent } from '@/lib/audit/events'
 import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
 import { getTrustedEffectiveLicence } from '@/lib/actions/licence-guard'
+import { getRequiredSession } from '@/lib/auth/session'
+import { resolveCurrentActionScope } from './action-scope'
 
 const updateOrgNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
 })
+
+export async function getCurrentOrganisationSettingsRecord() {
+  const session = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(session)
+  return db.query.organisations.findFirst({
+    where: eq(organisations.id, orgId),
+  })
+}
 
 export async function updateOrgName(
   orgId: string,

--- a/apps/web/lib/actions/tag-rules.ts
+++ b/apps/web/lib/actions/tag-rules.ts
@@ -2,6 +2,7 @@
 
 import { logError } from '@/lib/logging'
 import { requireOrgAccess, requireOrgAdminAccess, requireOrgWriteAccess } from '@/lib/actions/action-auth'
+import { getRequiredSession } from '@/lib/auth/session'
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
@@ -10,6 +11,7 @@ import type { HostFilter, TagRule, TagPair } from '@/lib/db/schema'
 import { and, eq, isNull } from 'drizzle-orm'
 import { buildHostFilterWhere, isEmptyFilter, type HostFilterResult } from '@/lib/hosts/filter'
 import { assignTagsToResource } from '@/lib/actions/tags'
+import { resolveCurrentActionScope } from './action-scope'
 
 const tagPairSchema = z.object({
   key: z.string().min(1).max(100),
@@ -94,7 +96,9 @@ export async function bulkAssignTags(
   }
 }
 
-export async function listTagRules(orgId: string): Promise<TagRule[]> {
+export async function listTagRules(): Promise<TagRule[]> {
+  const session = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(session)
   await requireOrgAccess(orgId)
   return db.query.tagRules.findMany({
     where: and(eq(tagRules.organisationId, orgId), isNull(tagRules.deletedAt)),
@@ -103,9 +107,10 @@ export async function listTagRules(orgId: string): Promise<TagRule[]> {
 }
 
 export async function createTagRule(
-  orgId: string,
   input: { name: string; filter: HostFilter; tags: TagPair[]; enabled?: boolean },
 ): Promise<{ success: true; id: string } | { error: string }> {
+  const session = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(session)
   await requireOrgAdminAccess(orgId)
   try {
     const parsed = createRuleSchema.safeParse(input)
@@ -130,10 +135,11 @@ export async function createTagRule(
 }
 
 export async function updateTagRule(
-  orgId: string,
   ruleId: string,
   input: Partial<{ name: string; filter: HostFilter; tags: TagPair[]; enabled: boolean }>,
 ): Promise<{ success: true } | { error: string }> {
+  const session = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(session)
   await requireOrgAdminAccess(orgId)
   try {
     const existing = await db.query.tagRules.findFirst({
@@ -172,9 +178,10 @@ export async function updateTagRule(
 }
 
 export async function deleteTagRule(
-  orgId: string,
   ruleId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const session = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(session)
   await requireOrgAdminAccess(orgId)
   try {
     await db
@@ -192,9 +199,10 @@ export async function deleteTagRule(
 // "Run now" button in the admin UI and (below) to auto-apply rules on host
 // approval.
 export async function runTagRule(
-  orgId: string,
   ruleId: string,
 ): Promise<{ success: true; applied: number } | { error: string }> {
+  const session = await getRequiredSession()
+  const orgId = resolveCurrentActionScope(session)
   await requireOrgWriteAccess(orgId)
   try {
     const rule = await db.query.tagRules.findFirst({

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -32,11 +32,9 @@ function hasSuperAdminRole(role: string | null | undefined, roles: readonly stri
   return normalizeAssignedRoles(roles, role).includes('super_admin')
 }
 
-export async function getOrgUsers(
-  scopeId?: string,
-): Promise<{ members: User[]; pendingInvites: Invitation[] }> {
+export async function getOrgUsers(): Promise<{ members: User[]; pendingInvites: Invitation[] }> {
   const session = await getRequiredSession()
-  const currentScope = scopeId ?? resolveCurrentActionScope(session)
+  const currentScope = resolveCurrentActionScope(session)
   await requireOrgAccess(currentScope)
 
   const [members, pendingInvites] = await Promise.all([
@@ -56,9 +54,10 @@ export async function getOrgUsers(
 }
 
 export async function inviteUser(
-  orgId: string,
   input: { email: string; roles: string[] },
 ): Promise<{ inviteLink: string } | { restored: true } | { error: string }> {
+  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const orgId = currentScope
   await requireOrgAccess(orgId)
   const parsed = inviteSchema.safeParse(input)
   if (!parsed.success) {
@@ -184,10 +183,11 @@ export async function inviteUser(
 }
 
 export async function updateUserRole(
-  orgId: string,
   targetUserId: string,
   roles: string[],
 ): Promise<{ success: true } | { error: string }> {
+  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const orgId = currentScope
   await requireOrgAccess(orgId)
   const parsed = updateRoleSchema.safeParse({ roles })
   if (!parsed.success) {
@@ -251,9 +251,10 @@ export async function updateUserRole(
 }
 
 export async function deactivateUser(
-  orgId: string,
   targetUserId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const orgId = currentScope
   await requireOrgAccess(orgId)
   try {
     const session = await requireOrgAdminAccess(orgId)
@@ -316,9 +317,10 @@ export async function deactivateUser(
 }
 
 export async function reactivateUser(
-  orgId: string,
   targetUserId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const orgId = currentScope
   await requireOrgAccess(orgId)
   try {
     const session = await requireOrgAdminAccess(orgId)
@@ -370,9 +372,10 @@ export async function reactivateUser(
 }
 
 export async function removeUser(
-  orgId: string,
   targetUserId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const orgId = currentScope
   await requireOrgAccess(orgId)
   try {
     const session = await requireOrgAdminAccess(orgId)
@@ -433,9 +436,10 @@ export async function removeUser(
 }
 
 export async function cancelInvite(
-  orgId: string,
   inviteId: string,
 ): Promise<{ success: true } | { error: string }> {
+  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const orgId = currentScope
   await requireOrgAccess(orgId)
   try {
     const session = await requireOrgAdminAccess(orgId)

--- a/apps/web/lib/notifications/notification-inbox.test.mjs
+++ b/apps/web/lib/notifications/notification-inbox.test.mjs
@@ -9,7 +9,7 @@ const source = readFileSync(path.join(here, '..', '..', 'app', '(dashboard)', 'n
 test('notification inbox waits for bulk delete refetches before clearing selection', () => {
   assert.match(
     source,
-    /const bulkDeleteMutation = useMutation\(\{[\s\S]*onSuccess: async \(\) => \{[\s\S]*await Promise\.all\(\[[\s\S]*queryKey: \['notifications', orgId\][\s\S]*queryKey: \['notifications-unread', orgId\][\s\S]*queryKey: \['notifications-stats', orgId\][\s\S]*queryKey: \['notifications-time-series', orgId\][\s\S]*\]\)[\s\S]*setSelectedIds\(new Set\(\)\)/,
+    /const bulkDeleteMutation = useMutation\(\{[\s\S]*onSuccess: async \(\) => \{[\s\S]*await Promise\.all\(\[[\s\S]*queryKey: \['notifications'\][\s\S]*queryKey: \['notifications-unread'\][\s\S]*queryKey: \['notifications-stats'\][\s\S]*queryKey: \['notifications-time-series'\][\s\S]*\]\)[\s\S]*setSelectedIds\(new Set\(\)\)/,
     'bulk delete must wait for notification list/count/chart refetches before clearing selected state',
   )
 })


### PR DESCRIPTION
## Summary
- remove caller-supplied org ids from Task 11 alerts, notifications, team, and agent enrolment surfaces
- switch the shared topbar notification UI and owned settings pages to session-derived instance scope
- update source-inspection tests and tracker notes for the remaining org-scoped internals that Task 13 must delete

## Validation
- pnpm install --frozen-lockfile
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint
- pnpm --dir apps/web test:unit
- pnpm --dir apps/web exec playwright test --list
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=test-secret pnpm --dir apps/web exec playwright test tests/e2e/notifications/bell.spec.ts --project=chromium --grep "authenticated user can review topbar notifications and open the linked resource" (fails before execution because instrumentation cannot import ./lib/agent/cache-prewarm in this checkout)
