### PR TITLE
fix(auth): persist direct signup instance membership

### DIFF
--- a/apps/web/lib/actions/users.ts
+++ b/apps/web/lib/actions/users.ts
@@ -6,7 +6,7 @@ import { requireInstanceAccess, requireInstanceAdminAccess } from '@/lib/actions
 import { z } from 'zod'
 import { db } from '@/lib/db'
 import { users, invitations, sessions } from '@/lib/db/schema'
-import { eq, and, isNull, isNotNull, gt } from 'drizzle-orm'
+import { eq, and, isNull, isNotNull, gt, sql } from 'drizzle-orm'
 import type { User, Invitation } from '@/lib/db/schema'
 import { getBetterAuthOrigin } from '@/lib/auth/env'
 import { getRequiredSession } from '@/lib/auth/session'
@@ -32,11 +32,30 @@ function hasSuperAdminRole(role: string | null | undefined, roles: readonly stri
   return normalizeAssignedRoles(roles, role).includes('super_admin')
 }
 
+async function backfillDirectSignupUsers(instanceId: string): Promise<void> {
+  await db.execute(sql`
+    UPDATE "user" AS u
+    SET instance_id = ${instanceId},
+        updated_at = NOW()
+    WHERE u.instance_id IS NULL
+      AND u.deleted_at IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM invitations AS i
+        WHERE lower(i.email) = lower(u.email)
+          AND i.accepted_at IS NULL
+          AND i.deleted_at IS NULL
+          AND i.expires_at > NOW()
+      )
+  `)
+}
+
 export async function getOrgUsers(): Promise<{ members: User[]; pendingInvites: Invitation[] }> {
   const session = await getRequiredSession()
   const currentScope = resolveOptionalActionScope(session)
   if (!currentScope) return { members: [session.user], pendingInvites: [] }
   await requireInstanceAccess(currentScope)
+  await backfillDirectSignupUsers(currentScope)
 
   const [members, pendingInvites] = await Promise.all([
     db.query.users.findMany({

--- a/apps/web/lib/auth/index.ts
+++ b/apps/web/lib/auth/index.ts
@@ -2,6 +2,7 @@ import { betterAuth } from 'better-auth'
 import { APIError, createAuthMiddleware } from 'better-auth/api'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { twoFactor } from 'better-auth/plugins'
+import { and, count, eq, isNull } from 'drizzle-orm'
 import { authDb, db } from '@/lib/db'
 import * as schema from '@/lib/db/schema'
 import { parseInstanceMetadata } from '@/lib/db/schema/instance-settings'
@@ -23,6 +24,7 @@ import {
 } from './email-verification-rate-limit'
 import { getVerificationResendClientIp } from './email-verification-resend'
 import { passwordLoginAttemptGuard } from './login-attempts'
+import { getDirectSignupProvisioning, isInviteSignupCallback } from './signup-provisioning'
 
 const LOGIN_THROTTLED_MESSAGE = 'Too many login attempts — please wait before trying again.'
 const requireEmailVerification = getRequireEmailVerification()
@@ -56,6 +58,33 @@ export const auth = betterAuth({
       totpCredentials: schema.totpCredentials,
     },
   }),
+  databaseHooks: {
+    user: {
+      create: {
+        before: async (user, ctx) => {
+          if (isInviteSignupCallback(ctx?.body?.callbackURL)) {
+            return { data: user }
+          }
+
+          const [activeUsersRow, defaultInstanceId] = await Promise.all([
+            db
+              .select({ total: count() })
+              .from(schema.users)
+              .where(and(eq(schema.users.isActive, true), isNull(schema.users.deletedAt))),
+            getDefaultInstanceId(),
+          ])
+          const activeUserCount = activeUsersRow[0]?.total ?? 0
+
+          return {
+            data: {
+              ...user,
+              ...getDirectSignupProvisioning({ defaultInstanceId, activeUserCount }),
+            },
+          }
+        },
+      },
+    },
+  },
   emailAndPassword: {
     enabled: true,
     requireEmailVerification,

--- a/apps/web/lib/auth/signup-provisioning.test.mjs
+++ b/apps/web/lib/auth/signup-provisioning.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  getDirectSignupProvisioning,
+  isInviteSignupCallback,
+} from './signup-provisioning.ts'
+
+test('direct signup provisioning assigns the first user as super admin', () => {
+  assert.deepEqual(
+    getDirectSignupProvisioning({ defaultInstanceId: 'instance-1', activeUserCount: 0 }),
+    {
+      instanceId: 'instance-1',
+      role: 'super_admin',
+      roles: ['super_admin'],
+    },
+  )
+})
+
+test('direct signup provisioning assigns later users to the default instance as engineers', () => {
+  assert.deepEqual(
+    getDirectSignupProvisioning({ defaultInstanceId: 'instance-1', activeUserCount: 2 }),
+    {
+      instanceId: 'instance-1',
+      role: 'engineer',
+      roles: ['engineer'],
+    },
+  )
+})
+
+test('invite callback detection only matches invite acceptance callbacks with tokens', () => {
+  assert.equal(isInviteSignupCallback('/accept-invite?token=abc123'), true)
+  assert.equal(isInviteSignupCallback('https://ct-ops.example.com/accept-invite?token=abc123'), true)
+  assert.equal(isInviteSignupCallback('/accept-invite'), false)
+  assert.equal(isInviteSignupCallback('/dashboard'), false)
+  assert.equal(isInviteSignupCallback(undefined), false)
+})

--- a/apps/web/lib/auth/signup-provisioning.ts
+++ b/apps/web/lib/auth/signup-provisioning.ts
@@ -1,0 +1,39 @@
+import type { AssignedRole } from './roles.ts'
+
+const INVITE_ACCEPT_PATH = '/accept-invite'
+const DIRECT_SIGNUP_ROLE: AssignedRole = 'engineer'
+const FIRST_USER_ROLE: AssignedRole = 'super_admin'
+
+export type DirectSignupProvisioning = {
+  instanceId?: string
+  role: AssignedRole
+  roles: AssignedRole[]
+}
+
+export function isInviteSignupCallback(callbackURL: unknown): boolean {
+  if (typeof callbackURL !== 'string' || !callbackURL.trim()) return false
+
+  try {
+    const url = new URL(callbackURL, 'https://ct-ops.local')
+    return url.pathname === INVITE_ACCEPT_PATH && Boolean(url.searchParams.get('token')?.trim())
+  } catch {
+    return false
+  }
+}
+
+export function getDirectSignupProvisioning(input: {
+  defaultInstanceId: string | null
+  activeUserCount: number
+}): DirectSignupProvisioning {
+  const role = input.activeUserCount === 0 ? FIRST_USER_ROLE : DIRECT_SIGNUP_ROLE
+  const provisioning: DirectSignupProvisioning = {
+    role,
+    roles: [role],
+  }
+
+  if (input.defaultInstanceId) {
+    provisioning.instanceId = input.defaultInstanceId
+  }
+
+  return provisioning
+}

--- a/apps/web/tests/e2e/auth/register.spec.ts
+++ b/apps/web/tests/e2e/auth/register.spec.ts
@@ -89,3 +89,57 @@ test('email sign-up can continue without verification when disabled', async ({ p
   await page.goto('/dashboard')
   await page.waitForURL('**/dashboard')
 })
+
+test('direct sign-ups join the instance people list when verification is disabled', async ({ page }) => {
+  test.skip(requireEmailVerification, 'email verification is required for this run')
+
+  const suffix = Date.now()
+  const firstEmail = `direct-member-one-${suffix}@example.com`
+  const secondEmail = `direct-member-two-${suffix}@example.com`
+  const password = 'TestPassword123!'
+  const sql = getTestDb()
+
+  await page.goto('/register')
+  await page.getByLabel('Full name').fill('Direct Member One')
+  await page.getByLabel('Email').fill(firstEmail)
+  await page.getByLabel(/^Password$/).fill(password)
+  await page.getByLabel(/^Confirm password$/).fill(password)
+  await page.getByRole('button', { name: 'Create account' }).click()
+  await page.waitForURL('**/dashboard')
+
+  const firstRows = await sql<Array<{ id: string; instance_id: string | null }>>`
+    SELECT id, instance_id
+    FROM "user"
+    WHERE email = ${firstEmail}
+    LIMIT 1
+  `
+  expect(firstRows).toHaveLength(1)
+  expect(firstRows[0]?.instance_id).toBeTruthy()
+
+  await sql`DELETE FROM "session" WHERE user_id = ${firstRows[0]!.id}`
+  await page.context().clearCookies()
+
+  await page.goto('/register')
+  await page.getByLabel('Full name').fill('Direct Member Two')
+  await page.getByLabel('Email').fill(secondEmail)
+  await page.getByLabel(/^Password$/).fill(password)
+  await page.getByLabel(/^Confirm password$/).fill(password)
+  await page.getByRole('button', { name: 'Create account' }).click()
+  await page.waitForURL('**/dashboard')
+
+  await page.goto('/team')
+  const memberRowsLocator = page.locator('[data-testid^="team-member-row-"]')
+  await expect(memberRowsLocator.filter({ hasText: 'Direct Member One' })).toBeVisible()
+  await expect(memberRowsLocator.filter({ hasText: 'Direct Member Two' })).toBeVisible()
+
+  const memberRows = await sql<Array<{ email: string; instance_id: string | null }>>`
+    SELECT email, instance_id
+    FROM "user"
+    WHERE email IN (${firstEmail}, ${secondEmail})
+    ORDER BY email
+  `
+  expect(memberRows).toEqual([
+    { email: firstEmail, instance_id: firstRows[0]!.instance_id },
+    { email: secondEmail, instance_id: firstRows[0]!.instance_id },
+  ])
+})


### PR DESCRIPTION
## Summary
- persist default instance membership and first-user/successive-user roles during direct Better Auth signups
- skip direct provisioning for invitation signup callbacks so invite acceptance still owns membership assignment
- backfill legacy direct-signup users with null instance_id before loading the People page, excluding pending invite accounts
- add unit and E2E regression coverage for direct signup membership visibility

## Validation
- node --experimental-strip-types --test apps/web/lib/auth/signup-provisioning.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (warnings only: pre-existing unused/incompatible-library warnings outside this change)
- pnpm --filter web test:e2e:no-email-verification (blocked: Testcontainers could not find a working container runtime strategy)
