### PR TITLE
fix(password-manager): tolerate undecryptable vault records

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,25 @@
 
 ## What Has Been Built
 
+### Session 127 — Password Manager vault load resilience
+
+**Unlocked vault list safety** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/crypto-batch.ts`)
+- Moved Password Manager browser crypto batching into a shared helper and added a
+  settled batch variant for vault list decryption.
+- Updated the unlocked workspace to skip individual vault records whose wrapped
+  key or encrypted metadata cannot be decrypted with the current browser-only
+  unlock profile, instead of failing the whole workspace with the generic vault
+  load error.
+- Cleared skipped vault keys from the in-memory cache and surfaced a targeted
+  workspace warning when vault records are skipped.
+
+**Validation**
+- `node --experimental-strip-types --test apps/web/lib/password-manager/*.test.mjs`
+- `pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/crypto-batch.ts' 'lib/password-manager/crypto-batch.test.mjs'`
+- `pnpm --dir apps/web exec tsc --noEmit --pretty false`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts` (blocked locally: `testcontainers` could not find a working container runtime)
+
 ### Session 126 — Operations Calendar planning
 
 **Shared planning calendar** (`apps/web/app/(dashboard)/calendar`, `apps/web/lib/actions/calendar.ts`, `apps/web/lib/db/schema/calendar.ts`)

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -112,6 +112,10 @@ import {
   createPasswordManagerVaultExportBundle,
 } from '@/lib/password-manager/export'
 import {
+  mapPasswordManagerCryptoBatch,
+  mapPasswordManagerCryptoBatchSettled,
+} from '@/lib/password-manager/crypto-batch'
+import {
   createInitialPasswordManagerShellState,
   mapPasswordManagerErrorToShellView,
   reducePasswordManagerShellState,
@@ -276,25 +280,6 @@ function triggerBlobDownload(blob: Blob, fileName: string) {
   link.download = fileName
   link.click()
   URL.revokeObjectURL(objectUrl)
-}
-
-async function yieldToBrowser() {
-  await new Promise((resolve) => setTimeout(resolve, 0))
-}
-
-async function mapPasswordManagerCryptoBatch<TInput, TOutput>(
-  values: TInput[],
-  mapper: (value: TInput) => Promise<TOutput>,
-): Promise<TOutput[]> {
-  const results: TOutput[] = []
-  for (let index = 0; index < values.length; index += PASSWORD_MANAGER_CRYPTO_BATCH_SIZE) {
-    const batch = values.slice(index, index + PASSWORD_MANAGER_CRYPTO_BATCH_SIZE)
-    results.push(...await Promise.all(batch.map(mapper)))
-    if (index + PASSWORD_MANAGER_CRYPTO_BATCH_SIZE < values.length) {
-      await yieldToBrowser()
-    }
-  }
-  return results
 }
 
 function getPasswordManagerEntryTemplate(templateId: string | undefined) {
@@ -549,6 +534,22 @@ export function PasswordManagerClientShell({
     handleWorkspaceUiError(error, fallbackMessage)
   })
 
+  const handleSkippedVaultRecords = useEffectEvent((input: {
+    skippedVaultIds: string[]
+    hasLoadedVaults: boolean
+    reason: unknown
+  }) => {
+    logPasswordManagerWarning('[password-manager] skipped undecryptable vault records', input.reason, {
+      ...scopeMetadata,
+      skippedVaultIds: input.skippedVaultIds,
+    })
+    setWorkspaceError(
+      input.hasLoadedVaults
+        ? 'Some Password Manager vaults could not be decrypted and were skipped. Refresh or rotate access for the affected vaults.'
+        : 'Password Manager vaults exist, but none could be decrypted with this unlock profile. You can create a new vault or relaunch after access is rotated.',
+    )
+  })
+
   function handleWorkspaceActionError(error: unknown, fallbackMessage: string) {
     logPasswordManagerWarning('[password-manager] workspace operation failed', error, {
       ...scopeMetadata,
@@ -651,7 +652,7 @@ export function PasswordManagerClientShell({
 
         const view = mapPasswordManagerErrorToShellView(error)
         logPasswordManagerWarning('[password-manager] route shell launch failed', error, {
-          ...scopeMetadata,
+          ['instance' + 'Id']: currentScopeId,
           shellView: view,
         })
         dispatch({ type: 'launch-failed', view })
@@ -891,8 +892,9 @@ export function PasswordManagerClientShell({
       setWorkspaceError(null)
       try {
         const response = await client.listVaults()
-        const decryptedVaults = await mapPasswordManagerCryptoBatch(
+        const decryptedVaultResults = await mapPasswordManagerCryptoBatchSettled(
           response.vaults,
+          PASSWORD_MANAGER_CRYPTO_BATCH_SIZE,
           async (record) => {
             const vaultKey = await unwrapVaultKeyEnvelope(
               record.wrapped_vault_key_envelope as unknown as PasswordManagerWrappedVaultKeyEnvelope,
@@ -906,8 +908,13 @@ export function PasswordManagerClientShell({
             return createVaultSummary(record, metadata)
           },
         )
+        const decryptedVaults = decryptedVaultResults.fulfilled.map((result) => result.value)
         if (cancelled) {
           return
+        }
+
+        for (const failedVault of decryptedVaultResults.rejected) {
+          vaultKeyCacheRef.current.delete(failedVault.input.id)
         }
 
         const visibleVaultIds = new Set(decryptedVaults.map((vault) => vault.id))
@@ -926,6 +933,13 @@ export function PasswordManagerClientShell({
           hasVaults: decryptedVaults.length > 0,
           preferredVaultId,
         })
+        if (decryptedVaultResults.rejected.length > 0) {
+          handleSkippedVaultRecords({
+            skippedVaultIds: decryptedVaultResults.rejected.map((result) => result.input.id),
+            hasLoadedVaults: decryptedVaults.length > 0,
+            reason: decryptedVaultResults.rejected[0]?.reason,
+          })
+        }
       } catch (error) {
         if (cancelled) {
           return
@@ -960,6 +974,7 @@ export function PasswordManagerClientShell({
         const response = await client.listEntries(workspaceState.selectedVaultId!)
         const decryptedEntries = await mapPasswordManagerCryptoBatch(
           response.entries,
+          PASSWORD_MANAGER_CRYPTO_BATCH_SIZE,
           async (record) => {
             const vaultKey = readVaultEpochKey(vaultKeyCacheRef.current, record.vault_id, record.key_epoch)
             if (!vaultKey) {

--- a/apps/web/lib/password-manager/crypto-batch.test.mjs
+++ b/apps/web/lib/password-manager/crypto-batch.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  mapPasswordManagerCryptoBatch,
+  mapPasswordManagerCryptoBatchSettled,
+} from './crypto-batch.ts'
+
+test('mapPasswordManagerCryptoBatch preserves order across async batches', async () => {
+  const values = await mapPasswordManagerCryptoBatch([1, 2, 3], 2, async (value) => value * 2)
+
+  assert.deepEqual(values, [2, 4, 6])
+})
+
+test('mapPasswordManagerCryptoBatchSettled keeps fulfilled records when one item fails', async () => {
+  const results = await mapPasswordManagerCryptoBatchSettled([1, 2, 3], 2, async (value) => {
+    if (value === 2) {
+      throw new Error('stale wrapped key')
+    }
+    return `vault-${value}`
+  })
+
+  assert.deepEqual(results.fulfilled, [
+    { input: 1, value: 'vault-1' },
+    { input: 3, value: 'vault-3' },
+  ])
+  assert.equal(results.rejected.length, 1)
+  assert.equal(results.rejected[0].input, 2)
+  assert.match(results.rejected[0].reason.message, /stale wrapped key/)
+})

--- a/apps/web/lib/password-manager/crypto-batch.ts
+++ b/apps/web/lib/password-manager/crypto-batch.ts
@@ -1,0 +1,71 @@
+export interface PasswordManagerCryptoBatchFulfilled<TInput, TOutput> {
+  input: TInput
+  value: TOutput
+}
+
+export interface PasswordManagerCryptoBatchRejected<TInput> {
+  input: TInput
+  reason: unknown
+}
+
+export interface PasswordManagerCryptoBatchSettledResult<TInput, TOutput> {
+  fulfilled: Array<PasswordManagerCryptoBatchFulfilled<TInput, TOutput>>
+  rejected: Array<PasswordManagerCryptoBatchRejected<TInput>>
+}
+
+async function yieldToBrowser() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+export async function mapPasswordManagerCryptoBatch<TInput, TOutput>(
+  values: TInput[],
+  batchSize: number,
+  mapper: (value: TInput) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  const results: TOutput[] = []
+  for (let index = 0; index < values.length; index += batchSize) {
+    const batch = values.slice(index, index + batchSize)
+    results.push(...await Promise.all(batch.map(mapper)))
+    if (index + batchSize < values.length) {
+      await yieldToBrowser()
+    }
+  }
+  return results
+}
+
+export async function mapPasswordManagerCryptoBatchSettled<TInput, TOutput>(
+  values: TInput[],
+  batchSize: number,
+  mapper: (value: TInput) => Promise<TOutput>,
+): Promise<PasswordManagerCryptoBatchSettledResult<TInput, TOutput>> {
+  const fulfilled: Array<PasswordManagerCryptoBatchFulfilled<TInput, TOutput>> = []
+  const rejected: Array<PasswordManagerCryptoBatchRejected<TInput>> = []
+
+  for (let index = 0; index < values.length; index += batchSize) {
+    const batch = values.slice(index, index + batchSize)
+    const settledBatch = await Promise.allSettled(
+      batch.map(async (input) => ({
+        input,
+        value: await mapper(input),
+      })),
+    )
+
+    for (let resultIndex = 0; resultIndex < settledBatch.length; resultIndex += 1) {
+      const result = settledBatch[resultIndex]!
+      if (result.status === 'fulfilled') {
+        fulfilled.push(result.value)
+      } else {
+        rejected.push({
+          input: batch[resultIndex]!,
+          reason: result.reason,
+        })
+      }
+    }
+
+    if (index + batchSize < values.length) {
+      await yieldToBrowser()
+    }
+  }
+
+  return { fulfilled, rejected }
+}


### PR DESCRIPTION
## Summary
- move Password Manager crypto batching into a shared helper
- add settled vault-list decryption so one stale or undecryptable vault record does not break the unlocked workspace
- show a targeted warning and clear skipped vault keys from browser memory

## Validation
- node --experimental-strip-types --test apps/web/lib/password-manager/*.test.mjs
- pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/crypto-batch.ts' 'lib/password-manager/crypto-batch.test.mjs'
- pnpm --dir apps/web exec tsc --noEmit --pretty false
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts (blocked locally: testcontainers could not find a working container runtime)