### PR TITLE
feat(password-manager): add entry field copy controls

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,24 @@
 
 ## What Has Been Built
 
+### Session 128 — Password Manager field copy controls
+
+**Entry dialog copy and masking hardening** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Added copy-to-clipboard controls to saved Password Manager entry view/edit
+  dialog fields, including title, template fields, password values, URLs, and
+  notes, while reusing the existing copy audit hook.
+- Changed saved password-style fields in entry dialogs to show a fixed
+  `************` mask while hidden, so the hidden display no longer discloses
+  the secret length. Revealing is required before editing the stored value.
+- Extended the hosted Password Manager E2E flow to cover dialog field copying,
+  fixed hidden password masking, and the additional copy-audit events.
+
+**Validation**
+- `pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'tests/e2e/tooling/password-manager.spec.ts'`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts` (blocked locally: `testcontainers` could not find a working container runtime)
+
 ### Session 127 — Password Manager vault load resilience
 
 **Unlocked vault list safety** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/crypto-batch.ts`)

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -150,6 +150,7 @@ const DEFAULT_PASSWORD_REVEAL_TIMEOUT_SECONDS = 10
 const DEFAULT_PASSWORD_CLIPBOARD_TIMEOUT_SECONDS = 20
 const MIN_PASSWORD_TIMEOUT_SECONDS = 1
 const MAX_PASSWORD_TIMEOUT_SECONDS = 300
+const PASSWORD_MANAGER_FIXED_MASK = '************'
 
 type PasswordManagerExportFormat = 'encrypted' | 'plaintext'
 type PasswordManagerEntryTemplateId = 'login' | 'card' | 'identity' | 'secure-note' | 'ssh-key-pair'
@@ -320,6 +321,10 @@ function getPasswordManagerEntryIcon(templateId: string | undefined): ReactNode 
     default:
       return <KeyRound className="size-4 text-muted-foreground" />
   }
+}
+
+function getPasswordManagerCopyActionLabel(label: string): string {
+  return label === 'URL' ? 'Copy URL' : `Copy ${label.toLowerCase()}`
 }
 
 function clampPasswordManagerTimeoutSeconds(value: unknown, fallback: number): number {
@@ -1910,8 +1915,25 @@ export function PasswordManagerClientShell({
     }
   }
 
-  async function handleCopyEntryField(entry: PasswordManagerEntrySummary, fieldId: string, fieldLabel: string) {
-    const value = entry.payload.fields?.[fieldId]
+  async function handleCopyEntryField(
+    entry: PasswordManagerEntrySummary,
+    fieldId: string,
+    fieldLabel: string,
+    valueOverride?: string,
+  ) {
+    const value =
+      valueOverride ??
+      (fieldId === 'title'
+        ? entry.payload.title
+        : fieldId === 'username'
+          ? entry.payload.username
+          : fieldId === 'password'
+            ? entry.payload.password
+            : fieldId === 'url'
+              ? entry.payload.url
+              : fieldId === 'notes'
+                ? entry.payload.notes
+                : entry.payload.fields?.[fieldId])
     if (!value) {
       setWorkspaceError(`${fieldLabel} is empty and cannot be copied.`)
       return
@@ -2817,7 +2839,12 @@ function PasswordManagerWorkspace({
   members: MemberRecord[]
   membersPending: boolean
   instanceUsers: PasswordManagerInstanceUser[]
-  onCopyEntryField: (entry: PasswordManagerEntrySummary, fieldId: string, fieldLabel: string) => Promise<void>
+  onCopyEntryField: (
+    entry: PasswordManagerEntrySummary,
+    fieldId: string,
+    fieldLabel: string,
+    valueOverride?: string,
+  ) => Promise<void>
   onCopyPassword: (entry: PasswordManagerEntrySummary) => Promise<void>
   onCreateVault: () => Promise<void>
   onCreateVaultDescriptionChange: (value: string) => void
@@ -2942,6 +2969,31 @@ function PasswordManagerWorkspace({
       ...current,
       [fieldId]: !current[fieldId],
     }))
+  }
+
+  function renderEntryDialogCopyButton(fieldId: string, fieldLabel: string, value: string) {
+    if ((!isViewingEntry && !editingEntryId) || !selectedEntry || !value) {
+      return null
+    }
+
+    const copyLabel = getPasswordManagerCopyActionLabel(fieldLabel)
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => void onCopyEntryField(selectedEntry, fieldId, fieldLabel, value)}
+            aria-label={copyLabel}
+            title={copyLabel}
+          >
+            <Copy className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{copyLabel}</TooltipContent>
+      </Tooltip>
+    )
   }
 
   function resetSshKeyGenerationControls() {
@@ -3406,7 +3458,10 @@ function PasswordManagerWorkspace({
               </DialogHeader>
               <div className="grid gap-4">
                 <div className="grid gap-2">
-                  <Label htmlFor="password-manager-entry-title">Title</Label>
+                  <div className="flex items-center justify-between gap-2">
+                    <Label htmlFor="password-manager-entry-title">Title</Label>
+                    {renderEntryDialogCopyButton('title', 'Title', entryTitle)}
+                  </div>
                   <Input
                     id="password-manager-entry-title"
                     value={entryTitle}
@@ -3567,16 +3622,11 @@ function PasswordManagerWorkspace({
                         onEntryFieldChange(field.id, nextValue)
                       }
                     }
-                    const sshCopyLabel =
-                      field.id === 'publicMaterial'
-                        ? 'Copy public key or certificate'
-                        : field.id === 'privateKey'
-                          ? 'Copy private key'
-                          : `Copy ${field.label.toLowerCase()}`
-                    const canCopySshField =
-                      isViewingEntry && activeEntryTemplate.id === 'ssh-key-pair' && !!editingEntryId && !!selectedEntry && !!value
+                    const canCopyDialogField = (isViewingEntry || !!editingEntryId) && !!selectedEntry && !!value
                     const canGeneratePassword = field.id === 'password' && !isViewingEntry
-                    const canTogglePasswordVisibility = field.type === 'password' && !isViewingEntry
+                    const canTogglePasswordVisibility = field.type === 'password'
+                    const useFixedPasswordMask =
+                      field.type === 'password' && !!value && !!editingEntryId && !visibleEntryPasswordFields[field.id]
                     const passwordVisibilityLabel = field.label.toLowerCase()
                     const fieldContainerClassName =
                       field.multiline || canGeneratePassword
@@ -3593,41 +3643,30 @@ function PasswordManagerWorkspace({
                       >
                         <div className="flex items-center justify-between gap-2">
                           <Label htmlFor={fieldId}>{field.label}</Label>
-                          {canGeneratePassword ? (
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setPasswordGeneratorDialogOpen(true)}
-                              disabled={!selectedVault}
-                            >
-                              <KeyRound className="size-4" />
-                              Generate password
-                            </Button>
-                          ) : canCopySshField ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon-sm"
-                                  onClick={() => void onCopyEntryField(selectedEntry!, field.id, field.label)}
-                                  aria-label={sshCopyLabel}
-                                  title={sshCopyLabel}
-                                >
-                                  <Copy className="size-4" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent>{sshCopyLabel}</TooltipContent>
-                            </Tooltip>
-                          ) : activeEntryTemplate.id === 'ssh-key-pair' && !isViewingEntry ? (
-                            <Label
-                              htmlFor={`${fieldId}-file`}
-                              className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground"
-                            >
-                              Upload file
-                            </Label>
-                          ) : null}
+                          <div className="flex items-center gap-1.5">
+                            {canGeneratePassword ? (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setPasswordGeneratorDialogOpen(true)}
+                                disabled={!selectedVault}
+                              >
+                                <KeyRound className="size-4" />
+                                Generate password
+                              </Button>
+                            ) : null}
+                            {canCopyDialogField ? (
+                              renderEntryDialogCopyButton(field.id, field.label, value)
+                            ) : activeEntryTemplate.id === 'ssh-key-pair' && !isViewingEntry ? (
+                              <Label
+                                htmlFor={`${fieldId}-file`}
+                                className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground"
+                              >
+                                Upload file
+                              </Label>
+                            ) : null}
+                          </div>
                         </div>
                         {field.multiline ? (
                           <Textarea
@@ -3641,10 +3680,11 @@ function PasswordManagerWorkspace({
                           <>
                             <Input
                               id={fieldId}
-                              type={canTogglePasswordVisibility && visibleEntryPasswordFields[field.id] ? 'text' : field.type}
-                              value={value}
+                              type={useFixedPasswordMask || visibleEntryPasswordFields[field.id] ? 'text' : field.type}
+                              value={useFixedPasswordMask ? PASSWORD_MANAGER_FIXED_MASK : value}
                               onChange={(event) => handleChange(event.target.value)}
                               disabled={!selectedVault || isViewingEntry}
+                              readOnly={useFixedPasswordMask}
                               className={canTogglePasswordVisibility ? 'pr-10' : undefined}
                             />
                             {canTogglePasswordVisibility ? (
@@ -3701,7 +3741,10 @@ function PasswordManagerWorkspace({
                   })}
                 </div>
                 <div className="grid gap-2">
-                  <Label htmlFor="password-manager-entry-notes">Notes</Label>
+                  <div className="flex items-center justify-between gap-2">
+                    <Label htmlFor="password-manager-entry-notes">Notes</Label>
+                    {renderEntryDialogCopyButton('notes', 'Notes', entryNotes)}
+                  </div>
                   <Textarea
                     id="password-manager-entry-notes"
                     value={entryNotes}

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -117,6 +117,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await page.getByLabel('Title').fill('Pasted deploy key')
   await page.getByLabel('Public key or certificate').fill(pastedSshPublicMaterial)
   await page.getByLabel('Private key').fill(pastedSshPrivateKey)
+  await page.getByLabel('Notes').fill('Pasted SSH deployment notes')
   await page.getByRole('button', { name: 'Create encrypted entry' }).click()
   const pastedSshEntry = page.getByTestId('password-manager-entry-entry-3')
   await expect(pastedSshEntry).toContainText('Pasted deploy key')
@@ -201,16 +202,21 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     .toBe('')
 
   await pastedSshEntry.getByRole('button', { name: 'View entry' }).click()
-  await expect(page.getByRole('dialog', { name: 'View SSH key pair' })).toBeVisible()
+  const viewSshDialog = page.getByRole('dialog', { name: 'View SSH key pair' })
+  await expect(viewSshDialog).toBeVisible()
   await expect(page.getByLabel('Title')).toBeDisabled()
   await expect(page.getByLabel('Public key or certificate')).toBeDisabled()
   await expect(page.getByLabel('Private key')).toBeDisabled()
+  await viewSshDialog.getByRole('button', { name: 'Copy title' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe('Pasted deploy key')
   await expect(page.getByRole('button', { name: 'Save encrypted entry' })).toHaveCount(0)
   await expect(page.getByRole('button', { name: 'Delete entry' })).toHaveCount(0)
-  await page.getByRole('button', { name: 'Copy public key or certificate' }).click()
+  await viewSshDialog.getByRole('button', { name: 'Copy public key or certificate' }).click()
   await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(pastedSshPublicMaterial)
-  await page.getByRole('button', { name: 'Copy private key' }).click()
+  await viewSshDialog.getByRole('button', { name: 'Copy private key' }).click()
   await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(pastedSshPrivateKey)
+  await viewSshDialog.getByRole('button', { name: 'Copy notes' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe('Pasted SSH deployment notes')
   await page.getByRole('button', { name: 'Close' }).click()
 
   const downloadPromise = page.waitForEvent('download')
@@ -224,7 +230,21 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await downloadPromise
 
   await entryCard.getByRole('button', { name: 'Edit' }).click()
-  await expect(page.getByRole('dialog', { name: 'Edit login' })).toBeVisible()
+  const editLoginDialog = page.getByRole('dialog', { name: 'Edit login' })
+  await expect(editLoginDialog).toBeVisible()
+  await expect(page.locator('#password-manager-entry-password')).toHaveAttribute('type', 'text')
+  await expect(page.locator('#password-manager-entry-password')).toHaveValue('************')
+  await editLoginDialog.getByRole('button', { name: 'Copy title' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe('Grafana admin')
+  await editLoginDialog.getByRole('button', { name: 'Copy username' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe('ops-admin')
+  await editLoginDialog.getByRole('button', { name: 'Copy password' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(entryPassword)
+  await editLoginDialog.getByRole('button', { name: 'Copy URL' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe('https://grafana.example.test')
+  await editLoginDialog.getByRole('button', { name: 'Copy notes' }).click()
+  await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(entryNotes)
+  await editLoginDialog.getByRole('button', { name: 'Show password' }).click()
   await page.getByLabel('Password', { exact: true }).fill(updatedEntryPassword)
   await page.getByRole('button', { name: 'Save encrypted entry' }).click()
   await expect(entryCard.getByRole('button', { name: 'Reveal password' })).toBeVisible()
@@ -303,7 +323,14 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     '/vaults/vault-1/entries/entry-2/copy-audit',
     '/vaults/vault-1/entries/entry-3/copy-audit',
     '/vaults/vault-1/entries/entry-3/copy-audit',
+    '/vaults/vault-1/entries/entry-3/copy-audit',
+    '/vaults/vault-1/entries/entry-3/copy-audit',
     '/vaults/vault-1/export-audit',
+    '/vaults/vault-1/entries/entry-2/copy-audit',
+    '/vaults/vault-1/entries/entry-2/copy-audit',
+    '/vaults/vault-1/entries/entry-2/copy-audit',
+    '/vaults/vault-1/entries/entry-2/copy-audit',
+    '/vaults/vault-1/entries/entry-2/copy-audit',
   ])
 
   for (const request of passwordManagerMock.auditRequests()) {
@@ -324,6 +351,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(request.rawBody).not.toContain(entryPassword)
     expect(request.rawBody).not.toContain(updatedEntryPassword)
     expect(request.rawBody).not.toContain(entryNotes)
+    expect(request.rawBody).not.toContain('Pasted SSH deployment notes')
     expect(request.rawBody).not.toContain(pastedSshPublicMaterial)
     expect(request.rawBody).not.toContain(pastedSshPrivateKey)
     expect(request.rawBody).not.toContain(uploadedSshPublicMaterial)
@@ -344,6 +372,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(message).not.toContain(entryPassword)
     expect(message).not.toContain(updatedEntryPassword)
     expect(message).not.toContain(entryNotes)
+    expect(message).not.toContain('Pasted SSH deployment notes')
     expect(message).not.toContain(pastedSshPublicMaterial)
     expect(message).not.toContain(pastedSshPrivateKey)
     expect(message).not.toContain(uploadedSshPublicMaterial)
@@ -364,6 +393,7 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(request.body).not.toContain(entryPassword)
     expect(request.body).not.toContain(updatedEntryPassword)
     expect(request.body).not.toContain(entryNotes)
+    expect(request.body).not.toContain('Pasted SSH deployment notes')
     expect(request.body).not.toContain(pastedSshPublicMaterial)
     expect(request.body).not.toContain(pastedSshPrivateKey)
     expect(request.body).not.toContain(uploadedSshPublicMaterial)


### PR DESCRIPTION
## Summary
- add copy-to-clipboard controls to Password Manager saved entry view/edit dialog fields
- use a fixed ************ hidden mask for saved password-style fields so masked length does not disclose secret length
- extend hosted Password Manager E2E coverage for dialog copy actions, fixed masking, and copy audits

## Validation
- pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'tests/e2e/tooling/password-manager.spec.ts'
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts (blocked locally: testcontainers could not find a working container runtime)
