### PR TITLE
feat(web): surface instance name context

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -19,6 +19,10 @@ interface OverviewData {
   alerts: { firing: number; acknowledged: number }
 }
 
+interface DashboardClientProps {
+  instanceName: string
+}
+
 function StatRow({
   label,
   value,
@@ -43,7 +47,7 @@ function StatRow({
   )
 }
 
-export function DashboardClient() {
+export function DashboardClient({ instanceName }: DashboardClientProps) {
   const { data, isLoading, error } = useQuery<OverviewData>({
     queryKey: ['overview'],
     queryFn: () => fetch('/api/overview').then((r) => r.json()),
@@ -76,8 +80,8 @@ export function DashboardClient() {
     <div className="space-y-6 max-w-3xl">
       <div>
         <h1 className="text-2xl font-semibold text-foreground" data-testid="dashboard-heading">Overview</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Current state of your infrastructure
+        <p className="text-sm text-muted-foreground mt-1" data-testid="dashboard-instance-name">
+          {instanceName}
         </p>
       </div>
 

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,10 +1,22 @@
 import type { Metadata } from 'next'
+import { getRequiredSession } from '@/lib/auth/session'
+import { getInstanceDisplayName } from '@/lib/instance-display-name'
 import { DashboardClient } from './dashboard-client'
 
-export const metadata: Metadata = {
-  title: 'Overview',
+export async function generateMetadata(): Promise<Metadata> {
+  const session = await getRequiredSession()
+  const instanceName = await getInstanceDisplayName(session.user.instanceId)
+
+  return {
+    title: {
+      absolute: `Overview | ${instanceName}`,
+    },
+  }
 }
 
-export default function DashboardPage() {
-  return <DashboardClient />
+export default async function DashboardPage() {
+  const session = await getRequiredSession()
+  const instanceName = await getInstanceDisplayName(session.user.instanceId)
+
+  return <DashboardClient instanceName={instanceName} />
 }

--- a/apps/web/app/(dashboard)/settings/settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/settings-client.tsx
@@ -1535,6 +1535,20 @@ export function SettingsClient({
                   licence key is bound to this install and cannot be used on another.
                 </p>
               </div>
+              <div className="grid gap-2 rounded-md border bg-background p-3 text-xs sm:grid-cols-2">
+                <div>
+                  <p className="text-muted-foreground">Instance name</p>
+                  <p className="mt-1 break-words font-medium text-foreground" data-testid="licence-instance-name">
+                    {org.name}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Instance ID</p>
+                  <p className="mt-1 break-all font-mono text-foreground" data-testid="licence-instance-id">
+                    {org.id}
+                  </p>
+                </div>
+              </div>
 
               {activationToken ? (
                 <div className="space-y-2">

--- a/apps/web/lib/actions/dashboard-standalone.test.mjs
+++ b/apps/web/lib/actions/dashboard-standalone.test.mjs
@@ -13,6 +13,18 @@ const overviewRouteSource = readFileSync(
   path.join(repoRoot, 'app/api/overview/route.ts'),
   'utf8',
 )
+const dashboardPageSource = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/dashboard/page.tsx'),
+  'utf8',
+)
+const dashboardClientSource = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/dashboard/dashboard-client.tsx'),
+  'utf8',
+)
+const settingsClientSource = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/settings/settings-client.tsx'),
+  'utf8',
+)
 const licenceGuardSource = readFileSync(
   path.join(repoRoot, 'lib/actions/licence-guard.ts'),
   'utf8',
@@ -134,6 +146,20 @@ test('overview API returns empty counts for a fresh standalone instance', () => 
   assert.match(overviewRouteSource, /getApiSession\(\)/)
   assert.doesNotMatch(overviewRouteSource, /getApiInstanceSession\(\)/)
   assert.match(overviewRouteSource, /if \(!instanceId\) \{\s*return Response\.json\(emptyOverview\)\s*\}/)
+})
+
+test('dashboard overview uses the instance display name for page context', () => {
+  assert.match(dashboardPageSource, /getInstanceDisplayName\(session\.user\.instanceId\)/)
+  assert.match(dashboardPageSource, /absolute: `Overview \| \$\{instanceName\}`/)
+  assert.match(dashboardClientSource, /instanceName: string/)
+  assert.match(dashboardClientSource, /data-testid="dashboard-instance-name"/)
+})
+
+test('licence activation panel shows instance purchase context', () => {
+  assert.match(settingsClientSource, /data-testid="licence-instance-name"/)
+  assert.match(settingsClientSource, /data-testid="licence-instance-id"/)
+  assert.match(settingsClientSource, /\{org\.name\}/)
+  assert.match(settingsClientSource, /\{org\.id\}/)
 })
 
 test('sidebar-linked pages do not force an instance-backed action scope', () => {

--- a/apps/web/lib/instance-display-name.ts
+++ b/apps/web/lib/instance-display-name.ts
@@ -1,0 +1,19 @@
+import 'server-only'
+
+import { eq } from 'drizzle-orm'
+
+import { db } from '@/lib/db'
+import { instanceSettings } from '@/lib/db/schema'
+
+export const PRODUCT_DISPLAY_NAME = 'CT-Ops'
+
+export async function getInstanceDisplayName(instanceId?: string | null): Promise<string> {
+  if (!instanceId) return PRODUCT_DISPLAY_NAME
+
+  const instance = await db.query.instanceSettings.findFirst({
+    columns: { name: true },
+    where: eq(instanceSettings.id, instanceId),
+  })
+
+  return instance?.name.trim() || PRODUCT_DISPLAY_NAME
+}

--- a/apps/web/tests/e2e/dashboard/overview.spec.ts
+++ b/apps/web/tests/e2e/dashboard/overview.spec.ts
@@ -122,6 +122,8 @@ test('overview aggregates agent, certificate, and alert counts for the instance'
   await page.goto('/dashboard')
 
   await expect(page.getByTestId('dashboard-heading')).toBeVisible()
+  await expect(page).toHaveTitle(`Overview | ${TEST_ORG.name}`)
+  await expect(page.getByTestId('dashboard-instance-name')).toHaveText(TEST_ORG.name)
   await expect(page.getByTestId('dashboard-agents-total')).toContainText('2')
   await expect(page.getByTestId('dashboard-agents-online')).toContainText('1')
   await expect(page.getByTestId('dashboard-agents-offline')).toContainText('1')

--- a/apps/web/tests/e2e/settings/activation-token.spec.ts
+++ b/apps/web/tests/e2e/settings/activation-token.spec.ts
@@ -7,6 +7,7 @@ test('admin can generate an activation token from settings', async ({ authentica
   await page.goto('/settings/licence')
 
   await expect(page.getByTestId('settings-heading')).toContainText('Instance')
+  await expect(page.getByTestId('licence-instance-name')).toHaveText(TEST_ORG.name)
   await page.getByTestId('activation-token-generate').click()
 
   const activationToken = page.getByTestId('activation-token')
@@ -21,6 +22,7 @@ test('admin can generate an activation token from settings', async ({ authentica
   if (firstDecoded.ok) {
     expect(firstDecoded.payload.installOrgName).toBe(TEST_ORG.name)
     expect(firstDecoded.payload.installOrgId).toBeTruthy()
+    await expect(page.getByTestId('licence-instance-id')).toHaveText(firstDecoded.payload.installOrgId)
   }
 
   await page.getByTestId('activation-token-copy').click()


### PR DESCRIPTION
## Summary
- show the instance display name on the Overview page and set the /dashboard browser title to `Overview | <Instance Name>`
- add licence activation context showing the friendly instance name and immutable instance id
- add source-level and E2E assertions for the instance-name wiring

## Validation
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `pnpm --filter web exec node --experimental-strip-types --test lib/actions/dashboard-standalone.test.mjs`
- `BETTER_AUTH_URL=https://ct-ops.example.test DATABASE_URL=postgresql://ct-ops:ct-ops@localhost:5432/ct-ops BETTER_AUTH_SECRET=0123456789abcdef0123456789abcdef pnpm --filter web build` (passes with existing Turbopack NFT warnings)

## Not run
- `pnpm --filter web test:e2e tests/e2e/dashboard/overview.spec.ts tests/e2e/settings/activation-token.spec.ts` could not start because Testcontainers could not find a working container runtime strategy in this environment.
- full `pnpm --filter web test:unit` reaches the same container runtime failure in `lib/integrations/ct-cve/db-nonce-store.test.mjs`; the changed source-level test file passes independently.