### PR TITLE
fix(agent): align enrolment token environment

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -81,6 +81,13 @@ func mergeTags(layers ...[]string) []*agentv1.Tag {
 	return out
 }
 
+func enrolmentTokenFromEnv() string {
+	if token := strings.TrimSpace(os.Getenv("CT_OPS_ENROLMENT_TOKEN")); token != "" {
+		return token
+	}
+	return strings.TrimSpace(os.Getenv("CT_OPS_ORG_TOKEN"))
+}
+
 func main() {
 	configPath := flag.String("config", "/etc/ct-ops/agent.toml", "Path to agent TOML config file")
 	tokenFlag := flag.String("token", "", "Enrolment token (overrides config file and CT_OPS_ENROLMENT_TOKEN)")
@@ -107,7 +114,7 @@ func main() {
 	if *installFlag {
 		token := strings.TrimSpace(*tokenFlag)
 		if token == "" {
-			token = strings.TrimSpace(os.Getenv("CT_OPS_ENROLMENT_TOKEN"))
+			token = enrolmentTokenFromEnv()
 		}
 		if token == "" {
 			slog.Error("--token or CT_OPS_ENROLMENT_TOKEN is required when using --install")

--- a/agent/cmd/agent/main_test.go
+++ b/agent/cmd/agent/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestEnrolmentTokenFromEnvUsesCanonicalEnv(t *testing.T) {
+	t.Setenv("CT_OPS_ENROLMENT_TOKEN", " canonical ")
+	t.Setenv("CT_OPS_ORG_TOKEN", "legacy")
+
+	if got := enrolmentTokenFromEnv(); got != "canonical" {
+		t.Fatalf("unexpected token: %q", got)
+	}
+}
+
+func TestEnrolmentTokenFromEnvFallsBackToLegacyOrgEnv(t *testing.T) {
+	t.Setenv("CT_OPS_ORG_TOKEN", " legacy ")
+
+	if got := enrolmentTokenFromEnv(); got != "legacy" {
+		t.Fatalf("unexpected token: %q", got)
+	}
+}

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -90,6 +90,8 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("CT_OPS_ENROLMENT_TOKEN"); v != "" {
 		cfg.Agent.EnrolmentToken = v
+	} else if v := os.Getenv("CT_OPS_ORG_TOKEN"); v != "" {
+		cfg.Agent.EnrolmentToken = v
 	}
 	if v := os.Getenv("CT_OPS_DATA_DIR"); v != "" {
 		cfg.Agent.DataDir = v

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -45,3 +45,21 @@ func TestLoadReadsSecureConfig(t *testing.T) {
 		t.Fatalf("unexpected enrolment token: %q", cfg.Agent.EnrolmentToken)
 	}
 }
+
+func TestLoadReadsLegacyOrgTokenEnvFallback(t *testing.T) {
+	t.Setenv("CT_OPS_ORG_TOKEN", " legacy ")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.toml")
+	if err := os.WriteFile(path, []byte("[agent]\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Agent.EnrolmentToken != "legacy" {
+		t.Fatalf("unexpected enrolment token: %q", cfg.Agent.EnrolmentToken)
+	}
+}

--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -360,7 +360,7 @@ export function AgentsSettingsClient({
                     <CopyButton text={newTokenValue} />
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    This token will not be shown again in full. The install command passes it via <code>CT_OPS_ORG_TOKEN</code>, not in the URL.
+                    This token will not be shown again in full. The install command passes it via <code>CT_OPS_ENROLMENT_TOKEN</code>, not in the URL.
                   </p>
                 </div>
               </details>
@@ -713,7 +713,7 @@ function BundleDialog({ open, onOpenChange, activeTokens }: BundleDialogProps) {
                 <div className="flex-1">
                   <span className="text-sm font-medium">No token (operator supplies it)</span>
                   <p className="text-xs text-muted-foreground">
-                    Installer reads the token from <code>CT_OPS_ORG_TOKEN</code> at install
+                    Installer reads the token from <code>CT_OPS_ENROLMENT_TOKEN</code> at install
                     time — safest for wide distribution.
                   </p>
                 </div>

--- a/apps/web/app/api/agent/install/route.ts
+++ b/apps/web/app/api/agent/install/route.ts
@@ -13,11 +13,11 @@ const installRateLimit = createRateLimiter({
 
 /**
  * Returns a shell bootstrap script that detects OS/arch, downloads the agent
- * binary from this server, and installs it when CT_OPS_ORG_TOKEN is supplied
+ * binary from this server, and installs it when CT_OPS_ENROLMENT_TOKEN is supplied
  * in the runtime environment.
  *
  * Usage — download and install after exporting a token:
- *   export CT_OPS_ORG_TOKEN="<TOKEN>"
+ *   export CT_OPS_ENROLMENT_TOKEN="<TOKEN>"
  *   curl -fsSL "https://ct-ops.example.com/api/agent/install" | sh
  *
  * Usage — download only, then install manually:

--- a/apps/web/lib/agent/bundle.ts
+++ b/apps/web/lib/agent/bundle.ts
@@ -145,10 +145,10 @@ export async function buildInstallBundle(opts: BundleOptions): Promise<{
 function renderAgentToml(opts: BundleOptions): string {
   const skipVerify = opts.skipVerify ? 'true' : 'false'
   const tokenLine = opts.token
-    ? `org_token = "${opts.token}"`
+    ? `enrolment_token = "${opts.token}"`
     : `# Paste the enrolment token from the CT-Ops UI (Administration → Agents → Enrolment).
-# Can also be set via the CT_OPS_ORG_TOKEN environment variable.
-org_token = ""`
+# Can also be set via the CT_OPS_ENROLMENT_TOKEN environment variable.
+enrolment_token = ""`
 
   return `# CT-Ops Agent Configuration
 # Generated install bundle — edit values as needed before running install.
@@ -182,11 +182,11 @@ ${renderTagTomlLine(opts.tags)}
 
 function renderUnixInstallScript(opts: BundleOptions): string {
   const tlsFlag = opts.skipVerify ? ' --tls-skip-verify' : ''
-  const tokenArg = opts.token ? `"${opts.token}"` : '"$CT_OPS_ORG_TOKEN"'
+  const tokenArg = opts.token ? `"${opts.token}"` : '"$CT_OPS_ENROLMENT_TOKEN"'
   const tokenGuard = opts.token
     ? ''
-    : `if [ -z "\${CT_OPS_ORG_TOKEN:-}" ]; then
-  echo "Set CT_OPS_ORG_TOKEN before running this script, or pass --token to the agent manually." >&2
+    : `if [ -z "\${CT_OPS_ENROLMENT_TOKEN:-}" ]; then
+  echo "Set CT_OPS_ENROLMENT_TOKEN before running this script, or pass --token to the agent manually." >&2
   exit 1
 fi
 `
@@ -235,11 +235,11 @@ function renderWindowsInstallScript(opts: BundleOptions): string {
   const tlsFlag = opts.skipVerify ? ' --tls-skip-verify' : ''
   const tokenExpr = opts.token
     ? `"${opts.token}"`
-    : '$env:CT_OPS_ORG_TOKEN'
+    : '$env:CT_OPS_ENROLMENT_TOKEN'
   const tokenGuard = opts.token
     ? ''
-    : `if (-not $env:CT_OPS_ORG_TOKEN) {
-  Write-Error "Set the CT_OPS_ORG_TOKEN environment variable before running this script."
+    : `if (-not $env:CT_OPS_ENROLMENT_TOKEN) {
+  Write-Error "Set the CT_OPS_ENROLMENT_TOKEN environment variable before running this script."
   exit 1
 }
 `
@@ -296,8 +296,8 @@ ${
 }`
     : `This bundle does **not** contain an enrolment token. Before running the install script:
 
-- **Linux / macOS:** \`export CT_OPS_ORG_TOKEN=<token-from-ui>\`
-- **Windows (PowerShell):** \`$env:CT_OPS_ORG_TOKEN = "<token-from-ui>"\`
+- **Linux / macOS:** \`export CT_OPS_ENROLMENT_TOKEN=<token-from-ui>\`
+- **Windows (PowerShell):** \`$env:CT_OPS_ENROLMENT_TOKEN = "<token-from-ui>"\`
 
 Create a token in the CT-Ops UI under **Administration → Agents → Enrolment**.`
 

--- a/apps/web/lib/agent/install-script.test.mjs
+++ b/apps/web/lib/agent/install-script.test.mjs
@@ -21,6 +21,7 @@ test('buildAgentInstallCommand downloads the script without embedding secrets in
   assert.equal(command, 'curl -fsSLk "https://ct-ops.example.com/api/agent/install?skip_verify=true" | sh')
   assert.equal(command.includes('token='), false)
   assert.equal(command.includes('CT_OPS_ORG_TOKEN='), false)
+  assert.equal(command.includes('CT_OPS_ENROLMENT_TOKEN='), false)
 })
 
 test('buildAgentInstallCommand can pass a newly-created token outside the URL', () => {
@@ -28,24 +29,27 @@ test('buildAgentInstallCommand can pass a newly-created token outside the URL', 
 
   assert.equal(
     command,
-    'curl -fsSL "https://ct-ops.example.com/api/agent/install" | env CT_OPS_ORG_TOKEN=\'ctops_test_token\' sh',
+    'curl -fsSL "https://ct-ops.example.com/api/agent/install" | env CT_OPS_ENROLMENT_TOKEN=\'ctops_test_token\' sh',
   )
   assert.equal(command.includes('token='), false)
-  assert.match(command, /CT_OPS_ORG_TOKEN='ctops_test_token'/)
+  assert.match(command, /CT_OPS_ENROLMENT_TOKEN='ctops_test_token'/)
+  assert.equal(command.includes('CT_OPS_ORG_TOKEN='), false)
 })
 
 test('buildAgentInstallCommand shell-quotes tokens', () => {
   const command = buildAgentInstallCommand('https://ct-ops.example.com', false, "token'with-quote")
 
-  assert.match(command, /CT_OPS_ORG_TOKEN='token'\\''with-quote'/)
+  assert.match(command, /CT_OPS_ENROLMENT_TOKEN='token'\\''with-quote'/)
   assert.equal(command.includes('token='), false)
 })
 
-test('buildAgentInstallScript only consumes CT_OPS_ORG_TOKEN from the runtime environment', () => {
+test('buildAgentInstallScript consumes CT_OPS_ENROLMENT_TOKEN from the runtime environment', () => {
   const script = buildAgentInstallScript('https://ct-ops.example.com', 'ct-ops.example.com:9443', false)
 
-  assert.match(script, /if \[ -n "\$\{CT_OPS_ORG_TOKEN:-\}" \]; then/)
-  assert.match(script, /sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" \.\/ct-ops-agent --install --address 'ct-ops\.example\.com:9443'/)
+  assert.match(script, /if \[ -n "\$\{CT_OPS_ENROLMENT_TOKEN:-\}" \]; then/)
+  assert.match(script, /sudo env CT_OPS_ENROLMENT_TOKEN="\$CT_OPS_ENROLMENT_TOKEN" \.\/ct-ops-agent --install --address 'ct-ops\.example\.com:9443'/)
+  assert.match(script, /elif \[ -n "\$\{CT_OPS_ORG_TOKEN:-\}" \]; then/)
+  assert.match(script, /sudo env CT_OPS_ENROLMENT_TOKEN="\$CT_OPS_ORG_TOKEN" \.\/ct-ops-agent --install --address 'ct-ops\.example\.com:9443'/)
   assert.equal(script.includes('token='), false)
 })
 

--- a/apps/web/lib/agent/install-script.ts
+++ b/apps/web/lib/agent/install-script.ts
@@ -90,7 +90,7 @@ export function buildAgentInstallCommand(
   token?: string,
 ): string {
   const curlFlags = skipVerify ? '-fsSLk' : '-fsSL'
-  const tokenPrefix = token ? `env CT_OPS_ORG_TOKEN=${shellSingleQuote(token)} ` : ''
+  const tokenPrefix = token ? `env CT_OPS_ENROLMENT_TOKEN=${shellSingleQuote(token)} ` : ''
   return `curl ${curlFlags} "${buildAgentInstallUrl(appUrl, skipVerify)}" | ${tokenPrefix}sh`
 }
 
@@ -128,13 +128,16 @@ chmod +x ct-ops-agent
 echo "Binary downloaded."
 
 # ── Install with runtime-provided token ───────────────────────────────────────
-if [ -n "\${CT_OPS_ORG_TOKEN:-}" ]; then
-  sudo env CT_OPS_ORG_TOKEN="\$CT_OPS_ORG_TOKEN" ./ct-ops-agent --install --address ${shellSingleQuote(safeIngestAddress)}${tlsFlag}
+if [ -n "\${CT_OPS_ENROLMENT_TOKEN:-}" ]; then
+  sudo env CT_OPS_ENROLMENT_TOKEN="\$CT_OPS_ENROLMENT_TOKEN" ./ct-ops-agent --install --address ${shellSingleQuote(safeIngestAddress)}${tlsFlag}
+  exit 0
+elif [ -n "\${CT_OPS_ORG_TOKEN:-}" ]; then
+  sudo env CT_OPS_ENROLMENT_TOKEN="\$CT_OPS_ORG_TOKEN" ./ct-ops-agent --install --address ${shellSingleQuote(safeIngestAddress)}${tlsFlag}
   exit 0
 fi
 
 echo ""
-echo "Export CT_OPS_ORG_TOKEN with an enrolment token, then rerun this command:"
+echo "Export CT_OPS_ENROLMENT_TOKEN with an enrolment token, then rerun this command:"
 echo "  curl ${curlFlags} \\"${serverURL}${installPath}\\" | sh"
 echo ""
 echo "You can also install manually:"

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -36,7 +36,7 @@ test('admin can create and revoke an enrolment token from agent settings', async
   await expect(installCommand).toContainText('/api/agent/install')
   await expect(installCommand).not.toContainText('token=')
   await expect(installCommand).not.toContainText('skip_verify=true')
-  await expect(installCommand).toContainText('CT_OPS_ORG_TOKEN=')
+  await expect(installCommand).toContainText('CT_OPS_ENROLMENT_TOKEN=')
 
   await page.getByText('Show raw token (for manual config)').click()
   const rawToken = (await page.getByTestId('agent-enrolment-raw-token').textContent())?.trim()


### PR DESCRIPTION
## Summary
- switch generated online install commands and UI copy to CT_OPS_ENROLMENT_TOKEN
- keep the downloaded install script and agent env loading compatible with legacy CT_OPS_ORG_TOKEN
- update offline install bundle templates to use enrolment_token / CT_OPS_ENROLMENT_TOKEN

## Validation
- node --experimental-strip-types --test lib/agent/install-script.test.mjs
- go test ./cmd/agent ./internal/config
- go test ./...

Note: pnpm --dir apps/web test:unit -- lib/agent/install-script.test.mjs expanded to the full web unit suite and unrelated tests failed because this new worktree has no node_modules; the targeted installer test was rerun directly and passed.