### PR TITLE
fix(web): guard team invites without instance scope

### DIFF
--- a/apps/web/app/(dashboard)/team/page.tsx
+++ b/apps/web/app/(dashboard)/team/page.tsx
@@ -15,6 +15,7 @@ export default async function TeamPage() {
     <TeamClient
       currentUserId={session.user.id}
       currentUserRole={session.user.role}
+      hasInstanceScope={Boolean(session.user.instanceId)}
       initialMembers={members}
       initialPendingInvites={pendingInvites}
     />

--- a/apps/web/app/(dashboard)/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/team/team-client.tsx
@@ -51,6 +51,7 @@ type InviteValues = z.infer<typeof inviteSchema>
 interface TeamClientProps {
   currentUserId: string
   currentUserRole: string
+  hasInstanceScope: boolean
   initialMembers: User[]
   initialPendingInvites: Invitation[]
 }
@@ -65,6 +66,7 @@ function getDisplayedRoles(entity: Pick<User | Invitation, 'role' | 'roles'>): s
 export function TeamClient({
   currentUserId,
   currentUserRole,
+  hasInstanceScope,
   initialMembers,
   initialPendingInvites,
 }: TeamClientProps) {
@@ -200,7 +202,7 @@ export function TeamClient({
             Manage members and pending invitations
           </p>
         </div>
-        {canManage(currentUserRole) && (
+        {canManage(currentUserRole) && hasInstanceScope && (
           <Button onClick={() => setIsInviteOpen(true)} size="sm" data-testid="team-invite-open">
             <UserPlus className="size-4 mr-2" />
             Invite member

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -21,6 +21,18 @@ const sessionSource = readFileSync(
   path.join(repoRoot, 'lib/auth/session.ts'),
   'utf8',
 )
+const usersActionSource = readFileSync(
+  path.join(repoRoot, 'lib/actions/users.ts'),
+  'utf8',
+)
+const teamPageSource = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/team/page.tsx'),
+  'utf8',
+)
+const teamClientSource = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/team/team-client.tsx'),
+  'utf8',
+)
 
 const sidebarLinkedPages = [
   'app/(dashboard)/alerts/page.tsx',
@@ -124,6 +136,17 @@ test('fresh standalone sessions promote the first active user to instance admin'
   assert.match(sessionSource, /ensureInstanceHasSuperAdmin\(user\)/)
   assert.match(sessionSource, /activeUsers\[0\]\?\.id !== user\.id/)
   assert.match(sessionSource, /set\(\{ role: INSTANCE_ADMIN_ROLE, roles, updatedAt: new Date\(\) \}\)/)
+})
+
+test('team invitations are disabled without an instance-backed scope', () => {
+  assert.match(usersActionSource, /const currentScope = resolveOptionalActionScope\(session\)/)
+  assert.match(
+    usersActionSource,
+    /if \(!currentScope\) return \{ error: 'Team invitations require an instance to be configured' \}/,
+  )
+  assert.match(teamPageSource, /hasInstanceScope=\{Boolean\(session\.user\.instanceId\)\}/)
+  assert.match(teamClientSource, /hasInstanceScope: boolean/)
+  assert.match(teamClientSource, /canManage\(currentUserRole\) && hasInstanceScope/)
 })
 
 test('administration pages use normalized role checks', () => {

--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -57,7 +57,9 @@ export async function getOrgUsers(): Promise<{ members: User[]; pendingInvites: 
 export async function inviteUser(
   input: { email: string; roles: string[] },
 ): Promise<{ inviteLink: string } | { restored: true } | { error: string }> {
-  const currentScope = resolveCurrentActionScope(await getRequiredSession())
+  const session = await getRequiredSession()
+  const currentScope = resolveOptionalActionScope(session)
+  if (!currentScope) return { error: 'Team invitations require an instance to be configured' }
   const instanceId = currentScope
   await requireInstanceAccess(instanceId)
   const parsed = inviteSchema.safeParse(input)
@@ -69,7 +71,7 @@ export async function inviteUser(
   const nextRole = getPrimaryRole(nextRoles)
 
   try {
-    const session = await requireInstanceAdminAccess(instanceId)
+    const adminSession = await requireInstanceAdminAccess(instanceId)
 
     // Check for a previously removed user — restore them rather than re-registering,
     // since their account (and email) still exist in the database.
@@ -90,7 +92,7 @@ export async function inviteUser(
 
         await writeAuditEvent(tx, {
           instanceId: instanceId,
-          actorUserId: session.user.id,
+          actorUserId: adminSession.user.id,
           action: 'user.restored',
           targetType: 'user',
           targetId: removedUser.id,
@@ -144,7 +146,7 @@ export async function inviteUser(
           role: nextRole,
           roles: nextRoles,
           instanceId: instanceId,
-          invitedById: session.user.id,
+          invitedById: adminSession.user.id,
           expiresAt,
         })
         .returning()
@@ -153,7 +155,7 @@ export async function inviteUser(
 
       await writeAuditEvent(tx, {
         instanceId: instanceId,
-        actorUserId: session.user.id,
+        actorUserId: adminSession.user.id,
         action: 'invitation.created',
         targetType: 'invitation',
         targetId: createdInvite.id,


### PR DESCRIPTION
## Summary
- return a controlled error when team invites are submitted without an instance-backed scope
- hide the invite button for no-instance standalone sessions
- add a standalone regression assertion for team invite behavior

## Validation
- pnpm --filter web exec node --experimental-strip-types --test lib/actions/dashboard-standalone.test.mjs
- pnpm --filter web exec eslint lib/actions/users.ts app/'(dashboard)'/team/page.tsx app/'(dashboard)'/team/team-client.tsx lib/actions/dashboard-standalone.test.mjs (passes with existing React Hook Form warning in team-client.tsx)
- pnpm --filter web type-check
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret POSTGRES_PASSWORD=ctops pnpm --filter web build (passes with existing Turbopack NFT warnings and dummy-secret warnings)
- pnpm --filter web test:unit (304/305 passed; fails only at lib/integrations/ct-cve/db-nonce-store.test.mjs because no working container runtime is available)