### PR TITLE
fix(web): allow dashboard without org scope

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -4,7 +4,7 @@ import { AppSidebar } from '@/components/shared/sidebar'
 import { Topbar } from '@/components/shared/topbar'
 import { CommandPaletteProvider } from '@/components/shared/command-palette'
 import { getRequiredSession } from '@/lib/auth/session'
-import { getEffectiveLicence } from '@/lib/actions/licence-guard'
+import { getInstanceEffectiveLicence } from '@/lib/actions/licence-guard'
 import { TerminalProviderWrapper, TerminalContentWrapper } from '@/components/terminal/terminal-layout-wrapper'
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -18,11 +18,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
     redirect('/pending-approval')
   }
 
-  const orgId = session.user.organisationId
-  if (!orgId) {
-    throw new Error('Instance scope is not configured')
-  }
-  const licence = await getEffectiveLicence(orgId)
+  const licence = await getInstanceEffectiveLicence(session.user.organisationId)
 
   return (
     <CommandPaletteProvider userRole={session.user.role}>

--- a/apps/web/app/api/overview/route.ts
+++ b/apps/web/app/api/overview/route.ts
@@ -1,14 +1,20 @@
 import { db } from '@/lib/db'
 import { agents, certificates, alertInstances } from '@/lib/db/schema'
 import { eq, and, isNull, count } from 'drizzle-orm'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
+
+const emptyOverview = {
+  agents: { online: 0, offline: 0, total: 0 },
+  certificates: { valid: 0, expiringSoon: 0, expired: 0 },
+  alerts: { firing: 0, acknowledged: 0 },
+}
 
 export async function GET() {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
@@ -17,6 +23,9 @@ export async function GET() {
   }
 
   const orgId = session.user.organisationId
+  if (!orgId) {
+    return Response.json(emptyOverview)
+  }
 
   const [agentRows, certRows, alertRows] = await Promise.all([
     db

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const dashboardLayoutSource = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/layout.tsx'),
+  'utf8',
+)
+const overviewRouteSource = readFileSync(
+  path.join(repoRoot, 'app/api/overview/route.ts'),
+  'utf8',
+)
+const licenceGuardSource = readFileSync(
+  path.join(repoRoot, 'lib/actions/licence-guard.ts'),
+  'utf8',
+)
+
+test('dashboard shell falls back to community licence without org-backed scope', () => {
+  assert.match(
+    dashboardLayoutSource,
+    /getInstanceEffectiveLicence\(session\.user\.organisationId\)/,
+  )
+  assert.doesNotMatch(dashboardLayoutSource, /throw new Error\('Instance scope is not configured'\)/)
+  assert.match(licenceGuardSource, /if \(!scopeId\) return getCommunityLicence\(\)/)
+})
+
+test('overview API returns empty counts for a fresh standalone instance', () => {
+  assert.match(overviewRouteSource, /getApiSession\(\)/)
+  assert.doesNotMatch(overviewRouteSource, /getApiOrgSession\(\)/)
+  assert.match(overviewRouteSource, /if \(!orgId\) \{\s*return Response\.json\(emptyOverview\)\s*\}/)
+})

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -41,11 +41,11 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
   })
 
   if (!org) {
-    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
+    return getCommunityLicence()
   }
 
   if (!org.licenceKey) {
-    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
+    return getCommunityLicence()
   }
 
   const result = await validateLicenceKey(org.licenceKey, {
@@ -55,12 +55,12 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
     // Invalid or expired keys silently degrade to community. The licenceTier
     // column still reflects what was last saved; the guard trusts only the
     // validated JWT, not the cached column.
-    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
+    return getCommunityLicence()
   }
 
   if (result.payload.sub !== orgId) {
     // Key belongs to a different organisation — reject it entirely.
-    return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
+    return getCommunityLicence()
   }
 
   return {
@@ -72,6 +72,17 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
     expiresAt: new Date(result.payload.exp * 1000),
   }
 })
+
+function getCommunityLicence(): EffectiveLicence {
+  return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
+}
+
+export async function getInstanceEffectiveLicence(
+  scopeId: string | null | undefined,
+): Promise<EffectiveLicence> {
+  if (!scopeId) return getCommunityLicence()
+  return getEffectiveLicence(scopeId)
+}
 
 export async function getEffectiveLicence(orgId: string): Promise<EffectiveLicence> {
   await requireOrgAccess(orgId)


### PR DESCRIPTION
## Summary
- stop the dashboard layout from throwing when a fresh standalone install has no org-backed scope
- fall back to Community licence capabilities without requiring an organisation row
- return empty overview counts from /api/overview when the authenticated user has no org-backed scope yet

## Validation
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing warnings)
- node --experimental-strip-types --test lib/actions/dashboard-standalone.test.mjs
- pnpm --dir apps/web test:unit (fails only known Testcontainers-backed tests: lib/db/rls.test.mjs and lib/integrations/ct-cve/db-nonce-store.test.mjs, no working container runtime)
- pnpm --dir apps/web exec playwright test --list
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=dummy-secret-for-ci-build-only-at-least-32 NEXT_PUBLIC_APP_URL=http://localhost:3000 DATABASE_URL=postgres://postgres:postgres@localhost:5432/dummy pnpm --filter web run build