### PR TITLE
fix(ingest): remove org-scoped agent identity

### DIFF
--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -870,7 +870,7 @@ Status: Complete
 
 Completed by: Codex automation
 
-PR:
+PR: [#1248](https://github.com/carrtech-dev/ct-ops/pull/1248)
 
 Summary: Built the Task 13 residue map, converted the remaining web app
 schema and action internals from organisation scope to standalone instance
@@ -982,19 +982,35 @@ and migration residue after the earlier slices have converted the live paths.
 
 ## Task 14 - Ingest And Agent Single-Instance Conversion
 
-Status: Not started
+Status: Complete
 
-Completed by:
+Completed by: Codex automation
 
 PR:
 
-Summary:
+Summary: Removed organisation-scoped identity from the agent, ingest, and
+registration protobuf paths by renaming the public registration token to
+`enrolment_token`, switching ingest SQL and handlers to `instance_id`,
+making host-collision and enrolment-token consumption instance-wide, and
+dropping the org claim from agent JWTs and mTLS SPIFFE identities so runtime
+auth now binds only to the agent identity inside a single CT-Ops instance.
 
-Files changed:
+Files changed: `ORGANISATION_REMOVAL_TASKS.md`, `agent/{cmd,examples,internal}`,
+`apps/ingest/{cmd,internal}`, `proto/agent/v1/registration.proto`,
+`proto/gen/go/agent/v1/registration.pb.go`
 
-Validation:
+Validation: `PATH="$PATH:$(go env GOPATH)/bin" make proto` (passes and
+regenerates Go protobuf bindings for `enrolment_token`);
+`gofmt -w $(git diff --name-only -- '*.go')` (passes);
+`go test ./agent/... ./apps/ingest/... ./proto/gen/go/...` (passes);
+`pnpm --dir apps/web type-check` fails in this worktree because
+`apps/web/node_modules` is absent and `tsc` is not installed locally;
+`rg -n "organisation|organization|orgID|orgId|org_id|organisation_id|OrgToken|org_token|tenant" apps/ingest agent proto`
+returns no matches.
 
-Follow-up:
+Follow-up: Start Task 15 next. Before re-running the web validation from this
+task, install the web workspace dependencies in the Task 14 worktree or use a
+worktree that already has `apps/web/node_modules` available.
 
 ### Required work
 

--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -13,9 +13,9 @@ import (
 
 	"google.golang.org/grpc"
 
-	agentgrpc "github.com/carrtech-dev/ct-ops/agent/internal/grpc"
 	"github.com/carrtech-dev/ct-ops/agent/internal/checks"
 	"github.com/carrtech-dev/ct-ops/agent/internal/config"
+	agentgrpc "github.com/carrtech-dev/ct-ops/agent/internal/grpc"
 	"github.com/carrtech-dev/ct-ops/agent/internal/heartbeat"
 	"github.com/carrtech-dev/ct-ops/agent/internal/identity"
 	"github.com/carrtech-dev/ct-ops/agent/internal/install"
@@ -83,7 +83,7 @@ func mergeTags(layers ...[]string) []*agentv1.Tag {
 
 func main() {
 	configPath := flag.String("config", "/etc/ct-ops/agent.toml", "Path to agent TOML config file")
-	tokenFlag := flag.String("token", "", "Enrolment token (overrides config file and CT_OPS_ORG_TOKEN)")
+	tokenFlag := flag.String("token", "", "Enrolment token (overrides config file and CT_OPS_ENROLMENT_TOKEN)")
 	addressFlag := flag.String("address", "", "Ingest address host:port (overrides config file and CT_OPS_INGEST_ADDRESS)")
 	installFlag := flag.Bool("install", false, "Install agent as a system service and exit (requires --token)")
 	uninstallFlag := flag.Bool("uninstall", false, "Stop and remove the agent service, binary, config, and data files")
@@ -107,10 +107,10 @@ func main() {
 	if *installFlag {
 		token := strings.TrimSpace(*tokenFlag)
 		if token == "" {
-			token = strings.TrimSpace(os.Getenv("CT_OPS_ORG_TOKEN"))
+			token = strings.TrimSpace(os.Getenv("CT_OPS_ENROLMENT_TOKEN"))
 		}
 		if token == "" {
-			slog.Error("--token or CT_OPS_ORG_TOKEN is required when using --install")
+			slog.Error("--token or CT_OPS_ENROLMENT_TOKEN is required when using --install")
 			os.Exit(1)
 		}
 		if err := install.Run(token, strings.TrimSpace(*addressFlag), *tlsSkipVerifyFlag, []string(tagFlags)); err != nil {
@@ -137,7 +137,7 @@ func main() {
 	}
 
 	if *tokenFlag != "" {
-		cfg.Agent.OrgToken = strings.TrimSpace(*tokenFlag)
+		cfg.Agent.EnrolmentToken = strings.TrimSpace(*tokenFlag)
 	}
 	if *addressFlag != "" {
 		cfg.Ingest.Address = strings.TrimSpace(*addressFlag)
@@ -146,8 +146,8 @@ func main() {
 		cfg.Ingest.TLSSkipVerify = true
 	}
 
-	if cfg.Agent.OrgToken == "" {
-		slog.Error("org_token is required in config or CT_OPS_ORG_TOKEN environment variable")
+	if cfg.Agent.EnrolmentToken == "" {
+		slog.Error("enrolment_token is required in config or CT_OPS_ENROLMENT_TOKEN environment variable")
 		os.Exit(1)
 	}
 
@@ -205,7 +205,7 @@ func runAgent(ctx context.Context, cfg *config.Config, tags []*agentv1.Tag) erro
 				slog.Error("connecting to ingest service", "err", err, "address", cfg.Ingest.Address)
 				return err
 			}
-			registrar := registration.New(agentv1.NewIngestServiceClient(regConn), keypair, cfg.Agent.OrgToken, version, tags, cfg.Agent.DataDir)
+			registrar := registration.New(agentv1.NewIngestServiceClient(regConn), keypair, cfg.Agent.EnrolmentToken, version, tags, cfg.Agent.DataDir)
 			newState, err := registrar.Register(ctx, state.AgentID)
 			regConn.Close()
 			if err != nil {

--- a/agent/cmd/loadtest/main.go
+++ b/agent/cmd/loadtest/main.go
@@ -62,7 +62,7 @@ func runCmd(args []string) error {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	cfg := &loadtest.Config{}
 	fs.StringVar(&cfg.Address, "address", "", "ingest gRPC host:port (required)")
-	fs.StringVar(&cfg.OrgToken, "token", "", "enrolment token with auto_approve=true (required)")
+	fs.StringVar(&cfg.EnrolmentToken, "token", "", "enrolment token with auto_approve=true (required)")
 	fs.StringVar(&cfg.CACertFile, "ca-cert", "", "path to server CA cert (optional)")
 	fs.BoolVar(&cfg.TLSSkipVerify, "tls-skip-verify", false, "skip TLS server verification (dev only)")
 	fs.IntVar(&cfg.Agents, "agents", 100, "total virtual agents")

--- a/agent/examples/agent.toml
+++ b/agent/examples/agent.toml
@@ -17,8 +17,8 @@ tls_skip_verify = false
 
 [agent]
 # Enrolment token from the CT-Ops UI (Administration → Agents → Enrolment)
-# Can also be set via CT_OPS_ORG_TOKEN environment variable.
-org_token = ""
+# Can also be set via CT_OPS_ENROLMENT_TOKEN environment variable.
+enrolment_token = ""
 
 # Directory where the agent stores its identity keypair and state.
 # Must be writable by the user running the agent.

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -25,8 +25,8 @@ type IngestConfig struct {
 }
 
 type AgentConfig struct {
-	// OrgToken is the enrolment token from the CT-Ops UI.
-	OrgToken string `toml:"org_token"`
+	// EnrolmentToken is the enrolment token from the CT-Ops UI.
+	EnrolmentToken string `toml:"enrolment_token"`
 	// DataDir is where the agent stores its keypair and state.
 	DataDir string `toml:"data_dir"`
 	// HeartbeatIntervalSecs is how often the agent sends a heartbeat.
@@ -88,13 +88,13 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("CT_OPS_INGEST_CA_CERT"); v != "" {
 		cfg.Ingest.CACertFile = v
 	}
-	if v := os.Getenv("CT_OPS_ORG_TOKEN"); v != "" {
-		cfg.Agent.OrgToken = v
+	if v := os.Getenv("CT_OPS_ENROLMENT_TOKEN"); v != "" {
+		cfg.Agent.EnrolmentToken = v
 	}
 	if v := os.Getenv("CT_OPS_DATA_DIR"); v != "" {
 		cfg.Agent.DataDir = v
 	}
 	// Trim accidental whitespace from tokens/addresses
-	cfg.Agent.OrgToken = strings.TrimSpace(cfg.Agent.OrgToken)
+	cfg.Agent.EnrolmentToken = strings.TrimSpace(cfg.Agent.EnrolmentToken)
 	cfg.Ingest.Address = strings.TrimSpace(cfg.Ingest.Address)
 }

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -12,7 +12,7 @@ func TestLoadRejectsGroupReadableConfig(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.toml")
-	if err := os.WriteFile(path, []byte("[agent]\norg_token = \"secret\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("[agent]\nenrolment_token = \"secret\"\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -30,7 +30,7 @@ func TestLoadReadsSecureConfig(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "agent.toml")
-	if err := os.WriteFile(path, []byte("[ingest]\naddress = \"ingest.example:9443\"\n\n[agent]\norg_token = \"secret\"\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte("[ingest]\naddress = \"ingest.example:9443\"\n\n[agent]\nenrolment_token = \"secret\"\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -41,7 +41,7 @@ func TestLoadReadsSecureConfig(t *testing.T) {
 	if cfg.Ingest.Address != "ingest.example:9443" {
 		t.Fatalf("unexpected ingest address: %q", cfg.Ingest.Address)
 	}
-	if cfg.Agent.OrgToken != "secret" {
-		t.Fatalf("unexpected org token: %q", cfg.Agent.OrgToken)
+	if cfg.Agent.EnrolmentToken != "secret" {
+		t.Fatalf("unexpected enrolment token: %q", cfg.Agent.EnrolmentToken)
 	}
 }

--- a/agent/internal/install/install.go
+++ b/agent/internal/install/install.go
@@ -17,16 +17,16 @@ import (
 
 // Run performs a full system installation for the current OS.
 // It must be called as root (Linux/macOS) or Administrator (Windows).
-// orgToken is required. ingestAddress is optional — pass empty string to keep the existing value.
+// enrolmentToken is required. ingestAddress is optional — pass empty string to keep the existing value.
 // tlsSkipVerify disables TLS certificate verification; use when ingest uses a self-signed cert.
-func Run(orgToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
+func Run(enrolmentToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
 	switch runtime.GOOS {
 	case "linux":
-		return installLinux(orgToken, ingestAddress, tlsSkipVerify, tags)
+		return installLinux(enrolmentToken, ingestAddress, tlsSkipVerify, tags)
 	case "darwin":
-		return installDarwin(orgToken, ingestAddress, tlsSkipVerify, tags)
+		return installDarwin(enrolmentToken, ingestAddress, tlsSkipVerify, tags)
 	case "windows":
-		return installWindows(orgToken, ingestAddress, tlsSkipVerify, tags)
+		return installWindows(enrolmentToken, ingestAddress, tlsSkipVerify, tags)
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}
@@ -35,8 +35,8 @@ func Run(orgToken, ingestAddress string, tlsSkipVerify bool, tags []string) erro
 // mergeConfig loads the existing config at cfgPath (if present), then overlays
 // any explicitly provided flag values on top. This preserves fields like
 // ca_cert_file and tls_skip_verify across reinstalls.
-// orgToken is always applied. ingestAddress and tlsSkipVerify are only applied if non-zero.
-func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string, tlsSkipVerify bool, tags []string) (*agentconfig.Config, error) {
+// enrolmentToken is always applied. ingestAddress and tlsSkipVerify are only applied if non-zero.
+func mergeConfig(cfgPath, enrolmentToken, ingestAddress, defaultDataDir string, tlsSkipVerify bool, tags []string) (*agentconfig.Config, error) {
 	cfg := &agentconfig.Config{
 		Ingest: agentconfig.IngestConfig{
 			Address: "localhost:9443",
@@ -57,7 +57,7 @@ func mergeConfig(cfgPath, orgToken, ingestAddress, defaultDataDir string, tlsSki
 		backupConfig(cfgPath)
 	}
 
-	cfg.Agent.OrgToken = orgToken
+	cfg.Agent.EnrolmentToken = enrolmentToken
 	if ingestAddress != "" {
 		cfg.Ingest.Address = ingestAddress
 	}
@@ -91,7 +91,7 @@ func backupConfig(cfgPath string) {
 
 // ── Linux / systemd ───────────────────────────────────────────────────────────
 
-func installLinux(orgToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
+func installLinux(enrolmentToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("install must be run as root (try: sudo ./ct-ops-agent --install ...)")
 	}
@@ -106,7 +106,7 @@ func installLinux(orgToken, ingestAddress string, tlsSkipVerify bool, tags []str
 	if err := mkdirs("/etc/ct-ops", dataDir); err != nil {
 		return fmt.Errorf("creating directories: %w", err)
 	}
-	cfg, err := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	cfg, err := mergeConfig(cfgPath, enrolmentToken, ingestAddress, dataDir, tlsSkipVerify, tags)
 	if err != nil {
 		return fmt.Errorf("loading existing config: %w", err)
 	}
@@ -151,7 +151,7 @@ WantedBy=multi-user.target
 
 // ── macOS / launchd ───────────────────────────────────────────────────────────
 
-func installDarwin(orgToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
+func installDarwin(enrolmentToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
 	if os.Getuid() != 0 {
 		return fmt.Errorf("install must be run as root (try: sudo ./ct-ops-agent --install ...)")
 	}
@@ -167,7 +167,7 @@ func installDarwin(orgToken, ingestAddress string, tlsSkipVerify bool, tags []st
 	if err := mkdirs("/etc/ct-ops", dataDir, "/var/log"); err != nil {
 		return fmt.Errorf("creating directories: %w", err)
 	}
-	cfg, err := mergeConfig(cfgPath, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	cfg, err := mergeConfig(cfgPath, enrolmentToken, ingestAddress, dataDir, tlsSkipVerify, tags)
 	if err != nil {
 		return fmt.Errorf("loading existing config: %w", err)
 	}
@@ -227,7 +227,7 @@ func installDarwin(orgToken, ingestAddress string, tlsSkipVerify bool, tags []st
 
 // ── Windows / Service Control Manager ────────────────────────────────────────
 
-func installWindows(orgToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
+func installWindows(enrolmentToken, ingestAddress string, tlsSkipVerify bool, tags []string) error {
 	if !isAdmin() {
 		return fmt.Errorf("install must be run as Administrator")
 	}
@@ -244,7 +244,7 @@ func installWindows(orgToken, ingestAddress string, tlsSkipVerify bool, tags []s
 	if err := copyBinary(dest); err != nil {
 		return fmt.Errorf("copying binary: %w", err)
 	}
-	cfg, err := mergeConfig(cfgFile, orgToken, ingestAddress, dataDir, tlsSkipVerify, tags)
+	cfg, err := mergeConfig(cfgFile, enrolmentToken, ingestAddress, dataDir, tlsSkipVerify, tags)
 	if err != nil {
 		return fmt.Errorf("loading existing config: %w", err)
 	}
@@ -351,7 +351,7 @@ func writeConfig(path string, cfg *agentconfig.Config) error {
 	}
 
 	b.WriteString("\n[agent]\n")
-	b.WriteString(fmt.Sprintf("org_token = %q\n", cfg.Agent.OrgToken))
+	b.WriteString(fmt.Sprintf("enrolment_token = %q\n", cfg.Agent.EnrolmentToken))
 	b.WriteString(fmt.Sprintf("data_dir   = %q\n", cfg.Agent.DataDir))
 	if cfg.Agent.HeartbeatIntervalSecs > 0 && cfg.Agent.HeartbeatIntervalSecs != 30 {
 		b.WriteString(fmt.Sprintf("heartbeat_interval_secs = %d\n", cfg.Agent.HeartbeatIntervalSecs))

--- a/agent/internal/loadtest/config.go
+++ b/agent/internal/loadtest/config.go
@@ -9,26 +9,26 @@ import (
 
 // Config is the fully-validated configuration for a load-test run.
 type Config struct {
-	Address               string
-	OrgToken              string
-	CACertFile            string
-	TLSSkipVerify         bool
-	Agents                int
-	Ramp                  time.Duration
-	Duration              time.Duration
-	HeartbeatInterval     time.Duration
-	RunID                 string
-	HostnamePrefix        string
-	ConnFanout            int
-	StatsInterval         time.Duration
-	RegistrationConc      int
-	MetricsJitter         float64
-	OutputJSON            string
-	SimulateTasks         bool
-	SimulateChecks        bool
-	SimulateTerminal      bool
-	SimulateInventory     bool
-	CheckFailureRate      float64
+	Address           string
+	EnrolmentToken    string
+	CACertFile        string
+	TLSSkipVerify     bool
+	Agents            int
+	Ramp              time.Duration
+	Duration          time.Duration
+	HeartbeatInterval time.Duration
+	RunID             string
+	HostnamePrefix    string
+	ConnFanout        int
+	StatsInterval     time.Duration
+	RegistrationConc  int
+	MetricsJitter     float64
+	OutputJSON        string
+	SimulateTasks     bool
+	SimulateChecks    bool
+	SimulateTerminal  bool
+	SimulateInventory bool
+	CheckFailureRate  float64
 }
 
 // Validate returns an error if the configuration is missing required fields
@@ -37,7 +37,7 @@ func (c *Config) Validate() error {
 	if c.Address == "" {
 		return fmt.Errorf("--address is required")
 	}
-	if c.OrgToken == "" {
+	if c.EnrolmentToken == "" {
 		return fmt.Errorf("--token is required")
 	}
 	if c.Agents < 1 {

--- a/agent/internal/loadtest/config_test.go
+++ b/agent/internal/loadtest/config_test.go
@@ -9,7 +9,7 @@ import (
 func validConfig() *Config {
 	return &Config{
 		Address:           "localhost:9443",
-		OrgToken:          "test-token",
+		EnrolmentToken:    "test-token",
 		Agents:            10,
 		HeartbeatInterval: 30 * time.Second,
 		ConnFanout:        5,
@@ -34,7 +34,7 @@ func TestConfigValidateRejectsMissingFields(t *testing.T) {
 		want   string
 	}{
 		{"no address", func(c *Config) { c.Address = "" }, "--address"},
-		{"no token", func(c *Config) { c.OrgToken = "" }, "--token"},
+		{"no token", func(c *Config) { c.EnrolmentToken = "" }, "--token"},
 		{"zero agents", func(c *Config) { c.Agents = 0 }, "--agents"},
 		{"hb too fast", func(c *Config) { c.HeartbeatInterval = 500 * time.Millisecond }, "--heartbeat-interval"},
 		{"jitter too high", func(c *Config) { c.MetricsJitter = 1.5 }, "--metrics-jitter"},

--- a/agent/internal/loadtest/runner.go
+++ b/agent/internal/loadtest/runner.go
@@ -177,7 +177,7 @@ func (r *Runner) preflight(ctx context.Context) error {
 
 	probe, err := NewVirtualAgent(-1, &Config{
 		Address:           r.cfg.Address,
-		OrgToken:          r.cfg.OrgToken,
+		EnrolmentToken:    r.cfg.EnrolmentToken,
 		CACertFile:        r.cfg.CACertFile,
 		TLSSkipVerify:     r.cfg.TLSSkipVerify,
 		HostnamePrefix:    r.cfg.HostnamePrefix,

--- a/agent/internal/loadtest/virtualagent.go
+++ b/agent/internal/loadtest/virtualagent.go
@@ -86,7 +86,7 @@ func (v *VirtualAgent) Register(ctx context.Context) (status string, err error) 
 	// Load-test agents share a single data dir on the driver host, but cert
 	// rotation doesn't matter here — they won't persist certs. Pass empty
 	// dataDir so SaveClientCert no-ops on an empty PEM.
-	reg := registration.New(client, v.keypair, v.cfg.OrgToken, agentVersion, nil, "")
+	reg := registration.New(client, v.keypair, v.cfg.EnrolmentToken, agentVersion, nil, "")
 	reg.SetHostnameOverride(v.hostname)
 	// Empty IP list — critical for the load tester so the server's hostname/IP
 	// collision check does not adopt an existing host onto this virtual agent's

--- a/agent/internal/registration/registrar.go
+++ b/agent/internal/registration/registrar.go
@@ -19,12 +19,12 @@ const pollInterval = 30 * time.Second
 
 // Registrar handles the agent registration lifecycle.
 type Registrar struct {
-	client   agentv1.IngestServiceClient
-	keypair  *identity.Keypair
-	orgToken string
-	version  string
-	tags     []*agentv1.Tag
-	dataDir  string
+	client         agentv1.IngestServiceClient
+	keypair        *identity.Keypair
+	enrolmentToken string
+	version        string
+	tags           []*agentv1.Tag
+	dataDir        string
 
 	// Optional overrides. When hostnameOverride is non-empty it replaces
 	// os.Hostname(). When ipsOverride is non-nil it replaces localIPs() —
@@ -38,14 +38,14 @@ type Registrar struct {
 // New creates a new Registrar. Tags are applied at registration; merged order
 // (config → CLI) is resolved by the caller. dataDir is where the agent
 // persists any client cert / CA bundle it receives from the server.
-func New(client agentv1.IngestServiceClient, keypair *identity.Keypair, orgToken, version string, tags []*agentv1.Tag, dataDir string) *Registrar {
+func New(client agentv1.IngestServiceClient, keypair *identity.Keypair, enrolmentToken, version string, tags []*agentv1.Tag, dataDir string) *Registrar {
 	return &Registrar{
-		client:   client,
-		keypair:  keypair,
-		orgToken: orgToken,
-		version:  version,
-		tags:     tags,
-		dataDir:  dataDir,
+		client:         client,
+		keypair:        keypair,
+		enrolmentToken: enrolmentToken,
+		version:        version,
+		tags:           tags,
+		dataDir:        dataDir,
 	}
 }
 
@@ -91,9 +91,9 @@ func (r *Registrar) Register(ctx context.Context, existingAgentID string) (*iden
 	}
 
 	req := &agentv1.RegisterRequest{
-		OrgToken:  r.orgToken,
-		PublicKey: r.keypair.PublicKeyPEM,
-		CsrDer:    csrDER,
+		EnrolmentToken: r.enrolmentToken,
+		PublicKey:      r.keypair.PublicKeyPEM,
+		CsrDer:         csrDER,
 		PlatformInfo: &agentv1.PlatformInfo{
 			Os:          runtime.GOOS,
 			Arch:        runtime.GOARCH,

--- a/apps/ingest/cmd/ingest/main.go
+++ b/apps/ingest/cmd/ingest/main.go
@@ -98,7 +98,7 @@ func main() {
 		cfg.TLS.KeyFile,
 		agentCA.TrustPool(),
 		func(chains [][]*x509.Certificate) error {
-			if _, _, err := pki.VerifyLeaf(chains, revocation); err != nil {
+			if _, err := pki.VerifyLeaf(chains, revocation); err != nil {
 				return err
 			}
 			return nil

--- a/apps/ingest/internal/auth/jwt.go
+++ b/apps/ingest/internal/auth/jwt.go
@@ -98,11 +98,10 @@ func marshalKeyToPEM(key *rsa.PrivateKey) string {
 }
 
 // IssueAgentToken creates a signed JWT for an active agent.
-func (j *JWTIssuer) IssueAgentToken(agentID, orgID string) (string, error) {
+func (j *JWTIssuer) IssueAgentToken(agentID string) (string, error) {
 	now := time.Now()
 	claims := jwt.MapClaims{
 		"sub": agentID,
-		"org": orgID,
 		"iss": j.issuer,
 		"iat": now.Unix(),
 		"exp": now.Add(j.tokenTTL).Unix(),
@@ -113,7 +112,7 @@ func (j *JWTIssuer) IssueAgentToken(agentID, orgID string) (string, error) {
 
 // ValidateAgentToken parses and validates an agent JWT.
 // Returns the agentID claim on success.
-func (j *JWTIssuer) ValidateAgentToken(tokenStr string) (agentID, orgID string, err error) {
+func (j *JWTIssuer) ValidateAgentToken(tokenStr string) (agentID string, err error) {
 	token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
@@ -122,27 +121,26 @@ func (j *JWTIssuer) ValidateAgentToken(tokenStr string) (agentID, orgID string, 
 	}, jwt.WithIssuedAt(), jwt.WithIssuer(j.issuer))
 
 	if err != nil {
-		return "", "", fmt.Errorf("invalid token: %w", err)
+		return "", fmt.Errorf("invalid token: %w", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
-		return "", "", fmt.Errorf("invalid token claims")
+		return "", fmt.Errorf("invalid token claims")
 	}
 
 	agentID, _ = claims["sub"].(string)
-	orgID, _ = claims["org"].(string)
 	if agentID == "" {
-		return "", "", fmt.Errorf("token missing sub claim")
+		return "", fmt.Errorf("token missing sub claim")
 	}
-	return agentID, orgID, nil
+	return agentID, nil
 }
 
 // ValidateAgentTokenAllowExpired parses an agent JWT, verifying the signature
 // and issuer but tolerating an expired token. This is used for the Terminal
 // gRPC handler where the agent may hold a JWT that outlived its TTL — the
 // agent identity is still trustworthy because the signature is valid.
-func (j *JWTIssuer) ValidateAgentTokenAllowExpired(tokenStr string) (agentID, orgID string, err error) {
+func (j *JWTIssuer) ValidateAgentTokenAllowExpired(tokenStr string) (agentID string, err error) {
 	token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
@@ -153,20 +151,19 @@ func (j *JWTIssuer) ValidateAgentTokenAllowExpired(tokenStr string) (agentID, or
 		jwt.WithLeeway(100*365*24*time.Hour))
 
 	if err != nil {
-		return "", "", fmt.Errorf("invalid token: %w", err)
+		return "", fmt.Errorf("invalid token: %w", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
-		return "", "", fmt.Errorf("invalid token claims")
+		return "", fmt.Errorf("invalid token claims")
 	}
 
 	agentID, _ = claims["sub"].(string)
-	orgID, _ = claims["org"].(string)
 	if agentID == "" {
-		return "", "", fmt.Errorf("token missing sub claim")
+		return "", fmt.Errorf("token missing sub claim")
 	}
-	return agentID, orgID, nil
+	return agentID, nil
 }
 
 // JWKSHandler returns an HTTP handler that serves the public key as JWKS.

--- a/apps/ingest/internal/db/queries/agents.sql.go
+++ b/apps/ingest/internal/db/queries/agents.sql.go
@@ -9,19 +9,19 @@ import (
 
 // AgentRow represents a row from the agents table.
 type AgentRow struct {
-	ID             string
-	OrganisationID string
-	Hostname       string
-	PublicKey      string
-	Status         string
-	Version        *string
+	ID               string
+	InstanceID       string
+	Hostname         string
+	PublicKey        string
+	Status           string
+	Version          *string
 	EnrolmentTokenID *string
 }
 
 // GetAgentByPublicKey retrieves an agent by its public key (for idempotent registration).
 func GetAgentByPublicKey(ctx context.Context, pool *pgxpool.Pool, publicKey string) (*AgentRow, error) {
 	const q = `
-		SELECT id, organisation_id, hostname, public_key, status, version, enrolment_token_id
+		SELECT id, instance_id, hostname, public_key, status, version, enrolment_token_id
 		FROM agents
 		WHERE public_key = $1 AND deleted_at IS NULL
 	`
@@ -29,7 +29,7 @@ func GetAgentByPublicKey(ctx context.Context, pool *pgxpool.Pool, publicKey stri
 
 	var a AgentRow
 	if err := row.Scan(
-		&a.ID, &a.OrganisationID, &a.Hostname, &a.PublicKey, &a.Status,
+		&a.ID, &a.InstanceID, &a.Hostname, &a.PublicKey, &a.Status,
 		&a.Version, &a.EnrolmentTokenID,
 	); err != nil {
 		return nil, err
@@ -38,13 +38,13 @@ func GetAgentByPublicKey(ctx context.Context, pool *pgxpool.Pool, publicKey stri
 }
 
 // InsertAgent inserts a new agent row and returns the generated ID.
-func InsertAgent(ctx context.Context, pool *pgxpool.Pool, orgID, hostname, publicKey, status, tokenID, agentOS, agentArch string) (string, error) {
+func InsertAgent(ctx context.Context, pool *pgxpool.Pool, instanceID, hostname, publicKey, status, tokenID, agentOS, agentArch string) (string, error) {
 	const q = `
-		INSERT INTO agents (id, organisation_id, hostname, public_key, status, enrolment_token_id, os, arch)
+		INSERT INTO agents (id, instance_id, hostname, public_key, status, enrolment_token_id, os, arch)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	`
 	id := newCUID()
-	_, err := pool.Exec(ctx, q, id, orgID, hostname, publicKey, status, nullableString(tokenID), nullableString(agentOS), nullableString(agentArch))
+	_, err := pool.Exec(ctx, q, id, instanceID, hostname, publicKey, status, nullableString(tokenID), nullableString(agentOS), nullableString(agentArch))
 	return id, err
 }
 
@@ -70,19 +70,19 @@ func UpdateAgentHeartbeat(ctx context.Context, pool *pgxpool.Pool, agentID strin
 }
 
 // InsertAgentStatusHistory appends a status history entry.
-func InsertAgentStatusHistory(ctx context.Context, pool *pgxpool.Pool, agentID, orgID, status string, actorID *string, reason string) error {
+func InsertAgentStatusHistory(ctx context.Context, pool *pgxpool.Pool, agentID, instanceID, status string, actorID *string, reason string) error {
 	const q = `
-		INSERT INTO agent_status_history (id, agent_id, organisation_id, status, actor_id, reason)
+		INSERT INTO agent_status_history (id, agent_id, instance_id, status, actor_id, reason)
 		VALUES ($1, $2, $3, $4, $5, $6)
 	`
-	_, err := pool.Exec(ctx, q, newCUID(), agentID, orgID, status, actorID, reason)
+	_, err := pool.Exec(ctx, q, newCUID(), agentID, instanceID, status, actorID, reason)
 	return err
 }
 
 // GetAgentByID retrieves an agent by its primary key.
 func GetAgentByID(ctx context.Context, pool *pgxpool.Pool, agentID string) (*AgentRow, error) {
 	const q = `
-		SELECT id, organisation_id, hostname, public_key, status, version, enrolment_token_id
+		SELECT id, instance_id, hostname, public_key, status, version, enrolment_token_id
 		FROM agents
 		WHERE id = $1 AND deleted_at IS NULL
 	`
@@ -90,7 +90,7 @@ func GetAgentByID(ctx context.Context, pool *pgxpool.Pool, agentID string) (*Age
 
 	var a AgentRow
 	if err := row.Scan(
-		&a.ID, &a.OrganisationID, &a.Hostname, &a.PublicKey, &a.Status,
+		&a.ID, &a.InstanceID, &a.Hostname, &a.PublicKey, &a.Status,
 		&a.Version, &a.EnrolmentTokenID,
 	); err != nil {
 		return nil, err

--- a/apps/ingest/internal/db/queries/alerts.sql.go
+++ b/apps/ingest/internal/db/queries/alerts.sql.go
@@ -13,7 +13,7 @@ import (
 type AlertRuleRow struct {
 	ID            string
 	HostID        *string // nil for org-wide rules
-	OrgID         string
+	InstanceID    string
 	Name          string
 	ConditionType string // "check_status" | "metric_threshold"
 	ConfigJSON    string // raw JSONB as text
@@ -45,17 +45,17 @@ type WebhookChannelRow struct {
 // given host OR org-wide (host_id IS NULL, isGlobalDefault = false).
 // Global defaults (is_global_default = true) are excluded — they are cloned as
 // host-specific rules at approval time and must not be double-evaluated.
-func GetAlertRulesForHost(ctx context.Context, pool *pgxpool.Pool, orgID, hostID string) ([]AlertRuleRow, error) {
+func GetAlertRulesForHost(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string) ([]AlertRuleRow, error) {
 	const q = `
-		SELECT id, host_id, organisation_id, name, condition_type, config::text, severity
+		SELECT id, host_id, instance_id, name, condition_type, config::text, severity
 		FROM alert_rules
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND enabled = true
 		  AND deleted_at IS NULL
 		  AND is_global_default = false
 		  AND (host_id = $2 OR host_id IS NULL)
 	`
-	rows, err := pool.Query(ctx, q, orgID, hostID)
+	rows, err := pool.Query(ctx, q, instanceID, hostID)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func GetAlertRulesForHost(ctx context.Context, pool *pgxpool.Pool, orgID, hostID
 	var result []AlertRuleRow
 	for rows.Next() {
 		var r AlertRuleRow
-		if err := rows.Scan(&r.ID, &r.HostID, &r.OrgID, &r.Name, &r.ConditionType, &r.ConfigJSON, &r.Severity); err != nil {
+		if err := rows.Scan(&r.ID, &r.HostID, &r.InstanceID, &r.Name, &r.ConditionType, &r.ConfigJSON, &r.Severity); err != nil {
 			return nil, err
 		}
 		result = append(result, r)
@@ -98,17 +98,17 @@ func GetActiveAlertInstance(ctx context.Context, pool *pgxpool.Pool, ruleID, hos
 func InsertAlertInstance(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	ruleID, hostID, orgID, severity, message string,
+	ruleID, hostID, instanceID, severity, message string,
 	triggeredAt time.Time,
 ) (string, error) {
 	const q = `
-		INSERT INTO alert_instances (id, rule_id, host_id, organisation_id, status, message, triggered_at)
+		INSERT INTO alert_instances (id, rule_id, host_id, instance_id, status, message, triggered_at)
 		VALUES ($1, $2, $3, $4, 'firing', $5, $6)
 		RETURNING id
 	`
 	id := newCUID()
 	var returnedID string
-	err := pool.QueryRow(ctx, q, id, ruleID, hostID, orgID, message, triggeredAt).Scan(&returnedID)
+	err := pool.QueryRow(ctx, q, id, ruleID, hostID, instanceID, message, triggeredAt).Scan(&returnedID)
 	return returnedID, err
 }
 
@@ -154,24 +154,24 @@ func GetRecentCheckResults(ctx context.Context, pool *pgxpool.Pool, checkID stri
 type SmtpChannelRow struct {
 	ID              string
 	ConfigJSON      string // raw notification_channels.config JSONB as text
-	RelayConfigJSON string // raw organisations.metadata.notificationSettings.smtpRelay JSONB as text; may be empty
+	RelayConfigJSON string // raw instances.metadata.notificationSettings.smtpRelay JSONB as text; may be empty
 }
 
 // GetEnabledSmtpChannels returns all enabled, non-deleted SMTP notification
-// channels for the given organisation.
-func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]SmtpChannelRow, error) {
+// channels for the given instance.
+func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]SmtpChannelRow, error) {
 	const q = `
 		SELECT c.id,
 		       c.config::text,
 		       COALESCE(o.metadata->'notificationSettings'->'smtpRelay', '{}'::jsonb)::text
 		FROM notification_channels c
-		JOIN organisations o ON o.id = c.organisation_id
-		WHERE c.organisation_id = $1
+		JOIN instances o ON o.id = c.instance_id
+		WHERE c.instance_id = $1
 		  AND c.type = 'smtp'
 		  AND c.enabled = true
 		  AND c.deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID)
+	rows, err := pool.Query(ctx, q, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -190,33 +190,33 @@ func GetEnabledSmtpChannels(ctx context.Context, pool *pgxpool.Pool, orgID strin
 
 // IsHostSilenced returns true if the given host (or the whole org) currently has
 // an active silence window covering now.
-func IsHostSilenced(ctx context.Context, pool *pgxpool.Pool, orgID, hostID string) (bool, error) {
+func IsHostSilenced(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string) (bool, error) {
 	const q = `
 		SELECT COUNT(*) > 0
 		FROM alert_silences
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND deleted_at IS NULL
 		  AND starts_at <= NOW()
 		  AND ends_at   >= NOW()
 		  AND (host_id = $2 OR host_id IS NULL)
 	`
 	var silenced bool
-	err := pool.QueryRow(ctx, q, orgID, hostID).Scan(&silenced)
+	err := pool.QueryRow(ctx, q, instanceID, hostID).Scan(&silenced)
 	return silenced, err
 }
 
 // GetEnabledWebhookChannels returns all enabled, non-deleted webhook notification
-// channels for the given organisation.
-func GetEnabledWebhookChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]WebhookChannelRow, error) {
+// channels for the given instance.
+func GetEnabledWebhookChannels(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]WebhookChannelRow, error) {
 	const q = `
 		SELECT id, config::text
 		FROM notification_channels
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND type = 'webhook'
 		  AND enabled = true
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID)
+	rows, err := pool.Query(ctx, q, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -240,17 +240,17 @@ type SlackChannelRow struct {
 }
 
 // GetEnabledSlackChannels returns all enabled, non-deleted Slack notification
-// channels for the given organisation.
-func GetEnabledSlackChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]SlackChannelRow, error) {
+// channels for the given instance.
+func GetEnabledSlackChannels(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]SlackChannelRow, error) {
 	const q = `
 		SELECT id, config::text
 		FROM notification_channels
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND type = 'slack'
 		  AND enabled = true
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID)
+	rows, err := pool.Query(ctx, q, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -274,17 +274,17 @@ type TelegramChannelRow struct {
 }
 
 // GetEnabledTelegramChannels returns all enabled, non-deleted Telegram notification
-// channels for the given organisation.
-func GetEnabledTelegramChannels(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]TelegramChannelRow, error) {
+// channels for the given instance.
+func GetEnabledTelegramChannels(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]TelegramChannelRow, error) {
 	const q = `
 		SELECT id, config::text
 		FROM notification_channels
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND type = 'telegram'
 		  AND enabled = true
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID)
+	rows, err := pool.Query(ctx, q, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ type OrgNotificationSettingsRow struct {
 
 // GetOrgNotificationSettings fetches the in-app notification settings for an org.
 // Returns sensible defaults if metadata is not set.
-func GetOrgNotificationSettings(ctx context.Context, pool *pgxpool.Pool, orgID string) (OrgNotificationSettingsRow, error) {
+func GetOrgNotificationSettings(ctx context.Context, pool *pgxpool.Pool, instanceID string) (OrgNotificationSettingsRow, error) {
 	const q = `
 		SELECT
 			COALESCE((metadata->'notificationSettings'->>'inAppEnabled')::boolean, true),
@@ -319,11 +319,11 @@ func GetOrgNotificationSettings(ctx context.Context, pool *pgxpool.Pool, orgID s
 				ARRAY['super_admin','org_admin','engineer']
 			),
 			COALESCE((metadata->'notificationSettings'->>'allowUserOptOut')::boolean, true)
-		FROM organisations
+		FROM instances
 		WHERE id = $1
 	`
 	var row OrgNotificationSettingsRow
-	err := pool.QueryRow(ctx, q, orgID).Scan(&row.InAppEnabled, &row.InAppRoles, &row.AllowUserOptOut)
+	err := pool.QueryRow(ctx, q, instanceID).Scan(&row.InAppEnabled, &row.InAppRoles, &row.AllowUserOptOut)
 	if err != nil {
 		// Return defaults on error
 		return OrgNotificationSettingsRow{
@@ -342,12 +342,12 @@ func GetOrgNotificationSettings(ctx context.Context, pool *pgxpool.Pool, orgID s
 
 // GetAlertTargetUsers returns user IDs in the org that should receive in-app notifications.
 // roles: the roles that are eligible; allowOptOut: if true, exclude users who have opted out.
-func GetAlertTargetUsers(ctx context.Context, pool *pgxpool.Pool, orgID string, roles []string, allowOptOut bool) ([]string, error) {
+func GetAlertTargetUsers(ctx context.Context, pool *pgxpool.Pool, instanceID string, roles []string, allowOptOut bool) ([]string, error) {
 	var q string
 	if allowOptOut {
 		q = `
 			SELECT id FROM "user"
-			WHERE organisation_id = $1
+			WHERE instance_id = $1
 			  AND is_active = true
 			  AND role = ANY($2)
 			  AND notifications_enabled = true
@@ -356,13 +356,13 @@ func GetAlertTargetUsers(ctx context.Context, pool *pgxpool.Pool, orgID string, 
 	} else {
 		q = `
 			SELECT id FROM "user"
-			WHERE organisation_id = $1
+			WHERE instance_id = $1
 			  AND is_active = true
 			  AND role = ANY($2)
 			  AND deleted_at IS NULL
 		`
 	}
-	rows, err := pool.Query(ctx, q, orgID, roles)
+	rows, err := pool.Query(ctx, q, instanceID, roles)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func GetAlertTargetUsers(ctx context.Context, pool *pgxpool.Pool, orgID string, 
 
 // NotificationInsert holds the data for a single notifications row insert.
 type NotificationInsert struct {
-	OrgID           string
+	InstanceID      string
 	UserID          string
 	AlertInstanceID string // may be empty
 	Subject         string
@@ -401,11 +401,11 @@ func InsertNotificationBatch(ctx context.Context, pool *pgxpool.Pool, rows []Not
 	batch := &pgx.Batch{}
 	const q = `
 		INSERT INTO notifications
-		  (id, organisation_id, user_id, alert_instance_id, subject, body, severity, resource_type, resource_id)
+		  (id, instance_id, user_id, alert_instance_id, subject, body, severity, resource_type, resource_id)
 		VALUES ($1, $2, $3, NULLIF($4,''), $5, $6, $7, $8, $9)
 	`
 	for _, r := range rows {
-		batch.Queue(q, newCUID(), r.OrgID, r.UserID, r.AlertInstanceID, r.Subject, r.Body, r.Severity, r.ResourceType, r.ResourceID)
+		batch.Queue(q, newCUID(), r.InstanceID, r.UserID, r.AlertInstanceID, r.Subject, r.Body, r.Severity, r.ResourceType, r.ResourceID)
 	}
 
 	br := pool.SendBatch(ctx, batch)

--- a/apps/ingest/internal/db/queries/certificates.sql.go
+++ b/apps/ingest/internal/db/queries/certificates.sql.go
@@ -29,7 +29,7 @@ type CertSummary struct {
 }
 
 // UpsertCertificate inserts or updates a certificate row identified by the
-// natural key (organisation_id, host, port, server_name, fingerprint_sha256).
+// natural key (instance_id, host, port, server_name, fingerprint_sha256).
 //
 // Returns:
 //   - certID: the ID of the inserted/updated row
@@ -38,7 +38,7 @@ type CertSummary struct {
 func UpsertCertificate(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, discoveredByHostID, checkID string,
+	instanceID, discoveredByHostID, checkID string,
 	host string, port int, serverName string,
 	commonName, issuer string,
 	sans []string,
@@ -50,7 +50,7 @@ func UpsertCertificate(
 	const selectQ = `
 		SELECT id, status
 		FROM certificates
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host = $2
 		  AND port = $3
 		  AND server_name = $4
@@ -59,7 +59,7 @@ func UpsertCertificate(
 		LIMIT 1
 	`
 	var existing CertRow
-	rowErr := pool.QueryRow(ctx, selectQ, orgID, host, port, serverName, fingerprint).
+	rowErr := pool.QueryRow(ctx, selectQ, instanceID, host, port, serverName, fingerprint).
 		Scan(&existing.ID, &existing.Status)
 
 	if rowErr != nil && !errors.Is(rowErr, pgx.ErrNoRows) {
@@ -72,7 +72,7 @@ func UpsertCertificate(
 		// Insert new row.
 		const insertQ = `
 			INSERT INTO certificates (
-				id, organisation_id, discovered_by_host_id, check_id,
+				id, instance_id, discovered_by_host_id, check_id,
 				source, host, port, server_name,
 				common_name, issuer, sans,
 				not_before, not_after, fingerprint_sha256, status,
@@ -89,7 +89,7 @@ func UpsertCertificate(
 		id := newCUID()
 		var returnedID string
 		err = pool.QueryRow(ctx, insertQ,
-			id, orgID, discoveredByHostID, checkID,
+			id, instanceID, discoveredByHostID, checkID,
 			host, port, serverName,
 			commonName, issuer, sansJSON,
 			notBefore, notAfter, fingerprint, status,
@@ -130,18 +130,18 @@ func UpsertCertificate(
 func FindCertsForEndpoint(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, host string, port int, serverName string,
+	instanceID, host string, port int, serverName string,
 ) ([]CertRow, error) {
 	const q = `
 		SELECT id, status
 		FROM certificates
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host = $2
 		  AND port = $3
 		  AND server_name = $4
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID, host, port, serverName)
+	rows, err := pool.Query(ctx, q, instanceID, host, port, serverName)
 	if err != nil {
 		return nil, err
 	}
@@ -162,12 +162,12 @@ func FindCertsForEndpoint(
 func InsertCertificateEvent(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	certID, orgID, eventType, previousStatus, newStatus, message string,
+	certID, instanceID, eventType, previousStatus, newStatus, message string,
 	metadataJSON []byte,
 ) error {
 	const q = `
 		INSERT INTO certificate_events (
-			id, organisation_id, certificate_id,
+			id, instance_id, certificate_id,
 			event_type, previous_status, new_status, message, occurred_at, metadata
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8)
 	`
@@ -179,7 +179,7 @@ func InsertCertificateEvent(
 		newPtr = &newStatus
 	}
 	_, err := pool.Exec(ctx, q,
-		newCUID(), orgID, certID,
+		newCUID(), instanceID, certID,
 		eventType, prevPtr, newPtr, message, metadataJSON,
 	)
 	return err
@@ -217,32 +217,32 @@ func GetActiveCertAlertInstance(
 func InsertCertAlertInstance(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	ruleID, hostID, orgID, severity, message, certID string,
+	ruleID, hostID, instanceID, severity, message, certID string,
 	triggeredAt time.Time,
 ) (string, error) {
 	meta, _ := json.Marshal(map[string]string{"certificateId": certID})
 	const q = `
-		INSERT INTO alert_instances (id, rule_id, host_id, organisation_id, status, message, triggered_at, metadata)
+		INSERT INTO alert_instances (id, rule_id, host_id, instance_id, status, message, triggered_at, metadata)
 		VALUES ($1, $2, $3, $4, 'firing', $5, $6, $7)
 		RETURNING id
 	`
 	id := newCUID()
 	var returnedID string
-	err := pool.QueryRow(ctx, q, id, ruleID, hostID, orgID, message, triggeredAt, meta).Scan(&returnedID)
+	err := pool.QueryRow(ctx, q, id, ruleID, hostID, instanceID, message, triggeredAt, meta).Scan(&returnedID)
 	return returnedID, err
 }
 
 // GetCertExpiryRulesForOrg returns all enabled cert_expiry alert rules for an org.
-func GetCertExpiryRulesForOrg(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]AlertRuleRow, error) {
+func GetCertExpiryRulesForOrg(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]AlertRuleRow, error) {
 	const q = `
-		SELECT id, host_id, organisation_id, name, condition_type, config::text, severity
+		SELECT id, host_id, instance_id, name, condition_type, config::text, severity
 		FROM alert_rules
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND condition_type = 'cert_expiry'
 		  AND enabled = true
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID)
+	rows, err := pool.Query(ctx, q, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func GetCertExpiryRulesForOrg(ctx context.Context, pool *pgxpool.Pool, orgID str
 	var result []AlertRuleRow
 	for rows.Next() {
 		var r AlertRuleRow
-		if err := rows.Scan(&r.ID, &r.HostID, &r.OrgID, &r.Name, &r.ConditionType, &r.ConfigJSON, &r.Severity); err != nil {
+		if err := rows.Scan(&r.ID, &r.HostID, &r.InstanceID, &r.Name, &r.ConditionType, &r.ConfigJSON, &r.Severity); err != nil {
 			return nil, err
 		}
 		result = append(result, r)
@@ -263,7 +263,7 @@ func GetCertExpiryRulesForOrg(ctx context.Context, pool *pgxpool.Pool, orgID str
 // enabled cert_expiry rule — used by the sweeper.
 func GetAllOrgsWithCertExpiryRules(ctx context.Context, pool *pgxpool.Pool) ([]string, error) {
 	const q = `
-		SELECT DISTINCT organisation_id
+		SELECT DISTINCT instance_id
 		FROM alert_rules
 		WHERE condition_type = 'cert_expiry'
 		  AND enabled = true
@@ -289,7 +289,7 @@ func GetAllOrgsWithCertExpiryRules(ctx context.Context, pool *pgxpool.Pool) ([]s
 // TrackedCertRow represents a row needed by the URL refresh sweeper.
 type TrackedCertRow struct {
 	ID                     string
-	OrgID                  string
+	InstanceID             string
 	Host                   string
 	Port                   int
 	ServerName             string
@@ -309,7 +309,7 @@ func ListCertsDueForUrlRefresh(
 	limit int,
 ) ([]TrackedCertRow, error) {
 	const q = `
-		SELECT id, organisation_id, host, port, server_name,
+		SELECT id, instance_id, host, port, server_name,
 		       tracked_url, COALESCE(refresh_interval_seconds, 3600),
 		       COALESCE((metadata->>'tlsSkipVerify')::boolean, false),
 		       fingerprint_sha256, not_after, status
@@ -333,7 +333,7 @@ func ListCertsDueForUrlRefresh(
 	for rows.Next() {
 		var r TrackedCertRow
 		if err := rows.Scan(
-			&r.ID, &r.OrgID, &r.Host, &r.Port, &r.ServerName,
+			&r.ID, &r.InstanceID, &r.Host, &r.Port, &r.ServerName,
 			&r.TrackedURL, &r.RefreshIntervalSeconds,
 			&r.TLSSkipVerify,
 			&r.FingerprintSHA256, &r.NotAfter, &r.Status,
@@ -389,7 +389,7 @@ func MarkCertRefreshFailed(
 func InsertRenewedTrackedCert(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	previousCertID, orgID string,
+	previousCertID, instanceID string,
 	host string, port int, serverName string,
 	commonName, issuer string,
 	sans []string,
@@ -408,7 +408,7 @@ func InsertRenewedTrackedCert(
 
 	const insertQ = `
 		INSERT INTO certificates (
-			id, organisation_id,
+			id, instance_id,
 			source, host, port, server_name,
 			common_name, issuer, sans,
 			not_before, not_after, fingerprint_sha256, status,
@@ -428,7 +428,7 @@ func InsertRenewedTrackedCert(
 	`
 	id := newCUID()
 	err = tx.QueryRow(ctx, insertQ,
-		id, orgID,
+		id, instanceID,
 		host, port, serverName,
 		commonName, issuer, sansJSON,
 		notBefore, notAfter, fingerprint, status,
@@ -463,17 +463,17 @@ func InsertRenewedTrackedCert(
 func ListCertificatesExpiringWithin(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID string,
+	instanceID string,
 	days int,
 ) ([]CertSummary, error) {
 	const q = `
 		SELECT id, common_name, issuer, host, port, not_after, status, COALESCE(discovered_by_host_id, '')
 		FROM certificates
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND deleted_at IS NULL
 		  AND not_after <= NOW() + ($2 || ' days')::interval
 	`
-	rows, err := pool.Query(ctx, q, orgID, days)
+	rows, err := pool.Query(ctx, q, instanceID, days)
 	if err != nil {
 		return nil, err
 	}
@@ -494,18 +494,18 @@ func ListCertificatesExpiringWithin(
 func GetCertificateByID(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, certID string,
+	instanceID, certID string,
 ) (*CertSummary, error) {
 	const q = `
 		SELECT id, common_name, issuer, host, port, not_after, status, COALESCE(discovered_by_host_id, '')
 		FROM certificates
 		WHERE id = $1
-		  AND organisation_id = $2
+		  AND instance_id = $2
 		  AND deleted_at IS NULL
 		LIMIT 1
 	`
 	var r CertSummary
-	err := pool.QueryRow(ctx, q, certID, orgID).
+	err := pool.QueryRow(ctx, q, certID, instanceID).
 		Scan(&r.ID, &r.CommonName, &r.Issuer, &r.Host, &r.Port, &r.NotAfter, &r.Status, &r.DiscoveredByHostID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/apps/ingest/internal/db/queries/checks.sql.go
+++ b/apps/ingest/internal/db/queries/checks.sql.go
@@ -26,21 +26,21 @@ type checkExecer interface {
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 }
 
-// GetChecksForHost returns all enabled, non-deleted checks for a given host and organisation.
-func GetChecksForHost(ctx context.Context, pool *pgxpool.Pool, hostID, orgID string) ([]CheckRow, error) {
-	return getChecksForHost(ctx, pool, hostID, orgID)
+// GetChecksForHost returns all enabled, non-deleted checks for a given host and instance.
+func GetChecksForHost(ctx context.Context, pool *pgxpool.Pool, hostID, instanceID string) ([]CheckRow, error) {
+	return getChecksForHost(ctx, pool, hostID, instanceID)
 }
 
-func getChecksForHost(ctx context.Context, queryer checkQueryer, hostID, orgID string) ([]CheckRow, error) {
+func getChecksForHost(ctx context.Context, queryer checkQueryer, hostID, instanceID string) ([]CheckRow, error) {
 	const sql = `
 		SELECT id, check_type, config::text, interval_seconds
 		FROM checks
 		WHERE host_id = $1
-		  AND organisation_id = $2
+		  AND instance_id = $2
 		  AND enabled = true
 		  AND deleted_at IS NULL
 	`
-	rows, err := queryer.Query(ctx, sql, hostID, orgID)
+	rows, err := queryer.Query(ctx, sql, hostID, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -57,18 +57,18 @@ func getChecksForHost(ctx context.Context, queryer checkQueryer, hostID, orgID s
 	return result, rows.Err()
 }
 
-var ErrCheckOwnershipMismatch = errors.New("check does not belong to host organisation")
+var ErrCheckOwnershipMismatch = errors.New("check does not belong to host instance")
 
 // InsertCheckResult persists a single check result row and prunes old rows beyond 100 per check.
 func InsertCheckResult(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	checkID, hostID, orgID string,
+	checkID, hostID, instanceID string,
 	status, output string,
 	durationMs int32,
 	ranAt time.Time,
 ) error {
-	if err := insertCheckResult(ctx, pool, checkID, hostID, orgID, status, output, durationMs, ranAt); err != nil {
+	if err := insertCheckResult(ctx, pool, checkID, hostID, instanceID, status, output, durationMs, ranAt); err != nil {
 		return err
 	}
 	return pruneCheckResults(ctx, pool, checkID)
@@ -77,25 +77,25 @@ func InsertCheckResult(
 func insertCheckResult(
 	ctx context.Context,
 	exec checkExecer,
-	checkID, hostID, orgID string,
+	checkID, hostID, instanceID string,
 	status, output string,
 	durationMs int32,
 	ranAt time.Time,
 ) error {
 	const q = `
-		INSERT INTO check_results (id, check_id, host_id, organisation_id, ran_at, status, output, duration_ms)
+		INSERT INTO check_results (id, check_id, host_id, instance_id, ran_at, status, output, duration_ms)
 		SELECT $1, $2, $3, $4, $5, $6, $7, $8
 		WHERE EXISTS (
 			SELECT 1
 			FROM checks
 			WHERE id = $2
 			  AND host_id = $3
-			  AND organisation_id = $4
+			  AND instance_id = $4
 			  AND deleted_at IS NULL
 		)
 	`
 	tag, err := exec.Exec(ctx, q,
-		newCUID(), checkID, hostID, orgID, ranAt, status, output, durationMs,
+		newCUID(), checkID, hostID, instanceID, ranAt, status, output, durationMs,
 	)
 	if err != nil {
 		return err

--- a/apps/ingest/internal/db/queries/checks_test.go
+++ b/apps/ingest/internal/db/queries/checks_test.go
@@ -36,7 +36,7 @@ func (f *fakeCheckExecer) Exec(_ context.Context, sql string, args ...any) (pgco
 	return f.tag, f.err
 }
 
-func TestGetChecksForHostScopesByHostAndOrganisation(t *testing.T) {
+func TestGetChecksForHostScopesByHostAndInstance(t *testing.T) {
 	t.Parallel()
 
 	queryErr := errors.New("stop after query capture")
@@ -49,15 +49,15 @@ func TestGetChecksForHostScopesByHostAndOrganisation(t *testing.T) {
 	if !strings.Contains(queryer.sql, "WHERE host_id = $1") {
 		t.Fatalf("query does not filter by host_id: %s", queryer.sql)
 	}
-	if !strings.Contains(queryer.sql, "AND organisation_id = $2") {
-		t.Fatalf("query does not filter by organisation_id: %s", queryer.sql)
+	if !strings.Contains(queryer.sql, "AND instance_id = $2") {
+		t.Fatalf("query does not filter by instance_id: %s", queryer.sql)
 	}
 	if len(queryer.args) != 2 || queryer.args[0] != "host-victim" || queryer.args[1] != "org-victim" {
-		t.Fatalf("args = %#v, want host and organisation", queryer.args)
+		t.Fatalf("args = %#v, want host and instance", queryer.args)
 	}
 }
 
-func TestInsertCheckResultRejectsCrossTenantCheckID(t *testing.T) {
+func TestInsertCheckResultRejectsCrossInstanceCheckID(t *testing.T) {
 	t.Parallel()
 
 	execer := &fakeCheckExecer{tag: pgconn.NewCommandTag("INSERT 0 0")}
@@ -78,7 +78,7 @@ func TestInsertCheckResultRejectsCrossTenantCheckID(t *testing.T) {
 	}
 	if !strings.Contains(execer.sql, "WHERE id = $2") ||
 		!strings.Contains(execer.sql, "AND host_id = $3") ||
-		!strings.Contains(execer.sql, "AND organisation_id = $4") {
+		!strings.Contains(execer.sql, "AND instance_id = $4") {
 		t.Fatalf("insert query does not enforce check ownership: %s", execer.sql)
 	}
 }

--- a/apps/ingest/internal/db/queries/enrolment.sql.go
+++ b/apps/ingest/internal/db/queries/enrolment.sql.go
@@ -22,15 +22,15 @@ type EnrolmentTokenMetadata struct {
 
 // EnrolmentToken represents a row from the agent_enrolment_tokens table.
 type EnrolmentToken struct {
-	ID             string
-	OrganisationID string
-	Label          string
-	Token          string
-	AutoApprove    bool
-	MaxUses        *int
-	UsageCount     int
-	ExpiresAt      *time.Time
-	Metadata       EnrolmentTokenMetadata
+	ID          string
+	InstanceID  string
+	Label       string
+	Token       string
+	AutoApprove bool
+	MaxUses     *int
+	UsageCount  int
+	ExpiresAt   *time.Time
+	Metadata    EnrolmentTokenMetadata
 }
 
 type enrolmentQueryer interface {
@@ -46,7 +46,7 @@ type enrolmentQueryer interface {
 // back to a direct plaintext comparison during the migration window.
 func GetEnrolmentToken(ctx context.Context, pool *pgxpool.Pool, token string) (*EnrolmentToken, error) {
 	const q = `
-		SELECT id, organisation_id, label, token, auto_approve, max_uses, usage_count, expires_at, metadata
+		SELECT id, instance_id, label, token, auto_approve, max_uses, usage_count, expires_at, metadata
 		FROM agent_enrolment_tokens
 		WHERE (token_hash = encode(sha256($1::bytea), 'hex') OR (token_hash IS NULL AND token = $1::text))
 		  AND deleted_at IS NULL
@@ -58,7 +58,7 @@ func GetEnrolmentToken(ctx context.Context, pool *pgxpool.Pool, token string) (*
 	var t EnrolmentToken
 	var rawMeta []byte
 	if err := row.Scan(
-		&t.ID, &t.OrganisationID, &t.Label, &t.Token,
+		&t.ID, &t.InstanceID, &t.Label, &t.Token,
 		&t.AutoApprove, &t.MaxUses, &t.UsageCount, &t.ExpiresAt, &rawMeta,
 	); err != nil {
 		return nil, err
@@ -92,14 +92,14 @@ func consumeEnrolmentToken(ctx context.Context, queryer enrolmentQueryer, token 
 		UPDATE agent_enrolment_tokens
 		SET usage_count = usage_count + 1, updated_at = NOW()
 		WHERE id = (SELECT id FROM candidate)
-		RETURNING id, organisation_id, label, token, auto_approve, max_uses, usage_count, expires_at, metadata
+		RETURNING id, instance_id, label, token, auto_approve, max_uses, usage_count, expires_at, metadata
 	`
 	row := queryer.QueryRow(ctx, q, token)
 
 	var t EnrolmentToken
 	var rawMeta []byte
 	if err := row.Scan(
-		&t.ID, &t.OrganisationID, &t.Label, &t.Token,
+		&t.ID, &t.InstanceID, &t.Label, &t.Token,
 		&t.AutoApprove, &t.MaxUses, &t.UsageCount, &t.ExpiresAt, &rawMeta,
 	); err != nil {
 		return nil, err

--- a/apps/ingest/internal/db/queries/enrolment_test.go
+++ b/apps/ingest/internal/db/queries/enrolment_test.go
@@ -52,7 +52,7 @@ func TestConsumeEnrolmentTokenAtomicallyChecksUsageLimit(t *testing.T) {
 	if !strings.Contains(queryer.sql, "FOR UPDATE") {
 		t.Fatalf("query does not lock the candidate token row: %s", queryer.sql)
 	}
-	if !strings.Contains(queryer.sql, "RETURNING id, organisation_id") {
+	if !strings.Contains(queryer.sql, "RETURNING id, instance_id") {
 		t.Fatalf("query does not return the consumed token row: %s", queryer.sql)
 	}
 	if len(queryer.args) != 1 || queryer.args[0] != "token-secret" {

--- a/apps/ingest/internal/db/queries/hosts.sql.go
+++ b/apps/ingest/internal/db/queries/hosts.sql.go
@@ -30,12 +30,12 @@ type HostCollision struct {
 // An "online" match means a host is still heartbeating under a different
 // keypair, so the new registration must be rejected. An "offline" or "unknown"
 // match is a suspicious identity claim and must not mutate the existing row.
-func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname string, ips []string) (*HostCollision, error) {
+func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, instanceID, hostname string, ips []string) (*HostCollision, error) {
 	const q = `
 		SELECT h.id, COALESCE(h.agent_id, ''), h.hostname, h.status, COALESCE(a.status, '')
 		FROM hosts h
 		LEFT JOIN agents a ON a.id = h.agent_id
-		WHERE h.organisation_id = $1
+		WHERE h.instance_id = $1
 		  AND h.deleted_at IS NULL
 		  AND (
 		    h.hostname = $2
@@ -50,7 +50,7 @@ func FindHostCollision(ctx context.Context, pool *pgxpool.Pool, orgID, hostname 
 		ips = []string{}
 	}
 	ips = FilterHostIdentityIPs(ips)
-	row := pool.QueryRow(ctx, q, orgID, hostname, ips)
+	row := pool.QueryRow(ctx, q, instanceID, hostname, ips)
 	var c HostCollision
 	if err := row.Scan(&c.HostID, &c.AgentID, &c.Hostname, &c.HostStatus, &c.AgentStatus); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -128,9 +128,9 @@ func ReattachHostToAgent(ctx context.Context, pool *pgxpool.Pool, hostID, agentI
 // approveAgent (TS) can drain and apply them once the operator approves the
 // agent. The ingest auto-approve path applies tags directly via
 // AssignTagsToResource and passes nil/empty here.
-func InsertHost(ctx context.Context, pool *pgxpool.Pool, orgID, agentID, hostname, agentOS, agentArch string, pendingTags []TagPair) (string, error) {
+func InsertHost(ctx context.Context, pool *pgxpool.Pool, instanceID, agentID, hostname, agentOS, agentArch string, pendingTags []TagPair) (string, error) {
 	const q = `
-		INSERT INTO hosts (id, organisation_id, agent_id, hostname, os, arch, status, metadata)
+		INSERT INTO hosts (id, instance_id, agent_id, hostname, os, arch, status, metadata)
 		VALUES ($1, $2, $3, $4, NULLIF($5, ''), NULLIF($6, ''), 'unknown', $7::jsonb)
 		RETURNING id
 	`
@@ -144,7 +144,7 @@ func InsertHost(ctx context.Context, pool *pgxpool.Pool, orgID, agentID, hostnam
 		}
 		metaJSON = string(b)
 	}
-	err := pool.QueryRow(ctx, q, id, orgID, agentID, hostname, agentOS, agentArch, metaJSON).Scan(&returnedID)
+	err := pool.QueryRow(ctx, q, id, instanceID, agentID, hostname, agentOS, agentArch, metaJSON).Scan(&returnedID)
 	return returnedID, err
 }
 

--- a/apps/ingest/internal/db/queries/metrics.sql.go
+++ b/apps/ingest/internal/db/queries/metrics.sql.go
@@ -12,20 +12,20 @@ import (
 func InsertHostMetricByAgentID(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, agentID string,
+	instanceID, agentID string,
 	recordedAt time.Time,
 	cpu, memory, disk float32,
 	uptime int64,
 ) error {
 	const q = `
-		INSERT INTO host_metrics (id, organisation_id, host_id, recorded_at, cpu_percent, memory_percent, disk_percent, uptime_seconds)
+		INSERT INTO host_metrics (id, instance_id, host_id, recorded_at, cpu_percent, memory_percent, disk_percent, uptime_seconds)
 		SELECT $1, $2, h.id, $3, $4, $5, $6, $7
 		FROM hosts h
 		WHERE h.agent_id = $8 AND h.deleted_at IS NULL
 		LIMIT 1
 	`
 	_, err := pool.Exec(ctx, q,
-		newCUID(), orgID, recordedAt,
+		newCUID(), instanceID, recordedAt,
 		cpu, memory, disk, uptime,
 		agentID,
 	)

--- a/apps/ingest/internal/db/queries/networks.sql.go
+++ b/apps/ingest/internal/db/queries/networks.sql.go
@@ -21,15 +21,15 @@ type HostNetworkMembershipRow struct {
 	AutoAssigned bool
 }
 
-// GetNetworksForOrg returns all active (non-deleted) networks for an organisation.
-func GetNetworksForOrg(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]NetworkRow, error) {
+// GetNetworksForOrg returns all active (non-deleted) networks for an instance.
+func GetNetworksForOrg(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]NetworkRow, error) {
 	const q = `
 		SELECT id, cidr
 		FROM networks
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID)
+	rows, err := pool.Query(ctx, q, instanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -73,10 +73,10 @@ func GetHostNetworkMemberships(ctx context.Context, pool *pgxpool.Pool, hostID s
 
 // UpsertHostNetworkMembership inserts a new auto-assigned membership or restores a
 // soft-deleted one. The unique index on (network_id, host_id) drives the conflict.
-func UpsertHostNetworkMembership(ctx context.Context, pool *pgxpool.Pool, orgID, networkID, hostID string) error {
+func UpsertHostNetworkMembership(ctx context.Context, pool *pgxpool.Pool, instanceID, networkID, hostID string) error {
 	const q = `
 		INSERT INTO host_network_memberships
-		    (id, organisation_id, network_id, host_id, auto_assigned)
+		    (id, instance_id, network_id, host_id, auto_assigned)
 		VALUES ($1, $2, $3, $4, true)
 		ON CONFLICT (network_id, host_id)
 		DO UPDATE SET
@@ -84,7 +84,7 @@ func UpsertHostNetworkMembership(ctx context.Context, pool *pgxpool.Pool, orgID,
 		    deleted_at    = NULL,
 		    updated_at    = NOW()
 	`
-	_, err := pool.Exec(ctx, q, newCUID(), orgID, networkID, hostID)
+	_, err := pool.Exec(ctx, q, newCUID(), instanceID, networkID, hostID)
 	return err
 }
 
@@ -104,7 +104,7 @@ func RemoveAutoHostNetworkMembership(ctx context.Context, pool *pgxpool.Pool, me
 }
 
 // SyncHostNetworks compares the host's current IP addresses against all network CIDR
-// definitions for the organisation and keeps auto-assigned memberships in sync.
+// definitions for the instance and keeps auto-assigned memberships in sync.
 //
 // Rules:
 //   - If an IP falls within a network's CIDR and the host has no active membership,
@@ -112,7 +112,7 @@ func RemoveAutoHostNetworkMembership(ctx context.Context, pool *pgxpool.Pool, me
 //   - If an existing auto-assigned membership's network no longer matches any IP, the
 //     membership is soft-deleted.
 //   - Manually assigned memberships (auto_assigned = false) are never touched.
-func SyncHostNetworks(ctx context.Context, pool *pgxpool.Pool, orgID, hostID string, hostIPs []string) error {
+func SyncHostNetworks(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string, hostIPs []string) error {
 	// Parse all host IPs, stripping any prefix length notation (e.g. "192.168.1.5/24").
 	var parsedIPs []net.IP
 	for _, raw := range hostIPs {
@@ -126,7 +126,7 @@ func SyncHostNetworks(ctx context.Context, pool *pgxpool.Pool, orgID, hostID str
 	}
 
 	// Fetch all active networks for the org.
-	networks, err := GetNetworksForOrg(ctx, pool, orgID)
+	networks, err := GetNetworksForOrg(ctx, pool, instanceID)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func SyncHostNetworks(ctx context.Context, pool *pgxpool.Pool, orgID, hostID str
 	// Add missing auto-assigned memberships.
 	for networkID := range matchingNetworkIDs {
 		if _, exists := currentMemberships[networkID]; !exists {
-			if err := UpsertHostNetworkMembership(ctx, pool, orgID, networkID, hostID); err != nil {
+			if err := UpsertHostNetworkMembership(ctx, pool, instanceID, networkID, hostID); err != nil {
 				return err
 			}
 		}

--- a/apps/ingest/internal/db/queries/patch_status.sql.go
+++ b/apps/ingest/internal/db/queries/patch_status.sql.go
@@ -19,7 +19,7 @@ type PatchUpdateInput struct {
 func UpsertHostPatchStatus(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, checkID, status string,
+	instanceID, hostID, checkID, status string,
 	lastPatchedAt *time.Time,
 	patchAgeDays *int,
 	maxAgeDays int,
@@ -33,7 +33,7 @@ func UpsertHostPatchStatus(
 ) error {
 	const q = `
 		INSERT INTO host_patch_statuses (
-			id, organisation_id, host_id, check_id, status, last_patched_at,
+			id, instance_id, host_id, check_id, status, last_patched_at,
 			patch_age_days, max_age_days, package_manager, updates_supported,
 			updates_count, updates_truncated, warnings, error, checked_at,
 			created_at, updated_at
@@ -55,7 +55,7 @@ func UpsertHostPatchStatus(
 			updated_at = NOW()
 	`
 	_, err := pool.Exec(ctx, q,
-		newCUID(), orgID, hostID, nullableString(checkID), status, lastPatchedAt,
+		newCUID(), instanceID, hostID, nullableString(checkID), status, lastPatchedAt,
 		patchAgeDays, maxAgeDays, nullableString(packageManager), updatesSupported,
 		updatesCount, updatesTruncated, string(warningsJSON), nullableString(errorMessage), checkedAt,
 	)
@@ -65,7 +65,7 @@ func UpsertHostPatchStatus(
 func ReplaceCurrentPackageUpdates(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, packageManager string,
+	instanceID, hostID, packageManager string,
 	updates []PatchUpdateInput,
 	seenAt time.Time,
 ) error {
@@ -80,17 +80,17 @@ func ReplaceCurrentPackageUpdates(
 		SET status = 'resolved',
 		    resolved_at = $4,
 		    updated_at = NOW()
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host_id = $2
 		  AND COALESCE(package_manager, '') = COALESCE($3, '')
 		  AND status = 'current'
-	`, orgID, hostID, nullableString(packageManager), seenAt); err != nil {
+	`, instanceID, hostID, nullableString(packageManager), seenAt); err != nil {
 		return err
 	}
 
 	const insertQ = `
 		INSERT INTO host_package_updates (
-			id, organisation_id, host_id, name, current_version, available_version,
+			id, instance_id, host_id, name, current_version, available_version,
 			architecture, repository, package_manager, status, first_seen_at,
 			last_seen_at, resolved_at, created_at, updated_at
 		)
@@ -107,7 +107,7 @@ func ReplaceCurrentPackageUpdates(
 			    resolved_at = NULL,
 			    repository = $7,
 			    updated_at = NOW()
-			WHERE organisation_id = $1
+			WHERE instance_id = $1
 			  AND host_id = $2
 			  AND name = $3
 			  AND current_version IS NOT DISTINCT FROM $4
@@ -115,7 +115,7 @@ func ReplaceCurrentPackageUpdates(
 			  AND architecture IS NOT DISTINCT FROM $6
 			  AND package_manager IS NOT DISTINCT FROM $8
 		`,
-			orgID, hostID, update.Name,
+			instanceID, hostID, update.Name,
 			nullableString(update.CurrentVersion),
 			nullableString(update.AvailableVersion),
 			nullableString(update.Architecture),
@@ -131,7 +131,7 @@ func ReplaceCurrentPackageUpdates(
 		}
 
 		if _, err := tx.Exec(ctx, insertQ,
-			newCUID(), orgID, hostID, update.Name,
+			newCUID(), instanceID, hostID, update.Name,
 			nullableString(update.CurrentVersion),
 			nullableString(update.AvailableVersion),
 			nullableString(update.Architecture),

--- a/apps/ingest/internal/db/queries/schedules.sql.go
+++ b/apps/ingest/internal/db/queries/schedules.sql.go
@@ -10,7 +10,7 @@ import (
 // DueSchedule represents a task_schedules row that is ready to fire.
 type DueSchedule struct {
 	ID             string
-	OrgID          string
+	InstanceID     string
 	Name           string
 	TaskType       string
 	ConfigJSON     string
@@ -26,7 +26,7 @@ type DueSchedule struct {
 // late schedules fire before freshly-due ones.
 func ListSchedulesDue(ctx context.Context, pool *pgxpool.Pool, limit int) ([]DueSchedule, error) {
 	const q = `
-		SELECT id, organisation_id, name, task_type, config::text,
+		SELECT id, instance_id, name, task_type, config::text,
 		       target_type, target_id, max_parallel, cron_expression, timezone
 		FROM task_schedules
 		WHERE enabled      = TRUE
@@ -46,7 +46,7 @@ func ListSchedulesDue(ctx context.Context, pool *pgxpool.Pool, limit int) ([]Due
 	for rows.Next() {
 		var s DueSchedule
 		if err := rows.Scan(
-			&s.ID, &s.OrgID, &s.Name, &s.TaskType, &s.ConfigJSON,
+			&s.ID, &s.InstanceID, &s.Name, &s.TaskType, &s.ConfigJSON,
 			&s.TargetType, &s.TargetID, &s.MaxParallel, &s.CronExpression, &s.Timezone,
 		); err != nil {
 			return nil, err
@@ -64,7 +64,7 @@ func ListSchedulesDue(ctx context.Context, pool *pgxpool.Pool, limit int) ([]Due
 func ResolveScheduleTargetHosts(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, targetType, targetID, taskType string,
+	instanceID, targetType, targetID, taskType string,
 ) (hostIDs []string, err error) {
 	linuxOnly := taskType == "patch" || taskType == "service"
 
@@ -73,11 +73,11 @@ func ResolveScheduleTargetHosts(
 			SELECT id
 			FROM hosts
 			WHERE id              = $1
-			  AND organisation_id = $2
+			  AND instance_id = $2
 			  AND deleted_at      IS NULL
 			  AND ($3 = FALSE OR LOWER(COALESCE(os, '')) = 'linux')
 		`
-		rows, err := pool.Query(ctx, q, targetID, orgID, linuxOnly)
+		rows, err := pool.Query(ctx, q, targetID, instanceID, linuxOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -98,12 +98,12 @@ func ResolveScheduleTargetHosts(
 		FROM host_group_members m
 		JOIN hosts h ON h.id = m.host_id
 		WHERE m.group_id        = $1
-		  AND m.organisation_id = $2
+		  AND m.instance_id = $2
 		  AND m.deleted_at      IS NULL
 		  AND h.deleted_at      IS NULL
 		  AND ($3 = FALSE OR LOWER(COALESCE(h.os, '')) = 'linux')
 	`
-	rows, err := pool.Query(ctx, q, targetID, orgID, linuxOnly)
+	rows, err := pool.Query(ctx, q, targetID, instanceID, linuxOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func ResolveScheduleTargetHosts(
 func InsertScheduledTaskRun(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	scheduleID, orgID, targetType, targetID, taskType, configJSON string,
+	scheduleID, instanceID, targetType, targetID, taskType, configJSON string,
 	maxParallel int,
 	hostIDs []string,
 ) (taskRunID string, err error) {
@@ -137,22 +137,22 @@ func InsertScheduledTaskRun(
 
 	const qRun = `
 		INSERT INTO task_runs
-		  (id, organisation_id, triggered_by, scheduled_from_id,
+		  (id, instance_id, triggered_by, scheduled_from_id,
 		   target_type, target_id, task_type, config, max_parallel,
 		   status, created_at, updated_at)
 		VALUES ($1, $2, NULL, $3, $4, $5, $6, $7::jsonb, $8, 'pending', NOW(), NOW())
 	`
-	if _, err = tx.Exec(ctx, qRun, taskRunID, orgID, scheduleID, targetType, targetID, taskType, configJSON, maxParallel); err != nil {
+	if _, err = tx.Exec(ctx, qRun, taskRunID, instanceID, scheduleID, targetType, targetID, taskType, configJSON, maxParallel); err != nil {
 		return "", err
 	}
 
 	const qHost = `
 		INSERT INTO task_run_hosts
-		  (id, organisation_id, task_run_id, host_id, status, raw_output, created_at, updated_at)
+		  (id, instance_id, task_run_id, host_id, status, raw_output, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, 'pending', '', NOW(), NOW())
 	`
 	for _, hostID := range hostIDs {
-		if _, err = tx.Exec(ctx, qHost, newCUID(), orgID, taskRunID, hostID); err != nil {
+		if _, err = tx.Exec(ctx, qHost, newCUID(), instanceID, taskRunID, hostID); err != nil {
 			return "", err
 		}
 	}

--- a/apps/ingest/internal/db/queries/service_accounts.sql.go
+++ b/apps/ingest/internal/db/queries/service_accounts.sql.go
@@ -24,12 +24,12 @@ type ServiceAccountRow struct {
 }
 
 // UpsertServiceAccount inserts or updates a service account by the natural key
-// (organisation_id, host_id, username). Returns the ID, whether it was an insert,
+// (instance_id, host_id, username). Returns the ID, whether it was an insert,
 // and the previous row (nil on insert).
 func UpsertServiceAccount(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID string,
+	instanceID, hostID string,
 	username string, uid, gid int,
 	homeDir, shell, accountType string,
 	hasLogin, hasProcs, accountLocked bool,
@@ -40,14 +40,14 @@ func UpsertServiceAccount(
 		SELECT id, username, uid, gid, home_directory, shell, account_type,
 		       has_login_capability, has_running_processes, status
 		FROM service_accounts
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host_id = $2
 		  AND username = $3
 		  AND deleted_at IS NULL
 		LIMIT 1
 	`
 	var existing ServiceAccountRow
-	rowErr := pool.QueryRow(ctx, selectQ, orgID, hostID, username).Scan(
+	rowErr := pool.QueryRow(ctx, selectQ, instanceID, hostID, username).Scan(
 		&existing.ID, &existing.Username, &existing.UID, &existing.GID,
 		&existing.HomeDirectory, &existing.Shell, &existing.AccountType,
 		&existing.HasLoginCapability, &existing.HasRunningProcesses, &existing.Status,
@@ -60,7 +60,7 @@ func UpsertServiceAccount(
 	if errors.Is(rowErr, pgx.ErrNoRows) {
 		const insertQ = `
 			INSERT INTO service_accounts (
-				id, organisation_id, host_id, username,
+				id, instance_id, host_id, username,
 				uid, gid, home_directory, shell, account_type,
 				has_login_capability, has_running_processes,
 				account_locked, password_expires_at, password_last_changed_at,
@@ -79,7 +79,7 @@ func UpsertServiceAccount(
 		newID := newCUID()
 		var returnedID string
 		err = pool.QueryRow(ctx, insertQ,
-			newID, orgID, hostID, username,
+			newID, instanceID, hostID, username,
 			uid, gid, homeDir, shell, accountType,
 			hasLogin, hasProcs,
 			accountLocked, passwordExpiresAt, passwordLastChangedAt,
@@ -124,17 +124,17 @@ func UpsertServiceAccount(
 func GetServiceAccountsForHost(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID string,
+	instanceID, hostID string,
 ) ([]ServiceAccountRow, error) {
 	const q = `
 		SELECT id, username, uid, gid, home_directory, shell, account_type,
 		       has_login_capability, has_running_processes, status
 		FROM service_accounts
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host_id = $2
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID, hostID)
+	rows, err := pool.Query(ctx, q, instanceID, hostID)
 	if err != nil {
 		return nil, err
 	}
@@ -170,14 +170,14 @@ func UpdateServiceAccountStatus(
 func InsertIdentityEvent(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID string,
+	instanceID, hostID string,
 	serviceAccountID, sshKeyID *string,
 	eventType, message string,
 	metadataJSON []byte,
 ) error {
 	const q = `
 		INSERT INTO identity_events (
-			id, organisation_id, service_account_id, ssh_key_id, host_id,
+			id, instance_id, service_account_id, ssh_key_id, host_id,
 			event_type, message, occurred_at, metadata
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), $8)
 	`
@@ -186,7 +186,7 @@ func InsertIdentityEvent(
 		metaPtr = &metadataJSON
 	}
 	_, err := pool.Exec(ctx, q,
-		newCUID(), orgID, serviceAccountID, sshKeyID, hostID,
+		newCUID(), instanceID, serviceAccountID, sshKeyID, hostID,
 		eventType, message, metaPtr,
 	)
 	return err
@@ -196,15 +196,15 @@ func InsertIdentityEvent(
 func GetServiceAccountByUsername(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, username string,
+	instanceID, hostID, username string,
 ) (string, error) {
 	const q = `
 		SELECT id FROM service_accounts
-		WHERE organisation_id = $1 AND host_id = $2 AND username = $3 AND deleted_at IS NULL
+		WHERE instance_id = $1 AND host_id = $2 AND username = $3 AND deleted_at IS NULL
 		LIMIT 1
 	`
 	var id string
-	err := pool.QueryRow(ctx, q, orgID, hostID, username).Scan(&id)
+	err := pool.QueryRow(ctx, q, instanceID, hostID, username).Scan(&id)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", nil
 	}

--- a/apps/ingest/internal/db/queries/software.sql.go
+++ b/apps/ingest/internal/db/queries/software.sql.go
@@ -8,18 +8,18 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// HostOrgForTaskRunHost returns the host_id and organisation_id for a given
+// HostOrgForTaskRunHost returns the host_id and instance_id for a given
 // task_run_hosts row, also checking that the row belongs to the given agent.
 type HostOrgForTask struct {
-	HostID string
-	OrgID  string
+	HostID     string
+	InstanceID string
 }
 
 // GetHostOrgForTaskRunHost looks up the host and org for a task_run_hosts row,
 // validating that the host's agent matches the caller.
 func GetHostOrgForTaskRunHost(ctx context.Context, pool *pgxpool.Pool, taskRunHostID, agentID string) (*HostOrgForTask, error) {
 	const q = `
-		SELECT h.id, h.organisation_id
+		SELECT h.id, h.instance_id
 		FROM task_run_hosts trh
 		JOIN hosts h ON h.id = trh.host_id
 		WHERE trh.id       = $1
@@ -29,20 +29,20 @@ func GetHostOrgForTaskRunHost(ctx context.Context, pool *pgxpool.Pool, taskRunHo
 		LIMIT 1
 	`
 	var r HostOrgForTask
-	err := pool.QueryRow(ctx, q, taskRunHostID, agentID).Scan(&r.HostID, &r.OrgID)
+	err := pool.QueryRow(ctx, q, taskRunHostID, agentID).Scan(&r.HostID, &r.InstanceID)
 	return &r, err
 }
 
 // InsertSoftwareScan inserts a new software_scans row with status='running' and
 // returns the generated scan ID.
-func InsertSoftwareScan(ctx context.Context, pool *pgxpool.Pool, orgID, hostID, taskRunHostID, source string, startedAt time.Time) (string, error) {
+func InsertSoftwareScan(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID, taskRunHostID, source string, startedAt time.Time) (string, error) {
 	id := newCUID()
 	const q = `
 		INSERT INTO software_scans
-		  (id, organisation_id, host_id, task_run_host_id, status, source, started_at, created_at)
+		  (id, instance_id, host_id, task_run_host_id, status, source, started_at, created_at)
 		VALUES ($1, $2, $3, $4, 'running', $5, $6, NOW())
 	`
-	_, err := pool.Exec(ctx, q, id, orgID, hostID, nullableString(taskRunHostID), nullableString(source), startedAt)
+	_, err := pool.Exec(ctx, q, id, instanceID, hostID, nullableString(taskRunHostID), nullableString(source), startedAt)
 	return id, err
 }
 
@@ -51,7 +51,7 @@ func InsertSoftwareScan(ctx context.Context, pool *pgxpool.Pool, orgID, hostID, 
 func UpsertSoftwarePackagesBatch(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, source string,
+	instanceID, hostID, source string,
 	names, versions, archs, publishers []string,
 	distroIDs, distroVersionIDs, distroCodenames []string,
 	distroIDLikes [][]string,
@@ -83,7 +83,7 @@ func UpsertSoftwarePackagesBatch(
 	const q = `
 		WITH ins AS (
 		  INSERT INTO software_packages
-		    (id, organisation_id, host_id, name, version, architecture, publisher, source,
+		    (id, instance_id, host_id, name, version, architecture, publisher, source,
 		     distro_id, distro_version_id, distro_codename, distro_id_like,
 		     source_name, source_version, package_epoch, package_release, repository, origin,
 		     install_date, first_seen_at, last_seen_at, created_at, updated_at)
@@ -107,7 +107,7 @@ func UpsertSoftwarePackagesBatch(
 		    NULLIF(unnest($18::text[]), ''),
 		    unnest($19::timestamptz[]),
 		    $20, $20, $20, $20
-		  ON CONFLICT (organisation_id, host_id, name, version, architecture)
+		  ON CONFLICT (instance_id, host_id, name, version, architecture)
 		  DO UPDATE SET
 		    last_seen_at = EXCLUDED.last_seen_at,
 		    publisher    = COALESCE(EXCLUDED.publisher, software_packages.publisher),
@@ -129,7 +129,7 @@ func UpsertSoftwarePackagesBatch(
 	`
 
 	err = pool.QueryRow(ctx, q,
-		ids, orgID, hostID,
+		ids, instanceID, hostID,
 		names, versions, archs, publishers,
 		source,
 		nullableStrings(distroIDs),
@@ -244,22 +244,22 @@ func UpdateHostLastSoftwareScanAt(ctx context.Context, pool *pgxpool.Pool, hostI
 
 // SoftwareSweeperHost is a minimal host row returned by the sweeper query.
 type SoftwareSweeperHost struct {
-	ID    string
-	OrgID string
+	ID         string
+	InstanceID string
 }
 
-// GetHostsDueForSoftwareScan returns hosts belonging to organisations that have
+// GetHostsDueForSoftwareScan returns hosts belonging to instances that have
 // software inventory enabled and whose last scan is older than the configured
 // interval (or who have never been scanned).
 func GetHostsDueForSoftwareScan(ctx context.Context, pool *pgxpool.Pool) ([]SoftwareSweeperHost, error) {
 	const q = `
-		SELECT h.id, h.organisation_id
+		SELECT h.id, h.instance_id
 		FROM hosts h
-		JOIN organisations o ON o.id = h.organisation_id
+		JOIN instances o ON o.id = h.instance_id
 		WHERE h.deleted_at IS NULL
 		  AND o.deleted_at IS NULL
 		  AND h.status     = 'online'
-		  -- Organisation must have software inventory enabled
+		  -- Instance must have software inventory enabled
 		  AND (o.metadata->'softwareInventorySettings'->>'enabled')::boolean = true
 		  -- Host is overdue: never scanned OR last scan older than intervalHours
 		  AND (
@@ -294,7 +294,7 @@ func GetHostsDueForSoftwareScan(ctx context.Context, pool *pgxpool.Pool) ([]Soft
 	var hosts []SoftwareSweeperHost
 	for rows.Next() {
 		var h SoftwareSweeperHost
-		if err := rows.Scan(&h.ID, &h.OrgID); err != nil {
+		if err := rows.Scan(&h.ID, &h.InstanceID); err != nil {
 			return nil, err
 		}
 		hosts = append(hosts, h)
@@ -304,25 +304,25 @@ func GetHostsDueForSoftwareScan(ctx context.Context, pool *pgxpool.Pool) ([]Soft
 
 // InsertSoftwareInventoryTask creates a task_runs row and a single
 // task_run_hosts row for an automated software inventory scan.
-func InsertSoftwareInventoryTask(ctx context.Context, pool *pgxpool.Pool, orgID, hostID string) (taskRunHostID string, err error) {
+func InsertSoftwareInventoryTask(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string) (taskRunHostID string, err error) {
 	taskRunID := newCUID()
 	taskRunHostID = newCUID()
 
 	const qRun = `
 		INSERT INTO task_runs
-		  (id, organisation_id, triggered_by, target_type, target_id,
+		  (id, instance_id, triggered_by, target_type, target_id,
 		   task_type, config, max_parallel, status, created_at, updated_at)
 		VALUES ($1, $2, NULL, 'host', $3, 'software_inventory', '{}', 1, 'pending', NOW(), NOW())
 	`
-	if _, err = pool.Exec(ctx, qRun, taskRunID, orgID, hostID); err != nil {
+	if _, err = pool.Exec(ctx, qRun, taskRunID, instanceID, hostID); err != nil {
 		return "", err
 	}
 
 	const qHost = `
 		INSERT INTO task_run_hosts
-		  (id, organisation_id, task_run_id, host_id, status, raw_output, created_at, updated_at)
+		  (id, instance_id, task_run_id, host_id, status, raw_output, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, 'pending', '', NOW(), NOW())
 	`
-	_, err = pool.Exec(ctx, qHost, taskRunHostID, orgID, taskRunID, hostID)
+	_, err = pool.Exec(ctx, qHost, taskRunHostID, instanceID, taskRunID, hostID)
 	return taskRunHostID, err
 }

--- a/apps/ingest/internal/db/queries/ssh_keys.sql.go
+++ b/apps/ingest/internal/db/queries/ssh_keys.sql.go
@@ -17,18 +17,18 @@ type SshKeyRow struct {
 	BitLength          int
 	Comment            string
 	KeySource          string
-	AssociatedUsername  string
+	AssociatedUsername string
 	ServiceAccountID   *string
 	Status             string
 	KeyAgeSeconds      *int
 }
 
 // UpsertSshKey inserts or updates an SSH key by the natural key
-// (organisation_id, host_id, fingerprint_sha256, file_path).
+// (instance_id, host_id, fingerprint_sha256, file_path).
 func UpsertSshKey(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID string,
+	instanceID, hostID string,
 	fingerprint, filePath string,
 	keyType string, bitLength int,
 	comment, keySource, associatedUsername string,
@@ -38,7 +38,7 @@ func UpsertSshKey(
 	const selectQ = `
 		SELECT id, status
 		FROM ssh_keys
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host_id = $2
 		  AND fingerprint_sha256 = $3
 		  AND file_path = $4
@@ -46,7 +46,7 @@ func UpsertSshKey(
 		LIMIT 1
 	`
 	var existingID, existingStatus string
-	rowErr := pool.QueryRow(ctx, selectQ, orgID, hostID, fingerprint, filePath).
+	rowErr := pool.QueryRow(ctx, selectQ, instanceID, hostID, fingerprint, filePath).
 		Scan(&existingID, &existingStatus)
 
 	if rowErr != nil && !errors.Is(rowErr, pgx.ErrNoRows) {
@@ -56,7 +56,7 @@ func UpsertSshKey(
 	if errors.Is(rowErr, pgx.ErrNoRows) {
 		const insertQ = `
 			INSERT INTO ssh_keys (
-				id, organisation_id, host_id, service_account_id,
+				id, instance_id, host_id, service_account_id,
 				key_type, bit_length, fingerprint_sha256, comment,
 				file_path, key_source, associated_username, status,
 				key_age_seconds, first_seen_at, last_seen_at, created_at, updated_at
@@ -71,7 +71,7 @@ func UpsertSshKey(
 		newID := newCUID()
 		var returnedID string
 		err = pool.QueryRow(ctx, insertQ,
-			newID, orgID, hostID, serviceAccountID,
+			newID, instanceID, hostID, serviceAccountID,
 			keyType, bitLength, fingerprint, comment,
 			filePath, keySource, associatedUsername,
 			keyAgeSeconds,
@@ -118,18 +118,18 @@ func UpsertSshKey(
 func GetSshKeysForHost(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID string,
+	instanceID, hostID string,
 ) ([]SshKeyRow, error) {
 	const q = `
 		SELECT id, fingerprint_sha256, file_path, key_type, bit_length,
 		       comment, key_source, associated_username, service_account_id,
 		       status, key_age_seconds
 		FROM ssh_keys
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND host_id = $2
 		  AND deleted_at IS NULL
 	`
-	rows, err := pool.Query(ctx, q, orgID, hostID)
+	rows, err := pool.Query(ctx, q, instanceID, hostID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/ingest/internal/db/queries/tags.sql.go
+++ b/apps/ingest/internal/db/queries/tags.sql.go
@@ -42,12 +42,12 @@ func lower(s string) string {
 	return string(b)
 }
 
-// GetOrgDefaultTags reads organisations.metadata.defaultTags. Returns nil when
+// GetOrgDefaultTags reads instances.metadata.defaultTags. Returns nil when
 // no defaults are set.
-func GetOrgDefaultTags(ctx context.Context, pool *pgxpool.Pool, orgID string) ([]TagPair, error) {
-	const q = `SELECT COALESCE(metadata, '{}'::jsonb) FROM organisations WHERE id = $1`
+func GetOrgDefaultTags(ctx context.Context, pool *pgxpool.Pool, instanceID string) ([]TagPair, error) {
+	const q = `SELECT COALESCE(metadata, '{}'::jsonb) FROM instances WHERE id = $1`
 	var raw []byte
-	if err := pool.QueryRow(ctx, q, orgID).Scan(&raw); err != nil {
+	if err := pool.QueryRow(ctx, q, instanceID).Scan(&raw); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
@@ -68,16 +68,16 @@ func GetOrgDefaultTags(ctx context.Context, pool *pgxpool.Pool, orgID string) ([
 // upsertTag case-insensitively resolves or inserts a single (org, key, value)
 // row in `tags` and returns its id. Mirrors the select-then-insert-then-reselect
 // pattern in the TS upsertTag so a concurrent unique-violation never bubbles up.
-func upsertTag(ctx context.Context, tx pgx.Tx, orgID string, pair TagPair) (string, error) {
+func upsertTag(ctx context.Context, tx pgx.Tx, instanceID string, pair TagPair) (string, error) {
 	const sel = `
 		SELECT id FROM tags
-		WHERE organisation_id = $1
+		WHERE instance_id = $1
 		  AND lower(key) = lower($2)
 		  AND lower(value) = lower($3)
 		LIMIT 1
 	`
 	var id string
-	err := tx.QueryRow(ctx, sel, orgID, pair.Key, pair.Value).Scan(&id)
+	err := tx.QueryRow(ctx, sel, instanceID, pair.Key, pair.Value).Scan(&id)
 	if err == nil {
 		return id, nil
 	}
@@ -86,12 +86,12 @@ func upsertTag(ctx context.Context, tx pgx.Tx, orgID string, pair TagPair) (stri
 	}
 
 	const ins = `
-		INSERT INTO tags (id, organisation_id, key, value, usage_count)
+		INSERT INTO tags (id, instance_id, key, value, usage_count)
 		VALUES ($1, $2, $3, $4, 0)
 		ON CONFLICT DO NOTHING
 		RETURNING id
 	`
-	err = tx.QueryRow(ctx, ins, newCUID(), orgID, pair.Key, pair.Value).Scan(&id)
+	err = tx.QueryRow(ctx, ins, newCUID(), instanceID, pair.Key, pair.Value).Scan(&id)
 	if err == nil {
 		return id, nil
 	}
@@ -99,7 +99,7 @@ func upsertTag(ctx context.Context, tx pgx.Tx, orgID string, pair TagPair) (stri
 		return "", err
 	}
 
-	if err := tx.QueryRow(ctx, sel, orgID, pair.Key, pair.Value).Scan(&id); err != nil {
+	if err := tx.QueryRow(ctx, sel, instanceID, pair.Key, pair.Value).Scan(&id); err != nil {
 		return "", fmt.Errorf("tag upsert could not resolve id: %w", err)
 	}
 	return id, nil
@@ -109,7 +109,7 @@ func upsertTag(ctx context.Context, tx pgx.Tx, orgID string, pair TagPair) (stri
 // resource_tags. Duplicate assignments are skipped (ON CONFLICT DO NOTHING);
 // usage_count only increments on fresh inserts. Mirrors assignTagsToResource
 // in apps/web/lib/actions/tags.ts.
-func AssignTagsToResource(ctx context.Context, pool *pgxpool.Pool, orgID, resourceType, resourceID string, pairs []TagPair) error {
+func AssignTagsToResource(ctx context.Context, pool *pgxpool.Pool, instanceID, resourceType, resourceID string, pairs []TagPair) error {
 	if len(pairs) == 0 {
 		return nil
 	}
@@ -122,18 +122,18 @@ func AssignTagsToResource(ctx context.Context, pool *pgxpool.Pool, orgID, resour
 	defer tx.Rollback(ctx)
 
 	for _, p := range deduped {
-		tagID, err := upsertTag(ctx, tx, orgID, p)
+		tagID, err := upsertTag(ctx, tx, instanceID, p)
 		if err != nil {
 			return fmt.Errorf("upserting tag %s=%s: %w", p.Key, p.Value, err)
 		}
 		const insLink = `
-			INSERT INTO resource_tags (id, organisation_id, resource_id, resource_type, tag_id)
+			INSERT INTO resource_tags (id, instance_id, resource_id, resource_type, tag_id)
 			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (resource_id, resource_type, tag_id) DO NOTHING
 			RETURNING id
 		`
 		var rtID string
-		err = tx.QueryRow(ctx, insLink, newCUID(), orgID, resourceID, resourceType, tagID).Scan(&rtID)
+		err = tx.QueryRow(ctx, insLink, newCUID(), instanceID, resourceID, resourceType, tagID).Scan(&rtID)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("inserting resource_tag: %w", err)
 		}

--- a/apps/ingest/internal/db/queries/terminal_sessions.sql.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions.sql.go
@@ -19,7 +19,7 @@ import (
 
 // TerminalSessionInfo is returned after validating and activating a terminal session.
 type TerminalSessionInfo struct {
-	OrganisationID string
+	InstanceID     string
 	UserID         string
 	HostID         string
 	Host           string
@@ -41,16 +41,16 @@ func ValidateAndActivateTerminalSession(ctx context.Context, pool *pgxpool.Pool,
 		SET status     = 'active',
 		    started_at = NOW(),
 		    updated_at = NOW()
-		FROM organisations o, hosts h
+		FROM instances o, hosts h
 		WHERE ts.session_id       = $1
 		  AND ts.websocket_token_hash = $2
 		  AND ts.status           = 'pending'
 		  AND COALESCE(ts.expires_at, ts.created_at + INTERVAL '5 minutes') > NOW()
-		  AND o.id                = ts.organisation_id
+		  AND o.id                = ts.instance_id
 		  AND h.id                = ts.host_id
-		  AND h.organisation_id   = ts.organisation_id
+		  AND h.instance_id   = ts.instance_id
 		  AND h.deleted_at        IS NULL
-			RETURNING ts.organisation_id, ts.host_id,
+			RETURNING ts.instance_id, ts.host_id,
 		          ts.user_id,
 		          COALESCE(NULLIF(h.hostname, ''), h.ip_addresses->>0) AS host,
 		          COALESCE(ts.username, '') AS username,
@@ -58,7 +58,7 @@ func ValidateAndActivateTerminalSession(ctx context.Context, pool *pgxpool.Pool,
 	`
 	var info TerminalSessionInfo
 	err := pool.QueryRow(ctx, q, sessionID, tokenHash).Scan(
-		&info.OrganisationID,
+		&info.InstanceID,
 		&info.HostID,
 		&info.UserID,
 		&info.Host,
@@ -309,7 +309,7 @@ func pruneTerminalAuthHits(hits []time.Time, now time.Time) []time.Time {
 
 func terminalAuthThrottleKeys(info TerminalSessionInfo, source string) []terminalAuthThrottleKey {
 	username := strings.ToLower(strings.TrimSpace(info.Username))
-	if info.OrganisationID == "" || info.HostID == "" || username == "" {
+	if info.InstanceID == "" || info.HostID == "" || username == "" {
 		return nil
 	}
 
@@ -317,12 +317,12 @@ func terminalAuthThrottleKeys(info TerminalSessionInfo, source string) []termina
 	if info.UserID != "" {
 		keys = append(keys, terminalAuthThrottleKey{
 			scope: "terminal:ssh:user-host-username",
-			key:   terminalAuthThrottleKeyHash(info.OrganisationID, info.UserID, info.HostID, username),
+			key:   terminalAuthThrottleKeyHash(info.InstanceID, info.UserID, info.HostID, username),
 		})
 	}
 	keys = append(keys, terminalAuthThrottleKey{
 		scope: "terminal:ssh:source-host-username",
-		key:   terminalAuthThrottleKeyHash(info.OrganisationID, terminalAuthSource(source), info.HostID, username),
+		key:   terminalAuthThrottleKeyHash(info.InstanceID, terminalAuthSource(source), info.HostID, username),
 	})
 	sort.Slice(keys, func(i, j int) bool {
 		if keys[i].scope == keys[j].scope {

--- a/apps/ingest/internal/db/queries/terminal_sessions_test.go
+++ b/apps/ingest/internal/db/queries/terminal_sessions_test.go
@@ -86,10 +86,10 @@ func TestVerifySSHHostKeyMetadataBlocksWhenPendingChangeExists(t *testing.T) {
 
 func TestTerminalAuthThrottleKeysIncludeUserHostUsernameAndSource(t *testing.T) {
 	info := TerminalSessionInfo{
-		OrganisationID: "org-1",
-		UserID:         "user-1",
-		HostID:         "host-1",
-		Username:       "Admin",
+		InstanceID: "org-1",
+		UserID:     "user-1",
+		HostID:     "host-1",
+		Username:   "Admin",
 	}
 
 	keys := terminalAuthThrottleKeys(info, "203.0.113.10")
@@ -116,10 +116,10 @@ func TestTerminalAuthThrottleKeysIncludeUserHostUsernameAndSource(t *testing.T) 
 
 func TestTerminalAuthThrottleKeyNormalisesUsernameAndSource(t *testing.T) {
 	base := TerminalSessionInfo{
-		OrganisationID: "org-1",
-		UserID:         "user-1",
-		HostID:         "host-1",
-		Username:       "Admin",
+		InstanceID: "org-1",
+		UserID:     "user-1",
+		HostID:     "host-1",
+		Username:   "Admin",
 	}
 	upper := terminalAuthThrottleKeys(base, "203.0.113.10:49152")
 

--- a/apps/ingest/internal/grpc/mtls_interceptor.go
+++ b/apps/ingest/internal/grpc/mtls_interceptor.go
@@ -67,10 +67,10 @@ func attachIdentity(ctx context.Context) (context.Context, error) {
 	if len(tlsInfo.State.VerifiedChains) == 0 {
 		return ctx, status.Error(codes.Unauthenticated, "client certificate required for this RPC")
 	}
-	orgID, agentID, err := pki.SpiffeURIFromCert(tlsInfo.State.VerifiedChains[0][0])
+	agentID, err := pki.SpiffeURIFromCert(tlsInfo.State.VerifiedChains[0][0])
 	if err != nil {
 		return ctx, status.Errorf(codes.Unauthenticated, "client cert missing SPIFFE identity: %v", err)
 	}
 	serial := tlsInfo.State.VerifiedChains[0][0].SerialNumber.Text(16)
-	return pki.WithIdentity(ctx, &pki.Identity{OrgID: orgID, AgentID: agentID, Serial: serial}), nil
+	return pki.WithIdentity(ctx, &pki.Identity{AgentID: agentID, Serial: serial}), nil
 }

--- a/apps/ingest/internal/handlers/alerts.go
+++ b/apps/ingest/internal/handlers/alerts.go
@@ -51,12 +51,12 @@ type notifChannels struct {
 func evaluateAlerts(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, hostname string,
+	instanceID, hostID, hostname string,
 	checkStatuses map[string]string,
 	metrics heartbeatMetrics,
 ) {
 	// Skip evaluation entirely if the host is currently silenced.
-	silenced, err := queries.IsHostSilenced(ctx, pool, orgID, hostID)
+	silenced, err := queries.IsHostSilenced(ctx, pool, instanceID, hostID)
 	if err != nil {
 		slog.Warn("evaluateAlerts: checking silence", "host_id", hostID, "err", err)
 	} else if silenced {
@@ -64,7 +64,7 @@ func evaluateAlerts(
 		return
 	}
 
-	rules, err := queries.GetAlertRulesForHost(ctx, pool, orgID, hostID)
+	rules, err := queries.GetAlertRulesForHost(ctx, pool, instanceID, hostID)
 	if err != nil {
 		slog.Warn("evaluateAlerts: fetching rules", "host_id", hostID, "err", err)
 		return
@@ -75,30 +75,30 @@ func evaluateAlerts(
 
 	var channels notifChannels
 
-	webhooks, err := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
+	webhooks, err := queries.GetEnabledWebhookChannels(ctx, pool, instanceID)
 	if err != nil {
-		slog.Warn("evaluateAlerts: fetching webhook channels", "org_id", orgID, "err", err)
+		slog.Warn("evaluateAlerts: fetching webhook channels", "instance_id", instanceID, "err", err)
 	} else {
 		channels.webhooks = webhooks
 	}
 
-	smtpChs, err := queries.GetEnabledSmtpChannels(ctx, pool, orgID)
+	smtpChs, err := queries.GetEnabledSmtpChannels(ctx, pool, instanceID)
 	if err != nil {
-		slog.Warn("evaluateAlerts: fetching smtp channels", "org_id", orgID, "err", err)
+		slog.Warn("evaluateAlerts: fetching smtp channels", "instance_id", instanceID, "err", err)
 	} else {
 		channels.smtp = smtpChs
 	}
 
-	slackChs, err := queries.GetEnabledSlackChannels(ctx, pool, orgID)
+	slackChs, err := queries.GetEnabledSlackChannels(ctx, pool, instanceID)
 	if err != nil {
-		slog.Warn("evaluateAlerts: fetching slack channels", "org_id", orgID, "err", err)
+		slog.Warn("evaluateAlerts: fetching slack channels", "instance_id", instanceID, "err", err)
 	} else {
 		channels.slack = slackChs
 	}
 
-	telegramChs, err := queries.GetEnabledTelegramChannels(ctx, pool, orgID)
+	telegramChs, err := queries.GetEnabledTelegramChannels(ctx, pool, instanceID)
 	if err != nil {
-		slog.Warn("evaluateAlerts: fetching telegram channels", "org_id", orgID, "err", err)
+		slog.Warn("evaluateAlerts: fetching telegram channels", "instance_id", instanceID, "err", err)
 	} else {
 		channels.telegram = telegramChs
 	}
@@ -160,7 +160,7 @@ func evaluateCheckStatusRule(
 	if allFailing && existing == nil {
 		// Fire a new alert.
 		message := fmt.Sprintf("Check failed %d consecutive time(s) on host %s", cfg.FailureThreshold, hostname)
-		id, err := queries.InsertAlertInstance(ctx, pool, rule.ID, hostID, rule.OrgID, rule.Severity, message, time.Now())
+		id, err := queries.InsertAlertInstance(ctx, pool, rule.ID, hostID, rule.InstanceID, rule.Severity, message, time.Now())
 		if err != nil {
 			slog.Warn("evaluateAlerts: inserting alert instance", "rule_id", rule.ID, "err", err)
 			return
@@ -178,7 +178,7 @@ func evaluateCheckStatusRule(
 		dispatchSmtp(channels.smtp, ev)
 		dispatchSlack(ctx, channels.slack, ev)
 		dispatchTelegram(ctx, channels.telegram, ev)
-		dispatchInApp(ctx, pool, rule.OrgID, id, "host", hostID, ev)
+		dispatchInApp(ctx, pool, rule.InstanceID, id, "host", hostID, ev)
 		return
 	}
 
@@ -201,7 +201,7 @@ func evaluateCheckStatusRule(
 		dispatchSmtp(channels.smtp, ev)
 		dispatchSlack(ctx, channels.slack, ev)
 		dispatchTelegram(ctx, channels.telegram, ev)
-		dispatchInApp(ctx, pool, rule.OrgID, existing.ID, "host", hostID, ev)
+		dispatchInApp(ctx, pool, rule.InstanceID, existing.ID, "host", hostID, ev)
 	}
 }
 
@@ -247,7 +247,7 @@ func evaluateMetricThresholdRule(
 		}
 		message := fmt.Sprintf("%s %s %.1f%% (current: %.1f%%) on host %s",
 			cfg.Metric, operatorLabel, cfg.Threshold, currentValue, hostname)
-		id, err := queries.InsertAlertInstance(ctx, pool, rule.ID, hostID, rule.OrgID, rule.Severity, message, time.Now())
+		id, err := queries.InsertAlertInstance(ctx, pool, rule.ID, hostID, rule.InstanceID, rule.Severity, message, time.Now())
 		if err != nil {
 			slog.Warn("evaluateAlerts: inserting alert instance", "rule_id", rule.ID, "err", err)
 			return
@@ -265,7 +265,7 @@ func evaluateMetricThresholdRule(
 		dispatchSmtp(channels.smtp, ev)
 		dispatchSlack(ctx, channels.slack, ev)
 		dispatchTelegram(ctx, channels.telegram, ev)
-		dispatchInApp(ctx, pool, rule.OrgID, id, "host", hostID, ev)
+		dispatchInApp(ctx, pool, rule.InstanceID, id, "host", hostID, ev)
 		return
 	}
 
@@ -287,7 +287,7 @@ func evaluateMetricThresholdRule(
 		dispatchSmtp(channels.smtp, ev)
 		dispatchSlack(ctx, channels.slack, ev)
 		dispatchTelegram(ctx, channels.telegram, ev)
-		dispatchInApp(ctx, pool, rule.OrgID, existing.ID, "host", hostID, ev)
+		dispatchInApp(ctx, pool, rule.InstanceID, existing.ID, "host", hostID, ev)
 	}
 }
 
@@ -304,22 +304,22 @@ type certExpiryConfig struct {
 func evaluateCertExpiryForCert(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, certID, commonName, issuer, host string, port int,
+	instanceID, certID, commonName, issuer, host string, port int,
 	notAfter time.Time, status string,
 ) {
-	rules, err := queries.GetCertExpiryRulesForOrg(ctx, pool, orgID)
+	rules, err := queries.GetCertExpiryRulesForOrg(ctx, pool, instanceID)
 	if err != nil {
-		slog.Warn("evaluateCertExpiry: fetching rules", "org_id", orgID, "err", err)
+		slog.Warn("evaluateCertExpiry: fetching rules", "instance_id", instanceID, "err", err)
 		return
 	}
 	if len(rules) == 0 {
 		return
 	}
 
-	webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
-	smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, orgID)
-	slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, orgID)
-	telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, orgID)
+	webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, instanceID)
+	smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, instanceID)
+	slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, instanceID)
+	telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, instanceID)
 	channels := notifChannels{webhooks: webhooks, smtp: smtpChs, slack: slackChs, telegram: telegramChs}
 
 	cert := queries.CertSummary{
@@ -333,7 +333,7 @@ func evaluateCertExpiryForCert(
 	}
 
 	for _, rule := range rules {
-		evaluateCertExpiryRule(ctx, pool, orgID, rule, cert, channels)
+		evaluateCertExpiryRule(ctx, pool, instanceID, rule, cert, channels)
 	}
 }
 
@@ -341,7 +341,7 @@ func evaluateCertExpiryForCert(
 func evaluateCertExpiryRule(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID string,
+	instanceID string,
 	rule queries.AlertRuleRow,
 	cert queries.CertSummary,
 	channels notifChannels,
@@ -388,7 +388,7 @@ func evaluateCertExpiryRule(
 				cert.CommonName, cert.Issuer, cert.Host, cert.Port, daysLeft)
 		}
 
-		id, err := queries.InsertCertAlertInstance(ctx, pool, rule.ID, hostID, orgID, rule.Severity, message, cert.ID, time.Now())
+		id, err := queries.InsertCertAlertInstance(ctx, pool, rule.ID, hostID, instanceID, rule.Severity, message, cert.ID, time.Now())
 		if err != nil {
 			slog.Warn("evaluateCertExpiryRule: inserting alert instance", "rule_id", rule.ID, "err", err)
 			return
@@ -406,7 +406,7 @@ func evaluateCertExpiryRule(
 		dispatchSmtp(channels.smtp, ev)
 		dispatchSlack(ctx, channels.slack, ev)
 		dispatchTelegram(ctx, channels.telegram, ev)
-		dispatchInApp(ctx, pool, orgID, id, "certificate", cert.ID, ev)
+		dispatchInApp(ctx, pool, instanceID, id, "certificate", cert.ID, ev)
 		return
 	}
 
@@ -429,7 +429,7 @@ func evaluateCertExpiryRule(
 		dispatchSmtp(channels.smtp, ev)
 		dispatchSlack(ctx, channels.slack, ev)
 		dispatchTelegram(ctx, channels.telegram, ev)
-		dispatchInApp(ctx, pool, orgID, existing.ID, "certificate", cert.ID, ev)
+		dispatchInApp(ctx, pool, instanceID, existing.ID, "certificate", cert.ID, ev)
 	}
 }
 
@@ -455,23 +455,23 @@ func RunCertExpirySweeper(ctx context.Context, pool *pgxpool.Pool, interval time
 }
 
 func runCertExpirySweep(ctx context.Context, pool *pgxpool.Pool) {
-	orgIDs, err := queries.GetAllOrgsWithCertExpiryRules(ctx, pool)
+	instanceIDs, err := queries.GetAllOrgsWithCertExpiryRules(ctx, pool)
 	if err != nil {
 		slog.Warn("cert sweeper: fetching orgs", "err", err)
 		return
 	}
 
-	for _, orgID := range orgIDs {
-		rules, err := queries.GetCertExpiryRulesForOrg(ctx, pool, orgID)
+	for _, instanceID := range instanceIDs {
+		rules, err := queries.GetCertExpiryRulesForOrg(ctx, pool, instanceID)
 		if err != nil {
-			slog.Warn("cert sweeper: fetching rules", "org_id", orgID, "err", err)
+			slog.Warn("cert sweeper: fetching rules", "instance_id", instanceID, "err", err)
 			continue
 		}
 
-		webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, orgID)
-		smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, orgID)
-		slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, orgID)
-		telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, orgID)
+		webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, instanceID)
+		smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, instanceID)
+		slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, instanceID)
+		telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, instanceID)
 		channels := notifChannels{webhooks: webhooks, smtp: smtpChs, slack: slackChs, telegram: telegramChs}
 
 		for _, rule := range rules {
@@ -482,25 +482,25 @@ func runCertExpirySweep(ctx context.Context, pool *pgxpool.Pool) {
 
 			var certs []queries.CertSummary
 			if cfg.Scope == "specific" && cfg.CertificateID != "" {
-				cert, err := queries.GetCertificateByID(ctx, pool, orgID, cfg.CertificateID)
+				cert, err := queries.GetCertificateByID(ctx, pool, instanceID, cfg.CertificateID)
 				if err != nil || cert == nil {
 					continue
 				}
 				certs = []queries.CertSummary{*cert}
 			} else {
-				certs, err = queries.ListCertificatesExpiringWithin(ctx, pool, orgID, cfg.DaysBeforeExpiry+1)
+				certs, err = queries.ListCertificatesExpiringWithin(ctx, pool, instanceID, cfg.DaysBeforeExpiry+1)
 				if err != nil {
-					slog.Warn("cert sweeper: fetching certs", "org_id", orgID, "err", err)
+					slog.Warn("cert sweeper: fetching certs", "instance_id", instanceID, "err", err)
 					continue
 				}
 			}
 
 			for _, cert := range certs {
-				evaluateCertExpiryRule(ctx, pool, orgID, rule, cert, channels)
+				evaluateCertExpiryRule(ctx, pool, instanceID, rule, cert, channels)
 			}
 		}
 	}
-	slog.Debug("cert expiry sweep complete", "orgs_checked", len(orgIDs))
+	slog.Debug("cert expiry sweep complete", "orgs_checked", len(instanceIDs))
 }
 
 // dispatchWebhooks fans out an AlertEvent to all configured webhook channels.

--- a/apps/ingest/internal/handlers/cert_refresh_sweeper.go
+++ b/apps/ingest/internal/handlers/cert_refresh_sweeper.go
@@ -90,7 +90,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 		}
 		if newStatus != row.Status && row.Status != "" {
 			if evErr := queries.InsertCertificateEvent(ctx, pool,
-				row.ID, row.OrgID,
+				row.ID, row.InstanceID,
 				newStatus, row.Status, newStatus,
 				fmt.Sprintf("Certificate status changed from %s to %s", row.Status, newStatus),
 				nil,
@@ -98,7 +98,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 				slog.Warn("cert refresh: insert status-change event", "err", evErr)
 			}
 		}
-		evaluateCertExpiryForCert(ctx, pool, row.OrgID, row.ID,
+		evaluateCertExpiryForCert(ctx, pool, row.InstanceID, row.ID,
 			leaf.Subject.CommonName, leaf.Issuer.CommonName,
 			row.Host, row.Port, leaf.NotAfter, newStatus)
 		return
@@ -119,7 +119,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 
 	newCertID, err := queries.InsertRenewedTrackedCert(
 		ctx, pool,
-		row.ID, row.OrgID,
+		row.ID, row.InstanceID,
 		row.Host, row.Port, row.ServerName,
 		commonName, issuer,
 		sans,
@@ -135,7 +135,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 
 	meta, _ := json.Marshal(map[string]string{"newCertificateId": newCertID})
 	if evErr := queries.InsertCertificateEvent(ctx, pool,
-		row.ID, row.OrgID,
+		row.ID, row.InstanceID,
 		"renewed", row.Status, "",
 		fmt.Sprintf("Certificate renewed: replaced by new fingerprint on %s:%d", row.Host, row.Port),
 		meta,
@@ -144,7 +144,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 	}
 
 	if evErr := queries.InsertCertificateEvent(ctx, pool,
-		newCertID, row.OrgID,
+		newCertID, row.InstanceID,
 		"renewed", "", newStatus,
 		fmt.Sprintf("Certificate renewed on %s:%d (CN: %s)", row.Host, row.Port, commonName),
 		nil,
@@ -154,7 +154,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 
 	if newStatus == "expiring_soon" || newStatus == "expired" {
 		if evErr := queries.InsertCertificateEvent(ctx, pool,
-			newCertID, row.OrgID,
+			newCertID, row.InstanceID,
 			newStatus, "", newStatus,
 			fmt.Sprintf("Certificate %s: expires %s", newStatus, leaf.NotAfter.Format("2006-01-02")),
 			nil,
@@ -163,7 +163,7 @@ func refreshTrackedCert(ctx context.Context, pool *pgxpool.Pool, row queries.Tra
 		}
 	}
 
-	evaluateCertExpiryForCert(ctx, pool, row.OrgID, newCertID,
+	evaluateCertExpiryForCert(ctx, pool, row.InstanceID, newCertID,
 		commonName, issuer, row.Host, row.Port, leaf.NotAfter, newStatus)
 
 	slog.Info("cert refresh: renewed",

--- a/apps/ingest/internal/handlers/certificates.go
+++ b/apps/ingest/internal/handlers/certificates.go
@@ -14,22 +14,22 @@ import (
 
 // certificateReport matches the JSON produced by the agent's certificate check.
 type certificateReport struct {
-	Host              string            `json:"host"`
-	Port              int               `json:"port"`
-	ServerName        string            `json:"server_name"`
-	CommonName        string            `json:"common_name"`
-	Subject           string            `json:"subject"`
-	Issuer            string            `json:"issuer"`
-	SANs              []string          `json:"sans"`
-	NotBefore         time.Time         `json:"not_before"`
-	NotAfter          time.Time         `json:"not_after"`
-	FingerprintSHA256 string            `json:"fingerprint_sha256"`
-	SerialNumber      string            `json:"serial_number"`
-	SignatureAlgo     string            `json:"signature_algorithm"`
-	KeyAlgo           string            `json:"key_algorithm"`
-	IsSelfSigned      bool              `json:"is_self_signed"`
-	Chain             []certChainEntry  `json:"chain"`
-	Error             string            `json:"error,omitempty"`
+	Host              string           `json:"host"`
+	Port              int              `json:"port"`
+	ServerName        string           `json:"server_name"`
+	CommonName        string           `json:"common_name"`
+	Subject           string           `json:"subject"`
+	Issuer            string           `json:"issuer"`
+	SANs              []string         `json:"sans"`
+	NotBefore         time.Time        `json:"not_before"`
+	NotAfter          time.Time        `json:"not_after"`
+	FingerprintSHA256 string           `json:"fingerprint_sha256"`
+	SerialNumber      string           `json:"serial_number"`
+	SignatureAlgo     string           `json:"signature_algorithm"`
+	KeyAlgo           string           `json:"key_algorithm"`
+	IsSelfSigned      bool             `json:"is_self_signed"`
+	Chain             []certChainEntry `json:"chain"`
+	Error             string           `json:"error,omitempty"`
 }
 
 type certChainEntry struct {
@@ -42,13 +42,13 @@ type certChainEntry struct {
 
 // certDetails is the JSONB stored in certificates.details.
 type certDetails struct {
-	Subject            string            `json:"subject"`
-	Issuer             string            `json:"issuer"`
-	SerialNumber       string            `json:"serialNumber"`
-	SignatureAlgorithm string            `json:"signatureAlgorithm"`
-	KeyAlgorithm       string            `json:"keyAlgorithm"`
-	IsSelfSigned       bool              `json:"isSelfSigned"`
-	Chain              []certChainEntry  `json:"chain"`
+	Subject            string           `json:"subject"`
+	Issuer             string           `json:"issuer"`
+	SerialNumber       string           `json:"serialNumber"`
+	SignatureAlgorithm string           `json:"signatureAlgorithm"`
+	KeyAlgorithm       string           `json:"keyAlgorithm"`
+	IsSelfSigned       bool             `json:"isSelfSigned"`
+	Chain              []certChainEntry `json:"chain"`
 }
 
 // computeCertStatus derives the certificate status from its expiry and a warning window.
@@ -68,7 +68,7 @@ func computeCertStatus(notAfter time.Time, warnDays int) string {
 func persistCertificateResult(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, checkID, output string,
+	instanceID, hostID, checkID, output string,
 ) {
 	var report certificateReport
 	if err := json.Unmarshal([]byte(output), &report); err != nil {
@@ -97,14 +97,14 @@ func persistCertificateResult(
 	detailsJSON, _ := json.Marshal(details)
 
 	// Detect renewal: find existing certs for same endpoint that have a DIFFERENT fingerprint.
-	existingCerts, err := queries.FindCertsForEndpoint(ctx, pool, orgID, report.Host, report.Port, report.ServerName)
+	existingCerts, err := queries.FindCertsForEndpoint(ctx, pool, instanceID, report.Host, report.Port, report.ServerName)
 	if err != nil {
 		slog.Warn("cert: finding existing certs for endpoint", "err", err)
 	}
 
 	certID, previousStatus, wasInsert, err := queries.UpsertCertificate(
 		ctx, pool,
-		orgID, hostID, checkID,
+		instanceID, hostID, checkID,
 		report.Host, report.Port, report.ServerName,
 		report.CommonName, report.Issuer,
 		report.SANs,
@@ -128,7 +128,7 @@ func persistCertificateResult(
 				// Emit a renewed event on the OLD cert.
 				meta, _ := json.Marshal(map[string]string{"newCertificateId": certID})
 				if evErr := queries.InsertCertificateEvent(ctx, pool,
-					existing.ID, orgID,
+					existing.ID, instanceID,
 					"renewed", existing.Status, "",
 					fmt.Sprintf("Certificate renewed: replaced by new fingerprint on %s:%d", report.Host, report.Port),
 					meta,
@@ -146,7 +146,7 @@ func persistCertificateResult(
 			message = fmt.Sprintf("Certificate renewed on %s:%d (CN: %s)", report.Host, report.Port, report.CommonName)
 		}
 		if evErr := queries.InsertCertificateEvent(ctx, pool,
-			certID, orgID,
+			certID, instanceID,
 			eventType, "", status,
 			message, nil,
 		); evErr != nil {
@@ -156,7 +156,7 @@ func persistCertificateResult(
 		// Emit expiring/expired event immediately if the newly discovered cert is already in bad shape.
 		if status == "expiring_soon" || status == "expired" {
 			if evErr := queries.InsertCertificateEvent(ctx, pool,
-				certID, orgID,
+				certID, instanceID,
 				status, "", status,
 				fmt.Sprintf("Certificate %s: expires %s", status, report.NotAfter.Format("2006-01-02")),
 				nil,
@@ -169,7 +169,7 @@ func persistCertificateResult(
 		// Existing cert — check for status transition.
 		if previousStatus != status && previousStatus != "" {
 			if evErr := queries.InsertCertificateEvent(ctx, pool,
-				certID, orgID,
+				certID, instanceID,
 				status, previousStatus, status,
 				fmt.Sprintf("Certificate status changed from %s to %s", previousStatus, status),
 				nil,
@@ -181,5 +181,5 @@ func persistCertificateResult(
 	}
 
 	// Immediately evaluate cert_expiry alert rules for this freshly-observed cert.
-	evaluateCertExpiryForCert(ctx, pool, orgID, certID, report.CommonName, report.Issuer, report.Host, report.Port, report.NotAfter, status)
+	evaluateCertExpiryForCert(ctx, pool, instanceID, certID, report.CommonName, report.Issuer, report.Host, report.Port, report.NotAfter, status)
 }

--- a/apps/ingest/internal/handlers/heartbeat.go
+++ b/apps/ingest/internal/handlers/heartbeat.go
@@ -65,7 +65,7 @@ func (h *HeartbeatHandler) Heartbeat(stream agentv1.IngestService_HeartbeatServe
 	}
 
 	// Validate the JWT and bind it to the verified mTLS client identity.
-	agentID, _, err := h.authenticateFirstHeartbeat(ctx, first.AgentId)
+	agentID, err := h.authenticateFirstHeartbeat(ctx, first.AgentId)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (h *HeartbeatHandler) Heartbeat(stream agentv1.IngestService_HeartbeatServe
 		if err := queries.SetAgentStatus(ctx, h.pool, agentID, "active"); err != nil {
 			slog.Warn("reactivating offline agent", "err", err)
 		}
-		if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, agent.OrganisationID, "active", nil, "agent reconnected"); err != nil {
+		if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, agent.InstanceID, "active", nil, "agent reconnected"); err != nil {
 			slog.Warn("inserting reconnect status history", "err", err)
 		}
 		agent.Status = "active"
@@ -103,7 +103,7 @@ func (h *HeartbeatHandler) Heartbeat(stream agentv1.IngestService_HeartbeatServe
 	slog.Info("heartbeat stream started", "agent_id", agentID)
 
 	// Process first message
-	if err := h.processHeartbeat(ctx, stream, agentID, agent.OrganisationID, hostID, agent.Hostname, first); err != nil {
+	if err := h.processHeartbeat(ctx, stream, agentID, agent.InstanceID, hostID, agent.Hostname, first); err != nil {
 		return err
 	}
 
@@ -168,7 +168,7 @@ loop:
 					slog.Info("resolved host after retry", "agent_id", agentID, "host_id", hostID)
 				}
 			}
-			if err := h.processHeartbeat(ctx, stream, agentID, agent.OrganisationID, hostID, agent.Hostname, req); err != nil {
+			if err := h.processHeartbeat(ctx, stream, agentID, agent.InstanceID, hostID, agent.Hostname, req); err != nil {
 				return err
 			}
 
@@ -269,7 +269,7 @@ loop:
 	if err := queries.SetHostOffline(context.Background(), h.pool, agentID); err != nil {
 		slog.Warn("setting host offline", "err", err)
 	}
-	if err := queries.InsertAgentStatusHistory(context.Background(), h.pool, agentID, agent.OrganisationID, "offline", nil, "heartbeat stream closed"); err != nil {
+	if err := queries.InsertAgentStatusHistory(context.Background(), h.pool, agentID, agent.InstanceID, "offline", nil, "heartbeat stream closed"); err != nil {
 		slog.Warn("inserting offline status history", "err", err)
 	}
 
@@ -277,25 +277,25 @@ loop:
 	return nil
 }
 
-func (h *HeartbeatHandler) authenticateFirstHeartbeat(ctx context.Context, token string) (agentID string, orgID string, err error) {
-	agentID, orgID, err = h.issuer.ValidateAgentToken(token)
+func (h *HeartbeatHandler) authenticateFirstHeartbeat(ctx context.Context, token string) (agentID string, err error) {
+	agentID, err = h.issuer.ValidateAgentToken(token)
 	if err != nil {
-		return "", "", status.Error(codes.Unauthenticated, "invalid or missing JWT")
+		return "", status.Error(codes.Unauthenticated, "invalid or missing JWT")
 	}
 	id, ok := pki.IdentityFromContext(ctx)
 	if !ok || id == nil {
-		return "", "", status.Error(codes.Unauthenticated, "missing client identity")
+		return "", status.Error(codes.Unauthenticated, "missing client identity")
 	}
-	if id.AgentID != agentID || id.OrgID != orgID {
-		return "", "", status.Error(codes.Unauthenticated, "client identity mismatch")
+	if id.AgentID != agentID {
+		return "", status.Error(codes.Unauthenticated, "client identity mismatch")
 	}
-	return agentID, orgID, nil
+	return agentID, nil
 }
 
 func (h *HeartbeatHandler) processHeartbeat(
 	ctx context.Context,
 	stream agentv1.IngestService_HeartbeatServer,
-	agentID, orgID, hostID, hostname string,
+	agentID, instanceID, hostID, hostname string,
 	req *agentv1.HeartbeatRequest,
 ) error {
 	now := time.Now()
@@ -340,13 +340,13 @@ func (h *HeartbeatHandler) processHeartbeat(
 
 	// Sync host↔network memberships based on current IP addresses.
 	if hostID != "" && len(ipAddresses) > 0 {
-		if err := queries.SyncHostNetworks(ctx, h.pool, orgID, hostID, ipAddresses); err != nil {
+		if err := queries.SyncHostNetworks(ctx, h.pool, instanceID, hostID, ipAddresses); err != nil {
 			slog.Warn("syncing host network memberships", "host_id", hostID, "err", err)
 		}
 	}
 
 	// Persist metric history row
-	if err := queries.InsertHostMetricByAgentID(ctx, h.pool, orgID, agentID, now,
+	if err := queries.InsertHostMetricByAgentID(ctx, h.pool, instanceID, agentID, now,
 		req.CpuPercent, req.MemoryPercent, req.DiskPercent, req.UptimeSeconds,
 	); err != nil {
 		slog.Warn("inserting host metric", "err", err)
@@ -356,7 +356,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 	if hostID != "" {
 		// Build a checkID → checkType map once per heartbeat to route cert results.
 		checkTypeMap := make(map[string]string)
-		if hostChecks, err := queries.GetChecksForHost(ctx, h.pool, hostID, orgID); err == nil {
+		if hostChecks, err := queries.GetChecksForHost(ctx, h.pool, hostID, instanceID); err == nil {
 			for _, c := range hostChecks {
 				checkTypeMap[c.ID] = c.CheckType
 			}
@@ -367,7 +367,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 		for _, result := range req.CheckResults {
 			ranAt := time.Unix(result.RanAtUnix, 0)
 			if err := queries.InsertCheckResult(ctx, h.pool,
-				result.CheckId, hostID, orgID,
+				result.CheckId, hostID, instanceID,
 				result.Status, result.Output,
 				result.DurationMs, ranAt,
 			); err != nil {
@@ -378,19 +378,19 @@ func (h *HeartbeatHandler) processHeartbeat(
 			switch checkTypeMap[result.CheckId] {
 			case "certificate":
 				if result.Output != "" {
-					persistCertificateResult(ctx, h.pool, orgID, hostID, result.CheckId, result.Output)
+					persistCertificateResult(ctx, h.pool, instanceID, hostID, result.CheckId, result.Output)
 				}
 			case "service_account":
 				if result.Output != "" {
-					persistServiceAccountResult(ctx, h.pool, orgID, hostID, result.CheckId, result.Output)
+					persistServiceAccountResult(ctx, h.pool, instanceID, hostID, result.CheckId, result.Output)
 				}
 			case "ssh_key_scan":
 				if result.Output != "" {
-					persistSshKeyResult(ctx, h.pool, orgID, hostID, result.CheckId, result.Output)
+					persistSshKeyResult(ctx, h.pool, instanceID, hostID, result.CheckId, result.Output)
 				}
 			case "patch_status":
 				if result.Output != "" {
-					persistPatchStatusResult(ctx, h.pool, orgID, hostID, result.CheckId, ranAt, result.Output)
+					persistPatchStatusResult(ctx, h.pool, instanceID, hostID, result.CheckId, ranAt, result.Output)
 				}
 			}
 		}
@@ -400,7 +400,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 		for _, result := range req.CheckResults {
 			checkStatuses[result.CheckId] = result.Status
 		}
-		evaluateAlerts(ctx, h.pool, orgID, hostID, hostname, checkStatuses, heartbeatMetrics{
+		evaluateAlerts(ctx, h.pool, instanceID, hostID, hostname, checkStatuses, heartbeatMetrics{
 			CPU:    req.CpuPercent,
 			Memory: req.MemoryPercent,
 			Disk:   req.DiskPercent,
@@ -454,7 +454,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 	// Publish to queue (for consumers/metrics in standard/ha deployments)
 	payload, _ := json.Marshal(map[string]interface{}{
 		"agent_id":      agentID,
-		"org_id":        orgID,
+		"instance_id":   instanceID,
 		"timestamp":     now.Unix(),
 		"cpu":           req.CpuPercent,
 		"memory":        req.MemoryPercent,
@@ -500,7 +500,7 @@ func (h *HeartbeatHandler) processHeartbeat(
 
 	// Push active check definitions to the agent
 	if hostID != "" {
-		checkRows, err := queries.GetChecksForHost(ctx, h.pool, hostID, orgID)
+		checkRows, err := queries.GetChecksForHost(ctx, h.pool, hostID, instanceID)
 		if err != nil {
 			slog.Warn("fetching checks for host", "host_id", hostID, "err", err)
 		} else {

--- a/apps/ingest/internal/handlers/heartbeat_test.go
+++ b/apps/ingest/internal/handlers/heartbeat_test.go
@@ -84,7 +84,7 @@ func TestHeartbeatAuthenticateFirstMessageBindsMTLSIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJWTIssuer: %v", err)
 	}
-	token, err := issuer.IssueAgentToken("agent-123", "org-456")
+	token, err := issuer.IssueAgentToken("agent-123")
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
@@ -104,23 +104,13 @@ func TestHeartbeatAuthenticateFirstMessageBindsMTLSIdentity(t *testing.T) {
 		{
 			name: "mismatched agent",
 			ctx: pki.WithIdentity(context.Background(), &pki.Identity{
-				OrgID:   "org-456",
 				AgentID: "agent-other",
-			}),
-			wantCode: codes.Unauthenticated,
-		},
-		{
-			name: "mismatched organisation",
-			ctx: pki.WithIdentity(context.Background(), &pki.Identity{
-				OrgID:   "org-other",
-				AgentID: "agent-123",
 			}),
 			wantCode: codes.Unauthenticated,
 		},
 		{
 			name: "matching identity",
 			ctx: pki.WithIdentity(context.Background(), &pki.Identity{
-				OrgID:   "org-456",
 				AgentID: "agent-123",
 			}),
 			wantCode: codes.OK,
@@ -129,13 +119,13 @@ func TestHeartbeatAuthenticateFirstMessageBindsMTLSIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agentID, orgID, err := handler.authenticateFirstHeartbeat(tt.ctx, token)
+			agentID, err := handler.authenticateFirstHeartbeat(tt.ctx, token)
 			if status.Code(err) != tt.wantCode {
 				t.Fatalf("authenticateFirstHeartbeat() code = %v, want %v (err=%v)", status.Code(err), tt.wantCode, err)
 			}
 			if tt.wantCode == codes.OK {
-				if agentID != "agent-123" || orgID != "org-456" {
-					t.Fatalf("authenticateFirstHeartbeat() = (%q, %q), want (agent-123, org-456)", agentID, orgID)
+				if agentID != "agent-123" {
+					t.Fatalf("authenticateFirstHeartbeat() = %q, want %q", agentID, "agent-123")
 				}
 			}
 		})

--- a/apps/ingest/internal/handlers/inventory.go
+++ b/apps/ingest/internal/handlers/inventory.go
@@ -86,7 +86,7 @@ func (h *InventoryHandler) SubmitSoftwareInventory(stream agentv1.IngestService_
 
 	// ── Create software_scans row ─────────────────────────────────────────────
 	startedAt := time.Now()
-	softwareScanID, err := queries.InsertSoftwareScan(ctx, h.pool, hostOrg.OrgID, hostOrg.HostID, scanID, source, startedAt)
+	softwareScanID, err := queries.InsertSoftwareScan(ctx, h.pool, hostOrg.InstanceID, hostOrg.HostID, scanID, source, startedAt)
 	if err != nil {
 		slog.Error("inventory: creating software scan", "err", err)
 		return status.Error(codes.Internal, "could not create scan record")
@@ -143,7 +143,7 @@ func (h *InventoryHandler) SubmitSoftwareInventory(stream agentv1.IngestService_
 
 		added, err := queries.UpsertSoftwarePackagesBatch(
 			ctx, h.pool,
-			hostOrg.OrgID, hostOrg.HostID, source,
+			hostOrg.InstanceID, hostOrg.HostID, source,
 			names, versions, archs, publishers,
 			distroIDs, distroVersionIDs, distroCodenames, distroIDLikes,
 			sourceNames, sourceVersions, packageEpochs, packageReleases,
@@ -278,7 +278,7 @@ func (h *InventoryHandler) authenticateStream(stream agentv1.IngestService_Submi
 	if len(token) > 7 && strings.EqualFold(token[:7], "bearer ") {
 		token = token[7:]
 	}
-	agentID, orgID, err := h.issuer.ValidateAgentToken(token)
+	agentID, err := h.issuer.ValidateAgentToken(token)
 	if err != nil {
 		return "", status.Error(codes.Unauthenticated, "invalid token")
 	}
@@ -286,7 +286,7 @@ func (h *InventoryHandler) authenticateStream(stream agentv1.IngestService_Submi
 	if !ok || id == nil {
 		return "", status.Error(codes.Unauthenticated, "missing client identity")
 	}
-	if id.AgentID != agentID || id.OrgID != orgID {
+	if id.AgentID != agentID {
 		return "", status.Error(codes.Unauthenticated, "client identity mismatch")
 	}
 	return agentID, nil

--- a/apps/ingest/internal/handlers/inventory_test.go
+++ b/apps/ingest/internal/handlers/inventory_test.go
@@ -84,14 +84,13 @@ func TestInventoryAuthenticateStreamRejectsExpiredJWT(t *testing.T) {
 		t.Fatalf("NewJWTIssuer: %v", err)
 	}
 
-	token, err := issuer.IssueAgentToken("agent-123", "org-123")
+	token, err := issuer.IssueAgentToken("agent-123")
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
 
 	stream := &inventoryAuthTestStream{
 		ctx: pki.WithIdentity(metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+token)), &pki.Identity{
-			OrgID:   "org-123",
 			AgentID: "agent-123",
 		}),
 	}
@@ -110,14 +109,13 @@ func TestInventoryAuthenticateStreamRejectsMTLSJWTMismatch(t *testing.T) {
 		t.Fatalf("NewJWTIssuer: %v", err)
 	}
 
-	token, err := issuer.IssueAgentToken("agent-123", "org-123")
+	token, err := issuer.IssueAgentToken("agent-123")
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
 
 	stream := &inventoryAuthTestStream{
 		ctx: pki.WithIdentity(metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+token)), &pki.Identity{
-			OrgID:   "org-123",
 			AgentID: "agent-999",
 		}),
 	}
@@ -136,14 +134,13 @@ func TestInventoryAuthenticateStreamAcceptsMatchingMTLSIdentity(t *testing.T) {
 		t.Fatalf("NewJWTIssuer: %v", err)
 	}
 
-	token, err := issuer.IssueAgentToken("agent-123", "org-123")
+	token, err := issuer.IssueAgentToken("agent-123")
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
 
 	stream := &inventoryAuthTestStream{
 		ctx: pki.WithIdentity(metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer "+token)), &pki.Identity{
-			OrgID:   "org-123",
 			AgentID: "agent-123",
 		}),
 	}

--- a/apps/ingest/internal/handlers/notify.go
+++ b/apps/ingest/internal/handlers/notify.go
@@ -499,10 +499,10 @@ func dispatchTelegram(ctx context.Context, channels []queries.TelegramChannelRow
 
 // dispatchInApp creates an in-app notification row for each eligible user in the org.
 // alertInstanceID may be empty (cert alerts use a different instance query).
-func dispatchInApp(ctx context.Context, pool *pgxpool.Pool, orgID, alertInstanceID, resourceType, resourceID string, event AlertEvent) {
-	settings, err := queries.GetOrgNotificationSettings(ctx, pool, orgID)
+func dispatchInApp(ctx context.Context, pool *pgxpool.Pool, instanceID, alertInstanceID, resourceType, resourceID string, event AlertEvent) {
+	settings, err := queries.GetOrgNotificationSettings(ctx, pool, instanceID)
 	if err != nil {
-		slog.Warn("dispatchInApp: fetching org notification settings", "org_id", orgID, "err", err)
+		slog.Warn("dispatchInApp: fetching org notification settings", "instance_id", instanceID, "err", err)
 		// Proceed with defaults (already set by the query function on error)
 	}
 
@@ -510,9 +510,9 @@ func dispatchInApp(ctx context.Context, pool *pgxpool.Pool, orgID, alertInstance
 		return
 	}
 
-	userIDs, err := queries.GetAlertTargetUsers(ctx, pool, orgID, settings.InAppRoles, settings.AllowUserOptOut)
+	userIDs, err := queries.GetAlertTargetUsers(ctx, pool, instanceID, settings.InAppRoles, settings.AllowUserOptOut)
 	if err != nil {
-		slog.Warn("dispatchInApp: fetching target users", "org_id", orgID, "err", err)
+		slog.Warn("dispatchInApp: fetching target users", "instance_id", instanceID, "err", err)
 		return
 	}
 	if len(userIDs) == 0 {
@@ -532,7 +532,7 @@ func dispatchInApp(ctx context.Context, pool *pgxpool.Pool, orgID, alertInstance
 	rows := make([]queries.NotificationInsert, 0, len(userIDs))
 	for _, uid := range userIDs {
 		rows = append(rows, queries.NotificationInsert{
-			OrgID:           orgID,
+			InstanceID:      instanceID,
 			UserID:          uid,
 			AlertInstanceID: alertInstanceID,
 			Subject:         subject,
@@ -544,6 +544,6 @@ func dispatchInApp(ctx context.Context, pool *pgxpool.Pool, orgID, alertInstance
 	}
 
 	if err := queries.InsertNotificationBatch(ctx, pool, rows); err != nil {
-		slog.Warn("dispatchInApp: inserting notifications", "org_id", orgID, "err", err)
+		slog.Warn("dispatchInApp: inserting notifications", "instance_id", instanceID, "err", err)
 	}
 }

--- a/apps/ingest/internal/handlers/patch_status.go
+++ b/apps/ingest/internal/handlers/patch_status.go
@@ -28,7 +28,7 @@ type patchStatusCheckReport struct {
 func persistPatchStatusResult(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, checkID string,
+	instanceID, hostID, checkID string,
 	ranAt time.Time,
 	output string,
 ) {
@@ -54,7 +54,7 @@ func persistPatchStatusResult(
 	if err := queries.UpsertHostPatchStatus(
 		ctx,
 		pool,
-		orgID,
+		instanceID,
 		hostID,
 		checkID,
 		report.Status,
@@ -74,7 +74,7 @@ func persistPatchStatusResult(
 	}
 
 	if report.UpdatesSupported {
-		if err := queries.ReplaceCurrentPackageUpdates(ctx, pool, orgID, hostID, report.PackageManager, report.Updates, ranAt); err != nil {
+		if err := queries.ReplaceCurrentPackageUpdates(ctx, pool, instanceID, hostID, report.PackageManager, report.Updates, ranAt); err != nil {
 			slog.Warn("patch_status: replace package updates", "check_id", checkID, "err", err)
 		}
 	}

--- a/apps/ingest/internal/handlers/register.go
+++ b/apps/ingest/internal/handlers/register.go
@@ -50,26 +50,26 @@ func decideHostCollision(collision *queries.HostCollision) (hostCollisionDecisio
 	return hostCollisionCreateSeparatePending, "existing offline or unknown host identity"
 }
 
-func existingAgentBelongsToTokenOrg(existing *queries.AgentRow, tokenOrgID string) bool {
-	return existing != nil && existing.OrganisationID == tokenOrgID
+func existingAgentBelongsToTokenInstance(existing *queries.AgentRow, tokenInstanceID string) bool {
+	return existing != nil && existing.InstanceID == tokenInstanceID
 }
 
 // Register handles agent registration.
 //
 // Flow:
-//  1. Validate org_token → UNAUTHENTICATED if invalid/expired
+//  1. Validate enrolment_token → UNAUTHENTICATED if invalid/expired
 //  2. Check if public_key already registered → return existing state (idempotent)
-//  3. Check for a colliding host (same hostname or overlapping IP) in the org:
+//  3. Check for a colliding host (same hostname or overlapping IP) in the instance:
 //     - Online match → reject with ALREADY_EXISTS (two live hosts can't share identity)
 //     - Offline/unknown linked match → create a separate pending registration
 //  4. Insert agent (status=pending) + host row
 //  5. If auto_approve on token → set active, issue JWT
 //  6. Return RegisterResponse
 func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error) {
-	if req.OrgToken == "" || req.PublicKey == "" {
-		return nil, status.Error(codes.InvalidArgument, "org_token and public_key are required")
+	if req.EnrolmentToken == "" || req.PublicKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "enrolment_token and public_key are required")
 	}
-	if err := h.registrationLimiter.Allow(ctx, req.OrgToken); err != nil {
+	if err := h.registrationLimiter.Allow(ctx, req.EnrolmentToken); err != nil {
 		slog.Warn("throttling agent registration attempt", "err", err)
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 
 	// Step 1: Validate enrolment token
-	token, err := queries.GetEnrolmentToken(ctx, h.pool, req.OrgToken)
+	token, err := queries.GetEnrolmentToken(ctx, h.pool, req.EnrolmentToken)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, status.Error(codes.Unauthenticated, "invalid or expired enrolment token")
@@ -93,7 +93,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		slog.Error("looking up enrolment token", "err", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
-	orgID := token.OrganisationID
+	instanceID := token.InstanceID
 
 	// Step 2: Check for existing registration (idempotent)
 	existing, err := queries.GetAgentByPublicKey(ctx, h.pool, req.PublicKey)
@@ -103,11 +103,11 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 
 	if existing != nil {
-		if !existingAgentBelongsToTokenOrg(existing, orgID) {
-			slog.Warn("rejecting registration for existing public key in different organisation",
+		if !existingAgentBelongsToTokenInstance(existing, instanceID) {
+			slog.Warn("rejecting registration for existing public key in different instance",
 				"agent_id", existing.ID,
-				"agent_org_id", existing.OrganisationID,
-				"token_org_id", orgID,
+				"agent_instance_id", existing.InstanceID,
+				"token_instance_id", instanceID,
 			)
 			return nil, status.Error(codes.Unauthenticated, "invalid or expired enrolment token")
 		}
@@ -120,7 +120,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 			}
 		}
 		if existing.Status == "active" {
-			jwtToken, err := h.issuer.IssueAgentToken(existing.ID, existing.OrganisationID)
+			jwtToken, err := h.issuer.IssueAgentToken(existing.ID)
 			if err != nil {
 				slog.Error("issuing JWT for existing agent", "err", err)
 				return nil, status.Error(codes.Internal, "internal error")
@@ -160,13 +160,13 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	}
 	mergedTags := queries.MergeTagLayers(token.Metadata.Tags, reqTagPairs)
 
-	// Step 3: Check for identity collision with an existing host in the org.
+	// Step 3: Check for identity collision with an existing host in the instance.
 	// Hostname or IP overlap is not sufficient proof that this is the same
 	// physical machine. Existing live identities are rejected; offline/unknown
 	// linked matches become separate pending registrations so an administrator
 	// can review the claim without mutating the existing agent's key material.
 	var collisionRequiringManualApproval *queries.HostCollision
-	collision, err := queries.FindHostCollision(ctx, h.pool, orgID, hostname, reportedIPs)
+	collision, err := queries.FindHostCollision(ctx, h.pool, instanceID, hostname, reportedIPs)
 	if err != nil {
 		slog.Error("checking host collision", "err", err)
 		return nil, status.Error(codes.Internal, "internal error")
@@ -184,7 +184,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 				"reason", reason,
 			)
 			return nil, status.Errorf(codes.AlreadyExists,
-				"a host matching this hostname or IP is already registered in this organisation (%s) — delete the existing host before re-registering",
+				"a host matching this hostname or IP is already registered in this instance (%s) — delete the existing host before re-registering",
 				reason,
 			)
 		case hostCollisionCreateSeparatePending:
@@ -206,7 +206,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	// Step 4: Atomically consume one token use before creating the new agent.
 	// Repeat registration with an existing public key returns above without
 	// consuming another use.
-	token, err = queries.ConsumeEnrolmentToken(ctx, h.pool, req.OrgToken)
+	token, err = queries.ConsumeEnrolmentToken(ctx, h.pool, req.EnrolmentToken)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, status.Error(codes.Unauthenticated, "invalid or expired enrolment token")
@@ -214,11 +214,11 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 		slog.Error("consuming enrolment token", "err", err)
 		return nil, status.Error(codes.Internal, "internal error")
 	}
-	orgID = token.OrganisationID
+	instanceID = token.InstanceID
 
 	// Step 5: Insert new agent
 	agentStatus := "pending"
-	agentID, err := queries.InsertAgent(ctx, h.pool, orgID, hostname, req.PublicKey, agentStatus, token.ID, agentOS, agentArch)
+	agentID, err := queries.InsertAgent(ctx, h.pool, instanceID, hostname, req.PublicKey, agentStatus, token.ID, agentOS, agentArch)
 	if err != nil {
 		slog.Error("inserting agent", "err", err)
 		return nil, status.Error(codes.Internal, "failed to register agent")
@@ -239,7 +239,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	if !token.AutoApprove || collisionRequiringManualApproval != nil {
 		pendingForInsert = mergedTags
 	}
-	hostID, err := queries.InsertHost(ctx, h.pool, orgID, agentID, hostname, agentOS, agentArch, pendingForInsert)
+	hostID, err := queries.InsertHost(ctx, h.pool, instanceID, agentID, hostname, agentOS, agentArch, pendingForInsert)
 	if err != nil {
 		slog.Warn("inserting host row", "err", err)
 	}
@@ -249,7 +249,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 	if collisionRequiringManualApproval != nil {
 		statusReason = "registration matched an existing host identity; requires explicit admin review before merge or rebind"
 	}
-	if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, orgID, "pending", nil, statusReason); err != nil {
+	if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, instanceID, "pending", nil, statusReason); err != nil {
 		slog.Warn("inserting status history", "err", err)
 	}
 
@@ -261,28 +261,28 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 			slog.Error("auto-approving agent", "err", err)
 			return nil, status.Error(codes.Internal, "internal error")
 		}
-		if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, orgID, "active", nil, "auto-approved by enrolment token"); err != nil {
+		if err := queries.InsertAgentStatusHistory(ctx, h.pool, agentID, instanceID, "active", nil, "auto-approved by enrolment token"); err != nil {
 			slog.Warn("inserting auto-approve history", "err", err)
 		}
 
-		// Apply merged tag layers (org defaults → token → request) to the host
+		// Apply merged tag layers (instance defaults → token → request) to the host
 		// row. There is no TS approval step in the auto-approve path, so tags
 		// must be written here. Saved tag_rules are evaluated later in TS by
 		// a cron/backfill job since they may depend on non-registration state.
 		if hostID != "" {
-			defaults, err := queries.GetOrgDefaultTags(ctx, h.pool, orgID)
+			defaults, err := queries.GetOrgDefaultTags(ctx, h.pool, instanceID)
 			if err != nil {
-				slog.Warn("loading org default tags", "err", err)
+				slog.Warn("loading instance default tags", "err", err)
 			}
 			finalTags := queries.MergeTagLayers(defaults, mergedTags)
 			if len(finalTags) > 0 {
-				if err := queries.AssignTagsToResource(ctx, h.pool, orgID, "host", hostID, finalTags); err != nil {
+				if err := queries.AssignTagsToResource(ctx, h.pool, instanceID, "host", hostID, finalTags); err != nil {
 					slog.Warn("applying tags on auto-approve", "err", err)
 				}
 			}
 		}
 
-		jwtToken, err := h.issuer.IssueAgentToken(agentID, orgID)
+		jwtToken, err := h.issuer.IssueAgentToken(agentID)
 		if err != nil {
 			slog.Error("issuing JWT for auto-approved agent", "err", err)
 			return nil, status.Error(codes.Internal, "internal error")
@@ -299,7 +299,7 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 			JwtToken: jwtToken,
 		}
 		if len(req.CsrDer) > 0 && h.ca != nil {
-			if err := signAndAttach(ctx, h.pool, h.ca, agentID, orgID, req.CsrDer, resp); err != nil {
+			if err := signAndAttach(ctx, h.pool, h.ca, agentID, req.CsrDer, resp); err != nil {
 				slog.Warn("inline signing CSR on auto-approve", "err", err)
 			}
 		}
@@ -321,8 +321,8 @@ func (h *RegisterHandler) Register(ctx context.Context, req *agentv1.RegisterReq
 
 // signAndAttach signs a CSR immediately, persists the leaf onto the agents
 // row, clears any pending queue entry, and attaches the cert + CA to resp.
-func signAndAttach(ctx context.Context, pool *pgxpool.Pool, ca *pki.AgentCA, agentID, orgID string, csrDER []byte, resp *agentv1.RegisterResponse) error {
-	leaf, err := ca.Sign(csrDER, agentID, orgID)
+func signAndAttach(ctx context.Context, pool *pgxpool.Pool, ca *pki.AgentCA, agentID string, csrDER []byte, resp *agentv1.RegisterResponse) error {
+	leaf, err := ca.Sign(csrDER, agentID)
 	if err != nil {
 		return err
 	}

--- a/apps/ingest/internal/handlers/register_rate_limiter.go
+++ b/apps/ingest/internal/handlers/register_rate_limiter.go
@@ -60,14 +60,14 @@ func NewDefaultRegistrationLimiter() *RegistrationLimiter {
 	return NewRegistrationLimiter(RegistrationLimiterConfig{})
 }
 
-func (l *RegistrationLimiter) Allow(ctx context.Context, orgToken string) error {
+func (l *RegistrationLimiter) Allow(ctx context.Context, enrolmentToken string) error {
 	if l == nil {
 		return nil
 	}
 
 	now := l.config.Now()
 	sourceKey := "source:" + registrationSource(ctx)
-	sourceTokenKey := sourceKey + ":token:" + tokenHashPrefix(orgToken)
+	sourceTokenKey := sourceKey + ":token:" + tokenHashPrefix(enrolmentToken)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/apps/ingest/internal/handlers/register_rate_limiter_test.go
+++ b/apps/ingest/internal/handlers/register_rate_limiter_test.go
@@ -97,8 +97,8 @@ func TestRegisterThrottlesBeforeTokenLookup(t *testing.T) {
 
 	handler := &RegisterHandler{registrationLimiter: limiter}
 	_, err := handler.Register(ctx, &agentv1.RegisterRequest{
-		OrgToken:  "enrolment-token-a",
-		PublicKey: "agent-public-key",
+		EnrolmentToken: "enrolment-token-a",
+		PublicKey:      "agent-public-key",
 	})
 	if status.Code(err) != codes.ResourceExhausted {
 		t.Fatalf("Register() error code = %v, want %v (err=%v)", status.Code(err), codes.ResourceExhausted, err)

--- a/apps/ingest/internal/handlers/register_test.go
+++ b/apps/ingest/internal/handlers/register_test.go
@@ -80,16 +80,16 @@ func TestDecideHostCollisionRejectsOnlineOrActiveHost(t *testing.T) {
 	}
 }
 
-func TestExistingAgentBelongsToTokenOrgRejectsOrgMismatch(t *testing.T) {
+func TestExistingAgentBelongsToTokenInstanceRejectsInstanceMismatch(t *testing.T) {
 	t.Parallel()
 
 	existing := &queries.AgentRow{
-		ID:             "agent_existing",
-		OrganisationID: "org_original",
-		Status:         "active",
+		ID:         "agent_existing",
+		InstanceID: "org_original",
+		Status:     "active",
 	}
 
-	if existingAgentBelongsToTokenOrg(existing, "org_attacker") {
-		t.Fatal("existing agent matched a different enrolment token organisation")
+	if existingAgentBelongsToTokenInstance(existing, "org_attacker") {
+		t.Fatal("existing agent matched a different enrolment token instance")
 	}
 }

--- a/apps/ingest/internal/handlers/renew_cert.go
+++ b/apps/ingest/internal/handlers/renew_cert.go
@@ -50,7 +50,7 @@ func (h *RenewCertHandler) Renew(ctx context.Context, req *agentv1.RenewCertific
 		return nil, status.Errorf(codes.PermissionDenied, "agent status is %s", agent.Status)
 	}
 
-	leaf, err := h.ca.Sign(req.CsrDer, req.AgentId, agent.OrganisationID)
+	leaf, err := h.ca.Sign(req.CsrDer, req.AgentId)
 	if err != nil {
 		slog.Error("signing renewal CSR", "agent_id", req.AgentId, "err", err)
 		return nil, status.Error(codes.Internal, "signing failed")

--- a/apps/ingest/internal/handlers/schedule_sweeper.go
+++ b/apps/ingest/internal/handlers/schedule_sweeper.go
@@ -70,7 +70,7 @@ func fireSchedule(ctx context.Context, pool *pgxpool.Pool, s queries.DueSchedule
 		return
 	}
 
-	hostIDs, err := queries.ResolveScheduleTargetHosts(ctx, pool, s.OrgID, s.TargetType, s.TargetID, s.TaskType)
+	hostIDs, err := queries.ResolveScheduleTargetHosts(ctx, pool, s.InstanceID, s.TargetType, s.TargetID, s.TaskType)
 	if err != nil {
 		slog.Warn("schedule sweeper: resolving target hosts", "schedule_id", s.ID, "err", err)
 		return
@@ -86,7 +86,7 @@ func fireSchedule(ctx context.Context, pool *pgxpool.Pool, s queries.DueSchedule
 	}
 
 	taskRunID, err := queries.InsertScheduledTaskRun(
-		ctx, pool, s.ID, s.OrgID, s.TargetType, s.TargetID, s.TaskType, s.ConfigJSON, s.MaxParallel, hostIDs,
+		ctx, pool, s.ID, s.InstanceID, s.TargetType, s.TargetID, s.TaskType, s.ConfigJSON, s.MaxParallel, hostIDs,
 	)
 	if err != nil {
 		slog.Warn("schedule sweeper: inserting task run", "schedule_id", s.ID, "err", err)

--- a/apps/ingest/internal/handlers/service_accounts.go
+++ b/apps/ingest/internal/handlers/service_accounts.go
@@ -20,24 +20,24 @@ type serviceAccountReport struct {
 }
 
 type accountEntry struct {
-	Username             string `json:"username"`
-	UID                  int    `json:"uid"`
-	GID                  int    `json:"gid"`
-	HomeDirectory        string `json:"home_directory"`
-	Shell                string `json:"shell"`
-	AccountType          string `json:"account_type"`
-	HasLoginCapability   bool   `json:"has_login_capability"`
-	HasRunningProcesses  bool   `json:"has_running_processes"`
-	AccountLocked        bool   `json:"account_locked"`
-	PasswordExpiresAt    string `json:"password_expires_at,omitempty"`
-	PasswordLastChanged  string `json:"password_last_changed,omitempty"`
+	Username            string `json:"username"`
+	UID                 int    `json:"uid"`
+	GID                 int    `json:"gid"`
+	HomeDirectory       string `json:"home_directory"`
+	Shell               string `json:"shell"`
+	AccountType         string `json:"account_type"`
+	HasLoginCapability  bool   `json:"has_login_capability"`
+	HasRunningProcesses bool   `json:"has_running_processes"`
+	AccountLocked       bool   `json:"account_locked"`
+	PasswordExpiresAt   string `json:"password_expires_at,omitempty"`
+	PasswordLastChanged string `json:"password_last_changed,omitempty"`
 }
 
 // persistServiceAccountResult upserts service accounts from a scan result and emits events.
 func persistServiceAccountResult(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, checkID, output string,
+	instanceID, hostID, checkID, output string,
 ) {
 	var report serviceAccountReport
 	if err := json.Unmarshal([]byte(output), &report); err != nil {
@@ -51,7 +51,7 @@ func persistServiceAccountResult(
 	}
 
 	// Load existing accounts for this host to detect missing accounts.
-	existingAccounts, err := queries.GetServiceAccountsForHost(ctx, pool, orgID, hostID)
+	existingAccounts, err := queries.GetServiceAccountsForHost(ctx, pool, instanceID, hostID)
 	if err != nil {
 		slog.Warn("svc-account: loading existing accounts", "host_id", hostID, "err", err)
 	}
@@ -82,7 +82,7 @@ func persistServiceAccountResult(
 		}
 
 		id, wasInsert, previous, err := queries.UpsertServiceAccount(
-			ctx, pool, orgID, hostID,
+			ctx, pool, instanceID, hostID,
 			acct.Username, acct.UID, acct.GID,
 			acct.HomeDirectory, acct.Shell, acct.AccountType,
 			acct.HasLoginCapability, acct.HasRunningProcesses,
@@ -97,7 +97,7 @@ func persistServiceAccountResult(
 		if wasInsert && previous == nil {
 			// Brand new account discovered.
 			if evErr := queries.InsertIdentityEvent(ctx, pool,
-				orgID, hostID, &id, nil,
+				instanceID, hostID, &id, nil,
 				"account_discovered",
 				fmt.Sprintf("Account '%s' discovered (UID %d, type: %s)", acct.Username, acct.UID, acct.AccountType),
 				nil,
@@ -113,7 +113,7 @@ func persistServiceAccountResult(
 			if previous.Status == "missing" {
 				// Account was missing, now restored.
 				if evErr := queries.InsertIdentityEvent(ctx, pool,
-					orgID, hostID, &id, nil,
+					instanceID, hostID, &id, nil,
 					"account_restored",
 					fmt.Sprintf("Account '%s' restored (was missing)", acct.Username),
 					nil,
@@ -128,7 +128,7 @@ func persistServiceAccountResult(
 			if len(changes) > 0 {
 				meta, _ := json.Marshal(changes)
 				if evErr := queries.InsertIdentityEvent(ctx, pool,
-					orgID, hostID, &id, nil,
+					instanceID, hostID, &id, nil,
 					"account_changed",
 					fmt.Sprintf("Account '%s' changed: %s", acct.Username, summarizeChanges(changes)),
 					meta,
@@ -150,7 +150,7 @@ func persistServiceAccountResult(
 		}
 		id := existing.ID
 		if evErr := queries.InsertIdentityEvent(ctx, pool,
-			orgID, hostID, &id, nil,
+			instanceID, hostID, &id, nil,
 			"account_missing",
 			fmt.Sprintf("Account '%s' no longer present on host", existing.Username),
 			nil,

--- a/apps/ingest/internal/handlers/software_sweeper.go
+++ b/apps/ingest/internal/handlers/software_sweeper.go
@@ -14,10 +14,10 @@ const softwareSweeperInterval = 60 * time.Second
 
 // RunSoftwareSweeper ticks every minute and enqueues software_inventory tasks
 // for hosts that are overdue for a scan. A host is overdue when:
-//   - Its organisation has softwareInventorySettings.enabled = true, AND
+//   - Its instance has softwareInventorySettings.enabled = true, AND
 //   - lastSoftwareScanAt IS NULL or older than the configured intervalHours
 //
-// The sweeper does nothing when no organisation has scanning enabled, so it
+// The sweeper does nothing when no instance has scanning enabled, so it
 // adds no overhead for installations that don't use the feature.
 func RunSoftwareSweeper(ctx context.Context, pool *pgxpool.Pool) {
 	ticker := time.NewTicker(softwareSweeperInterval)
@@ -48,11 +48,11 @@ func runSweeperTick(ctx context.Context, pool *pgxpool.Pool) {
 
 	slog.Info("software sweeper: enqueuing scans", "count", len(hosts))
 	for _, h := range hosts {
-		_, err := queries.InsertSoftwareInventoryTask(ctx, pool, h.OrgID, h.ID)
+		_, err := queries.InsertSoftwareInventoryTask(ctx, pool, h.InstanceID, h.ID)
 		if err != nil {
 			slog.Warn("software sweeper: inserting task", "host_id", h.ID, "err", err)
 			continue
 		}
-		slog.Info("software sweeper: enqueued scan", "host_id", h.ID, "org_id", h.OrgID)
+		slog.Info("software sweeper: enqueued scan", "host_id", h.ID, "instance_id", h.InstanceID)
 	}
 }

--- a/apps/ingest/internal/handlers/ssh_keys.go
+++ b/apps/ingest/internal/handlers/ssh_keys.go
@@ -32,7 +32,7 @@ type sshKeyEntry struct {
 func persistSshKeyResult(
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	orgID, hostID, checkID, output string,
+	instanceID, hostID, checkID, output string,
 ) {
 	var report sshKeyScanReport
 	if err := json.Unmarshal([]byte(output), &report); err != nil {
@@ -46,7 +46,7 @@ func persistSshKeyResult(
 	}
 
 	// Load existing keys for this host to detect missing keys.
-	existingKeys, err := queries.GetSshKeysForHost(ctx, pool, orgID, hostID)
+	existingKeys, err := queries.GetSshKeysForHost(ctx, pool, instanceID, hostID)
 	if err != nil {
 		slog.Warn("ssh-key: loading existing keys", "host_id", hostID, "err", err)
 	}
@@ -64,7 +64,7 @@ func persistSshKeyResult(
 		// Resolve service account ID from username.
 		var serviceAccountID *string
 		if key.AssociatedUsername != "" {
-			if saID, err := queries.GetServiceAccountByUsername(ctx, pool, orgID, hostID, key.AssociatedUsername); err == nil && saID != "" {
+			if saID, err := queries.GetServiceAccountByUsername(ctx, pool, instanceID, hostID, key.AssociatedUsername); err == nil && saID != "" {
 				serviceAccountID = &saID
 			}
 		}
@@ -76,7 +76,7 @@ func persistSshKeyResult(
 		}
 
 		id, wasInsert, err := queries.UpsertSshKey(
-			ctx, pool, orgID, hostID,
+			ctx, pool, instanceID, hostID,
 			key.FingerprintSHA256, key.FilePath,
 			key.KeyType, key.BitLength,
 			key.Comment, key.KeySource, key.AssociatedUsername,
@@ -105,7 +105,7 @@ func persistSshKeyResult(
 			}
 
 			if evErr := queries.InsertIdentityEvent(ctx, pool,
-				orgID, hostID, nil, &id,
+				instanceID, hostID, nil, &id,
 				eventType, message, nil,
 			); evErr != nil {
 				slog.Warn("ssh-key: insert event", "err", evErr)
@@ -126,7 +126,7 @@ func persistSshKeyResult(
 		}
 		id := existing.ID
 		if evErr := queries.InsertIdentityEvent(ctx, pool,
-			orgID, hostID, nil, &id,
+			instanceID, hostID, nil, &id,
 			"key_missing",
 			fmt.Sprintf("SSH key no longer present: %s %s in %s",
 				existing.KeyType, truncateFingerprint(existing.FingerprintSHA256), existing.FilePath),

--- a/apps/ingest/internal/pki/ca.go
+++ b/apps/ingest/internal/pki/ca.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	caCommonName = "ct-ops Agent CA"
-	caOrg        = "ct-ops"
 	caValidity   = 10 * 365 * 24 * time.Hour // 10 years
 )
 
@@ -233,8 +232,7 @@ func generateCA() (*AgentCA, error) {
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject: pkix.Name{
-			CommonName:   caCommonName,
-			Organization: []string{caOrg},
+			CommonName: caCommonName,
 		},
 		NotBefore:             now.Add(-1 * time.Minute),
 		NotAfter:              now.Add(caValidity),

--- a/apps/ingest/internal/pki/identity.go
+++ b/apps/ingest/internal/pki/identity.go
@@ -5,7 +5,6 @@ import "context"
 // Identity is the SPIFFE-derived wire identity of the agent on the current
 // RPC, populated by the mTLS gRPC interceptor after chain verification.
 type Identity struct {
-	OrgID   string
 	AgentID string
 	Serial  string
 }

--- a/apps/ingest/internal/pki/pki_test.go
+++ b/apps/ingest/internal/pki/pki_test.go
@@ -51,7 +51,7 @@ func TestSignProducesVerifiableLeaf(t *testing.T) {
 	ca := newTestCA(t)
 	csrDER := buildEd25519CSR(t)
 
-	leaf, err := ca.Sign(csrDER, "agent-123", "org-abc")
+	leaf, err := ca.Sign(csrDER, "agent-123")
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
@@ -72,12 +72,12 @@ func TestSignProducesVerifiableLeaf(t *testing.T) {
 		t.Fatal("expected at least one verified chain")
 	}
 
-	orgID, agentID, err := SpiffeURIFromCert(cert)
+	agentID, err := SpiffeURIFromCert(cert)
 	if err != nil {
 		t.Fatalf("extracting SPIFFE: %v", err)
 	}
-	if orgID != "org-abc" || agentID != "agent-123" {
-		t.Fatalf("wrong SPIFFE identity: got org=%s agent=%s", orgID, agentID)
+	if agentID != "agent-123" {
+		t.Fatalf("wrong SPIFFE identity: got agent=%s", agentID)
 	}
 
 	if leaf.Serial == "" {
@@ -92,50 +92,47 @@ func TestSignRejectsEmptyIDs(t *testing.T) {
 	ca := newTestCA(t)
 	csrDER := buildEd25519CSR(t)
 
-	if _, err := ca.Sign(csrDER, "", "org"); err == nil {
+	if _, err := ca.Sign(csrDER, ""); err == nil {
 		t.Fatal("expected error with empty agentID")
-	}
-	if _, err := ca.Sign(csrDER, "agent", ""); err == nil {
-		t.Fatal("expected error with empty orgID")
 	}
 }
 
 func TestSignRejectsMalformedCSR(t *testing.T) {
 	ca := newTestCA(t)
-	if _, err := ca.Sign([]byte("not a csr"), "agent", "org"); err == nil {
+	if _, err := ca.Sign([]byte("not a csr"), "agent"); err == nil {
 		t.Fatal("expected error on malformed CSR")
 	}
 }
 
 func TestVerifyLeafDetectsRevocation(t *testing.T) {
 	ca := newTestCA(t)
-	leaf, err := ca.Sign(buildEd25519CSR(t), "agent-xyz", "org-xyz")
+	leaf, err := ca.Sign(buildEd25519CSR(t), "agent-xyz")
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
 	cert := parseLeafPEM(t, leaf.PEM)
 
 	rev := &Revocation{set: map[string]struct{}{leaf.Serial: {}}}
-	if _, _, err := VerifyLeaf([][]*x509.Certificate{{cert}}, rev); err == nil {
+	if _, err := VerifyLeaf([][]*x509.Certificate{{cert}}, rev); err == nil {
 		t.Fatal("expected revocation rejection")
 	}
 }
 
 func TestVerifyLeafWithoutRevocationPasses(t *testing.T) {
 	ca := newTestCA(t)
-	leaf, err := ca.Sign(buildEd25519CSR(t), "agent-ok", "org-ok")
+	leaf, err := ca.Sign(buildEd25519CSR(t), "agent-ok")
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
 	cert := parseLeafPEM(t, leaf.PEM)
 
 	rev := &Revocation{set: map[string]struct{}{}}
-	orgID, agentID, err := VerifyLeaf([][]*x509.Certificate{{cert}}, rev)
+	agentID, err := VerifyLeaf([][]*x509.Certificate{{cert}}, rev)
 	if err != nil {
 		t.Fatalf("verify: %v", err)
 	}
-	if orgID != "org-ok" || agentID != "agent-ok" {
-		t.Fatalf("wrong identity returned: got org=%s agent=%s", orgID, agentID)
+	if agentID != "agent-ok" {
+		t.Fatalf("wrong identity returned: got agent=%s", agentID)
 	}
 }
 
@@ -146,7 +143,7 @@ func TestTrustPoolIncludesPreviousCAs(t *testing.T) {
 
 	pool := ca2.TrustPool()
 	// Sign a leaf with ca1 and verify against ca2's overlap pool.
-	leaf, err := ca1.Sign(buildEd25519CSR(t), "a", "o")
+	leaf, err := ca1.Sign(buildEd25519CSR(t), "a")
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}

--- a/apps/ingest/internal/pki/sign.go
+++ b/apps/ingest/internal/pki/sign.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	LeafValidity    = 90 * 24 * time.Hour  // 90 days
-	RenewalWindow   = 30 * 24 * time.Hour  // renew at 30d remaining (~1/3 of life)
+	LeafValidity    = 90 * 24 * time.Hour // 90 days
+	RenewalWindow   = 30 * 24 * time.Hour // renew at 30d remaining (~1/3 of life)
 	spiffeScheme    = "spiffe"
 	spiffeAuthority = "ct-ops"
 )
@@ -27,10 +27,10 @@ type SignedLeaf struct {
 }
 
 // Sign verifies a PKCS#10 CSR (DER-encoded) and issues a short-lived client
-// cert bound to the given agent and organisation via a SPIFFE-style URI SAN.
-func (a *AgentCA) Sign(csrDER []byte, agentID, orgID string) (*SignedLeaf, error) {
-	if agentID == "" || orgID == "" {
-		return nil, errors.New("agentID and orgID are required")
+// cert bound to the given agent via a SPIFFE-style URI SAN.
+func (a *AgentCA) Sign(csrDER []byte, agentID string) (*SignedLeaf, error) {
+	if agentID == "" {
+		return nil, errors.New("agentID is required")
 	}
 	csr, err := x509.ParseCertificateRequest(csrDER)
 	if err != nil {
@@ -48,15 +48,14 @@ func (a *AgentCA) Sign(csrDER []byte, agentID, orgID string) (*SignedLeaf, error
 	spiffeURI := &url.URL{
 		Scheme: spiffeScheme,
 		Host:   spiffeAuthority,
-		Path:   fmt.Sprintf("/org/%s/agent/%s", orgID, agentID),
+		Path:   fmt.Sprintf("/agent/%s", agentID),
 	}
 
 	now := time.Now().UTC()
 	tmpl := &x509.Certificate{
 		SerialNumber: serialInt,
 		Subject: pkix.Name{
-			CommonName:   agentID,
-			Organization: []string{orgID},
+			CommonName: agentID,
 		},
 		NotBefore:             now.Add(-1 * time.Minute),
 		NotAfter:              now.Add(LeafValidity),
@@ -80,20 +79,20 @@ func (a *AgentCA) Sign(csrDER []byte, agentID, orgID string) (*SignedLeaf, error
 }
 
 // SpiffeURIFromCert extracts the ct-ops SPIFFE URI from a leaf cert, returning
-// the (orgID, agentID) it encodes. Returns an error if the URI is missing or
+// the agent ID it encodes. Returns an error if the URI is missing or
 // malformed.
-func SpiffeURIFromCert(cert *x509.Certificate) (orgID, agentID string, err error) {
+func SpiffeURIFromCert(cert *x509.Certificate) (agentID string, err error) {
 	for _, u := range cert.URIs {
 		if u.Scheme != spiffeScheme || u.Host != spiffeAuthority {
 			continue
 		}
-		// Path looks like /org/{orgID}/agent/{agentID}
+		// Path looks like /agent/{agentID}
 		parts := splitPath(u.Path)
-		if len(parts) == 4 && parts[0] == "org" && parts[2] == "agent" {
-			return parts[1], parts[3], nil
+		if len(parts) == 2 && parts[0] == "agent" {
+			return parts[1], nil
 		}
 	}
-	return "", "", errors.New("no ct-ops SPIFFE URI SAN found in client cert")
+	return "", errors.New("no ct-ops SPIFFE URI SAN found in client cert")
 }
 
 // splitPath splits "/a/b/c/d" into ["a","b","c","d"].

--- a/apps/ingest/internal/pki/sweeper.go
+++ b/apps/ingest/internal/pki/sweeper.go
@@ -30,15 +30,15 @@ func RunCSRSweeper(ctx context.Context, pool *pgxpool.Pool, ca *AgentCA, interva
 }
 
 type pendingRow struct {
-	ID      string
-	AgentID string
-	OrgID   string
-	CsrDER  []byte
+	ID         string
+	AgentID    string
+	InstanceID string
+	CsrDER     []byte
 }
 
 func drain(ctx context.Context, pool *pgxpool.Pool, ca *AgentCA) error {
 	rows, err := pool.Query(ctx, `
-		SELECT p.id, p.agent_id, a.organisation_id, p.csr_der
+		SELECT p.id, p.agent_id, a.instance_id, p.csr_der
 		  FROM pending_cert_signings p
 		  JOIN agents a ON a.id = p.agent_id
 		 ORDER BY p.requested_at ASC
@@ -51,7 +51,7 @@ func drain(ctx context.Context, pool *pgxpool.Pool, ca *AgentCA) error {
 	var pending []pendingRow
 	for rows.Next() {
 		var row pendingRow
-		if err := rows.Scan(&row.ID, &row.AgentID, &row.OrgID, &row.CsrDER); err != nil {
+		if err := rows.Scan(&row.ID, &row.AgentID, &row.InstanceID, &row.CsrDER); err != nil {
 			return err
 		}
 		pending = append(pending, row)
@@ -75,7 +75,7 @@ func drain(ctx context.Context, pool *pgxpool.Pool, ca *AgentCA) error {
 }
 
 func signOne(ctx context.Context, pool *pgxpool.Pool, ca *AgentCA, row pendingRow) error {
-	leaf, err := ca.Sign(row.CsrDER, row.AgentID, row.OrgID)
+	leaf, err := ca.Sign(row.CsrDER, row.AgentID)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,6 @@ func signOne(ctx context.Context, pool *pgxpool.Pool, ca *AgentCA, row pendingRo
 	}
 	slog.Info("signed agent client cert",
 		"agent_id", row.AgentID,
-		"org_id", row.OrgID,
 		"serial", leaf.Serial,
 		"not_after", leaf.NotAfter,
 	)

--- a/apps/ingest/internal/pki/verify.go
+++ b/apps/ingest/internal/pki/verify.go
@@ -10,23 +10,23 @@ import (
 // It assumes the standard chain verification has already run (via
 // tls.RequireAndVerifyClientCert + ClientCAs). On top of that it enforces:
 //
-//   - The verified chain includes a SPIFFE URI SAN naming a ct-ops org+agent.
+//   - The verified chain includes a SPIFFE URI SAN naming a ct-ops agent.
 //   - The leaf serial is not in the revocation set.
 //
-// The returned orgID/agentID are the SPIFFE-encoded identity bound to the
-// handshake. Callers (auth interceptors) must compare these against the
-// JWT sub/org claim to catch a cert-JWT mismatch.
-func VerifyLeaf(verifiedChains [][]*x509.Certificate, revoked *Revocation) (orgID, agentID string, err error) {
+// The returned agent ID is the SPIFFE-encoded identity bound to the handshake.
+// Callers (auth interceptors) must compare it against the JWT sub claim to
+// catch a cert-JWT mismatch.
+func VerifyLeaf(verifiedChains [][]*x509.Certificate, revoked *Revocation) (agentID string, err error) {
 	if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
-		return "", "", errors.New("no verified chain presented")
+		return "", errors.New("no verified chain presented")
 	}
 	leaf := verifiedChains[0][0]
-	orgID, agentID, err = SpiffeURIFromCert(leaf)
+	agentID, err = SpiffeURIFromCert(leaf)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	if revoked != nil && revoked.Has(leaf.SerialNumber.Text(16)) {
-		return "", "", fmt.Errorf("client cert serial %s is revoked", leaf.SerialNumber.Text(16))
+		return "", fmt.Errorf("client cert serial %s is revoked", leaf.SerialNumber.Text(16))
 	}
-	return orgID, agentID, nil
+	return agentID, nil
 }

--- a/proto/agent/v1/registration.proto
+++ b/proto/agent/v1/registration.proto
@@ -12,7 +12,7 @@ message Tag {
 }
 
 message RegisterRequest {
-  string org_token = 1;    // enrolment token from UI
+  string enrolment_token = 1;  // enrolment token from UI
   string public_key = 2;   // PEM-encoded Ed25519 public key
   PlatformInfo platform_info = 3;
   AgentInfo agent_info = 4;

--- a/proto/gen/go/agent/v1/registration.pb.go
+++ b/proto/gen/go/agent/v1/registration.pb.go
@@ -74,12 +74,12 @@ func (x *Tag) GetValue() string {
 }
 
 type RegisterRequest struct {
-	state        protoimpl.MessageState `protogen:"open.v1"`
-	OrgToken     string                 `protobuf:"bytes,1,opt,name=org_token,json=orgToken,proto3" json:"org_token,omitempty"`    // enrolment token from UI
-	PublicKey    string                 `protobuf:"bytes,2,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"` // PEM-encoded Ed25519 public key
-	PlatformInfo *PlatformInfo          `protobuf:"bytes,3,opt,name=platform_info,json=platformInfo,proto3" json:"platform_info,omitempty"`
-	AgentInfo    *AgentInfo             `protobuf:"bytes,4,opt,name=agent_info,json=agentInfo,proto3" json:"agent_info,omitempty"`
-	Tags         []*Tag                 `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"` // tags applied at registration (CLI + config merged)
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	EnrolmentToken string                 `protobuf:"bytes,1,opt,name=enrolment_token,json=enrolmentToken,proto3" json:"enrolment_token,omitempty"` // enrolment token from UI
+	PublicKey      string                 `protobuf:"bytes,2,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`                // PEM-encoded Ed25519 public key
+	PlatformInfo   *PlatformInfo          `protobuf:"bytes,3,opt,name=platform_info,json=platformInfo,proto3" json:"platform_info,omitempty"`
+	AgentInfo      *AgentInfo             `protobuf:"bytes,4,opt,name=agent_info,json=agentInfo,proto3" json:"agent_info,omitempty"`
+	Tags           []*Tag                 `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty"` // tags applied at registration (CLI + config merged)
 	// DER-encoded PKCS#10 CSR signed with the agent's Ed25519 private key.
 	// Used by the ingest to mint a client cert for mTLS on subsequent calls.
 	// Empty for legacy agents — server will request one via HeartbeatResponse.
@@ -118,9 +118,9 @@ func (*RegisterRequest) Descriptor() ([]byte, []int) {
 	return file_agent_v1_registration_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *RegisterRequest) GetOrgToken() string {
+func (x *RegisterRequest) GetEnrolmentToken() string {
 	if x != nil {
-		return x.OrgToken
+		return x.EnrolmentToken
 	}
 	return ""
 }
@@ -263,9 +263,9 @@ const file_agent_v1_registration_proto_rawDesc = "" +
 	"\x1bagent/v1/registration.proto\x12\bagent.v1\x1a\x14agent/v1/agent.proto\"-\n" +
 	"\x03Tag\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\xfa\x01\n" +
-	"\x0fRegisterRequest\x12\x1b\n" +
-	"\torg_token\x18\x01 \x01(\tR\borgToken\x12\x1d\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\x86\x02\n" +
+	"\x0fRegisterRequest\x12'\n" +
+	"\x0fenrolment_token\x18\x01 \x01(\tR\x0eenrolmentToken\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x02 \x01(\tR\tpublicKey\x12;\n" +
 	"\rplatform_info\x18\x03 \x01(\v2\x16.agent.v1.PlatformInfoR\fplatformInfo\x122\n" +


### PR DESCRIPTION
## Summary
- remove org-scoped identity from agent registration, JWT, mTLS, and ingest SQL/handlers
- rename the public registration field and agent config key to `enrolment_token`
- update Task 14 in `ORGANISATION_REMOVAL_TASKS.md` with validation and follow-up

## Validation
- PATH="$PATH:$(go env GOPATH)/bin" make proto
- go test ./agent/... ./apps/ingest/... ./proto/gen/go/...
- rg -n "organisation|organization|orgID|orgId|org_id|organisation_id|OrgToken|org_token|tenant" apps/ingest agent proto
- pnpm --dir apps/web type-check *(fails here because `apps/web/node_modules` and `tsc` are not installed in this worktree)*
