### PR TITLE
fix(auth): hold direct signups for role assignment

### DIFF
--- a/apps/web/app/(dashboard)/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/team/team-client.tsx
@@ -35,10 +35,12 @@ function roleBadgeVariant(role: string): 'destructive' | 'default' | 'secondary'
 
 function roleBadgeClassName(role: string): string {
   if (role === 'pending') return 'border-yellow-600 text-yellow-700 dark:border-yellow-500 dark:text-yellow-400'
+  if (role === 'no_role') return 'border-yellow-600 text-yellow-700 dark:border-yellow-500 dark:text-yellow-400'
   return ''
 }
 
 function formatRole(role: string) {
+  if (role === 'no_role') return 'No Role assigned'
   return role.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
@@ -60,6 +62,7 @@ const canManage = (role: string) => role === 'super_admin' || role === 'org_admi
 
 function getDisplayedRoles(entity: Pick<User | Invitation, 'role' | 'roles'>): string[] {
   const roles = normalizeAssignedRoles(entity.roles, entity.role)
+  if (roles.length === 0 && entity.role === 'pending') return ['no_role']
   return roles.length > 0 ? roles : [entity.role]
 }
 
@@ -493,7 +496,7 @@ function RoleBadgeList({ roles }: { roles: string[] }) {
     <div className="flex flex-wrap gap-1.5">
       {roles.map((role) => (
         <Badge key={role} variant={roleBadgeVariant(role)} className={roleBadgeClassName(role)}>
-          {role === 'pending' ? 'Pending Approval' : formatRole(role)}
+          {formatRole(role)}
         </Badge>
       ))}
     </div>

--- a/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
+++ b/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
@@ -19,13 +19,12 @@ export function PendingApprovalCard() {
       <CardHeader>
         <CardTitle data-testid="pending-approval-heading">Account pending approval</CardTitle>
         <CardDescription>
-          Your account has been created but needs to be approved by an administrator.
-          You&apos;ll be able to access the dashboard once a role has been assigned to you.
+          Waiting for a role to be assigned.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <p className="text-sm text-muted-foreground">
-          If you believe this is an error, please contact your system administrator.
+          Your account has been created. You&apos;ll be able to access CT-Ops once a Super Admin assigns a role.
         </p>
       </CardContent>
       <CardFooter>

--- a/apps/web/lib/auth/signup-provisioning.test.mjs
+++ b/apps/web/lib/auth/signup-provisioning.test.mjs
@@ -17,13 +17,13 @@ test('direct signup provisioning assigns the first user as super admin', () => {
   )
 })
 
-test('direct signup provisioning assigns later users to the default instance as engineers', () => {
+test('direct signup provisioning holds later users without a role until approval', () => {
   assert.deepEqual(
     getDirectSignupProvisioning({ defaultInstanceId: 'instance-1', activeUserCount: 2 }),
     {
       instanceId: 'instance-1',
-      role: 'engineer',
-      roles: ['engineer'],
+      role: 'pending',
+      roles: [],
     },
   )
 })

--- a/apps/web/lib/auth/signup-provisioning.ts
+++ b/apps/web/lib/auth/signup-provisioning.ts
@@ -1,12 +1,12 @@
-import type { AssignedRole } from './roles.ts'
+import type { AssignedRole, LegacyRole } from './roles.ts'
 
 const INVITE_ACCEPT_PATH = '/accept-invite'
-const DIRECT_SIGNUP_ROLE: AssignedRole = 'engineer'
+const DIRECT_SIGNUP_ROLE: LegacyRole = 'pending'
 const FIRST_USER_ROLE: AssignedRole = 'super_admin'
 
 export type DirectSignupProvisioning = {
   instanceId?: string
-  role: AssignedRole
+  role: LegacyRole
   roles: AssignedRole[]
 }
 
@@ -28,7 +28,7 @@ export function getDirectSignupProvisioning(input: {
   const role = input.activeUserCount === 0 ? FIRST_USER_ROLE : DIRECT_SIGNUP_ROLE
   const provisioning: DirectSignupProvisioning = {
     role,
-    roles: [role],
+    roles: role === 'pending' ? [] : [role],
   }
 
   if (input.defaultInstanceId) {

--- a/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
+++ b/apps/web/tests/e2e/auth/authenticated-redirects.spec.ts
@@ -29,7 +29,7 @@ test('pending users are redirected to approval and can sign out', async ({ authe
     await page.waitForURL('**/pending-approval')
     await expect(page.getByTestId('pending-approval-card')).toBeVisible()
     await expect(page.getByTestId('pending-approval-heading')).toContainText('Account pending approval')
-    await expect(page.getByText('needs to be approved by an administrator.')).toBeVisible()
+    await expect(page.getByText('Waiting for a role to be assigned.')).toBeVisible()
 
     await page.getByTestId('pending-approval-signout').click()
     await page.waitForURL('**/login')

--- a/apps/web/tests/e2e/auth/register.spec.ts
+++ b/apps/web/tests/e2e/auth/register.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures/test'
 import { countVerificationEmails, waitForVerificationUrl } from '../fixtures/email'
 import { getTestDb } from '../fixtures/db'
+import { TEST_USER } from '../fixtures/seed'
 
 const requireEmailVerification = process.env.REQUIRE_EMAIL_VERIFICATION !== 'false'
 
@@ -90,56 +91,48 @@ test('email sign-up can continue without verification when disabled', async ({ p
   await page.waitForURL('**/dashboard')
 })
 
-test('direct sign-ups join the instance people list when verification is disabled', async ({ page }) => {
+test('direct sign-ups wait for role assignment and appear in the people list', async ({ page }) => {
   test.skip(requireEmailVerification, 'email verification is required for this run')
 
   const suffix = Date.now()
-  const firstEmail = `direct-member-one-${suffix}@example.com`
-  const secondEmail = `direct-member-two-${suffix}@example.com`
+  const directEmail = `direct-member-${suffix}@example.com`
   const password = 'TestPassword123!'
   const sql = getTestDb()
 
   await page.goto('/register')
-  await page.getByLabel('Full name').fill('Direct Member One')
-  await page.getByLabel('Email').fill(firstEmail)
+  await page.getByLabel('Full name').fill('Direct Member')
+  await page.getByLabel('Email').fill(directEmail)
   await page.getByLabel(/^Password$/).fill(password)
   await page.getByLabel(/^Confirm password$/).fill(password)
   await page.getByRole('button', { name: 'Create account' }).click()
-  await page.waitForURL('**/dashboard')
+  await page.waitForURL('**/pending-approval')
+  await expect(page.getByTestId('pending-approval-card')).toBeVisible()
+  await expect(page.getByText('Waiting for a role to be assigned.')).toBeVisible()
 
-  const firstRows = await sql<Array<{ id: string; instance_id: string | null }>>`
-    SELECT id, instance_id
+  const directRows = await sql<Array<{ id: string; instance_id: string | null; role: string; roles: string[] }>>`
+    SELECT id, instance_id, role, roles
     FROM "user"
-    WHERE email = ${firstEmail}
+    WHERE email = ${directEmail}
     LIMIT 1
   `
-  expect(firstRows).toHaveLength(1)
-  expect(firstRows[0]?.instance_id).toBeTruthy()
+  expect(directRows).toHaveLength(1)
+  expect(directRows[0]?.instance_id).toBeTruthy()
+  expect(directRows[0]?.role).toBe('pending')
+  expect(directRows[0]?.roles).toEqual([])
 
-  await sql`DELETE FROM "session" WHERE user_id = ${firstRows[0]!.id}`
+  await sql`DELETE FROM "session" WHERE user_id = ${directRows[0]!.id}`
   await page.context().clearCookies()
 
-  await page.goto('/register')
-  await page.getByLabel('Full name').fill('Direct Member Two')
-  await page.getByLabel('Email').fill(secondEmail)
-  await page.getByLabel(/^Password$/).fill(password)
-  await page.getByLabel(/^Confirm password$/).fill(password)
-  await page.getByRole('button', { name: 'Create account' }).click()
+  await page.goto('/login')
+  await page.getByTestId('login-email').fill(TEST_USER.email)
+  await page.getByTestId('login-password').fill(TEST_USER.password)
+  await page.getByTestId('login-submit').click()
   await page.waitForURL('**/dashboard')
 
   await page.goto('/team')
+  await expect(page.getByTestId('team-invite-open')).toBeVisible()
   const memberRowsLocator = page.locator('[data-testid^="team-member-row-"]')
-  await expect(memberRowsLocator.filter({ hasText: 'Direct Member One' })).toBeVisible()
-  await expect(memberRowsLocator.filter({ hasText: 'Direct Member Two' })).toBeVisible()
-
-  const memberRows = await sql<Array<{ email: string; instance_id: string | null }>>`
-    SELECT email, instance_id
-    FROM "user"
-    WHERE email IN (${firstEmail}, ${secondEmail})
-    ORDER BY email
-  `
-  expect(memberRows).toEqual([
-    { email: firstEmail, instance_id: firstRows[0]!.instance_id },
-    { email: secondEmail, instance_id: firstRows[0]!.instance_id },
-  ])
+  const directMemberRow = memberRowsLocator.filter({ hasText: 'Direct Member' })
+  await expect(directMemberRow).toBeVisible()
+  await expect(directMemberRow).toContainText('No Role assigned')
 })


### PR DESCRIPTION
## Summary
- hold non-invited direct signups in the pending approval state with no assigned roles
- show pending direct signup users as "No Role assigned" in People
- update pending approval copy and e2e coverage for the role-assignment wait state

## Validation
- node --experimental-strip-types --test apps/web/lib/auth/signup-provisioning.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (warnings only, pre-existing)
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-test-secret-00000000000000000000000000000000 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/ctops pnpm --filter web build

## Not run
- pnpm --filter web test:e2e:no-email-verification: local environment has no working container runtime for the test database
- pnpm --filter web test:unit: one existing Testcontainers-backed nonce-store test fails locally for the same missing container runtime; 307/308 tests passed