### PR TITLE
fix(web): restore standalone admin access

### DIFF
--- a/apps/web/app/(dashboard)/settings/agents/defaults/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/defaults/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Agent Defaults',
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function AgentDefaultsPage() {
   const session = await getRequiredSession()
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const org = await getCurrentOrganisationSettingsRecord()

--- a/apps/web/app/(dashboard)/settings/agents/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/page.tsx
@@ -4,6 +4,7 @@ import { listEnrolmentTokens } from '@/lib/actions/agents'
 import { AgentsSettingsClient } from './agents-client'
 import { redirect } from 'next/navigation'
 import { AdminTabs } from '@/components/shared/admin-tabs'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Agent Enrolment',
@@ -12,8 +13,7 @@ export const metadata: Metadata = {
 export default async function AgentsSettingsPage() {
   const session = await getRequiredSession()
 
-  const isAdmin =
-    session.user.role === 'super_admin' || session.user.role === 'org_admin'
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const tokens = await listEnrolmentTokens()

--- a/apps/web/app/(dashboard)/settings/agents/software/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/software/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Software Inventory Settings',
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function SoftwareInventorySettingsPage() {
   const session = await getRequiredSession()
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const org = await getCurrentOrganisationSettingsRecord()

--- a/apps/web/app/(dashboard)/settings/agents/tags/page.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/tags/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { listTagRules } from '@/lib/actions/tag-rules'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { TagRulesClient } from '../../tag-rules/tag-rules-client'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Agent Tag Rules',
@@ -11,8 +12,7 @@ export const metadata: Metadata = {
 
 export default async function AgentTagRulesPage() {
   const session = await getRequiredSession()
-  const isAdmin =
-    session.user.role === 'super_admin' || session.user.role === 'org_admin'
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const rules = await listTagRules()

--- a/apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/ct-cve/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
 import { getRequiredSession } from '@/lib/auth/session'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { hasRole } from '@/lib/auth/guards'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { buildCtCveConnectorSetupOverview } from '@/lib/integrations/ct-cve/setup-status'
 import {
@@ -28,7 +28,7 @@ const tabs = [
 export default async function CtCveIntegrationSettingsPage() {
   const session = await getRequiredSession()
 
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  if (!hasRole(session.user, ['org_admin', 'super_admin'])) {
     redirect('/settings')
   }
 

--- a/apps/web/app/(dashboard)/settings/integrations/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getLdapConfigurations } from '@/lib/actions/ldap'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { hasRole } from '@/lib/auth/guards'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { LdapSettingsClient } from '../ldap/ldap-client'
 
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default async function IntegrationsSettingsPage() {
   const session = await getRequiredSession()
 
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  if (!hasRole(session.user, ['org_admin', 'super_admin'])) {
     redirect('/settings')
   }
 

--- a/apps/web/app/(dashboard)/settings/integrations/smtp/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/smtp/page.tsx
@@ -6,6 +6,7 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'SMTP Relay Settings',
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
 
 export default async function SmtpRelaySettingsPage() {
   const session = await getRequiredSession()
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const orgId = session.user.organisationId

--- a/apps/web/app/(dashboard)/settings/licence/page.tsx
+++ b/apps/web/app/(dashboard)/settings/licence/page.tsx
@@ -8,6 +8,7 @@ import { AdminTabs } from '@/components/shared/admin-tabs'
 import { getEffectiveLicence } from '@/lib/actions/licence-guard'
 import { getOrgSeatUsage } from '@/lib/actions/seat-enforcement'
 import { createCommunityLicence } from '@/lib/standalone-empty-state'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Licence Settings',
@@ -59,7 +60,7 @@ export default async function LicenceSettingsPage() {
 
   if (!org) return null
 
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
 
   return (
     <div className="space-y-6">
@@ -73,7 +74,7 @@ export default async function LicenceSettingsPage() {
         org={org}
         isAdmin={isAdmin}
         sections={['licence']}
-        title="Organisation"
+        title="Licence"
         description="Manage seats, licence expiry, and Enterprise capabilities."
         effectiveLicence={{
           tier: effectiveLicence.tier,

--- a/apps/web/app/(dashboard)/settings/monitoring/notifications/page.tsx
+++ b/apps/web/app/(dashboard)/settings/monitoring/notifications/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
 import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Notification Policy Settings',
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function NotificationPolicyPage() {
   const session = await getRequiredSession()
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const org = await getCurrentOrganisationSettingsRecord()

--- a/apps/web/app/(dashboard)/settings/monitoring/page.tsx
+++ b/apps/web/app/(dashboard)/settings/monitoring/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { getGlobalAlertDefaults } from '@/lib/actions/alerts'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { GlobalAlertsClient } from '../alerts/alerts-client'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Monitoring Settings',
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function MonitoringSettingsPage() {
   const session = await getRequiredSession()
-  const isAdmin = session.user.role === 'super_admin' || session.user.role === 'org_admin'
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const defaults = await getGlobalAlertDefaults()

--- a/apps/web/app/(dashboard)/settings/monitoring/retention/page.tsx
+++ b/apps/web/app/(dashboard)/settings/monitoring/retention/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
 import { getCurrentOrganisationSettingsRecord } from '@/lib/actions/settings'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
   title: 'Metric Retention Settings',
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function MetricRetentionSettingsPage() {
   const session = await getRequiredSession()
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   const org = await getCurrentOrganisationSettingsRecord()

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -5,9 +5,10 @@ import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
 import { SettingsClient } from './settings-client'
 import { AdminTabs } from '@/components/shared/admin-tabs'
+import { hasRole } from '@/lib/auth/guards'
 
 export const metadata: Metadata = {
-  title: 'Organisation Settings',
+  title: 'Instance Settings',
 }
 
 export default async function SettingsPage() {
@@ -30,16 +31,16 @@ export default async function SettingsPage() {
           ]}
         />
         <div className="space-y-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Organisation</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Instance</h1>
           <p className="text-sm text-muted-foreground">
-            Organisation profile settings will be available after instance setup is complete.
+            Instance profile settings will be available after setup is complete.
           </p>
         </div>
       </div>
     )
   }
 
-  const isAdmin = ['org_admin', 'super_admin'].includes(session.user.role)
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
 
   return (
     <div className="space-y-6">
@@ -53,8 +54,8 @@ export default async function SettingsPage() {
         org={org}
         isAdmin={isAdmin}
         sections={['organisation']}
-        title="Organisation"
-        description="Manage your organisation profile."
+        title="Instance"
+        description="Manage your instance profile."
       />
     </div>
   )

--- a/apps/web/app/(dashboard)/settings/security/page.tsx
+++ b/apps/web/app/(dashboard)/settings/security/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getSecurityOverview } from '@/lib/actions/security'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { hasRole } from '@/lib/auth/guards'
 import { SecuritySettingsClient } from './security-client'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function SecuritySettingsPage() {
   const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  if (!hasRole(session.user, ['org_admin', 'super_admin'])) {
     redirect('/settings')
   }
 

--- a/apps/web/app/(dashboard)/settings/security/terminal/page.tsx
+++ b/apps/web/app/(dashboard)/settings/security/terminal/page.tsx
@@ -4,7 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { db } from '@/lib/db'
 import { organisations } from '@/lib/db/schema'
 import { eq } from 'drizzle-orm'
-import { ADMIN_ROLES } from '@/lib/auth/roles'
+import { hasRole } from '@/lib/auth/guards'
 import { AdminTabs } from '@/components/shared/admin-tabs'
 import { SettingsClient } from '../../settings-client'
 
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 
 export default async function TerminalAccessSettingsPage() {
   const session = await getRequiredSession()
-  if (!ADMIN_ROLES.includes(session.user.role)) {
+  if (!hasRole(session.user, ['org_admin', 'super_admin'])) {
     redirect('/settings')
   }
 

--- a/apps/web/app/(dashboard)/settings/system/page.tsx
+++ b/apps/web/app/(dashboard)/settings/system/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
+import { hasRole } from '@/lib/auth/guards'
 import { SystemHealthClient } from './system-client'
 
 export const metadata: Metadata = {
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
 
 export default async function SystemHealthPage() {
   const session = await getRequiredSession()
-  const isAdmin = session.user.role === 'super_admin' || session.user.role === 'org_admin'
+  const isAdmin = hasRole(session.user, ['org_admin', 'super_admin'])
   if (!isAdmin) redirect('/dashboard')
 
   return <SystemHealthClient />

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -17,6 +17,10 @@ const licenceGuardSource = readFileSync(
   path.join(repoRoot, 'lib/actions/licence-guard.ts'),
   'utf8',
 )
+const sessionSource = readFileSync(
+  path.join(repoRoot, 'lib/auth/session.ts'),
+  'utf8',
+)
 
 const sidebarLinkedPages = [
   'app/(dashboard)/alerts/page.tsx',
@@ -58,6 +62,24 @@ const standaloneApiRoutes = [
   'app/api/system/health/route.ts',
 ]
 
+const administrationPages = [
+  'app/(dashboard)/settings/agents/defaults/page.tsx',
+  'app/(dashboard)/settings/agents/page.tsx',
+  'app/(dashboard)/settings/agents/software/page.tsx',
+  'app/(dashboard)/settings/agents/tags/page.tsx',
+  'app/(dashboard)/settings/integrations/ct-cve/page.tsx',
+  'app/(dashboard)/settings/integrations/page.tsx',
+  'app/(dashboard)/settings/integrations/smtp/page.tsx',
+  'app/(dashboard)/settings/licence/page.tsx',
+  'app/(dashboard)/settings/monitoring/notifications/page.tsx',
+  'app/(dashboard)/settings/monitoring/page.tsx',
+  'app/(dashboard)/settings/monitoring/retention/page.tsx',
+  'app/(dashboard)/settings/page.tsx',
+  'app/(dashboard)/settings/security/page.tsx',
+  'app/(dashboard)/settings/security/terminal/page.tsx',
+  'app/(dashboard)/settings/system/page.tsx',
+]
+
 test('dashboard shell falls back to community licence without org-backed scope', () => {
   assert.match(
     dashboardLayoutSource,
@@ -94,5 +116,23 @@ test('standalone sidebar APIs use regular session auth and empty no-org fallback
     const source = readFileSync(path.join(repoRoot, relativePath), 'utf8')
     assert.match(source, /getApiSession\(/, `${relativePath} should allow no-org sessions`)
     assert.doesNotMatch(source, /getApiOrg(Admin)?Session\(/)
+  }
+})
+
+test('fresh standalone sessions promote the first active user to instance admin', () => {
+  assert.match(sessionSource, /ensureInstanceHasSuperAdmin\(user\)/)
+  assert.match(sessionSource, /activeUsers\[0\]\?\.id !== user\.id/)
+  assert.match(sessionSource, /set\(\{ role: INSTANCE_ADMIN_ROLE, roles, updatedAt: new Date\(\) \}\)/)
+})
+
+test('administration pages use normalized role checks', () => {
+  for (const relativePath of administrationPages) {
+    const source = readFileSync(path.join(repoRoot, relativePath), 'utf8')
+    assert.match(source, /hasRole\(session\.user, \['org_admin', 'super_admin'\]\)/)
+    assert.doesNotMatch(
+      source,
+      /ADMIN_ROLES\.includes\(session\.user\.role\)|session\.user\.role === 'super_admin'|\['org_admin', 'super_admin'\]\.includes\(session\.user\.role\)/,
+      `${relativePath} should not depend on the primary legacy role string`,
+    )
   }
 })

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -3,7 +3,7 @@ import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { db } from '@/lib/db'
 import { users } from '@/lib/db/schema'
-import { eq } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
 import type { User } from '@/lib/db/schema'
 import { requireActiveUser, requireOrgAdmin } from './guards'
 import { EXPIRED_SESSION_LOGIN_PATH } from './redirects'
@@ -13,6 +13,8 @@ import { organisations } from '@/lib/db/schema'
 import { parseOrgMetadata } from '@/lib/db/schema/organisations'
 import { getTwoFactorPolicyRedirect } from './two-factor-policy'
 import { getDefaultOrganisationId } from '@/lib/default-organisation'
+
+const INSTANCE_ADMIN_ROLE = 'super_admin'
 
 // Re-export User as SessionUser for convenience
 export type { User as SessionUser }
@@ -40,10 +42,12 @@ export class ApiAuthError extends Error {
 }
 
 async function findSessionUser(userId: string): Promise<User | null> {
-  const user = await db.query.users.findFirst({
+  let user = await db.query.users.findFirst({
     where: eq(users.id, userId),
   })
   if (!user) return null
+
+  user = await ensureInstanceHasSuperAdmin(user)
 
   const organisationId = user.organisationId ?? await getDefaultOrganisationId()
 
@@ -53,6 +57,31 @@ async function findSessionUser(userId: string): Promise<User | null> {
     role: getPrimaryRole(user.roles, user.role),
     roles: normalizeAssignedRoles(user.roles, user.role),
   }
+}
+
+async function ensureInstanceHasSuperAdmin(user: User): Promise<User> {
+  if (!user.isActive || user.deletedAt) return user
+  if (normalizeAssignedRoles(user.roles, user.role).includes(INSTANCE_ADMIN_ROLE)) return user
+
+  const activeUsers = await db.query.users.findMany({
+    where: (table, { eq, and, isNull }) => and(eq(table.isActive, true), isNull(table.deletedAt)),
+    columns: { id: true, role: true, roles: true },
+    orderBy: [asc(users.createdAt), asc(users.email)],
+  })
+
+  const hasSuperAdmin = activeUsers.some((row) =>
+    normalizeAssignedRoles(row.roles, row.role).includes(INSTANCE_ADMIN_ROLE),
+  )
+  if (hasSuperAdmin || activeUsers[0]?.id !== user.id) return user
+
+  const roles = normalizeAssignedRoles([INSTANCE_ADMIN_ROLE])
+  const [promoted] = await db
+    .update(users)
+    .set({ role: INSTANCE_ADMIN_ROLE, roles, updatedAt: new Date() })
+    .where(eq(users.id, user.id))
+    .returning()
+
+  return promoted ?? { ...user, role: INSTANCE_ADMIN_ROLE, roles }
 }
 
 async function loadSessionWithUser(requestHeaders: Headers): Promise<RequiredSession | null> {


### PR DESCRIPTION
## Summary
- promote the first active standalone user to super_admin during session loading when no super_admin exists
- update Administration route guards to use normalized role checks instead of direct legacy role string checks
- replace the no-org Instance profile copy so it no longer tells users about an organisation profile
- add regression coverage for first-user admin promotion and Administration route guards

## Follow-up
- Licence request-token restoration for fully no-org standalone installs needs an instance-scoped licence redesign: #1241

## Validation
- node --experimental-strip-types --test lib/actions/dashboard-standalone.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (warnings only, existing)
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=00000000000000000000000000000000 DATABASE_URL=postgres://ct_ops:ct_ops@localhost:5432/ct_ops pnpm --filter web build