### PR TITLE
ci(dependabot): use root pnpm workspace updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,10 +46,10 @@ updates:
 
   # --- Node / pnpm workspaces ----------------------------------------------
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/apps/web"
-      - "/apps/docs"
+    # This is a pnpm workspace with a shared root lockfile. Let Dependabot
+    # update workspace manifests through the root entry so package.json and
+    # pnpm-lock.yaml stay in sync.
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
- remove app-scoped npm Dependabot entries for the pnpm workspace
- rely on the root workspace entry so package manifests and pnpm-lock.yaml stay in sync
- prevents duplicate app-specific PRs that fail CI with ERR_PNPM_OUTDATED_LOCKFILE

## Validation
- git diff --check