### PR TITLE
fix(auth): prevent cached session data after account changes

### DIFF
--- a/apps/web/app/(auth)/login/login-form.tsx
+++ b/apps/web/app/(auth)/login/login-form.tsx
@@ -4,7 +4,6 @@ import { useState, type FormEvent } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -17,6 +16,7 @@ import {
   getInviteRegisterPath,
 } from '@/lib/auth/invite-redirects'
 import type { LdapLoginOption } from '@/lib/auth/ldap-login-options'
+import { navigateWithFreshDocument } from '@/lib/auth/fresh-navigation'
 
 const localLoginSchema = z.object({
   email: z.string().email('Enter a valid email address'),
@@ -59,7 +59,6 @@ function cleanTwoFactorCode(code: string, method: LocalTwoFactorMethod): string 
 }
 
 export function LoginForm({ ldapLoginOptions = [], inviteToken = null, notice = null }: LoginFormProps) {
-  const router = useRouter()
   const inviteAcceptPath = getInviteAcceptPath(inviteToken)
   const ldapLoginEnabled = ldapLoginOptions.length > 0
   const defaultLdapLoginOption = ldapLoginOptions[0] ?? null
@@ -118,7 +117,7 @@ export function LoginForm({ ldapLoginOptions = [], inviteToken = null, notice = 
       return
     }
 
-    router.push(inviteAcceptPath ?? '/dashboard')
+    navigateWithFreshDocument(inviteAcceptPath ?? '/dashboard', 'replace')
   }
 
   async function onLocalTwoFactorSubmit(event: FormEvent<HTMLFormElement>) {
@@ -138,7 +137,7 @@ export function LoginForm({ ldapLoginOptions = [], inviteToken = null, notice = 
         return
       }
 
-      router.push(inviteAcceptPath ?? '/dashboard')
+      navigateWithFreshDocument(inviteAcceptPath ?? '/dashboard', 'replace')
     } catch {
       setServerError('An unexpected error occurred.')
     } finally {
@@ -180,7 +179,7 @@ export function LoginForm({ ldapLoginOptions = [], inviteToken = null, notice = 
         return
       }
 
-      router.push('/dashboard')
+      navigateWithFreshDocument('/dashboard', 'replace')
     } catch {
       setServerError('An unexpected error occurred.')
     }
@@ -207,7 +206,7 @@ export function LoginForm({ ldapLoginOptions = [], inviteToken = null, notice = 
         return
       }
 
-      router.push('/dashboard')
+      navigateWithFreshDocument('/dashboard', 'replace')
     } catch {
       setServerError('An unexpected error occurred.')
     }

--- a/apps/web/app/(auth)/register/register-form.tsx
+++ b/apps/web/app/(auth)/register/register-form.tsx
@@ -21,6 +21,7 @@ import {
 import { signIn, signUp } from '@/lib/auth/client'
 import { getInviteByToken } from '@/lib/actions/auth'
 import { getInviteAcceptPath, getInviteLoginPath } from '@/lib/auth/invite-redirects'
+import { navigateWithFreshDocument } from '@/lib/auth/fresh-navigation'
 
 const registerSchema = z
   .object({
@@ -100,7 +101,7 @@ export function RegisterForm({ requireEmailVerification }: RegisterFormProps) {
       return
     }
 
-    router.push(callbackURL)
+    navigateWithFreshDocument(callbackURL, 'replace')
   }
 
   return (

--- a/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
+++ b/apps/web/app/(setup)/pending-approval/pending-approval-card.tsx
@@ -1,17 +1,14 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { signOut } from '@/lib/auth/client'
+import { navigateWithFreshDocument } from '@/lib/auth/fresh-navigation'
 
 export function PendingApprovalCard() {
-  const router = useRouter()
-
   async function handleSignOut() {
     await signOut()
-    router.push('/login')
-    router.refresh()
+    navigateWithFreshDocument('/login', 'replace')
   }
 
   return (

--- a/apps/web/app/(setup)/seat-limit-exceeded/seat-limit-exceeded-card.tsx
+++ b/apps/web/app/(setup)/seat-limit-exceeded/seat-limit-exceeded-card.tsx
@@ -1,17 +1,14 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { signOut } from '@/lib/auth/client'
+import { navigateWithFreshDocument } from '@/lib/auth/fresh-navigation'
 
 export function SeatLimitExceededCard() {
-  const router = useRouter()
-
   async function handleSignOut() {
     await signOut()
-    router.push('/login')
-    router.refresh()
+    navigateWithFreshDocument('/login', 'replace')
   }
 
   return (

--- a/apps/web/components/shared/topbar.tsx
+++ b/apps/web/components/shared/topbar.tsx
@@ -2,6 +2,7 @@
 
 import { signOut, useSession } from '@/lib/auth/client'
 import { useRouter } from 'next/navigation'
+import { navigateWithFreshDocument } from '@/lib/auth/fresh-navigation'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import {
@@ -31,7 +32,7 @@ export function Topbar() {
   const router = useRouter()
 
   async function handleSignOut() {
-    await signOut({ fetchOptions: { onSuccess: () => router.push('/login') } })
+    await signOut({ fetchOptions: { onSuccess: () => navigateWithFreshDocument('/login', 'replace') } })
   }
 
   const userName = session?.user?.name ?? 'User'

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -37,6 +37,30 @@ const teamClientSource = readFileSync(
   path.join(repoRoot, 'app/(dashboard)/team/team-client.tsx'),
   'utf8',
 )
+const loginFormSource = readFileSync(
+  path.join(repoRoot, 'app/(auth)/login/login-form.tsx'),
+  'utf8',
+)
+const registerFormSource = readFileSync(
+  path.join(repoRoot, 'app/(auth)/register/register-form.tsx'),
+  'utf8',
+)
+const topbarSource = readFileSync(
+  path.join(repoRoot, 'components/shared/topbar.tsx'),
+  'utf8',
+)
+const pendingApprovalCardSource = readFileSync(
+  path.join(repoRoot, 'app/(setup)/pending-approval/pending-approval-card.tsx'),
+  'utf8',
+)
+const seatLimitCardSource = readFileSync(
+  path.join(repoRoot, 'app/(setup)/seat-limit-exceeded/seat-limit-exceeded-card.tsx'),
+  'utf8',
+)
+const proxySource = readFileSync(
+  path.join(repoRoot, 'proxy.ts'),
+  'utf8',
+)
 
 const sidebarLinkedPages = [
   'app/(dashboard)/alerts/page.tsx',
@@ -174,6 +198,24 @@ test('people administration keeps the member list fresh after invite conflicts',
   assert.match(teamClientSource, /refetchOnWindowFocus: 'always'/)
   assert.match(teamClientSource, /refetchInterval: 15_000/)
   assert.match(teamClientSource, /onSettled: invalidate/)
+})
+
+test('auth transitions use fresh document navigations and no-store responses', () => {
+  for (const [name, source] of [
+    ['login form', loginFormSource],
+    ['register form', registerFormSource],
+    ['topbar sign out', topbarSource],
+    ['pending approval sign out', pendingApprovalCardSource],
+    ['seat-limit sign out', seatLimitCardSource],
+  ]) {
+    assert.match(source, /navigateWithFreshDocument/, `${name} should avoid cached App Router transitions`)
+    assert.doesNotMatch(source, /router\.push\((inviteAcceptPath \?\? )?'\/dashboard'\)/, `${name} should not soft-navigate after auth changes`)
+    assert.doesNotMatch(source, /router\.push\('\/login'\)/, `${name} should not soft-navigate after sign-out`)
+  }
+
+  assert.match(proxySource, /NO_STORE_CACHE_CONTROL/)
+  assert.match(proxySource, /applyNoStoreHeaders\(response\)/)
+  assert.match(proxySource, /isSessionScopedRoute/)
 })
 
 test('role assignment can claim pending users that signed up outside the instance scope', () => {

--- a/apps/web/lib/auth/fresh-navigation.ts
+++ b/apps/web/lib/auth/fresh-navigation.ts
@@ -1,0 +1,10 @@
+'use client'
+
+export function navigateWithFreshDocument(path: string, mode: 'assign' | 'replace' = 'assign'): void {
+  if (mode === 'replace') {
+    window.location.replace(path)
+    return
+  }
+
+  window.location.assign(path)
+}

--- a/apps/web/lib/auth/redirects.test.mjs
+++ b/apps/web/lib/auth/redirects.test.mjs
@@ -11,21 +11,31 @@ test('authenticated redirect only accepts active non-deleted users', () => {
   assert.equal(getAuthenticatedRedirectPath({
     isActive: true,
     deletedAt: null,
+    role: 'super_admin',
   }), '/dashboard')
 
   assert.equal(getAuthenticatedRedirectPath({
     isActive: true,
     deletedAt: null,
+    role: 'engineer',
   }), '/dashboard')
+
+  assert.equal(getAuthenticatedRedirectPath({
+    isActive: true,
+    deletedAt: null,
+    role: 'pending',
+  }), '/pending-approval')
 
   assert.equal(getAuthenticatedRedirectPath({
     isActive: false,
     deletedAt: null,
+    role: 'pending',
   }), null)
 
   assert.equal(getAuthenticatedRedirectPath({
     isActive: true,
     deletedAt: new Date('2026-04-30T12:00:00.000Z'),
+    role: 'super_admin',
   }), null)
 })
 

--- a/apps/web/lib/auth/redirects.ts
+++ b/apps/web/lib/auth/redirects.ts
@@ -1,6 +1,6 @@
 import type { User } from '@/lib/db/schema'
 
-type RedirectUser = Pick<User, 'isActive' | 'deletedAt'>
+type RedirectUser = Pick<User, 'isActive' | 'deletedAt' | 'role'>
 
 export const EXPIRED_SESSION_LOGIN_PATH = '/login?session=expired'
 
@@ -10,9 +10,13 @@ export function shouldBypassAuthenticatedRedirect(searchParams: Record<string, s
   return session === 'expired'
 }
 
-export function getAuthenticatedRedirectPath(user: RedirectUser | null | undefined): '/dashboard' | null {
+export function getAuthenticatedRedirectPath(user: RedirectUser | null | undefined): '/dashboard' | '/pending-approval' | null {
   if (!user?.isActive || user.deletedAt) {
     return null
+  }
+
+  if (user.role === 'pending') {
+    return '/pending-approval'
   }
 
   return '/dashboard'

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -4,6 +4,8 @@ import { getClientIpFromHeaders } from '@/lib/client-ip'
 import { buildContentSecurityPolicy } from '@/lib/security/csp'
 
 const AUTH_ROUTES = ['/login', '/register']
+const SETUP_ROUTES = ['/pending-approval', '/seat-limit-exceeded', '/setup-email', '/check-email']
+const NO_STORE_CACHE_CONTROL = 'no-store, no-cache, must-revalidate, proxy-revalidate'
 
 const PROTECTED_PATHS = [
   '/dashboard',
@@ -44,14 +46,29 @@ function checkAuthRateLimit(ip: string, now = Date.now()): boolean {
   return true
 }
 
+function applyCommonSecurityHeaders(response: NextResponse, requestId: string, csp: string): NextResponse {
+  response.headers.set('X-Request-Id', requestId)
+  response.headers.set('Content-Security-Policy', csp)
+  return response
+}
+
+function applyNoStoreHeaders(response: NextResponse): NextResponse {
+  response.headers.set('Cache-Control', NO_STORE_CACHE_CONTROL)
+  response.headers.set('Pragma', 'no-cache')
+  response.headers.set('Expires', '0')
+  return response
+}
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const isAuthenticated = hasBetterAuthSessionCookie(request.cookies)
 
   const isAuthRoute = AUTH_ROUTES.some((r) => pathname.startsWith(r))
+  const isSetupRoute = SETUP_ROUTES.some((r) => pathname === r || pathname.startsWith(r + '/'))
   const isProtectedRoute = PROTECTED_PATHS.some(
     (r) => pathname === r || pathname.startsWith(r + '/'),
   )
+  const isSessionScopedRoute = isAuthRoute || isSetupRoute || isProtectedRoute || pathname.startsWith('/api/auth/')
 
   // Honour an upstream-supplied request ID (load balancer, proxy) or generate one.
   const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID()
@@ -75,25 +92,23 @@ export function proxy(request: NextRequest) {
         { error: 'Too many requests — please wait before trying again.' },
         { status: 429 },
       )
-      limitResponse.headers.set('X-Request-Id', requestId)
-      limitResponse.headers.set('Content-Security-Policy', csp)
-      return limitResponse
+      applyCommonSecurityHeaders(limitResponse, requestId, csp)
+      return applyNoStoreHeaders(limitResponse)
     }
   }
 
   if (!isAuthenticated && isProtectedRoute) {
     const redirectResponse = NextResponse.redirect(new URL('/login', request.url))
-    redirectResponse.headers.set('X-Request-Id', requestId)
-    redirectResponse.headers.set('Content-Security-Policy', csp)
-    return redirectResponse
+    applyCommonSecurityHeaders(redirectResponse, requestId, csp)
+    return applyNoStoreHeaders(redirectResponse)
   }
-
-  void isAuthRoute
 
   const response = NextResponse.next({ request: { headers: requestHeaders } })
   // Echo the ID back to the client so it appears in browser DevTools / client logs.
-  response.headers.set('X-Request-Id', requestId)
-  response.headers.set('Content-Security-Policy', csp)
+  applyCommonSecurityHeaders(response, requestId, csp)
+  if (isSessionScopedRoute) {
+    applyNoStoreHeaders(response)
+  }
   return response
 }
 


### PR DESCRIPTION
## Summary
- use full document navigation after sign-in, sign-up, two-factor completion, and sign-out so App Router state from a previous user cannot be reused
- route pending users directly to the pending approval page from auth pages
- add no-store headers to session-scoped routes and auth responses
- add regression coverage for pending redirects and auth cache boundaries

## Validation
- node --experimental-strip-types --test lib/auth/redirects.test.mjs lib/actions/dashboard-standalone.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint