### PR TITLE
fix(web): refresh people list after invite conflicts

### DIFF
--- a/apps/web/app/(dashboard)/team/team-client.tsx
+++ b/apps/web/app/(dashboard)/team/team-client.tsx
@@ -82,6 +82,9 @@ export function TeamClient({
     queryKey: ['org-users'],
     queryFn: () => getOrgUsers(),
     initialData: { members: initialMembers, pendingInvites: initialPendingInvites },
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: 'always',
+    refetchInterval: 15_000,
   })
 
   const members = data?.members ?? []
@@ -114,13 +117,12 @@ export function TeamClient({
       }
       if ('restored' in result) {
         closeInviteDialog()
-        invalidate()
         return
       }
       setInviteLink(result.inviteLink)
-      invalidate()
     },
     onError: () => setInviteError('An unexpected error occurred'),
+    onSettled: invalidate,
   })
 
   const updateRoleMutation = useMutation({

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -169,6 +169,13 @@ test('people administration claims unscoped direct signups as pending members', 
   assert.match(usersActionSource, /await claimDirectSignupUsers\(currentScope\)/)
 })
 
+test('people administration keeps the member list fresh after invite conflicts', () => {
+  assert.match(teamClientSource, /refetchOnMount: 'always'/)
+  assert.match(teamClientSource, /refetchOnWindowFocus: 'always'/)
+  assert.match(teamClientSource, /refetchInterval: 15_000/)
+  assert.match(teamClientSource, /onSettled: invalidate/)
+})
+
 test('role assignment can claim pending users that signed up outside the instance scope', () => {
   assert.match(usersActionSource, /const targetUserWhere = or\(/)
   assert.match(usersActionSource, /and\(eq\(users\.id, targetUserId\), isNull\(users\.instanceId\), eq\(users\.role, 'pending'\), isNull\(users\.deletedAt\)\)/)


### PR DESCRIPTION
## Summary
- refetch the People list whenever the administration screen mounts, regains focus, or stays open
- invalidate the People list after invite attempts even when the server returns an already-member conflict
- add regression coverage for the stale People list behavior

## Validation
- node --experimental-strip-types --test lib/actions/dashboard-standalone.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint