### PR TITLE
fix(auth): create configured standalone instance scope

### DIFF
--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -21,6 +21,10 @@ const sessionSource = readFileSync(
   path.join(repoRoot, 'lib/auth/session.ts'),
   'utf8',
 )
+const defaultInstanceSource = readFileSync(
+  path.join(repoRoot, 'lib/default-instance.ts'),
+  'utf8',
+)
 const usersActionSource = readFileSync(
   path.join(repoRoot, 'lib/actions/users.ts'),
   'utf8',
@@ -136,6 +140,13 @@ test('fresh standalone sessions promote the first active user to instance admin'
   assert.match(sessionSource, /ensureInstanceHasSuperAdmin\(user\)/)
   assert.match(sessionSource, /activeUsers\[0\]\?\.id !== user\.id/)
   assert.match(sessionSource, /set\(\{ role: INSTANCE_ADMIN_ROLE, roles, updatedAt: new Date\(\) \}\)/)
+})
+
+test('configured standalone installs create a default instance scope', () => {
+  assert.match(defaultInstanceSource, /process\.env\['CT_OPS_INSTANCE_ID'\]/)
+  assert.match(defaultInstanceSource, /\.insert\(instanceSettings\)/)
+  assert.match(defaultInstanceSource, /onConflictDoNothing\(\)/)
+  assert.match(sessionSource, /user\.instanceId \?\? await getDefaultInstanceId\(\)/)
 })
 
 test('team invitations are disabled without an instance-backed scope', () => {

--- a/apps/web/lib/default-instance.ts
+++ b/apps/web/lib/default-instance.ts
@@ -1,9 +1,44 @@
 import 'server-only'
 
-import { asc } from 'drizzle-orm'
+import { asc, eq } from 'drizzle-orm'
 
 import { db } from '@/lib/db'
 import { instanceSettings } from '@/lib/db/schema'
+
+function getConfiguredInstanceId(): string | null {
+  const id = process.env['CT_OPS_INSTANCE_ID']?.trim()
+  return id || null
+}
+
+function toInstanceSlug(id: string): string {
+  const slug = id
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return slug || 'ct-ops'
+}
+
+async function ensureConfiguredDefaultInstance(): Promise<string | null> {
+  const id = getConfiguredInstanceId()
+  if (!id) return null
+
+  await db
+    .insert(instanceSettings)
+    .values({
+      id,
+      name: 'CT-Ops',
+      slug: toInstanceSlug(id),
+    })
+    .onConflictDoNothing()
+
+  const settings = await db.query.instanceSettings.findFirst({
+    columns: { id: true },
+    where: eq(instanceSettings.id, id),
+  })
+
+  return settings?.id ?? null
+}
 
 export async function getDefaultInstanceId(): Promise<string | null> {
   const settings = await db.query.instanceSettings.findFirst({
@@ -11,5 +46,5 @@ export async function getDefaultInstanceId(): Promise<string | null> {
     orderBy: [asc(instanceSettings.createdAt), asc(instanceSettings.id)],
   })
 
-  return settings?.id ?? null
+  return settings?.id ?? await ensureConfiguredDefaultInstance()
 }


### PR DESCRIPTION
## Summary
- create the configured CT_OPS_INSTANCE_ID instance_settings row when no default instance exists
- preserve existing default instance behavior when an instance row already exists
- cover the standalone bootstrap path so People can claim direct signups into a real scope

## Diagnosis
On the test VM, both Simon and Theo existed with NULL instance_id and instance_settings was empty. With no instance scope, People returned only the current session user, so Theo could never appear.

## Validation
- node --test apps/web/lib/actions/dashboard-standalone.test.mjs
- node --experimental-strip-types --test apps/web/lib/auth/signup-provisioning.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-test-secret-00000000000000000000000000000000 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/ctops pnpm --filter web build