### PR TITLE
fix(web): allow standalone sidebar routes

### DIFF
--- a/apps/web/app/(dashboard)/build-docs/page.tsx
+++ b/apps/web/app/(dashboard)/build-docs/page.tsx
@@ -17,17 +17,19 @@ export const metadata: Metadata = {
 export default async function BuildDocsPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const orgId = session.user.organisationId!
-  const [docs, templates, snippets, storageSettings] = await Promise.all([
-    listBuildDocs(orgId),
-    listBuildDocTemplates(orgId),
-    listBuildDocSnippets(orgId),
-    ['org_admin', 'super_admin'].includes(session.user.role) ? getBuildDocAssetStorageSettings(orgId) : Promise.resolve(null),
-  ])
+  const orgId = session.user.organisationId
+  const [docs, templates, snippets, storageSettings] = orgId
+    ? await Promise.all([
+      listBuildDocs(orgId),
+      listBuildDocTemplates(orgId),
+      listBuildDocSnippets(orgId),
+      ['org_admin', 'super_admin'].includes(session.user.role) ? getBuildDocAssetStorageSettings(orgId) : Promise.resolve(null),
+    ])
+    : [[], [], [], null]
 
   return (
     <BuildDocsClient
-      orgId={orgId}
+      orgId={orgId ?? ''}
       userRole={session.user.role}
       initialDocs={docs}
       initialTemplates={templates}

--- a/apps/web/app/(dashboard)/bundlers/page.tsx
+++ b/apps/web/app/(dashboard)/bundlers/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 export default async function BundlersPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId ?? ''
 
   return (
     <div className="space-y-6">

--- a/apps/web/app/(dashboard)/calendar/page.tsx
+++ b/apps/web/app/(dashboard)/calendar/page.tsx
@@ -11,8 +11,24 @@ export const metadata: Metadata = {
 
 export default async function OperationsCalendarPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
   const canEdit = hasRole(session.user, MEMBERSHIP_ROLES)
+
+  if (!orgId) {
+    return (
+      <OperationsCalendarClient
+        orgId=""
+        canEdit={canEdit}
+        initialHosts={[]}
+        initialUsers={[{
+          id: session.user.id,
+          name: session.user.name,
+          email: session.user.email,
+          role: session.user.role,
+        }]}
+      />
+    )
+  }
 
   const [hostResult, userResult] = await Promise.all([
     searchCalendarHosts(orgId, { limit: 100 }),

--- a/apps/web/app/(dashboard)/certificate-checker/page.tsx
+++ b/apps/web/app/(dashboard)/certificate-checker/page.tsx
@@ -11,6 +11,6 @@ export const metadata: Metadata = {
 export default async function CertificateCheckerPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId ?? ''
   return <CertificateCheckerClient orgId={orgId} />
 }

--- a/apps/web/app/(dashboard)/certificates/page.tsx
+++ b/apps/web/app/(dashboard)/certificates/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getCertificates, getCertificateCounts } from '@/lib/actions/certificates'
+import { EMPTY_CERTIFICATE_COUNTS } from '@/lib/standalone-empty-state'
 import { CertificatesClient } from './certificates-client'
 
 export const metadata: Metadata = {
@@ -9,7 +10,17 @@ export const metadata: Metadata = {
 
 export default async function CertificatesPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
+
+  if (!orgId) {
+    return (
+      <CertificatesClient
+        orgId=""
+        initialCertificates={[]}
+        initialCounts={EMPTY_CERTIFICATE_COUNTS}
+      />
+    )
+  }
 
   const [initialCertificates, initialCounts] = await Promise.all([
     getCertificates(orgId, { sortBy: 'not_after', sortDir: 'asc', limit: 100 }),

--- a/apps/web/app/(dashboard)/directory-lookup/page.tsx
+++ b/apps/web/app/(dashboard)/directory-lookup/page.tsx
@@ -16,8 +16,8 @@ export const metadata: Metadata = {
 export default async function DirectoryLookupPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const orgId = session.user.organisationId!
-  const configs = await getLookupConfigOptions(orgId)
+  const orgId = session.user.organisationId
+  const configs = orgId ? await getLookupConfigOptions(orgId) : []
 
   if (configs.length === 0) {
     return (
@@ -44,5 +44,5 @@ export default async function DirectoryLookupPage() {
     )
   }
 
-  return <DirectoryLookupClient orgId={orgId} configs={configs} />
+  return <DirectoryLookupClient orgId={orgId ?? ''} configs={configs} />
 }

--- a/apps/web/app/(dashboard)/password-manager/page.tsx
+++ b/apps/web/app/(dashboard)/password-manager/page.tsx
@@ -15,22 +15,24 @@ export default async function PasswordManagerPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
   const currentUserId = session.user.id
-  const organisationUsers = await db.query.users.findMany({
-    where: and(eq(users.organisationId, orgId), eq(users.isActive, true), isNull(users.deletedAt)),
-    orderBy: [asc(users.name), asc(users.email)],
-    columns: {
-      id: true,
-      name: true,
-      email: true,
-    },
-  })
+  const organisationUsers = orgId
+    ? await db.query.users.findMany({
+      where: and(eq(users.organisationId, orgId), eq(users.isActive, true), isNull(users.deletedAt)),
+      orderBy: [asc(users.name), asc(users.email)],
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    })
+    : [{ id: session.user.id, name: session.user.name, email: session.user.email }]
 
   return (
     <PasswordManagerClientShell
-      key={orgId}
-      orgId={orgId}
+      key={orgId ?? 'standalone'}
+      orgId={orgId ?? ''}
       currentUserId={currentUserId}
       organisationUsers={organisationUsers}
     />

--- a/apps/web/app/(dashboard)/reports/patch-status/page.tsx
+++ b/apps/web/app/(dashboard)/reports/patch-status/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getPatchManagementReport } from '@/lib/actions/patch-status'
+import { createEmptyPatchManagementReport } from '@/lib/standalone-empty-state'
 import { PatchStatusReportClient } from './patch-status-report-client'
 
 export const metadata: Metadata = {
@@ -9,8 +10,8 @@ export const metadata: Metadata = {
 
 export default async function PatchStatusReportPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
 
-  const report = await getPatchManagementReport(orgId)
+  const report = orgId ? await getPatchManagementReport(orgId) : createEmptyPatchManagementReport()
   return <PatchStatusReportClient report={report} />
 }

--- a/apps/web/app/(dashboard)/reports/software/page.tsx
+++ b/apps/web/app/(dashboard)/reports/software/page.tsx
@@ -12,7 +12,15 @@ export const metadata: Metadata = {
 
 export default async function SoftwareReportPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
+
+  if (!orgId) {
+    return (
+      <NuqsAdapter>
+        <SoftwareReportClient orgId="" orgName="CT-Ops" hostGroups={[]} />
+      </NuqsAdapter>
+    )
+  }
 
   const [org, groups] = await Promise.all([
     db.query.organisations.findFirst({

--- a/apps/web/app/(dashboard)/reports/vulnerabilities/page.tsx
+++ b/apps/web/app/(dashboard)/reports/vulnerabilities/page.tsx
@@ -11,7 +11,11 @@ export const metadata: Metadata = {
 
 export default async function VulnerabilityReportPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
+
+  if (!orgId) {
+    return <VulnerabilityReportClient orgId="" hostGroups={[]} />
+  }
 
   const groups = await db.query.hostGroups.findMany({
     where: and(eq(hostGroups.organisationId, orgId), isNull(hostGroups.deletedAt)),

--- a/apps/web/app/(dashboard)/service-accounts/page.tsx
+++ b/apps/web/app/(dashboard)/service-accounts/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getDomainAccounts, getDomainAccountCounts } from '@/lib/actions/domain-accounts'
+import { EMPTY_DOMAIN_ACCOUNT_COUNTS } from '@/lib/standalone-empty-state'
 import { ServiceAccountsClient } from './service-accounts-client'
 
 export const metadata: Metadata = {
@@ -9,7 +10,17 @@ export const metadata: Metadata = {
 
 export default async function ServiceAccountsPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
+
+  if (!orgId) {
+    return (
+      <ServiceAccountsClient
+        orgId=""
+        initialAccounts={[]}
+        initialCounts={EMPTY_DOMAIN_ACCOUNT_COUNTS}
+      />
+    )
+  }
 
   const [initialAccounts, initialCounts] = await Promise.all([
     getDomainAccounts(orgId, { sortBy: 'username', sortDir: 'asc', limit: 100 }),

--- a/apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx
@@ -12,6 +12,7 @@ import {
   getCtCveConnectorSettingsForAdmin,
   getDefaultCtOpsBaseUrl,
 } from '@/lib/integrations/ct-cve/connector-settings'
+import { createEmptyCtCveConnectorSetupOverview } from '@/lib/standalone-empty-state'
 import { CtCveSettingsClient } from './ct-cve-settings-client'
 
 export const metadata: Metadata = {
@@ -31,11 +32,13 @@ export default async function CtCveIntegrationSettingsPage() {
     redirect('/settings')
   }
 
-  const orgId = session.user.organisationId!
-  const [overview, settings] = await Promise.all([
-    buildCtCveConnectorSetupOverview({ orgId }),
-    getCtCveConnectorSettingsForAdmin(orgId),
-  ])
+  const orgId = session.user.organisationId ?? ''
+  const [overview, settings] = orgId
+    ? await Promise.all([
+        buildCtCveConnectorSetupOverview({ orgId }),
+        getCtCveConnectorSettingsForAdmin(orgId),
+      ])
+    : [createEmptyCtCveConnectorSetupOverview(), null] as const
   const ctOpsBaseUrl = getDefaultCtOpsBaseUrl()
   const ctCveConfigJson = settings && ctOpsBaseUrl
     ? buildCtCveCtOpsConnectionJson(settings, ctOpsBaseUrl)

--- a/apps/web/app/(dashboard)/settings/integrations/smtp/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/smtp/page.tsx
@@ -16,12 +16,32 @@ export default async function SmtpRelaySettingsPage() {
   const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
   if (!isAdmin) redirect('/dashboard')
 
-  const orgId = session.user.organisationId!
-  const org = await db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
-  })
+  const orgId = session.user.organisationId
+  const org = orgId
+    ? await db.query.organisations.findFirst({
+        where: eq(organisations.id, orgId),
+      })
+    : null
 
-  if (!org) return null
+  if (!org) {
+    return (
+      <div className="space-y-6">
+        <AdminTabs
+          tabs={[
+            { title: 'LDAP / Directory', href: '/settings/integrations' },
+            { title: 'SMTP relay', href: '/settings/integrations/smtp' },
+            { title: 'CT-CVE', href: '/settings/integrations/ct-cve' },
+          ]}
+        />
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">SMTP Relay</h1>
+          <p className="text-sm text-muted-foreground">
+            SMTP relay settings will be available after instance setup is complete.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-6">

--- a/apps/web/app/(dashboard)/settings/licence/page.tsx
+++ b/apps/web/app/(dashboard)/settings/licence/page.tsx
@@ -7,6 +7,7 @@ import { SettingsClient } from '../settings-client'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { getEffectiveLicence } from '@/lib/actions/licence-guard'
 import { getOrgSeatUsage } from '@/lib/actions/seat-enforcement'
+import { createCommunityLicence } from '@/lib/standalone-empty-state'
 
 export const metadata: Metadata = {
   title: 'Licence Settings',
@@ -14,7 +15,34 @@ export const metadata: Metadata = {
 
 export default async function LicenceSettingsPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
+
+  if (!orgId) {
+    const effectiveLicence = createCommunityLicence()
+    return (
+      <div className="space-y-6">
+        <AdminTabs
+          tabs={[
+            { title: 'Profile', href: '/settings' },
+            { title: 'Licence', href: '/settings/licence' },
+          ]}
+        />
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Licence</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            This standalone instance is running on the Community licence.
+          </p>
+        </div>
+        <div className="rounded-lg border p-6">
+          <p className="text-sm text-muted-foreground">Current tier</p>
+          <p className="text-2xl font-semibold capitalize">{effectiveLicence.tier}</p>
+          <p className="text-sm text-muted-foreground mt-2">
+            {effectiveLicence.maxUsers} included user seats.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   const [org, activeUsers, effectiveLicence, seatUsage] = await Promise.all([
     db.query.organisations.findFirst({

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -12,13 +12,32 @@ export const metadata: Metadata = {
 
 export default async function SettingsPage() {
   const session = await getRequiredSession()
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
 
-  const org = await db.query.organisations.findFirst({
-    where: eq(organisations.id, orgId),
-  })
+  const org = orgId
+    ? await db.query.organisations.findFirst({
+        where: eq(organisations.id, orgId),
+      })
+    : null
 
-  if (!org) return null
+  if (!org) {
+    return (
+      <div className="space-y-6">
+        <AdminTabs
+          tabs={[
+            { title: 'Profile', href: '/settings' },
+            { title: 'Licence', href: '/settings/licence' },
+          ]}
+        />
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Organisation</h1>
+          <p className="text-sm text-muted-foreground">
+            Organisation profile settings will be available after instance setup is complete.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
 

--- a/apps/web/app/(dashboard)/settings/security/terminal/page.tsx
+++ b/apps/web/app/(dashboard)/settings/security/terminal/page.tsx
@@ -18,7 +18,9 @@ export default async function TerminalAccessSettingsPage() {
     redirect('/settings')
   }
 
-  const orgId = session.user.organisationId!
+  const orgId = session.user.organisationId
+  if (!orgId) return null
+
   const org = await db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
   })

--- a/apps/web/app/(dashboard)/tasks/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { canAccessTooling } from '@/lib/auth/tooling'
-import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
 import { listSchedules } from '@/lib/actions/task-schedules'
 import { SchedulesClient } from './schedules-client'
 
@@ -13,8 +12,7 @@ export const metadata: Metadata = {
 export default async function ScheduledTasksPage() {
   const session = await getRequiredSession()
   if (!canAccessTooling(session.user)) redirect('/dashboard')
-  const currentScope = resolveCurrentActionScope(session)
-  const schedules = await listSchedules(currentScope)
+  const schedules = await listSchedules()
 
   return (
     <SchedulesClient

--- a/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
+++ b/apps/web/app/(dashboard)/tasks/schedules/new/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { ADMIN_ROLES } from '@/lib/auth/roles'
-import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
 import { listHosts } from '@/lib/actions/agents'
 import { listGroups } from '@/lib/actions/host-groups'
 import { ScheduleForm } from '../schedule-form'
@@ -14,11 +13,10 @@ export const metadata: Metadata = {
 export default async function NewSchedulePage() {
   const session = await getRequiredSession()
   if (!ADMIN_ROLES.includes(session.user.role)) redirect('/tasks')
-  const currentScope = resolveCurrentActionScope(session)
 
   const [hostRows, groupRows] = await Promise.all([
-    listHosts(currentScope),
-    listGroups(currentScope),
+    listHosts(),
+    listGroups(),
   ])
 
   return (

--- a/apps/web/app/api/certificates/counts/route.ts
+++ b/apps/web/app/api/certificates/counts/route.ts
@@ -1,6 +1,7 @@
 import { getCertificateCounts } from '@/lib/actions/certificates'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
+import { EMPTY_CERTIFICATE_COUNTS } from '@/lib/standalone-empty-state'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,16 +9,18 @@ export const dynamic = 'force-dynamic'
 export async function GET() {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  const orgId = session.user.organisationId
+  if (!orgId) return Response.json(EMPTY_CERTIFICATE_COUNTS)
 
   try {
-    const counts = await getCertificateCounts(session.user.organisationId)
+    const counts = await getCertificateCounts(orgId)
     return Response.json(counts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/certificates/route.ts
+++ b/apps/web/app/api/certificates/route.ts
@@ -3,7 +3,7 @@ import { getCertificates } from '@/lib/actions/certificates'
 import type { CertificateListFilters } from '@/lib/actions/certificates'
 import type { CertificateStatus } from '@/lib/db/schema'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,13 +11,15 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  const orgId = session.user.organisationId
+  if (!orgId) return Response.json([])
 
   const { searchParams } = request.nextUrl
   const filters: CertificateListFilters = {
@@ -30,7 +32,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const certificates = await getCertificates(session.user.organisationId, filters)
+    const certificates = await getCertificates(orgId, filters)
     return Response.json(certificates)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/domain-accounts/counts/route.ts
+++ b/apps/web/app/api/domain-accounts/counts/route.ts
@@ -1,22 +1,25 @@
 import { getDomainAccountCounts } from '@/lib/actions/domain-accounts'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
+import { EMPTY_DOMAIN_ACCOUNT_COUNTS } from '@/lib/standalone-empty-state'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  const orgId = session.user.organisationId
+  if (!orgId) return Response.json(EMPTY_DOMAIN_ACCOUNT_COUNTS)
 
   try {
-    const counts = await getDomainAccountCounts(session.user.organisationId)
+    const counts = await getDomainAccountCounts(orgId)
     return Response.json(counts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/domain-accounts/route.ts
+++ b/apps/web/app/api/domain-accounts/route.ts
@@ -3,20 +3,22 @@ import { getDomainAccounts } from '@/lib/actions/domain-accounts'
 import type { DomainAccountListFilters } from '@/lib/actions/domain-accounts'
 import type { DomainAccountStatus } from '@/lib/db/schema'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(request: NextRequest) {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  const orgId = session.user.organisationId
+  if (!orgId) return Response.json([])
 
   const { searchParams } = request.nextUrl
   const filters: DomainAccountListFilters = {
@@ -29,7 +31,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accounts = await getDomainAccounts(session.user.organisationId, filters)
+    const accounts = await getDomainAccounts(orgId, filters)
     return Response.json(accounts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/service-accounts/counts/route.ts
+++ b/apps/web/app/api/service-accounts/counts/route.ts
@@ -1,6 +1,6 @@
 import { getServiceAccountCounts } from '@/lib/actions/service-accounts'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,16 +8,18 @@ export const dynamic = 'force-dynamic'
 export async function GET() {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  const orgId = session.user.organisationId
+  if (!orgId) return Response.json({ total: 0, human: 0, service: 0, system: 0, disabled: 0, missing: 0 })
 
   try {
-    const counts = await getServiceAccountCounts(session.user.organisationId)
+    const counts = await getServiceAccountCounts(orgId)
     return Response.json(counts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/service-accounts/route.ts
+++ b/apps/web/app/api/service-accounts/route.ts
@@ -3,7 +3,7 @@ import { getServiceAccounts } from '@/lib/actions/service-accounts'
 import type { ServiceAccountListFilters } from '@/lib/actions/service-accounts'
 import type { ServiceAccountStatus, ServiceAccountType } from '@/lib/db/schema'
 import { LicenceRequiredError } from '@/lib/actions/licence-guard'
-import { ApiAuthError, getApiOrgSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,13 +11,15 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   let session
   try {
-    session = await getApiOrgSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  const orgId = session.user.organisationId
+  if (!orgId) return Response.json([])
 
   const { searchParams } = request.nextUrl
   const filters: ServiceAccountListFilters = {
@@ -32,7 +34,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accounts = await getServiceAccounts(session.user.organisationId, filters)
+    const accounts = await getServiceAccounts(orgId, filters)
     return Response.json(accounts)
   } catch (err) {
     if (err instanceof LicenceRequiredError) {

--- a/apps/web/app/api/system/health/route.ts
+++ b/apps/web/app/api/system/health/route.ts
@@ -9,7 +9,8 @@ import {
   type IngestSnapshotSummaryRow,
 } from '@/lib/system/health'
 import pkg from '../../../../package.json'
-import { ApiAuthError, getApiOrgAdminSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
+import { ADMIN_ROLES } from '@/lib/auth/roles'
 
 export const dynamic = 'force-dynamic'
 
@@ -22,15 +23,39 @@ function summariseAgentError(message: string) {
 export async function GET() {
   let session
   try {
-    session = await getApiOrgAdminSession()
+    session = await getApiSession()
   } catch (err) {
     if (err instanceof ApiAuthError) {
       return Response.json({ error: err.message }, { status: err.status })
     }
     throw err
   }
+  if (!ADMIN_ROLES.includes(session.user.role)) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
 
   const orgId = session.user.organisationId
+  if (!orgId) {
+    const ingestSummary = calculateIngestHealthSummary([], [])
+    const agentUpgradeSummary = calculateAgentUpgradeSummary([], REQUIRED_AGENT_VERSION)
+    return Response.json({
+      version: pkg.version,
+      licenceTier: 'community',
+      metricRetentionDays: 30,
+      database: { connected: true },
+      agents: {
+        online: 0,
+        offline: 0,
+        total: 0,
+        upgrades: agentUpgradeSummary,
+        errors: [],
+      },
+      ingest: {
+        ...ingestSummary,
+        servers: [],
+      },
+    })
+  }
 
   const [agentRows, org, agentVersionRows, ingestLatestRows, ingestHistoryRows, agentErrorRows] = await Promise.all([
     db

--- a/apps/web/lib/actions/action-scope.ts
+++ b/apps/web/lib/actions/action-scope.ts
@@ -9,3 +9,9 @@ export function resolveCurrentActionScope(
   }
   return currentScope
 }
+
+export function resolveOptionalActionScope(
+  session: Awaited<ReturnType<typeof getRequiredSession>>,
+): string | null {
+  return session.user.organisationId ?? null
+}

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -26,11 +26,27 @@ import {
   type HostWithAgent,
   type MetricsQuery,
 } from './agents-core'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
+
+const EMPTY_HOST_PAGE: HostListResult = { hosts: [], total: 0 }
+const EMPTY_HOST_INVENTORY_STATS: HostInventoryStats = {
+  total: 0,
+  online: 0,
+  offline: 0,
+  unknown: 0,
+  pending: 0,
+  staleHosts: 0,
+  highCpu: 0,
+  highMemory: 0,
+  highDisk: 0,
+  hostsWithFiringAlerts: 0,
+  osBreakdown: [],
+}
 
 export async function listPendingAgents(...args: [] | [string]): Promise<Agent[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listPendingAgentsCore(currentScope)
 }
 
@@ -54,7 +70,8 @@ export async function rejectAgent(
 
 export async function listHosts(...args: [] | [string]): Promise<HostWithAgent[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listHostsCore(currentScope)
 }
 
@@ -62,7 +79,8 @@ export async function listHostsPaginated(
   ...args: [HostListParams?] | [string, HostListParams?]
 ): Promise<HostListResult> {
   const session = await getRequiredSession()
-  const currentScope = args.length === 2 ? args[0] : resolveCurrentActionScope(session)
+  const currentScope = args.length === 2 ? args[0] : resolveOptionalActionScope(session)
+  if (!currentScope) return EMPTY_HOST_PAGE
   const params: HostListParams | undefined =
     args.length === 2 ? args[1] : args[0] as HostListParams | undefined
   return listHostsPaginatedCore(currentScope, params)
@@ -70,13 +88,15 @@ export async function listHostsPaginated(
 
 export async function getHostInventoryStats(...args: [] | [string]): Promise<HostInventoryStats> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return EMPTY_HOST_INVENTORY_STATS
   return getHostInventoryStatsCore(currentScope)
 }
 
 export async function listDistinctHostOses(...args: [] | [string]): Promise<string[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listDistinctHostOsesCore(currentScope)
 }
 
@@ -96,7 +116,9 @@ export async function createEnrolmentToken(
 
 export async function listEnrolmentTokens(): Promise<EnrolmentTokenSafe[]> {
   const session = await getRequiredSession()
-  return listEnrolmentTokensCore(resolveCurrentActionScope(session))
+  const currentScope = resolveOptionalActionScope(session)
+  if (!currentScope) return []
+  return listEnrolmentTokensCore(currentScope)
 }
 
 export async function revokeEnrolmentToken(

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -36,11 +36,16 @@ import type {
 import { organisations } from '@/lib/db/schema'
 import type { SmtpEncryption } from '@/lib/notifications/smtp-settings'
 import { getRequiredSession } from '@/lib/auth/session'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 
 async function resolveCurrentAlertScope(): Promise<string> {
   const session = await getRequiredSession()
   return resolveCurrentActionScope(session)
+}
+
+async function resolveOptionalAlertScope(): Promise<string | null> {
+  const session = await getRequiredSession()
+  return resolveOptionalActionScope(session)
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -140,7 +145,8 @@ export async function getAlertRules(hostId?: string): Promise<AlertRule[]> {
 }
 
 export async function getGlobalAlertDefaults(): Promise<AlertRule[]> {
-  const orgId = await resolveCurrentAlertScope()
+  const orgId = await resolveOptionalAlertScope()
+  if (!orgId) return []
   await requireOrgAccess(orgId)
   return db.query.alertRules.findMany({
     where: and(
@@ -375,7 +381,8 @@ export type AlertHistoryFilters = {
 export async function getAlertInstances(
   filters: AlertHistoryFilters = {},
 ): Promise<AlertInstanceWithRule[]> {
-  const orgId = await resolveCurrentAlertScope()
+  const orgId = await resolveOptionalAlertScope()
+  if (!orgId) return []
   await requireOrgAccess(orgId)
   const limit = filters.limit ?? 50
   const offset = filters.offset ?? 0
@@ -522,7 +529,8 @@ function normaliseSmtpConfig(raw: unknown): SmtpChannelConfig {
 }
 
 export async function getNotificationChannels(): Promise<NotificationChannelSafe[]> {
-  const orgId = await resolveCurrentAlertScope()
+  const orgId = await resolveOptionalAlertScope()
+  if (!orgId) return []
   await requireOrgAccess(orgId)
   const rows = await db.query.notificationChannels.findMany({
     where: and(
@@ -930,7 +938,8 @@ const createSilenceSchema = z.object({
 })
 
 export async function getSilences(): Promise<AlertSilenceWithHost[]> {
-  const orgId = await resolveCurrentAlertScope()
+  const orgId = await resolveOptionalAlertScope()
+  if (!orgId) return []
   await requireOrgAccess(orgId)
   const rows = await db
     .select({

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -18,6 +18,46 @@ const licenceGuardSource = readFileSync(
   'utf8',
 )
 
+const sidebarLinkedPages = [
+  'app/(dashboard)/alerts/page.tsx',
+  'app/(dashboard)/build-docs/page.tsx',
+  'app/(dashboard)/bundlers/page.tsx',
+  'app/(dashboard)/calendar/page.tsx',
+  'app/(dashboard)/certificate-checker/page.tsx',
+  'app/(dashboard)/certificates/page.tsx',
+  'app/(dashboard)/dashboard/page.tsx',
+  'app/(dashboard)/directory-lookup/page.tsx',
+  'app/(dashboard)/hosts/groups/page.tsx',
+  'app/(dashboard)/hosts/networks/page.tsx',
+  'app/(dashboard)/hosts/page.tsx',
+  'app/(dashboard)/notifications/page.tsx',
+  'app/(dashboard)/password-generator/page.tsx',
+  'app/(dashboard)/password-manager/page.tsx',
+  'app/(dashboard)/reports/patch-status/page.tsx',
+  'app/(dashboard)/reports/software/page.tsx',
+  'app/(dashboard)/reports/vulnerabilities/page.tsx',
+  'app/(dashboard)/service-accounts/page.tsx',
+  'app/(dashboard)/settings/agents/page.tsx',
+  'app/(dashboard)/settings/integrations/page.tsx',
+  'app/(dashboard)/settings/monitoring/page.tsx',
+  'app/(dashboard)/settings/page.tsx',
+  'app/(dashboard)/settings/security/page.tsx',
+  'app/(dashboard)/settings/system/page.tsx',
+  'app/(dashboard)/tasks/page.tsx',
+  'app/(dashboard)/team/page.tsx',
+]
+
+const standaloneApiRoutes = [
+  'app/api/certificates/counts/route.ts',
+  'app/api/certificates/route.ts',
+  'app/api/domain-accounts/counts/route.ts',
+  'app/api/domain-accounts/route.ts',
+  'app/api/overview/route.ts',
+  'app/api/service-accounts/counts/route.ts',
+  'app/api/service-accounts/route.ts',
+  'app/api/system/health/route.ts',
+]
+
 test('dashboard shell falls back to community licence without org-backed scope', () => {
   assert.match(
     dashboardLayoutSource,
@@ -31,4 +71,28 @@ test('overview API returns empty counts for a fresh standalone instance', () => 
   assert.match(overviewRouteSource, /getApiSession\(\)/)
   assert.doesNotMatch(overviewRouteSource, /getApiOrgSession\(\)/)
   assert.match(overviewRouteSource, /if \(!orgId\) \{\s*return Response\.json\(emptyOverview\)\s*\}/)
+})
+
+test('sidebar-linked pages do not force an organisation-backed action scope', () => {
+  for (const relativePath of sidebarLinkedPages) {
+    const source = readFileSync(path.join(repoRoot, relativePath), 'utf8')
+    assert.doesNotMatch(
+      source,
+      /resolveCurrentActionScope\(session\)/,
+      `${relativePath} should use an optional scope or empty standalone state`,
+    )
+    assert.doesNotMatch(
+      source,
+      /session\.user\.organisationId!/,
+      `${relativePath} should not assert an organisation id during initial render`,
+    )
+  }
+})
+
+test('standalone sidebar APIs use regular session auth and empty no-org fallbacks', () => {
+  for (const relativePath of standaloneApiRoutes) {
+    const source = readFileSync(path.join(repoRoot, relativePath), 'utf8')
+    assert.match(source, /getApiSession\(/, `${relativePath} should allow no-org sessions`)
+    assert.doesNotMatch(source, /getApiOrg(Admin)?Session\(/)
+  }
 })

--- a/apps/web/lib/actions/host-groups.ts
+++ b/apps/web/lib/actions/host-groups.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { getRequiredSession } from '@/lib/auth/session'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 import {
   addHostToGroup as addHostToGroupCore,
   createGroup as createGroupCore,
@@ -49,7 +49,8 @@ export async function listGroups(
   ...args: [] | [string]
 ): Promise<HostGroupWithCount[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listGroupsCore(currentScope)
 }
 

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -85,7 +85,8 @@ const updateLdapConfigSchema = z.object({
 
 export async function getLdapConfigurations(
 ): Promise<LdapConfigurationSafe[]> {
-  const orgId = await getInstanceOrganisationId()
+  const orgId = await getDefaultOrganisationId()
+  if (!orgId) return []
   await requireOrgAdminAccess(orgId)
   const rows = await db.query.ldapConfigurations.findMany({
     where: and(

--- a/apps/web/lib/actions/licence-guard.ts
+++ b/apps/web/lib/actions/licence-guard.ts
@@ -5,7 +5,8 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 import { validateLicenceKey } from '@/lib/licence'
-import { featuresForTier, hasFeature, type Feature, type LicenceTier } from '@/lib/features'
+import { hasFeature, type Feature, type LicenceTier } from '@/lib/features'
+import { createCommunityLicence } from '@/lib/standalone-empty-state'
 import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
 
 export class LicenceRequiredError extends Error {
@@ -74,7 +75,7 @@ const loadEffectiveLicence = cache(async (orgId: string): Promise<EffectiveLicen
 })
 
 function getCommunityLicence(): EffectiveLicence {
-  return { tier: 'community', features: featuresForTier('community'), maxUsers: FREE_INCLUDED_USER_SEATS }
+  return createCommunityLicence()
 }
 
 export async function getInstanceEffectiveLicence(

--- a/apps/web/lib/actions/networks.ts
+++ b/apps/web/lib/actions/networks.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { getRequiredSession } from '@/lib/auth/session'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 import {
   addHostToNetwork as addHostToNetworkCore,
   createNetwork as createNetworkCore,
@@ -31,7 +31,8 @@ export async function listNetworks(
   ...args: [] | [string]
 ): Promise<NetworkWithCount[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listNetworksCore(currentScope)
 }
 
@@ -115,7 +116,8 @@ export async function listNetworksWithHosts(
   ...args: [] | [string]
 ): Promise<NetworkWithHosts[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listNetworksWithHostsCore(currentScope)
 }
 

--- a/apps/web/lib/actions/notifications-authz.test.mjs
+++ b/apps/web/lib/actions/notifications-authz.test.mjs
@@ -37,7 +37,7 @@ test('notification actions derive the user scope from the authenticated session'
     )
     assert.match(
       segment,
-      /const authSession = await getRequiredSession\(\)[\s\S]*resolveCurrentActionScope\(authSession\)/,
+      /const authSession = await getRequiredSession\(\)[\s\S]*resolve(?:Current|Optional)ActionScope\(authSession\)/,
       `${action} must derive the authenticated session and instance scope before querying notifications`,
     )
     assert.match(

--- a/apps/web/lib/actions/notifications.ts
+++ b/apps/web/lib/actions/notifications.ts
@@ -2,7 +2,7 @@
 
 import { requireOrgAccess } from '@/lib/actions/action-auth'
 import { getRequiredSession } from '@/lib/auth/session'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 
 import { db } from '@/lib/db'
 import { notifications } from '@/lib/db/schema'
@@ -14,7 +14,8 @@ export async function getNotifications(
   offset = 0,
 ): Promise<Notification[]> {
   const authSession = await getRequiredSession()
-  const orgId = resolveCurrentActionScope(authSession)
+  const orgId = resolveOptionalActionScope(authSession)
+  if (!orgId) return []
   const session = await requireOrgAccess(orgId)
   return db.query.notifications.findMany({
     where: and(
@@ -30,7 +31,8 @@ export async function getNotifications(
 
 export async function getUnreadCount(): Promise<number> {
   const authSession = await getRequiredSession()
-  const orgId = resolveCurrentActionScope(authSession)
+  const orgId = resolveOptionalActionScope(authSession)
+  if (!orgId) return 0
   const session = await requireOrgAccess(orgId)
   const [result] = await db
     .select({ value: count() })

--- a/apps/web/lib/actions/settings.ts
+++ b/apps/web/lib/actions/settings.ts
@@ -14,7 +14,7 @@ import { writeAuditEvent } from '@/lib/audit/events'
 import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
 import { getTrustedEffectiveLicence } from '@/lib/actions/licence-guard'
 import { getRequiredSession } from '@/lib/auth/session'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveOptionalActionScope } from './action-scope'
 
 const updateOrgNameSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(100),
@@ -22,7 +22,8 @@ const updateOrgNameSchema = z.object({
 
 export async function getCurrentOrganisationSettingsRecord() {
   const session = await getRequiredSession()
-  const orgId = resolveCurrentActionScope(session)
+  const orgId = resolveOptionalActionScope(session)
+  if (!orgId) return null
   return db.query.organisations.findFirst({
     where: eq(organisations.id, orgId),
   })

--- a/apps/web/lib/actions/tag-rules.ts
+++ b/apps/web/lib/actions/tag-rules.ts
@@ -11,7 +11,7 @@ import type { HostFilter, TagRule, TagPair } from '@/lib/db/schema'
 import { and, eq, isNull } from 'drizzle-orm'
 import { buildHostFilterWhere, isEmptyFilter, type HostFilterResult } from '@/lib/hosts/filter'
 import { assignTagsToResource } from '@/lib/actions/tags'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 
 const tagPairSchema = z.object({
   key: z.string().min(1).max(100),
@@ -98,7 +98,8 @@ export async function bulkAssignTags(
 
 export async function listTagRules(): Promise<TagRule[]> {
   const session = await getRequiredSession()
-  const orgId = resolveCurrentActionScope(session)
+  const orgId = resolveOptionalActionScope(session)
+  if (!orgId) return []
   await requireOrgAccess(orgId)
   return db.query.tagRules.findMany({
     where: and(eq(tagRules.organisationId, orgId), isNull(tagRules.deletedAt)),

--- a/apps/web/lib/actions/task-schedules.ts
+++ b/apps/web/lib/actions/task-schedules.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { getRequiredSession } from '@/lib/auth/session'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 import {
   createSchedule as createScheduleCore,
   deleteSchedule as deleteScheduleCore,
@@ -20,7 +20,8 @@ export async function listSchedules(
   ...args: [] | [string]
 ): Promise<ScheduleWithTargetName[]> {
   const session = await getRequiredSession()
-  const currentScope = args[0] ?? resolveCurrentActionScope(session)
+  const currentScope = args[0] ?? resolveOptionalActionScope(session)
+  if (!currentScope) return []
   return listSchedulesCore(currentScope)
 }
 

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -13,7 +13,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { writeAuditEvent } from '@/lib/audit/events'
 import { ASSIGNED_ROLES, INVITABLE_ROLES, getPrimaryRole, normalizeAssignedRoles } from '@/lib/auth/roles'
 import { assertCanReserveUserSeat, toSeatLimitErrorMessage } from '@/lib/actions/seat-enforcement'
-import { resolveCurrentActionScope } from './action-scope'
+import { resolveCurrentActionScope, resolveOptionalActionScope } from './action-scope'
 
 const inviteSchema = z.object({
   email: z.string().email('Enter a valid email address'),
@@ -34,7 +34,8 @@ function hasSuperAdminRole(role: string | null | undefined, roles: readonly stri
 
 export async function getOrgUsers(): Promise<{ members: User[]; pendingInvites: Invitation[] }> {
   const session = await getRequiredSession()
-  const currentScope = resolveCurrentActionScope(session)
+  const currentScope = resolveOptionalActionScope(session)
+  if (!currentScope) return { members: [session.user], pendingInvites: [] }
   await requireOrgAccess(currentScope)
 
   const [members, pendingInvites] = await Promise.all([

--- a/apps/web/lib/standalone-empty-state.ts
+++ b/apps/web/lib/standalone-empty-state.ts
@@ -1,0 +1,79 @@
+import type { CertificateCounts } from '@/lib/actions/certificates'
+import type { DomainAccountCounts } from '@/lib/actions/domain-accounts'
+import type { PatchManagementReport } from '@/lib/actions/patch-status'
+import type { EffectiveLicence } from '@/lib/actions/licence-guard'
+import type { CtCveConnectorSetupOverview } from '@/lib/integrations/ct-cve/setup-status'
+import { featuresForTier } from '@/lib/features'
+import { FREE_INCLUDED_USER_SEATS } from '@/lib/licence-seats'
+
+export const EMPTY_CERTIFICATE_COUNTS: CertificateCounts = {
+  valid: 0,
+  expiringSoon: 0,
+  expired: 0,
+  invalid: 0,
+}
+
+export const EMPTY_DOMAIN_ACCOUNT_COUNTS: DomainAccountCounts = {
+  total: 0,
+  active: 0,
+  disabled: 0,
+  locked: 0,
+  expired: 0,
+}
+
+export function createEmptyPatchManagementReport(): PatchManagementReport {
+  return {
+    generatedAt: new Date(),
+    summary: {
+      totalHosts: 0,
+      passingCount: 0,
+      failingCount: 0,
+      errorCount: 0,
+      unknownCount: 0,
+      averagePatchAgeDays: null,
+      oldestPatchAgeDays: null,
+      totalAvailableUpdates: 0,
+    },
+    networks: [],
+    hosts: [],
+  }
+}
+
+export function createCommunityLicence(): EffectiveLicence {
+  return {
+    tier: 'community',
+    features: featuresForTier('community'),
+    maxUsers: FREE_INCLUDED_USER_SEATS,
+  }
+}
+
+export function createEmptyCtCveConnectorSetupOverview(orgId = ''): CtCveConnectorSetupOverview {
+  return {
+    configured: false,
+    enabled: false,
+    inbound: {
+      configured: false,
+      tokenCount: 0,
+      revokedTokenCount: 0,
+      scopes: [],
+      error: null,
+    },
+    inventoryPush: {
+      configured: false,
+      targetCount: 0,
+      targets: [],
+      error: null,
+    },
+    status: {
+      contractVersion: '2026-04-30',
+      orgId,
+      configured: false,
+      enabled: false,
+      lastInventoryPushAt: null,
+      lastFindingIngestAt: null,
+      lastHealthCheckAt: null,
+      lastErrorCode: null,
+      lastErrorAt: null,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- allow fresh standalone instances without an organisation-backed scope to render sidebar-linked pages with empty/default state
- return empty no-org responses from sidebar-backed list APIs
- add regression coverage so sidebar-linked pages and APIs do not require org scope during initial render

## Validation
- node --experimental-strip-types --test lib/actions/dashboard-standalone.test.mjs lib/actions/notifications-authz.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (warnings only, existing)
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=00000000000000000000000000000000 DATABASE_URL=postgres://ct_ops:ct_ops@localhost:5432/ct_ops pnpm --filter web build
- pnpm --filter web test:unit (299/301 passed; only failures were existing Testcontainers-backed DB tests because this environment has no working container runtime: lib/db/rls.test.mjs and lib/integrations/ct-cve/db-nonce-store.test.mjs)