### PR TITLE
docs(remove-org): update standalone instance docs and contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ CT_OPS_TRUST_PROXY_HEADERS=true
 
 # 🔒 64-character random hex used to sign auth session cookies AND used as
 # input to LDAP bind-password decryption. Anyone with this value can forge
-# session cookies for any user in any organisation. start.sh will generate
+# session cookies for any user in this CT-Ops instance. start.sh will generate
 # one for you on first run if you leave this blank — do NOT copy a value
 # between environments. Rotating this invalidates all active sessions.
 BETTER_AUTH_SECRET=
@@ -86,7 +86,7 @@ INGEST_WS_URL=
 
 # === Vulnerability intelligence ===
 
-# Configure each organisation's CT-CVE connector in CT Ops:
+# Configure the CT-CVE connector for this CT-Ops instance:
 # Administration -> Integrations -> CT-CVE.
 # The page stores CT Ops-side tokens in the database and generates the matching
 # CT_CVE_CT_OPS_CONNECTIONS JSON for the CT-CVE service.

--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -1042,19 +1042,31 @@ worktree that already has `apps/web/node_modules` available.
 
 ## Task 15 - Docs, Deploy, And External Contracts
 
-Status: Not started
+Status: Complete
 
-Completed by:
+Completed by: Codex automation
 
 PR:
 
-Summary:
+Summary: Updated the public setup, licensing, deployment, and CT-CVE/plugin
+contract docs to describe CT-Ops as a standalone installation, replaced the
+old public `org_token` naming with `enrolment_token`, and removed the customer
+bundle's direct `organisations` query in favor of instance settings.
 
-Files changed:
+Files changed: `ORGANISATION_REMOVAL_TASKS.md`, `README.md`,
+`.env.example`, `apps/web/.env.example`, `docs/{getting-started,agent,enrolment-tokens,ct-cve-migration-plan,ct-ops-ct-cve-api-contract,ct-ops-licensing-and-ct-cve-product-decision,ct-ops-plugin-entitlement-storage,ct-ops-plugin-identity-broker}.md`,
+`apps/docs/docs/{architecture,deployment,development,features,getting-started,licensing,security}`,
+`deploy/customer-bundle/{README.md,start.sh}`
 
-Validation:
+Validation: `pnpm install --frozen-lockfile` (passes);
+`pnpm --dir apps/docs build` (passes after installing workspace deps in this
+fresh worktree); `rg -n "organisation|organization|orgId|organisationId|organisation_id|org_id|tenant|organisations" README.md docs apps/docs deploy .env.example apps/web/.env.example`
+(no matches); `rg -n "org_token|CT_OPS_ORG_TOKEN|agent\\.org_token" docs apps/docs deploy README.md .env.example apps/web/.env.example`
+(no matches)
 
-Follow-up:
+Follow-up: Start Task 16 next. A broader repository residue sweep still needs
+to cover code, tests, migrations, and non-doc paths outside the Task 15 doc
+and deploy validation scope.
 
 ### Required work
 

--- a/ORGANISATION_REMOVAL_TASKS.md
+++ b/ORGANISATION_REMOVAL_TASKS.md
@@ -986,7 +986,7 @@ Status: Complete
 
 Completed by: Codex automation
 
-PR:
+PR: [#1250](https://github.com/carrtech-dev/ct-ops/pull/1250)
 
 Summary: Removed organisation-scoped identity from the agent, ingest, and
 registration protobuf paths by renaming the public registration token to

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CT-Ops is an open-source monitoring and operations platform designed to run **en
 - **Host groups & tagging** — flexible `key:value` tags on any resource, group-based access control for teams.
 - **Terminal workspace** — split-pane browser terminal for ad-hoc investigation without leaving the dashboard.
 - **Air-gap agent bundles** — download a self-contained zip (binary + config + install script) for hosts that can't reach the internet.
-- **Multi-tenant RBAC** — `super_admin` → `org_admin` → `engineer` → `read_only` → `agent` role hierarchy.
+- **Instance-scoped RBAC** — `super_admin` → `org_admin` → `engineer` → `read_only` → `agent` role hierarchy.
 - **Three deployment profiles** — `single` (one host), `standard` (Redpanda), `ha` (clustered) — same codebase, different `docker-compose` files.
 
 ---

--- a/apps/docs/docs/architecture/agent.md
+++ b/apps/docs/docs/architecture/agent.md
@@ -103,7 +103,7 @@ address = "ingest.corp.example.com:9443"
 ca_cert_file = "/etc/ct-ops/ca.crt"
 
 [agent]
-org_token = "tok_..."          # or CT_OPS_ORG_TOKEN env var
+enrolment_token = "tok_..."    # or CT_OPS_ENROLMENT_TOKEN env var
 data_dir  = "/var/lib/ct-ops/agent"
 version   = "0.1.0"
 heartbeat_interval_secs = 30
@@ -115,7 +115,7 @@ heartbeat_interval_secs = 30
 |---|---|
 | `CT_OPS_INGEST_ADDRESS` | `ingest.address` |
 | `CT_OPS_INGEST_CA_CERT` | `ingest.ca_cert_file` |
-| `CT_OPS_ORG_TOKEN` | `agent.org_token` |
+| `CT_OPS_ENROLMENT_TOKEN` | `agent.enrolment_token` |
 | `CT_OPS_DATA_DIR` | `agent.data_dir` |
 
 ---

--- a/apps/docs/docs/architecture/deployment-profiles.md
+++ b/apps/docs/docs/architecture/deployment-profiles.md
@@ -9,7 +9,7 @@ CT-Ops ships with three deployment profiles, each targeting a different scale. A
 | Profile | Queue | Ingest instances | Database | Suitable for |
 |---|---|---|---|---|
 | `single` | In-process (channels + WAL) | 1 | PostgreSQL (single node) | < 50 hosts, homelab, trial |
-| `standard` | Redpanda (single node) | 1 | PostgreSQL (single node) | Most organisations |
+| `standard` | Redpanda (single node) | 1 | PostgreSQL (single node) | Most production instances |
 | `ha` | Redpanda cluster | Multiple (behind HAProxy) | PostgreSQL primary + replica | High availability required |
 
 ---

--- a/apps/docs/docs/architecture/overview.md
+++ b/apps/docs/docs/architecture/overview.md
@@ -40,7 +40,7 @@ The queue is abstracted behind an interface, allowing the implementation to be s
 | Profile | Queue type | When to use |
 |---|---|---|
 | `small` | In-process (Go channels + WAL) | < 50 hosts |
-| `standard` | Redpanda single node | Most organisations |
+| `standard` | Redpanda single node | Most production instances |
 | `ha` | Redpanda cluster | High availability required |
 
 ### Consumers

--- a/apps/docs/docs/deployment/air-gap.md
+++ b/apps/docs/docs/deployment/air-gap.md
@@ -108,7 +108,7 @@ From **Administration → Agents → Enrolment**, an `org_admin` or `super_admin
 - `agent.toml` pre-populated with this server's ingest address
 - `SHA256SUMS` and a `README.md`
 
-The bundle can be transferred by any approved mechanism (USB, jump host, managed file share) and installed with a single command — no outbound connectivity to the CT-Ops server is required during install. A single-use, short-expiry enrolment token can be embedded in the bundle, or left out so the operator supplies it via `CT_OPS_ORG_TOKEN` at install time.
+The bundle can be transferred by any approved mechanism (USB, jump host, managed file share) and installed with a single command — no outbound connectivity to the CT-Ops server is required during install. A single-use, short-expiry enrolment token can be embedded in the bundle, or left out so the operator supplies it via `CT_OPS_ENROLMENT_TOKEN` at install time.
 
 See [Offline Agent Install Bundle](../getting-started/agent-install-bundle.md) for the full walkthrough.
 

--- a/apps/docs/docs/development/testing.md
+++ b/apps/docs/docs/development/testing.md
@@ -15,7 +15,7 @@ That single command will:
 1. Start a `timescale/timescaledb:latest-pg16` container via Testcontainers (tmpfs-backed).
 2. Run all Drizzle migrations against the container.
 3. Launch Next.js dev on port `3100` (configurable via `E2E_PORT`).
-4. Run a setup project that seeds an organisation and an admin user (`e2e@example.com` / `TestPassword123!`).
+4. Run a setup project that seeds the baseline CT-Ops instance and an admin user (`e2e@example.com` / `TestPassword123!`).
 5. Run the chromium test project.
 6. Stop the container on exit.
 
@@ -51,7 +51,7 @@ After the container is ready, the runner builds a mapped `postgres://test:test@<
 
 Once Playwright is running, seeding happens as a dedicated setup project (`auth.setup.ts`). The `chromium` project declares it as a dependency, so the seed runs before any spec.
 
-Per-test isolation is provided by an auto-running `autoTruncate` fixture that runs `TRUNCATE ... RESTART IDENTITY CASCADE` on every app table between tests and deletes all sessions. Seed rows (organisations, user, account) are preserved. Tests run serially with a single worker; moving to parallel workers would require one Next.js process per worker on distinct ports.
+Per-test isolation is provided by an auto-running `autoTruncate` fixture that runs `TRUNCATE ... RESTART IDENTITY CASCADE` on every app table between tests and deletes all sessions. Seed rows (instance settings, user, account) are preserved. Tests run serially with a single worker; moving to parallel workers would require one Next.js process per worker on distinct ports.
 
 ## Authentication in tests
 
@@ -81,10 +81,10 @@ test('shows seeded hosts', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
 
   await sql`
-    INSERT INTO hosts (id, organisation_id, hostname, status)
+    INSERT INTO hosts (id, instance_id, hostname, status)
     VALUES (
       'test-host-1',
-      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      (SELECT id FROM instance_settings WHERE slug = ${TEST_ORG.slug}),
       'web-01',
       'online'
     )
@@ -97,19 +97,19 @@ test('shows seeded hosts', async ({ authenticatedPage: page }) => {
 
 Use direct SQL seeding when the setup is only test data and does not need to verify a UI or HTTP workflow. Use the product UI or an API request when the creation path itself is part of the behavior under test, or when production code must perform side effects such as password hashing, session creation, token generation, or validation.
 
-The baseline seed is `seedOrgAndUser()` in `tests/e2e/fixtures/seed.ts`. It is intentionally idempotent: it signs up `e2e@example.com` through Better Auth so the password and account rows are correct, creates the `e2e-test-org` organisation if needed, promotes the user to admin, and deletes the sign-up session so login tests start cleanly.
+The baseline seed is `seedOrgAndUser()` in `tests/e2e/fixtures/seed.ts`. It is intentionally idempotent: it signs up `e2e@example.com` through Better Auth so the password and account rows are correct, creates the baseline `instance_settings` row if needed, promotes the user to admin, and deletes the sign-up session so login tests start cleanly.
 
 When adding feature-specific seed helpers:
 
 1. Put shared helpers near the E2E feature or in `tests/e2e/fixtures/` if they will be reused.
 2. Keep seed data minimal and deterministic.
-3. Always create required relationships explicitly, especially `organisation_id`, ownership fields, and foreign keys.
+3. Always create required relationships explicitly, especially `instance_id`, ownership fields, and foreign keys.
 4. Prefer IDs and names that make assertions readable.
 5. Avoid relying on records created by another spec; each spec should seed what it needs.
 
 ## Isolation and cleanup
 
-Every spec that imports `test` from `tests/e2e/fixtures/test.ts` gets the auto-running `autoTruncate` fixture. That fixture truncates application tables before each test and deletes sessions, while preserving Better Auth/account rows and the baseline organisation/user created by the setup project.
+Every spec that imports `test` from `tests/e2e/fixtures/test.ts` gets the auto-running `autoTruncate` fixture. That fixture truncates application tables before each test and deletes sessions, while preserving Better Auth/account rows and the baseline instance/user created by the setup project.
 
 When a migration adds a new application table, update the `APP_TABLES` list in `tests/e2e/fixtures/db.ts` if that table can receive data during E2E tests. Otherwise, state can leak between tests and make failures order-dependent. Do not add Better Auth identity tables such as `user` or `account` to the truncate list unless the baseline seeding strategy is changed at the same time.
 
@@ -134,10 +134,10 @@ test('feature behavior', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
 
   await sql`
-    INSERT INTO example_table (id, organisation_id, name)
+    INSERT INTO example_table (id, instance_id, name)
     VALUES (
       'example-1',
-      (SELECT id FROM organisations WHERE slug = ${TEST_ORG.slug}),
+      (SELECT id FROM instance_settings WHERE slug = ${TEST_ORG.slug}),
       'Example'
     )
   `

--- a/apps/docs/docs/features/directory-lookup.md
+++ b/apps/docs/docs/features/directory-lookup.md
@@ -49,4 +49,4 @@ This is intentional for environments where the directory contains tens of thousa
 
 ## Permissions
 
-Any authenticated user in the organisation can run directory lookups. Managing LDAP configurations (adding, editing, deleting) is restricted to `org_admin` and `super_admin`.
+Any authenticated user in the CT-Ops instance can run directory lookups. Managing LDAP configurations (adding, editing, deleting) is restricted to `org_admin` and `super_admin`.

--- a/apps/docs/docs/features/host-groups.md
+++ b/apps/docs/docs/features/host-groups.md
@@ -1,6 +1,6 @@
 # Host Groups
 
-Host Groups let you organise hosts into logical collections — by environment (production / staging), team ownership, geography, or any other dimension that makes sense for your organisation.
+Host Groups let you organise hosts into logical collections — by environment (production / staging), team ownership, geography, or any other dimension that makes sense for your CT-Ops instance.
 
 ---
 

--- a/apps/docs/docs/features/hosts.md
+++ b/apps/docs/docs/features/hosts.md
@@ -74,9 +74,9 @@ To reject a pending agent, click **Revoke**.
 
 ## Duplicate-Host Protection
 
-Two live hosts in the same organisation cannot share a hostname or IP address — on a real network that would be a configuration error. CT-Ops enforces this at two points:
+Two live hosts in the same CT-Ops instance cannot share a hostname or IP address — on a real network that would be a configuration error. CT-Ops enforces this at two points:
 
-- **At registration time** — when an agent calls `Register`, the ingest service checks for an existing non-deleted host in the same organisation whose hostname matches or whose reported IP addresses overlap any of the new agent's IPs.
+- **At registration time** — when an agent calls `Register`, the ingest service checks for an existing non-deleted host in the same instance whose hostname matches or whose reported IP addresses overlap any of the new agent's IPs.
 - **At approval time** — the same check runs when an admin approves a pending agent, in case a collision emerged while the agent was queued.
 
 What happens on a match depends on the state of the existing host:

--- a/apps/docs/docs/features/networks.md
+++ b/apps/docs/docs/features/networks.md
@@ -16,7 +16,7 @@ Networks let you define IP subnets (CIDRs) and automatically group hosts by the 
 
 ## Auto-Assignment
 
-On every agent heartbeat, CT-Ops compares the host's reported IP addresses against all defined network CIDRs for the organisation. Membership is kept in sync automatically:
+On every agent heartbeat, CT-Ops compares the host's reported IP addresses against all defined network CIDRs for the instance. Membership is kept in sync automatically:
 
 - If an IP falls within a network's CIDR, the host is added to that network (marked **Auto**).
 - If the host's IPs change so that none match a network's CIDR, the auto-assigned membership is removed.

--- a/apps/docs/docs/features/operations-calendar.md
+++ b/apps/docs/docs/features/operations-calendar.md
@@ -45,4 +45,4 @@ Deleting or editing the whole series affects the parent recurring event.
 | `engineer` | ✅ | ✅ |
 | `read_only` | ✅ | ❌ |
 
-All writes are validated on the server, scoped to the user's organisation, rate-limited, and recorded in the audit log.
+All writes are validated on the server, scoped to the user's CT-Ops instance, rate-limited, and recorded in the audit log.

--- a/apps/docs/docs/features/scheduled-tasks.md
+++ b/apps/docs/docs/features/scheduled-tasks.md
@@ -75,7 +75,7 @@ From the Scheduled Tasks list, click the **Play** icon next to a schedule to tri
 | `engineer` | ✅ | ✅ | ✅ |
 | `read_only` | ❌ | ❌ | ❌ |
 
-Schedules are scoped to the creator's organisation; read access requires no additional permission beyond a dashboard session.
+Schedules are scoped to the creator's CT-Ops instance; read access requires no additional permission beyond a dashboard session.
 
 ---
 

--- a/apps/docs/docs/features/service-accounts.md
+++ b/apps/docs/docs/features/service-accounts.md
@@ -17,7 +17,7 @@ The **Service Accounts** page holds a manually-curated list of the service or do
 
 | Field | Description |
 |---|---|
-| **Username** | Unique within the organisation |
+| **Username** | Unique within the CT-Ops instance |
 | **Display Name** | Friendly label |
 | **Email** | Optional contact address |
 | **Status** | `active`, `disabled`, `locked`, or `expired` |

--- a/apps/docs/docs/features/tags.md
+++ b/apps/docs/docs/features/tags.md
@@ -25,7 +25,7 @@ Merge order: `org defaults → token tags → CLI tags → rules` (last-wins).
 ## Autocomplete and dedupe
 
 All tags live in a normalised catalogue. The TagEditor's two-field key + value
-inputs autocomplete from tags already used in the organisation. The unique
+inputs autocomplete from tags already used in the instance. The unique
 index is case-insensitive, so typing `Prod` where `prod` already exists
 suggests the canonical spelling instead of creating a near-duplicate.
 

--- a/apps/docs/docs/getting-started/agent-install-bundle.md
+++ b/apps/docs/docs/getting-started/agent-install-bundle.md
@@ -16,7 +16,7 @@ Each zip contains everything needed to install the agent on one OS / architectur
 
 ## Who can generate a bundle
 
-Bundle generation is gated to **`super_admin`** and **`org_admin`** roles. Every bundle is scoped to the organisation of the requesting user.
+Bundle generation is gated to **`super_admin`** and **`org_admin`** roles. Every bundle is scoped to the CT-Ops instance of the requesting user.
 
 ## Generate and download
 
@@ -27,16 +27,16 @@ Bundle generation is gated to **`super_admin`** and **`org_admin`** roles. Every
 5. Choose how the enrolment token is handled:
    - **Create a new single-use token** (recommended). A fresh token is generated, limited to one use, and expires in the number of days you choose (default 7). The token is embedded in `agent.toml` and the install script.
    - **Embed an existing token**. Pick one of your active tokens — useful when you have a long-lived token shared across a rollout batch.
-   - **No token**. The bundle ships without a token. The operator exports `CT_OPS_ORG_TOKEN` on the target host before running the install script.
+  - **No token**. The bundle ships without a token. The operator exports `CT_OPS_ENROLMENT_TOKEN` on the target host before running the install script.
 6. Optionally override the **ingest address** (defaults to `<this-server>:9443`).
 7. Optionally add **tags** as `key:value` pairs. These are baked into
    `agent.toml` and passed as `--tag` flags by the install script, so every
    host installed from the bundle registers with those tags. See
-   [Tags](../features/tags.md) for how tags are merged with org defaults and
+   [Tags](../features/tags.md) for how tags are merged with instance defaults and
    CLI flags.
 8. Click **Download**. The browser downloads `ct-ops-agent-<os>-<arch>.zip`.
 
-> **Heads up — token sensitivity.** When a token is embedded, treat the zip as sensitive: anyone with the file can register an agent against your organisation until the token is used, expired, or revoked. Single-use + short-expiry defaults limit the blast radius if the file leaks.
+> **Heads up — token sensitivity.** When a token is embedded, treat the zip as sensitive: anyone with the file can register an agent against your CT-Ops instance until the token is used, expired, or revoked. Single-use + short-expiry defaults limit the blast radius if the file leaks.
 
 ## Install on Linux / macOS
 
@@ -51,7 +51,7 @@ sudo ./install.sh
 If the bundle does **not** contain a token:
 
 ```sh
-export CT_OPS_ORG_TOKEN="<token-from-ui>"
+export CT_OPS_ENROLMENT_TOKEN="<token-from-ui>"
 sudo -E ./install.sh
 ```
 
@@ -68,7 +68,7 @@ From an elevated PowerShell session in the extracted bundle directory:
 If the bundle does **not** contain a token:
 
 ```powershell
-$env:CT_OPS_ORG_TOKEN = "<token-from-ui>"
+$env:CT_OPS_ENROLMENT_TOKEN = "<token-from-ui>"
 .\install.ps1
 ```
 

--- a/apps/docs/docs/getting-started/configuration.md
+++ b/apps/docs/docs/getting-started/configuration.md
@@ -24,7 +24,7 @@ All CT-Ops configuration is via environment variables. There are no config files
 | `INGEST_WS_URL` | — | *(empty)* | WebSocket URL of the ingest service. Empty = same-origin via the bundled nginx (recommended). Set to an absolute `wss://` URL only to bypass the bundled proxy |
 | `WEB_TLS_CERT` | — | `/var/lib/ct-ops/server-tls/server.crt` | Path to the nginx-facing server cert. The enrolment bundle route reads this file and embeds it so agents can verify the HTTPS download URL |
 | `CT_CVE_SERVICE_TOKENS` | — 🔒 | *(empty)* | JSON allow-list of signed CT-CVE service tokens that can deliver findings or call CT Ops connection health; use `findings:write` and `connection:read` scopes for the initial inbound connector |
-| `CT_CVE_INVENTORY_PUSH_TARGETS` | — 🔒 | *(empty)* | JSON list of outbound CT-CVE inventory targets. Each entry contains `name`, `baseUrl`, and a token object with `id`, `secret`, `orgId`, and `scopes:["inventory:write"]`; schedule `pnpm --dir apps/web ct-cve:push-inventory` to send snapshots |
+| `CT_CVE_INVENTORY_PUSH_TARGETS` | — 🔒 | *(empty)* | JSON list of outbound CT-CVE inventory targets. Each entry contains `name`, `baseUrl`, and a token object with `id`, `secret`, `ctOpsInstallationId`, and `scopes:["inventory:write"]`; schedule `pnpm --dir apps/web ct-cve:push-inventory` to send snapshots |
 
 ### Licence verification
 
@@ -88,8 +88,8 @@ ca_cert_file = "/etc/ct-ops/ca.crt"
 
 [agent]
 # Enrolment token from Administration → Agents → Enrolment
-# Can also be set via CT_OPS_ORG_TOKEN env var
-org_token = "tok_..."
+# Can also be set via CT_OPS_ENROLMENT_TOKEN env var
+enrolment_token = "tok_..."
 
 # Directory where agent stores its identity (keypair + JWT)
 data_dir = "/var/lib/ct-ops/agent"
@@ -109,7 +109,7 @@ All TOML values can be overridden via environment variables:
 |---|---|
 | `CT_OPS_INGEST_ADDRESS` | `ingest.address` |
 | `CT_OPS_INGEST_CA_CERT` | `ingest.ca_cert_file` |
-| `CT_OPS_ORG_TOKEN` | `agent.org_token` |
+| `CT_OPS_ENROLMENT_TOKEN` | `agent.enrolment_token` |
 | `CT_OPS_DATA_DIR` | `agent.data_dir` |
 
 ---

--- a/apps/docs/docs/getting-started/installation.md
+++ b/apps/docs/docs/getting-started/installation.md
@@ -122,14 +122,14 @@ docker compose -f docker-compose.single.yml exec web sh -c "cd /app && node_modu
 Open [https://localhost](https://localhost) in a browser. On first visit your browser will warn about the self-signed certificate — accept it to continue, or see [Replacing the TLS certificate](../deployment/docker-compose.md#replacing-the-tls-certificate) to install one from your own CA.
 
 1. Click **Register** and create your account
-2. Complete the **onboarding wizard** — enter your organisation name and click **Create Organisation**
+2. CT-Ops opens directly into the standalone instance setup flow after registration
 3. You're now logged in as `super_admin`
 
 ---
 
 ## Create an enrolment token
 
-An enrolment token is what the agent uses to register itself with your organisation.
+An enrolment token is what the agent uses to register itself with your CT-Ops instance.
 
 1. In the sidebar, click **Administration → Agents → Enrolment**
 2. Click **New Token**
@@ -162,7 +162,7 @@ address = "localhost:9443"
 ca_cert_file = "deploy/dev-tls/server.crt"
 
 [agent]
-org_token = "YOUR_ENROLMENT_TOKEN"
+enrolment_token = "YOUR_ENROLMENT_TOKEN"
 data_dir = "/tmp/ct-ops-agent"
 version = "0.1.0"
 heartbeat_interval_secs = 30

--- a/apps/docs/docs/licensing.md
+++ b/apps/docs/docs/licensing.md
@@ -94,7 +94,7 @@ application. Validation does not require an outbound network connection.
 
 Every CT-Ops key can encode:
 
-- Install organisation (`sub`)
+- Installation identifier (`sub`)
 - Tier (`community` or `enterprise`)
 - User-seat limit (`maxUsers`)
 - Expiry (`exp`)
@@ -115,7 +115,7 @@ but CT-Ops commercial licensing uses user-seat capacity.
 
 The activation token binds the issued licence to the specific CT-Ops install.
 The server validates the licence signature, issuer, audience, expiry, and
-organisation binding locally before saving the key.
+installation binding locally before saving the key.
 
 For air-gapped installs, generate the activation token inside the air-gapped
 network, transfer it out to complete checkout, then transfer the returned

--- a/apps/docs/docs/security/mtls.md
+++ b/apps/docs/docs/security/mtls.md
@@ -71,7 +71,7 @@ downtime. The UI shows the overlap window.
 1. Agent boots, loads its Ed25519 keypair from `${DATA_DIR}/agent_key.pem`
    (generated on first ever start).
 2. Agent builds a DER-encoded PKCS#10 CSR signed with that key.
-3. Agent calls `Register(RegisterRequest{ csr_der, public_key, org_token, … })`.
+3. Agent calls `Register(RegisterRequest{ csr_der, public_key, enrolment_token, … })`.
 4. Ingest validates the CSR signature, stashes it in
    `pending_cert_signings`, and returns `status = pending` until an admin
    approves the agent (auto-approve tokens short-circuit this: the sign

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,7 +17,7 @@ DATABASE_URL=postgresql://ctops:ctops@localhost:5432/ctops
 # --- Better Auth ---
 # 🔒 Secret used to sign session cookies AND as KDF input for LDAP bind
 # password decryption. Anyone with this value can forge session cookies for
-# any user in any organisation. Generate with: openssl rand -base64 32.
+# any user in this CT-Ops instance. Generate with: openssl rand -base64 32.
 # NEVER reuse across environments — rotating invalidates all active sessions.
 BETTER_AUTH_SECRET=
 # 🔒 Public URL of this CT-Ops instance — Better Auth uses it to set

--- a/deploy/customer-bundle/README.md
+++ b/deploy/customer-bundle/README.md
@@ -52,7 +52,7 @@ This will:
 5. A one-shot migration container applies database migrations before web and ingest start
 
 Open `https://localhost` (or whatever you set as `BETTER_AUTH_URL`) and
-follow the in-app onboarding to create your first organisation and admin
+register your first admin user for this CT-Ops instance
 user. Your browser will warn about the self-signed certificate on first
 visit unless you replace `deploy/tls/server.{crt,key}` with a certificate
 from your own CA.

--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -458,18 +458,16 @@ show_version() {
     | sed -n 's/.*"apps\/web"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
   echo "App version:      ${APP_VERSION:-unknown}"
 
-  # Tier lives on the organisations row — query the DB directly so the licence
-  # status is accurate even if no user is logged in. Multiple orgs are unusual
-  # on a single-host install but possible; show all of them.
+  # Tier lives on instance_settings — query the DB directly so the licence
+  # status is accurate even if no user is logged in.
   : "${POSTGRES_USER:=ctops}"
   : "${POSTGRES_DB:=ctops}"
   TIERS=$(docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -At \
-    -c "SELECT name || ': ' || licence_tier FROM organisations WHERE deleted_at IS NULL ORDER BY created_at;" 2>/dev/null || true)
+    -c "SELECT COALESCE(licence_tier, 'community') FROM instance_settings LIMIT 1;" 2>/dev/null || true)
   if [ -z "$TIERS" ]; then
-    echo "Licence tier:     unknown (no organisation configured yet)"
+    echo "Licence tier:     unknown (instance settings not configured yet)"
   else
-    echo "Licence tier:"
-    printf '  %s\n' $TIERS
+    echo "Licence tier:     $TIERS"
   fi
 }
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -14,7 +14,7 @@ Agent                         Ingest Service               Database
   ├─ generate Ed25519 keypair       │                           │
   ├─ load/create agent state        │                           │
   │                                │                           │
-  ├── Register(org_token, pubkey) ──►                           │
+  ├── Register(enrolment_token, pubkey) ──►                     │
   │                                ├── validate enrolment token─►
   │                                ├── insert agent (pending) ──►
   │◄─ {agent_id, status:"pending"} ─┤                           │
@@ -106,8 +106,8 @@ ca_cert_file = ""
 
 [agent]
 # Enrolment token from the CT-Ops UI (Administration → Agents → Enrolment).
-# Can also be set via the CT_OPS_ORG_TOKEN environment variable.
-org_token = ""
+# Can also be set via the CT_OPS_ENROLMENT_TOKEN environment variable.
+enrolment_token = ""
 
 # Directory where the agent stores its identity.
 # Contains: agent_key.pem, agent_key.pub, agent_state.json
@@ -130,13 +130,13 @@ All config values can be overridden with environment variables. Useful for conta
 |---|---|
 | `CT_OPS_INGEST_ADDRESS` | `ingest.address` |
 | `CT_OPS_INGEST_CA_CERT` | `ingest.ca_cert_file` |
-| `CT_OPS_ORG_TOKEN` | `agent.org_token` |
+| `CT_OPS_ENROLMENT_TOKEN` | `agent.enrolment_token` |
 | `CT_OPS_DATA_DIR` | `agent.data_dir` |
 
 Example:
 
 ```bash
-CT_OPS_ORG_TOKEN=abc123 \
+CT_OPS_ENROLMENT_TOKEN=abc123 \
 CT_OPS_INGEST_ADDRESS=ingest.internal:9443 \
 ct-ops-agent -config /etc/ct-ops/agent.toml
 ```
@@ -161,7 +161,7 @@ The agent generates and persists its identity on first run. The data directory c
 
 When the agent starts for the first time (no `agent_state.json`):
 
-1. Sends `Register` RPC with the org token and its Ed25519 public key
+1. Sends `Register` RPC with the enrolment token and its Ed25519 public key
 2. Server validates the token and inserts an `agents` row
 3. If the token has **auto-approve** enabled → server sets status to `active` and returns a JWT immediately
 4. If not → server returns `status: "pending"`; agent polls every 30 seconds

--- a/docs/ct-cve-migration-plan.md
+++ b/docs/ct-cve-migration-plan.md
@@ -136,14 +136,14 @@ product:
 - CT-CVE owns vulnerability feed sync, CVE/advisory catalog management, package
   matching, vulnerability enrichment, and its own configuration/status GUI/API.
 - CT Ops remains the fleet, asset, agent, operations, and reporting system.
-- CT-CVE requires CT Ops for host inventory, organisation context, vulnerability
+- CT-CVE requires CT Ops for host inventory, instance context, vulnerability
   reporting, and customer-facing finding workflows.
 - CT-CVE must not be marketed, deployed, or designed as useful by itself.
 - CT Ops ingests CT-CVE findings and remains the reporting surface.
 - CT-CVE's GUI is for operational configuration and observability only, such as
   CVE ingestion API keys, feed update schedules, source health, detailed feed
   sync status, and source/API logs.
-- CT Ops is also the required identity, organisation, and licensing anchor for
+- CT Ops is also the required identity, instance, and licensing anchor for
   CT-CVE and future first-party plugin products. Plugin GUIs must not require a
   separate username/password database per plugin.
 - Plugins keep their own databases for plugin-owned data, but authenticate users
@@ -152,7 +152,7 @@ product:
   database.
 - Plugin GUIs may generate signed licence request tokens for CT Portal, but CT
   Portal-issued plugin entitlements should be bound to the CT Ops installation,
-  organisation, product, and plugin instance.
+  instance, product, and plugin instance.
 - Extension-specific forms and workflow logic should live in the extension, not
   CT Ops. CT Ops should launch or embed registered extension UIs and provide
   signed identity context rather than rendering every plugin configuration form
@@ -410,7 +410,7 @@ Expected work:
 - Add README.
 
 CT-CVE should have its own release cadence and published container images, but
-runtime deployments require CT Ops integration for inventory, organisation
+runtime deployments require CT Ops integration for inventory, instance
 context, and reporting. Any local development mode that runs without CT Ops must
 be documented as developer-only and must not imply standalone production use.
 
@@ -501,13 +501,13 @@ Expected decisions:
 - Plugin services must not authenticate users by directly querying the CT Ops
   database.
 - CT Ops issues short-lived signed user assertions with plugin-bound audience,
-  organisation, user, role/permission, product, expiry, and nonce claims.
+  instance, user, role/permission, product, expiry, and nonce claims.
 - Plugin instances store the CT Ops issuer and public signing key or equivalent
   trust anchor.
 - CT Ops stores plugin instance identifiers, plugin trust material, allowed
-  organisation scope, enabled product, and revocation state.
+  installation scope, enabled product, and revocation state.
 - Plugin GUIs generate signed licence request tokens for CT Portal purchasing.
-- CT Portal-issued plugin licences bind to CT Ops installation, organisation,
+- CT Portal-issued plugin licences bind to CT Ops installation, instance,
   product, and plugin instance or key fingerprint.
 - CT Ops exposes derived subscription status to plugins through signed APIs.
 
@@ -526,7 +526,7 @@ Expected work:
   assertions.
 - Store plugin instance public keys or shared verification material.
 - Issue short-lived signed user assertions bound to a plugin instance audience.
-- Include organisation, user, role/permission, product, expiry, and replay
+- Include instance, user, role/permission, product, expiry, and replay
   claims.
 - Add revocation and rotation paths.
 - Add tests for signature validity, issuer/audience binding, org scoping,
@@ -541,12 +541,12 @@ Expected work:
 - Define the CT Portal licence request-token payload.
 - Generate request tokens from a registered CT Ops/plugin instance pair.
 - Validate and store CT Portal-issued plugin licence keys.
-- Bind plugin licences to CT Ops installation, organisation, product, and
+- Bind plugin licences to CT Ops installation, instance, product, and
   plugin instance or key fingerprint.
 - Add server-side plugin entitlement checks in CT Ops where CT Ops launches or
   displays plugin-dependent workflows.
 - Expose signed subscription-status APIs for plugins.
-- Add tests for tampered request tokens, wrong organisation, wrong plugin
+- Add tests for tampered request tokens, wrong instance, wrong plugin
   instance, expired/revoked licences, and safe degradation.
 
 ### 15. CT-CVE Auth and Subscription Integration
@@ -562,7 +562,7 @@ Expected work:
 - Keep CT-CVE-owned forms, validation, source configuration handlers, and
   workflow logic inside CT-CVE. CT Ops should only launch, redirect, proxy, or
   iframe the registered CT-CVE UI with a signed assertion.
-- Add CT-CVE-side verification of CT Ops issuer, audience, organisation,
+- Add CT-CVE-side verification of CT Ops issuer, audience, instance,
   product, expiry, and revocation status.
 - Add CT-CVE licence request-token generation for CT Portal.
 - Consume CT Ops subscription-status APIs.
@@ -741,7 +741,7 @@ Append dated notes here as phases progress. Keep notes short and factual.
 - Completed Phase 12 on branch `docs/plugin-auth-licensing` by updating the
   product decision record, CT Ops/CT-CVE API contract, and migration plan with
   the shared plugin identity and licensing model. CT Ops remains the required
-  visualization, identity, organisation, and licensing anchor. Plugins keep
+  visualization, identity, instance, and licensing anchor. Plugins keep
   their own databases and own their configuration forms/workflow logic, while
   CT Ops launches or embeds registered plugin UIs with short-lived signed
   assertions and exposes derived subscription status through signed APIs.
@@ -758,10 +758,9 @@ Append dated notes here as phases progress. Keep notes short and factual.
   token IDs or secrets. Validation: CT-CVE integration unit tests, full web
   unit suite, targeted ESLint, web type-check, and migration validation.
 - Followed up Phase 9 by moving CT Ops-side CT-CVE connector configuration into
-  the Administration -> Integrations -> CT-CVE screen as org-scoped app
-  settings. The screen now stores encrypted per-organisation service tokens,
-  supports multiple CT Ops organisations pointing at one CT-CVE installation,
-  and generates the matching CT_CVE_CT_OPS_CONNECTIONS JSON for CT-CVE.
+  the Administration -> Integrations -> CT-CVE screen as instance-scoped app
+  settings. The screen now stores encrypted per-instance service tokens and
+  generates the matching CT_CVE_CT_OPS_CONNECTIONS JSON for CT-CVE.
 - Continued Phase 10 on branch `feat/remove-ct-cve-source-settings` by removing
   the legacy CT Ops Settings -> Vulnerabilities source-management page, its
   sidebar entry, NVD API-key storage server actions, and E2E coverage that only

--- a/docs/ct-ops-ct-cve-api-contract.md
+++ b/docs/ct-ops-ct-cve-api-contract.md
@@ -31,7 +31,7 @@ CT Ops may store imported finding rows for reporting and host context, but CT-CV
 remains the source of truth for vulnerability intelligence and matching.
 
 CT-CVE is independently deployed and released, but it is not a standalone
-customer product. CT Ops is always required for user identity, organisation
+customer product. CT Ops is always required for user identity, installation
 context, inventory, visualization, and customer-facing reporting.
 
 ## Integration Direction
@@ -47,22 +47,23 @@ CT-CVE must not connect to the CT Ops database or import CT Ops server modules.
 CT-CVE pull APIs can be added later for deployment profiles that require them,
 but the initial connector should be implemented with explicit HTTPS APIs.
 
-## Organisation Scoping
+## Installation Scoping
 
-Every request is scoped to exactly one CT Ops organisation.
+Every request is scoped to exactly one CT Ops installation.
 
 The scoped identity fields are:
 
 | Field | Source | Purpose |
 | --- | --- | --- |
-| `orgId` | CT Ops `organisations.id` | Stable tenant identifier in CT Ops. |
-| `orgSlug` | CT Ops `organisations.slug` | Human-readable diagnostic context only. |
-| `ctCveTenantId` | CT-CVE | Optional CT-CVE tenant/subscription identifier once configured. |
+| `ctOpsInstallationId` | CT Ops installation identity | Stable installation identifier in CT Ops. |
+| `instanceSlug` | CT Ops `instance_settings.slug` | Human-readable diagnostic context only. |
+| `ctCveInstallationId` | CT-CVE | Optional CT-CVE installation/subscription identifier once configured. |
 
-`orgId` is the required scoping key for both inventory exports and finding
-ingestion. CT Ops must reject any finding delivery where the token subject is
-not allowed to write findings for the supplied `orgId`. CT-CVE must keep CT Ops
-inventory from different `orgId` values physically or logically isolated.
+`ctOpsInstallationId` is the required scoping key for both inventory exports
+and finding ingestion. CT Ops must reject any finding delivery where the token
+subject is not allowed to write findings for the supplied
+`ctOpsInstallationId`. CT-CVE must keep CT Ops inventory from different
+installation identifiers physically or logically isolated.
 
 ## Host Identity
 
@@ -141,9 +142,9 @@ Request shape:
 ```json
 {
   "contractVersion": "2026-04-30",
-  "orgId": "org_123",
-  "orgSlug": "acme",
-  "snapshotId": "inv_20260430_091500_org_123",
+  "ctOpsInstallationId": "ctops_inst_123",
+  "instanceSlug": "acme",
+  "snapshotId": "inv_20260430_091500_ctops_inst_123",
   "snapshotType": "incremental",
   "generatedAt": "2026-04-30T09:15:00Z",
   "cursor": "opaque-next-cursor",
@@ -158,7 +159,7 @@ Rules:
 - CT Ops should send a full snapshot after connector setup and then incremental
   snapshots after successful software inventory scans or relevant host changes.
 - Each request may contain at most 500 hosts and 25,000 packages.
-- CT-CVE must upsert by `(orgId, hostId)` and `(orgId, softwarePackageId)`.
+- CT-CVE must upsert by `(ctOpsInstallationId, hostId)` and `(ctOpsInstallationId, softwarePackageId)`.
 - Replaying the same `snapshotId` must be safe and return the original result.
 - CT-CVE must report accepted, rejected, and skipped row counts in the response.
 
@@ -167,7 +168,7 @@ Response shape:
 ```json
 {
   "accepted": true,
-  "snapshotId": "inv_20260430_091500_org_123",
+  "snapshotId": "inv_20260430_091500_ctops_inst_123",
   "hostsAccepted": 10,
   "packagesAccepted": 1200,
   "rowsRejected": 0,
@@ -188,8 +189,8 @@ Request shape:
 ```json
 {
   "contractVersion": "2026-04-30",
-  "orgId": "org_123",
-  "batchId": "findings_20260430_092000_org_123",
+  "ctOpsInstallationId": "ctops_inst_123",
+  "batchId": "findings_20260430_092000_ctops_inst_123",
   "generatedAt": "2026-04-30T09:20:00Z",
   "findings": [
     {
@@ -237,12 +238,12 @@ Rules:
 - `batchId` is the idempotency key for the whole delivery.
 - `findingId` is the CT-CVE stable finding key and must be stored by CT Ops in
   imported finding metadata.
-- CT Ops upserts by `(orgId, hostId, softwarePackageId, cveId)` for compatibility
+- CT Ops upserts by `(ctOpsInstallationId, hostId, softwarePackageId, cveId)` for compatibility
   with current CT Ops finding uniqueness.
 - `status` is `open` or `resolved`.
 - `severity` is `critical`, `high`, `medium`, `low`, `none`, or `unknown`.
 - `confidence` is `confirmed`, `probable`, or `unsupported`.
-- CT Ops must reject findings for unknown, deleted, or cross-org hosts unless
+- CT Ops must reject findings for unknown, deleted, or cross-instance hosts unless
   the finding is a `resolved` tombstone for an already-imported finding.
 - CT Ops must reject unknown active `softwarePackageId` values for open findings.
 - Replaying the same `batchId` must not duplicate findings or regress newer
@@ -253,7 +254,7 @@ Response shape:
 ```json
 {
   "accepted": true,
-  "batchId": "findings_20260430_092000_org_123",
+  "batchId": "findings_20260430_092000_ctops_inst_123",
   "findingsAccepted": 100,
   "findingsRejected": 0,
   "findingsSkipped": 2
@@ -264,7 +265,7 @@ Response shape:
 
 The first connector uses signed service tokens issued during CT Ops/CT-CVE
 connection setup for service-to-service APIs. CT Ops stores its side of the
-connector as org-scoped app settings in Administration -> Integrations ->
+connector as instance-scoped app settings in Administration -> Integrations ->
 CT-CVE and emits the matching `CT_CVE_CT_OPS_CONNECTIONS` JSON for CT-CVE.
 
 Required request headers:
@@ -289,17 +290,17 @@ Signature input:
 
 Token requirements:
 
-- Tokens are scoped to one `orgId` and one direction: `inventory:write` for CT
+- Tokens are scoped to one `ctOpsInstallationId` and one direction: `inventory:write` for CT
   Ops to CT-CVE or `findings:write` for CT-CVE to CT Ops. Tokens that call
   connection-health endpoints also carry `connection:read`.
 - Token secrets are generated with at least 256 bits of entropy and stored only
   as encrypted secrets or one-way verification material.
 - Tokens can be rotated without downtime by allowing two active token IDs during
   a grace period.
-- Tokens must be revocable per organisation.
+- Tokens must be revocable per installation.
 
 Authorization decisions must be made server-side from the token scope and bound
-`orgId`; request body fields are not trusted on their own.
+`ctOpsInstallationId`; request body fields are not trusted on their own.
 
 ### User Authentication For The CT-CVE GUI
 
@@ -314,7 +315,7 @@ specific API and claim requirements aligned to that shared model.
 
 The target user-flow is:
 
-1. A CT Ops administrator registers a CT-CVE instance for an organisation.
+1. A CT Ops administrator registers a CT-CVE instance for a CT-Ops installation.
 2. CT Ops and CT-CVE exchange or pin instance trust material during setup. The
    minimum trust material is a CT Ops issuer identifier and public signing key
    stored by CT-CVE, plus a CT-CVE instance identifier and public key or
@@ -330,7 +331,7 @@ The target user-flow is:
    route that forwards the assertion server-side.
 8. CT-CVE verifies the assertion with the pinned CT Ops public key, creates a
    short-lived plugin-local web session, and authorizes access from the included
-   organisation, user, role, permission, product, and expiry claims.
+   installation, user, role, permission, product, and expiry claims.
 
 Required assertion claims:
 
@@ -339,13 +340,13 @@ Required assertion claims:
 | `iss` | CT Ops installation or issuer identifier. |
 | `aud` | CT-CVE plugin instance identifier. |
 | `sub` | CT Ops user identifier. |
-| `orgId` | CT Ops organisation identifier. |
+| `ctOpsInstallationId` | CT Ops installation identifier. |
 | `product` | Plugin product identifier, initially `ct-cve`. |
 | `roles` or `permissions` | CT Ops-derived plugin permissions. |
 | `iat` / `exp` | Issued-at and expiry timestamps. |
 | `jti` or `nonce` | Replay-resistant token identifier. |
 
-CT-CVE must reject assertions with the wrong issuer, audience, organisation,
+CT-CVE must reject assertions with the wrong issuer, audience, installation,
 product, expiry, signature, or revoked plugin instance. Assertions should be
 short-lived; long-lived refresh, session, and revocation policy remains owned by
 CT Ops.
@@ -384,7 +385,7 @@ The request token should include:
 | --- | --- |
 | `product` | Plugin product identifier, initially `ct-cve`. |
 | `ctOpsInstallationId` | Stable CT Ops installation identifier. |
-| `orgId` | CT Ops organisation identifier. |
+| `ctOpsInstallationId` | CT Ops installation identifier. |
 | `pluginInstanceId` | CT-CVE instance identifier paired with CT Ops. |
 | `pluginKeyFingerprint` | Fingerprint of CT-CVE instance public key or equivalent binding material. |
 | `requestedPlan` | Optional requested CT-CVE plan or capacity. |
@@ -397,7 +398,7 @@ token was generated by the paired CT Ops/plugin installation and has not been
 edited by the customer.
 
 CT Portal-issued plugin licence keys should be bound to the CT Ops installation,
-organisation, product, and plugin instance or key fingerprint. CT Ops should
+product, and plugin instance or key fingerprint. CT Ops should
 store and validate the active plugin entitlement and expose the resulting status
 to CT-CVE through a signed subscription-status API.
 
@@ -408,17 +409,17 @@ the entitlement model in `docs/ct-ops-plugin-entitlement-storage.md` is
 implemented:
 
 ```text
-GET /api/integrations/ct-cve/v1/subscription-status?orgId=<orgId>&pluginInstanceId=<instanceId>
+GET /api/integrations/ct-cve/v1/subscription-status?ctOpsInstallationId=<ctOpsInstallationId>&pluginInstanceId=<instanceId>
 ```
 
-The endpoint must require a token scoped to the requested organisation and the
+The endpoint must require a token scoped to the requested installation and the
 CT-CVE product. The response should avoid returning licence secrets and should
 only include derived status fields:
 
 ```json
 {
   "product": "ct-cve",
-  "orgId": "org_123",
+  "ctOpsInstallationId": "ctops_inst_123",
   "pluginInstanceId": "ctcve_inst_123",
   "configured": true,
   "licensed": true,
@@ -515,17 +516,17 @@ The status model should include:
 CT-CVE should expose:
 
 ```text
-GET /api/v1/ct-ops/connection-health?orgId=<orgId>
+GET /api/v1/ct-ops/connection-health?ctOpsInstallationId=<ctOpsInstallationId>
 ```
 
 CT Ops should expose:
 
 ```text
-GET /api/integrations/ct-cve/v1/connection-health?orgId=<orgId>
+GET /api/integrations/ct-cve/v1/connection-health?ctOpsInstallationId=<ctOpsInstallationId>
 ```
 
 Both endpoints require the same signed service-token headers and return only
-status data for the token-bound organisation.
+status data for the token-bound installation.
 
 ## Versioning
 

--- a/docs/ct-ops-licensing-and-ct-cve-product-decision.md
+++ b/docs/ct-ops-licensing-and-ct-cve-product-decision.md
@@ -114,7 +114,7 @@ contract rather than by CT Ops-owned feed and matching internals.
 
 CT-CVE must not be designed as useful without CT Ops. Customers can run the
 CT-CVE service separately, but CT Ops is always required as the visualization,
-organisation, inventory, user identity, and customer-facing reporting layer.
+instance, inventory, user identity, and customer-facing reporting layer.
 
 CT-CVE's own GUI is intentionally small. It exists for operational
 configuration, observability, and generating a signed licence request token that
@@ -125,7 +125,7 @@ CT-CVE licence key.
 
 First-party plugin products, including CT-CVE, must not maintain independent
 username and password databases for customer users. CT Ops is the source of
-truth for users, organisations, roles, and seats.
+truth for users, instance membership, roles, and seats.
 
 The concrete shared broker design for pairing, trust storage, launch
 assertions, revocation, and backend checks now lives in
@@ -159,13 +159,13 @@ The target model is:
   the CT Ops issuer identifier and public signing key or certificate
   fingerprint.
 - CT Ops stores the registered plugin instance identifier, plugin public key or
-  shared verification material, allowed organisation scope, enabled products,
+  shared verification material, allowed installation scope, enabled products,
   and revocation state.
 - User access to a plugin GUI uses short-lived CT Ops-issued signed assertions
   with an audience bound to the plugin instance. Assertions must include at
-  least the CT Ops installation identifier, organisation identifier, user
-  identifier, role or permission claims, plugin product identifier, expiry, and
-  nonce or token identifier.
+  least the CT Ops installation identifier, user identifier, role or
+  permission claims, plugin product identifier, expiry, and nonce or token
+  identifier.
 - Plugins create their own local web session only after verifying the CT
   Ops-issued launch assertion. The plugin session should be short-lived,
   same-site where possible, scoped to that plugin instance, and revocable when
@@ -177,7 +177,7 @@ The target model is:
   message shape.
 - Plugins verify CT Ops-issued assertions locally using the pinned CT Ops trust
   anchor and authorize access from the claims. Plugins must reject assertions
-  with the wrong issuer, audience, organisation, product, expiry, or revoked
+  with the wrong issuer, audience, installation, product, expiry, or revoked
   plugin instance.
 - Service-to-service calls continue to use scoped signed service tokens for
   inventory, finding, health, and subscription-status APIs.
@@ -200,18 +200,18 @@ product-level summary.
 
 The target licensing flow is:
 
-1. CT Ops registers or pairs a plugin instance for an organisation.
+1. CT Ops registers or pairs a plugin instance for a CT-Ops installation.
 2. The plugin GUI displays a licence request-token generator.
 3. The generated request token includes the product identifier, plugin instance
-   identifier, CT Ops installation identifier, organisation identifier, plugin
-   public-key fingerprint or service-token binding, requested edition/capacity
-   metadata, creation timestamp, and nonce.
+   identifier, CT Ops installation identifier, plugin public-key fingerprint
+   or service-token binding, requested edition/capacity metadata, creation
+   timestamp, and nonce.
 4. The request token is signed by CT Ops, the plugin, or both, depending on the
    final CT Portal contract. CT Portal must be able to verify that the request
    came from a paired CT Ops/plugin installation and was not edited by the
    customer.
 5. CT Portal issues a licence key bound to the CT Ops installation,
-   organisation, plugin product, and plugin instance or key fingerprint.
+   plugin product, and plugin instance or key fingerprint.
 6. CT Ops stores and validates the active plugin entitlement status and exposes
    that status to the plugin through a signed subscription-status API.
 7. The plugin enforces product-specific entitlement checks server-side for

--- a/docs/ct-ops-plugin-entitlement-storage.md
+++ b/docs/ct-ops-plugin-entitlement-storage.md
@@ -20,7 +20,7 @@ paired plugin instance, expose derived entitlement status to the plugin, and
 gate CT Ops-owned launch surfaces.
 
 This phase is especially important because some external plugin products may
-need to stay invisible in CT Ops unless the organization has a valid
+need to stay invisible in CT Ops unless the installation has a valid
 entitlement. No plugin nav item, settings card, search result, route teaser, or
 launch action should appear based only on frontend state or a
 customer-managed flag when the product policy requires backend-hidden
@@ -28,8 +28,8 @@ visibility.
 
 ## Goals
 
-- Keep plugin entitlements bound to the paired CT Ops installation, organization,
-  product, and plugin instance.
+- Keep plugin entitlements bound to the paired CT Ops installation, product,
+  and plugin instance.
 - Reuse one entitlement model for CT-CVE and future first-party plugins.
 - Ensure CT Ops-owned launch and visibility checks are enforceable server-side.
 - Let plugins fetch derived subscription status without learning licence secrets.
@@ -54,9 +54,9 @@ an imported CT Portal-issued licence artifact.
 
 | Object | Owned by | Responsibility |
 | --- | --- | --- |
-| Plugin request token | CT Ops + plugin | Proves a paired installation is requesting a plugin licence for a specific product, org, and instance. |
+| Plugin request token | CT Ops + plugin | Proves a paired installation is requesting a plugin licence for a specific product and plugin instance. |
 | Imported plugin licence artifact | CT Ops | Stores the signed CT Portal response needed for revalidation and audit. |
-| Derived entitlement record | CT Ops | Stores normalized product/org/instance binding, current status, and visibility decisions. |
+| Derived entitlement record | CT Ops | Stores normalized product/installation/instance binding, current status, and visibility decisions. |
 | Entitlement audit events | CT Ops | Records import, replacement, validation failure, revocation, expiry, and visibility transitions. |
 
 ### Suggested Entitlement Record Fields
@@ -65,7 +65,6 @@ Required normalized fields:
 
 - `pluginEntitlementId`
 - `product`, for example `ct-cve`
-- `organisationId`
 - `ctOpsInstallationId`
 - `pluginInstanceId`
 - `pluginKeyFingerprint`
@@ -134,7 +133,7 @@ Required request-token fields:
 | --- | --- |
 | `product` | Plugin product identifier. |
 | `ctOpsInstallationId` | Stable CT Ops installation identity from the broker. |
-| `orgId` | Organization that will own the entitlement. |
+| `ctOpsInstallationId` | CT Ops installation that will own the entitlement. |
 | `pluginInstanceId` | Paired plugin instance audience. |
 | `pluginKeyFingerprint` | Fingerprint of the paired plugin trust material. |
 | `visibilityPolicy` | Product gating policy expected by CT Ops. |
@@ -151,7 +150,7 @@ Request-token rules:
   CT Portal contract. Dual signing is preferred when practical because it proves
   both the CT Ops installation and the paired plugin instance agree on the
   request.
-- CT Portal must reject tokens whose `product`, `orgId`, `pluginInstanceId`, or
+- CT Portal must reject tokens whose `product`, `ctOpsInstallationId`, `pluginInstanceId`, or
   `pluginKeyFingerprint` do not match the paired installation contract.
 - CT Ops must log request-token creation without logging the raw token value.
 - Request tokens must be single use within their validity window.
@@ -165,7 +164,6 @@ Required binding claims:
 
 - `product`
 - `ctOpsInstallationId`
-- `organisationId`
 - `pluginInstanceId`
 - `pluginKeyFingerprint`
 - `plan`
@@ -180,14 +178,14 @@ Validation rules:
 
 - CT Ops must verify the licence signature against a pinned CT Portal verifier
   key set.
-- CT Ops must reject a licence whose installation, organization, product,
+- CT Ops must reject a licence whose installation, product,
   instance, or plugin-key fingerprint does not exactly match the paired plugin
   record.
 - Replaced or superseded licences must keep audit history but only one
   entitlement record may be authoritative for a given
-  `product + organisationId + pluginInstanceId`.
+  `product + ctOpsInstallationId + pluginInstanceId`.
 - Import failures must return machine-readable error codes such as
-  `invalid_signature`, `wrong_installation`, `wrong_organisation`,
+  `invalid_signature`, `wrong_installation`,
   `wrong_product`, `wrong_plugin_instance`, `wrong_plugin_key`,
   `expired_licence`, or `revoked_licence`.
 
@@ -195,13 +193,13 @@ Validation rules:
 
 1. An admin uses a generic CT Ops plugin-licence import path or installer
    workflow.
-2. CT Ops authenticates the admin, checks organization scope, and requires an
+2. CT Ops authenticates the admin, checks installation scope, and requires an
    existing paired plugin instance for the target product.
-3. CT Ops validates the CT Portal signature and exact installation/org/product/
+3. CT Ops validates the CT Portal signature and exact installation/product/
    instance binding.
 4. CT Ops stores the raw licence artifact encrypted at rest, writes the
    normalized entitlement row, and emits an audit event.
-5. CT Ops recalculates visibility for the product and organization.
+5. CT Ops recalculates visibility for the product and installation.
 6. CT Ops exposes only derived status to plugin or UI consumers.
 
 Periodic revalidation:
@@ -222,14 +220,14 @@ licence artifact.
 Suggested generic endpoint:
 
 ```text
-GET /api/plugins/v1/subscription-status?product=<product>&orgId=<orgId>&pluginInstanceId=<instanceId>
+GET /api/plugins/v1/subscription-status?product=<product>&ctOpsInstallationId=<ctOpsInstallationId>&pluginInstanceId=<instanceId>
 ```
 
 Required checks:
 
 - Service-to-service authentication using the signed token or mTLS contract
   already required for plugin integrations.
-- Organization binding.
+- Installation binding.
 - Product binding.
 - Plugin-instance binding.
 - Per-token rate limits and replay protection.
@@ -239,7 +237,7 @@ Suggested response:
 ```json
 {
   "product": "ct-cve",
-  "orgId": "org_123",
+  "ctOpsInstallationId": "ctops_inst_123",
   "pluginInstanceId": "ctcve_inst_123",
   "configured": true,
   "licensed": true,
@@ -300,7 +298,7 @@ Audit events should exist for:
 - plugin visibility enabled
 - plugin visibility disabled
 
-Audit rows must include actor, organization, product, plugin instance, status
+Audit rows must include actor, installation, product, plugin instance, status
 transition, and normalized error code, but never raw licence values.
 
 ## Security Considerations

--- a/docs/ct-ops-plugin-identity-broker.md
+++ b/docs/ct-ops-plugin-identity-broker.md
@@ -13,7 +13,7 @@ Related:
 ## Context
 
 CT-CVE and future external CT Ops plugins need CT Ops to remain the
-installation entry point, identity provider, and organization authority without
+installation entry point, identity provider, and installation authority without
 forcing each plugin to run its own user database. The existing product
 decision record and CT-CVE API contract already define that direction, but
 they stop short of a concrete shared broker design for pairing, trust storage,
@@ -51,7 +51,7 @@ That missing broker detail now blocks multiple follow-on tasks:
 | Component | Owned by | Responsibility |
 | --- | --- | --- |
 | Installation identity | CT Ops | Stable installation identifier plus signing keys for plugin launch assertions. |
-| Plugin instance registry | CT Ops | Tracks paired plugin instances, allowed origins/URLs, product, org scope, keys, and revocation state. |
+| Plugin instance registry | CT Ops | Tracks paired plugin instances, allowed origins/URLs, product, installation scope, keys, and revocation state. |
 | Pairing endpoint | Plugin + CT Ops | Exchanges trust material and registers an instance relationship. |
 | Launch service | CT Ops | Issues short-lived signed user assertions for a specific plugin instance. |
 | Plugin verifier | Plugin | Verifies CT Ops assertions against pinned CT Ops trust material. |
@@ -91,7 +91,7 @@ Required registry fields:
 
 - `pluginInstanceId`
 - `product`, for example `ct-cve`
-- `organisationId`
+- `ctOpsInstallationId`
 - `displayName`
 - `launchUrl`
 - `allowedOrigins`
@@ -108,7 +108,7 @@ Registry invariants:
 - Every launch target must be explicitly registered; CT Ops must never redirect
   users to an arbitrary plugin URL.
 - The `product` claim and the registered plugin instance must agree.
-- A plugin instance belongs to exactly one CT Ops organization scope.
+- A plugin instance belongs to exactly one CT Ops installation scope.
 - Revoked or disabled instances cannot receive fresh user assertions.
 - Trust material changes are auditable and require org-admin or super-admin
   authority.
@@ -122,7 +122,7 @@ Minimum pairing flow:
 
 1. An administrator creates or starts plugin registration inside CT Ops.
 2. CT Ops generates a one-time pairing challenge bound to the installation,
-   organization, product, and intended plugin origin.
+   product, and intended plugin origin.
 3. The plugin receives the challenge through a plugin-owned pairing endpoint and
    returns its `pluginInstanceId`, product identifier, public verification key,
    canonical launch URL, and allowed browser origins.
@@ -137,13 +137,13 @@ Pairing rules:
 - CT Ops must reject a plugin response whose product or origin does not match
   the admin-approved target.
 - Plugins must pin the CT Ops installation identity and reject assertions from
-  any other issuer, even if usernames and org IDs look plausible.
+  any other issuer, even if usernames and installation IDs look plausible.
 - Re-pairing rotates trust material but must preserve an auditable history.
 
 ## Launch Assertions
 
-CT Ops launches a plugin by minting a compact signed assertion for one user, one
-organization, one plugin instance, and one product.
+CT Ops launches a plugin by minting a compact signed assertion for one user,
+one installation, one plugin instance, and one product.
 
 Format:
 
@@ -158,8 +158,8 @@ Required claims:
 | `iss` | CT Ops issuer for the paired installation. |
 | `aud` | Exact `pluginInstanceId`. |
 | `sub` | CT Ops user identifier. |
-| `orgId` | CT Ops organization identifier. |
-| `orgSlug` | Optional human-readable diagnostics only. |
+| `ctOpsInstallationId` | CT Ops installation identifier. |
+| `instanceSlug` | Optional human-readable diagnostics only. |
 | `product` | Plugin product identifier such as `ct-cve`. |
 | `roles` | CT Ops roles available to the plugin. |
 | `permissions` | Optional derived permissions for plugin launch decisions. |
@@ -172,10 +172,10 @@ Assertion rules:
 - Assertions must not contain secrets, licence keys, API tokens, plugin config,
   customer data, product-owned credentials, or other sensitive payloads.
 - CT Ops issues assertions only after backend checks confirm the user session is
-  active, the user still belongs to the organization, seat admission has not
-  blocked the user, and the plugin instance is active for that product/org.
+  active, the user still belongs to the installation, seat admission has not
+  blocked the user, and the plugin instance is active for that product.
 - Assertions are audience-bound to one plugin instance and cannot be reused for
-  another plugin or another organization.
+  another plugin or another installation.
 - Assertions are delivered by redirect, iframe bootstrap, or CT Ops-hosted
   proxy launch, but they are never written to logs or durable analytics.
 
@@ -202,7 +202,7 @@ After launch, the plugin verifies the assertion before creating a local session.
 Verification requirements:
 
 - Check signature against the pinned CT Ops public key set.
-- Check `iss`, `aud`, `product`, `orgId`, `exp`, and `jti`.
+- Check `iss`, `aud`, `product`, `ctOpsInstallationId`, `exp`, and `jti`.
 - Reject replayed `jti` values during the assertion lifetime.
 - Reject assertions for disabled or revoked plugin instances.
 
@@ -214,7 +214,7 @@ Plugin-local session rules:
   embedding genuinely requires it, plus CSRF protections on plugin mutations.
 - Keep plugin sessions short lived. Default policy is a 15-minute idle timeout
   and a bounded absolute lifetime; higher-risk plugins may shorten further.
-- Store the source `jti`, user ID, org ID, product, and plugin instance ID on
+- Store the source `jti`, user ID, installation ID, product, and plugin instance ID on
   the session row so later checks can invalidate the session precisely.
 
 ## Revocation And Session Status
@@ -223,7 +223,7 @@ Revocation has to cover more than assertion expiry. The broker therefore uses
 three layers:
 
 1. CT Ops stops issuing new assertions immediately when the user loses access,
-   the organization mapping changes, or the plugin instance is disabled.
+   the installation mapping changes, or the plugin instance is disabled.
 2. Plugins keep local sessions short lived so stale access naturally expires on
    a bounded timeline.
 3. Plugins can call a CT Ops session-status endpoint on sensitive or periodic
@@ -242,7 +242,7 @@ Request body:
 {
   "pluginInstanceId": "plugin_inst_123",
   "product": "ct-cve",
-  "orgId": "org_123",
+  "ctOpsInstallationId": "ctops_inst_123",
   "userId": "user_123",
   "sid": "sess_123"
 }
@@ -256,7 +256,7 @@ Response shape:
   "reason": "ok",
   "userStillAuthorized": true,
   "pluginInstanceActive": true,
-  "organisationMatch": true
+  "installationMatch": true
 }
 ```
 
@@ -274,10 +274,10 @@ Rules:
 CT Ops backend checks before issuing a launch assertion:
 
 - Authenticated CT Ops user session exists and is not revoked.
-- User belongs to the requested organization.
+- User belongs to the requested installation.
 - User is still admitted under CT Ops seat rules.
 - Plugin instance is active, paired, and registered for the requested product
-  and organization.
+  and installation.
 - The launch route is authorized for the user role.
 
 Plugin backend checks after launch:
@@ -296,7 +296,7 @@ Plugin backend checks after launch:
 
 ### CT-CVE
 
-- CT-CVE uses the broker only for operator identity and organization scope.
+- CT-CVE uses the broker only for operator identity and installation scope.
 - CT-CVE still owns feed credentials, source configuration, and vulnerability
   processing in its own service and database.
 

--- a/docs/enrolment-tokens.md
+++ b/docs/enrolment-tokens.md
@@ -1,6 +1,6 @@
 # Enrolment Tokens
 
-Enrolment tokens are how you control which agents are allowed to register with your organisation. An agent must present a valid token when it first connects — without one, the ingest service rejects the registration.
+Enrolment tokens are how you control which agents are allowed to register with your CT-Ops instance. An agent must present a valid token when it first connects — without one, the ingest service rejects the registration.
 
 ---
 
@@ -87,7 +87,7 @@ Without auto-approve, the agent waits in `pending` state. An admin must click **
 ## Security notes
 
 - Enrolment tokens only control **who can register**. Once registered, the agent uses a JWT for all communication — the token plays no further role.
-- A token grants access to your entire organisation. Treat tokens with the same care as API keys — don't commit them to source control or share them in chat.
+- A token grants access to your CT-Ops instance. Treat tokens with the same care as API keys — don't commit them to source control or share them in chat.
 - Set an expiry date on tokens you hand to third parties or contractors.
 - Use `Max uses: 1` for registering a single known host when you want to prevent the token being reused.
 - All token activity is logged — the usage count on the token table increments for each registration.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,14 +97,14 @@ docker compose -f docker-compose.single.yml exec web sh -c "cd /app && node_modu
 Open [http://localhost:3000](http://localhost:3000) in a browser.
 
 1. Click **Register** and create your account
-2. You'll be taken through the **onboarding wizard** — enter your organisation name and click **Create Organisation**
+2. CT-Ops opens directly into the standalone instance setup flow after registration
 3. You're now logged in as `super_admin`
 
 ---
 
 ## Step: Create an enrolment token
 
-An enrolment token is what the agent uses to register itself with your organisation.
+An enrolment token is what the agent uses to register itself with your CT-Ops instance.
 
 1. In the sidebar, click **Agents** (under Administration), then use the **Enrolment** tab
 2. Click **New Token**
@@ -141,7 +141,7 @@ address = "localhost:9443"
 ca_cert_file = "deploy/dev-tls/server.crt"   # path to the dev cert
 
 [agent]
-org_token = "YOUR_ENROLMENT_TOKEN"            # paste the token here
+enrolment_token = "YOUR_ENROLMENT_TOKEN"      # paste the token here
 data_dir = "/tmp/ct-ops-agent"
 version = "0.1.0"
 heartbeat_interval_secs = 30


### PR DESCRIPTION
## Summary
- update public setup, deployment, licensing, and contract docs for standalone CT-Ops instances
- replace lingering public `org_token` documentation with `enrolment_token`
- remove the customer bundle licence-tier query against `organisations`

## Validation
- pnpm install --frozen-lockfile
- pnpm --dir apps/docs build
- rg -n "organisation|organization|orgId|organisationId|organisation_id|org_id|tenant|organisations" README.md docs apps/docs deploy .env.example apps/web/.env.example
- rg -n "org_token|CT_OPS_ORG_TOKEN|agent\.org_token" docs apps/docs deploy README.md .env.example apps/web/.env.example
