### PR TITLE
fix(password-manager): allow standalone launch assertions

### DIFF
--- a/apps/web/app/api/password-manager/launch-assertion/route.ts
+++ b/apps/web/app/api/password-manager/launch-assertion/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { eq } from 'drizzle-orm'
-import { ApiAuthError, getApiInstanceSession } from '@/lib/auth/session'
+import { ApiAuthError, getApiSession } from '@/lib/auth/session'
 import { requireToolingAccess } from '@/lib/auth/tooling'
 import { db } from '@/lib/db'
 import { instanceSettings } from '@/lib/db/schema'
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   let session
   try {
-    session = await getApiInstanceSession(request.headers)
+    session = await getApiSession(request.headers)
     requireToolingAccess(session.user)
   } catch (error) {
     if (error instanceof ApiAuthError) {
@@ -52,20 +52,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     throw error
   }
 
-  const rateLimitKey = `${session.user.instanceId}:${session.user.id}`
-  if (!await launchAssertionRateLimit.check(rateLimitKey)) {
-    return NextResponse.json(
-      { error: 'Too many requests — please wait before trying again.' },
-      { status: 429 },
-    )
-  }
-
   try {
     const config = getPasswordManagerLaunchAssertionConfig()
-    const instanceName = await findInstanceName(session.user.instanceId)
+    const launchScopeId = session.user.instanceId ?? config.ctOpsInstanceId
+    const rateLimitKey = `${launchScopeId}:${session.user.id}`
+    if (!await launchAssertionRateLimit.check(rateLimitKey)) {
+      return NextResponse.json(
+        { error: 'Too many requests — please wait before trying again.' },
+        { status: 429 },
+      )
+    }
+
+    const instanceName = session.user.instanceId
+      ? await findInstanceName(session.user.instanceId)
+      : null
     const assertion = await signPasswordManagerLaunchAssertion(
       {
-        instanceId: session.user.instanceId,
+        instanceId: launchScopeId,
         instanceName,
         userId: session.user.id,
         email: session.user.email,
@@ -84,7 +87,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     )
   } catch (error) {
     logError('[password-manager] failed to mint launch assertion', error, {
-      instanceId: session.user.instanceId,
+      instanceId: session.user.instanceId ?? null,
       userId: session.user.id,
     })
 

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -57,6 +57,7 @@ const standaloneApiRoutes = [
   'app/api/domain-accounts/counts/route.ts',
   'app/api/domain-accounts/route.ts',
   'app/api/overview/route.ts',
+  'app/api/password-manager/launch-assertion/route.ts',
   'app/api/service-accounts/counts/route.ts',
   'app/api/service-accounts/route.ts',
   'app/api/system/health/route.ts',


### PR DESCRIPTION
## Summary
- allow the Password Manager launch assertion route to authenticate standalone CT-Ops sessions without an instance-backed org scope
- use CT_OPS_INSTANCE_ID as the Password Manager launch scope when no session instance exists
- add launch assertion route coverage to the standalone API regression test

## Validation
- node --experimental-strip-types --test apps/web/lib/password-manager/launch-assertion.test.mjs apps/web/lib/actions/dashboard-standalone.test.mjs
- pnpm --dir apps/web lint 'app/api/password-manager/launch-assertion/route.ts' 'lib/actions/dashboard-standalone.test.mjs'
- pnpm --dir apps/web type-check
- git diff --check
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts

## E2E note
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts is blocked locally because Testcontainers could not find a working container runtime strategy.