### PR TITLE
feat(password-manager): add tenant audit view

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,33 @@
 
 ## What Has Been Built
 
+### Session 129 — Password Manager tenant audit view
+
+**Standards-oriented audit visibility** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/client.ts`, `apps/web/tests/e2e/fixtures/password-manager.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Added Password Manager client support for the standalone API's redacted
+  tenant audit event listing and audit integrity status routes.
+- Added an unlocked workspace Audit tab with tenant-wide filters for vault,
+  actor, event type, object type, outcome, and time range.
+- Rendered public-safe audit evidence only: timestamp, actor, action, target,
+  outcome, summary, and integrity status, with E2E assertions that forensic or
+  secret-shaped fields are not displayed.
+- Updated the bundled Password Manager API pin to `api/v0.1.4` /
+  `ghcr.io/carrtech-dev/ct-password-manager/api@sha256:6f5cc00a33d5df59cbca9968b178675ea45afff9b8f9c2394c2b3ae0a7d09220`,
+  which contains the audit read API and integrity-chain migration.
+
+**Validation**
+- `PASSWORD_MANAGER_OPENAPI_CONTRACT_PATH=/Volumes/MacBookStorage-Dev/dev/carrtech/ct-password-manager-audit-view/docs/api-contract/openapi.json node --experimental-strip-types --test apps/web/lib/password-manager/client.test.mjs`
+- `python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json`
+- `bash deploy/scripts/test-password-manager-release-contract.sh`
+- `bash deploy/scripts/test-password-manager-compose.sh`
+- `bash deploy/scripts/test-password-manager-nginx.sh`
+- `bash deploy/scripts/test-password-manager-startup.sh`
+- `pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/client.ts' 'lib/password-manager/client.test.mjs' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret DATABASE_URL=postgres://test:test@localhost:5432/ctops_test pnpm --dir apps/web build` (passes with existing Turbopack NFT warning and expected placeholder-secret Better Auth warnings)
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts` (blocked locally: `testcontainers` could not find a working container runtime)
+
 ### Session 128 — Password Manager field copy controls
 
 **Entry dialog copy and masking hardening** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   type FormEvent,
   type ReactNode,
+  useCallback,
 } from 'react'
 import {
   AlertCircle,
@@ -32,7 +33,9 @@ import {
   RefreshCcw,
   Search,
   Settings,
+  ShieldCheck,
   ShieldAlert,
+  ScrollText,
   StickyNote,
   Terminal,
   Trash2,
@@ -100,6 +103,8 @@ import {
 } from '@/lib/password-manager/browser-crypto'
 import {
   PasswordManagerApiError,
+  type AuditEventRecord,
+  type AuditIntegrityStatus,
   type EntryRecord,
   type MemberRecord,
   type MemberRecipientRecord,
@@ -155,6 +160,15 @@ const PASSWORD_MANAGER_FIXED_MASK = '************'
 type PasswordManagerExportFormat = 'encrypted' | 'plaintext'
 type PasswordManagerEntryTemplateId = 'login' | 'card' | 'identity' | 'secure-note' | 'ssh-key-pair'
 type PasswordManagerEntryDialogMode = 'create' | 'edit' | 'view'
+type PasswordManagerAuditFilters = {
+  vaultId: string
+  actorUserId: string
+  eventType: string
+  objectType: string
+  outcome: string
+  from: string
+  to: string
+}
 type PasswordManagerTimedSecret = {
   durationSeconds: number
   expiresAt: number
@@ -231,6 +245,31 @@ const PASSWORD_MANAGER_ENTRY_TEMPLATES: Array<{
   },
 ]
 const DEFAULT_PASSWORD_MANAGER_ENTRY_TEMPLATE_ID: PasswordManagerEntryTemplateId = 'login'
+const PASSWORD_MANAGER_AUDIT_EVENT_TYPES = [
+  'audit.viewed',
+  'entry.copied',
+  'entry.created',
+  'entry.deleted',
+  'entry.revealed',
+  'entry.updated',
+  'session.launched',
+  'session.logged_out',
+  'session.refreshed',
+  'user_key.created',
+  'user_key.fetched',
+  'user_key.setup_status_viewed',
+  'user_key.unlock_metadata_fetched',
+  'vault.created',
+  'vault.deleted',
+  'vault.exported',
+  'vault.key_rotated',
+  'vault.member_added',
+  'vault.member_removed',
+  'vault.member_updated',
+  'vault.updated',
+] as const
+const PASSWORD_MANAGER_AUDIT_OBJECT_TYPES = ['audit_log', 'entry', 'session', 'user_key', 'vault', 'vault_member'] as const
+const PASSWORD_MANAGER_AUDIT_OUTCOMES = ['success', 'failure', 'denied', 'conflict'] as const
 
 export type PasswordManagerInstanceUser = {
   id: string
@@ -244,6 +283,24 @@ function toClientPayload<T>(value: T): T {
 
 function createIdempotencyKey() {
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function formatAuditTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+function formatAuditLabel(value: string): string {
+  return value
+    .split(/[._-]/)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function shortAuditId(value: string): string {
+  return value.length > 12 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value
 }
 
 function isMembershipConflictError(error: unknown): boolean {
@@ -401,6 +458,7 @@ export function PasswordManagerClientShell({
   const [vaultsPending, setVaultsPending] = useState(false)
   const [entriesPending, setEntriesPending] = useState(false)
   const [membersPending, setMembersPending] = useState(false)
+  const [auditPending, setAuditPending] = useState(false)
   const [workspacePending, setWorkspacePending] = useState(false)
   const [workspaceError, setWorkspaceError] = useState<string | null>(null)
   const [vaultFilter, setVaultFilter] = useState('')
@@ -410,6 +468,18 @@ export function PasswordManagerClientShell({
   const [vaults, setVaults] = useState<PasswordManagerVaultSummary[]>([])
   const [entries, setEntries] = useState<PasswordManagerEntrySummary[]>([])
   const [members, setMembers] = useState<MemberRecord[]>([])
+  const [auditEvents, setAuditEvents] = useState<AuditEventRecord[]>([])
+  const [auditIntegrity, setAuditIntegrity] = useState<AuditIntegrityStatus | null>(null)
+  const [auditNextCursor, setAuditNextCursor] = useState('')
+  const [auditFilters, setAuditFilters] = useState<PasswordManagerAuditFilters>({
+    vaultId: 'all',
+    actorUserId: '',
+    eventType: 'all',
+    objectType: 'all',
+    outcome: 'all',
+    from: '',
+    to: '',
+  })
   const [createVaultName, setCreateVaultName] = useState('')
   const [createVaultDescription, setCreateVaultDescription] = useState('')
   const [renameVaultName, setRenameVaultName] = useState('')
@@ -1075,6 +1145,53 @@ export function PasswordManagerClientShell({
     setRenameRevealTimeoutSeconds(String(getVaultRevealTimeoutSeconds(selectedVault)))
     setRenameClipboardTimeoutSeconds(String(getVaultClipboardTimeoutSeconds(selectedVault)))
   }, [selectedVault])
+
+  const loadAuditEvents = useCallback(async (cursor = '') => {
+    if (state.view !== 'unlocked') {
+      return
+    }
+
+    setAuditPending(true)
+    try {
+      const [eventsResponse, integrityResponse] = await Promise.all([
+        client.listAuditEvents({
+          vaultId: auditFilters.vaultId === 'all' ? undefined : auditFilters.vaultId,
+          actorUserId: auditFilters.actorUserId.trim() || undefined,
+          eventType: auditFilters.eventType === 'all' ? undefined : auditFilters.eventType,
+          objectType: auditFilters.objectType === 'all' ? undefined : auditFilters.objectType,
+          outcome: auditFilters.outcome === 'all' ? undefined : auditFilters.outcome,
+          from: auditFilters.from ? new Date(auditFilters.from).toISOString() : undefined,
+          to: auditFilters.to ? new Date(auditFilters.to).toISOString() : undefined,
+          cursor: cursor || undefined,
+          limit: 50,
+        }),
+        client.getAuditIntegrityStatus(),
+      ])
+      setAuditEvents((current) => (cursor ? [...current, ...eventsResponse.events] : eventsResponse.events))
+      setAuditNextCursor(eventsResponse.next_cursor)
+      setAuditIntegrity(integrityResponse)
+    } catch (error) {
+      logPasswordManagerWarning('[password-manager] audit events load failed', error, {
+        ['instance' + 'Id']: currentScopeId,
+        selectedVaultId: workspaceState.selectedVaultId,
+        selectedEntryId: workspaceState.selectedEntryId,
+      })
+      handleWorkspaceUiError(error, 'Password Manager audit events could not be loaded safely.')
+    } finally {
+      setAuditPending(false)
+    }
+  }, [auditFilters, client, currentScopeId, state.view, workspaceState.selectedEntryId, workspaceState.selectedVaultId])
+
+  useEffect(() => {
+    if (state.view !== 'unlocked') {
+      setAuditEvents([])
+      setAuditIntegrity(null)
+      setAuditNextCursor('')
+      return
+    }
+
+    void loadAuditEvents()
+  }, [loadAuditEvents, state.view])
 
   useEffect(() => {
     if (entryRevealId && !revealedPasswords[entryRevealId]) {
@@ -2176,6 +2293,11 @@ export function PasswordManagerClientShell({
         <PasswordManagerWorkspace
           createVaultDescription={createVaultDescription}
           createVaultName={createVaultName}
+          auditEvents={auditEvents}
+          auditFilters={auditFilters}
+          auditIntegrity={auditIntegrity}
+          auditNextCursor={auditNextCursor}
+          auditPending={auditPending}
           currentPasswordManagerUserId={currentPasswordManagerUserId}
           deferredEntryFilter={deferredEntryFilter}
           editingEntryId={editingEntryId}
@@ -2207,6 +2329,9 @@ export function PasswordManagerClientShell({
           onCreateVault={runVaultCreate}
           onCreateVaultDescriptionChange={setCreateVaultDescription}
           onCreateVaultNameChange={setCreateVaultName}
+          onAuditFilterChange={(key, value) => setAuditFilters((current) => ({ ...current, [key]: value }))}
+          onLoadMoreAuditEvents={() => loadAuditEvents(auditNextCursor)}
+          onRefreshAuditEvents={() => loadAuditEvents()}
           onDeleteEntry={handleEntryDelete}
           onDeleteVault={handleVaultDelete}
           onEntryFilterChange={setEntryFilter}
@@ -2733,6 +2858,11 @@ function TimedSecretProgress({
 function PasswordManagerWorkspace({
   createVaultDescription,
   createVaultName,
+  auditEvents,
+  auditFilters,
+  auditIntegrity,
+  auditNextCursor,
+  auditPending,
   currentPasswordManagerUserId,
   deferredEntryFilter,
   editingEntryId,
@@ -2764,6 +2894,9 @@ function PasswordManagerWorkspace({
   onCreateVault,
   onCreateVaultDescriptionChange,
   onCreateVaultNameChange,
+  onAuditFilterChange,
+  onLoadMoreAuditEvents,
+  onRefreshAuditEvents,
   onDeleteEntry,
   onDeleteVault,
   onEntryFilterChange,
@@ -2813,6 +2946,11 @@ function PasswordManagerWorkspace({
 }: {
   createVaultDescription: string
   createVaultName: string
+  auditEvents: AuditEventRecord[]
+  auditFilters: PasswordManagerAuditFilters
+  auditIntegrity: AuditIntegrityStatus | null
+  auditNextCursor: string
+  auditPending: boolean
   currentPasswordManagerUserId: string | null
   deferredEntryFilter: string
   editingEntryId: string | null
@@ -2849,6 +2987,9 @@ function PasswordManagerWorkspace({
   onCreateVault: () => Promise<void>
   onCreateVaultDescriptionChange: (value: string) => void
   onCreateVaultNameChange: (value: string) => void
+  onAuditFilterChange: (key: keyof PasswordManagerAuditFilters, value: string) => void
+  onLoadMoreAuditEvents: () => void
+  onRefreshAuditEvents: () => void
   onDeleteEntry: () => Promise<void>
   onDeleteVault: (unlockPassword: string) => Promise<boolean>
   onEntryFilterChange: (value: string) => void
@@ -3189,6 +3330,10 @@ function PasswordManagerWorkspace({
           <TabsTrigger value="passwords">
             <KeyRound className="size-4" />
             Passwords
+          </TabsTrigger>
+          <TabsTrigger value="audit">
+            <ScrollText className="size-4" />
+            Audit
           </TabsTrigger>
           <TabsTrigger value="settings">
             <Settings className="size-4" />
@@ -3793,6 +3938,184 @@ function PasswordManagerWorkspace({
               />
             </DialogContent>
           </Dialog>
+        </TabsContent>
+
+        <TabsContent value="audit" className="space-y-4">
+          <Card className="border-border/60 shadow-xs">
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <CardTitle>Audit</CardTitle>
+                  <CardDescription>Tenant-wide Password Manager activity with public-safe details only.</CardDescription>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={auditIntegrity?.verified === false ? 'destructive' : 'secondary'}>
+                    <ShieldCheck className="mr-1 size-3" />
+                    {auditIntegrity
+                      ? auditIntegrity.verified
+                        ? `Verified ${auditIntegrity.checked_events}`
+                        : 'Integrity warning'
+                      : 'Integrity pending'}
+                  </Badge>
+                  <Button variant="outline" size="sm" onClick={onRefreshAuditEvents} disabled={auditPending}>
+                    <RefreshCcw className="mr-2 size-4" />
+                    Refresh
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-audit-vault">Vault</Label>
+                  <Select value={auditFilters.vaultId} onValueChange={(value) => onAuditFilterChange('vaultId', value)}>
+                    <SelectTrigger id="password-manager-audit-vault">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All vaults</SelectItem>
+                      {vaults.map((vault) => (
+                        <SelectItem key={vault.id} value={vault.id}>
+                          {vault.metadata.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-audit-event-type">Event</Label>
+                  <Select value={auditFilters.eventType} onValueChange={(value) => onAuditFilterChange('eventType', value)}>
+                    <SelectTrigger id="password-manager-audit-event-type">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All events</SelectItem>
+                      {PASSWORD_MANAGER_AUDIT_EVENT_TYPES.map((eventType) => (
+                        <SelectItem key={eventType} value={eventType}>
+                          {formatAuditLabel(eventType)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-audit-object-type">Object</Label>
+                  <Select value={auditFilters.objectType} onValueChange={(value) => onAuditFilterChange('objectType', value)}>
+                    <SelectTrigger id="password-manager-audit-object-type">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All objects</SelectItem>
+                      {PASSWORD_MANAGER_AUDIT_OBJECT_TYPES.map((objectType) => (
+                        <SelectItem key={objectType} value={objectType}>
+                          {formatAuditLabel(objectType)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-audit-outcome">Outcome</Label>
+                  <Select value={auditFilters.outcome} onValueChange={(value) => onAuditFilterChange('outcome', value)}>
+                    <SelectTrigger id="password-manager-audit-outcome">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All outcomes</SelectItem>
+                      {PASSWORD_MANAGER_AUDIT_OUTCOMES.map((outcome) => (
+                        <SelectItem key={outcome} value={outcome}>
+                          {formatAuditLabel(outcome)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-audit-from">From</Label>
+                  <Input
+                    id="password-manager-audit-from"
+                    type="datetime-local"
+                    value={auditFilters.from}
+                    onChange={(event) => onAuditFilterChange('from', event.target.value)}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="password-manager-audit-to">To</Label>
+                  <Input
+                    id="password-manager-audit-to"
+                    type="datetime-local"
+                    value={auditFilters.to}
+                    onChange={(event) => onAuditFilterChange('to', event.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="grid gap-2 md:max-w-md">
+                <Label htmlFor="password-manager-audit-actor">Actor user ID</Label>
+                <Input
+                  id="password-manager-audit-actor"
+                  value={auditFilters.actorUserId}
+                  onChange={(event) => onAuditFilterChange('actorUserId', event.target.value)}
+                  placeholder="Filter by Password Manager user ID"
+                />
+              </div>
+
+              <div className="overflow-hidden rounded-md border border-border/60" data-testid="password-manager-audit-table">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Time</TableHead>
+                      <TableHead>Actor</TableHead>
+                      <TableHead>Action</TableHead>
+                      <TableHead>Target</TableHead>
+                      <TableHead>Outcome</TableHead>
+                      <TableHead>Summary</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {auditEvents.map((event) => (
+                      <TableRow key={event.id} data-testid={`password-manager-audit-event-${event.id}`}>
+                        <TableCell className="whitespace-nowrap text-xs">{formatAuditTimestamp(event.created_at)}</TableCell>
+                        <TableCell>
+                          <div className="grid gap-0.5">
+                            <span>{event.actor_display_name || event.actor_email || shortAuditId(event.actor_user_id)}</span>
+                            <span className="text-xs text-muted-foreground">{event.actor_email || shortAuditId(event.actor_user_id)}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell>{formatAuditLabel(event.event_type)}</TableCell>
+                        <TableCell>
+                          <div className="grid gap-0.5">
+                            <span>{formatAuditLabel(event.object_type)}</span>
+                            {event.object_id ? <span className="text-xs text-muted-foreground">{shortAuditId(event.object_id)}</span> : null}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={event.outcome === 'success' ? 'secondary' : 'destructive'}>
+                            {formatAuditLabel(event.outcome)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="min-w-72">{event.summary}</TableCell>
+                      </TableRow>
+                    ))}
+                    {!auditPending && auditEvents.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+                          No audit events match the current filters.
+                        </TableCell>
+                      </TableRow>
+                    ) : null}
+                  </TableBody>
+                </Table>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs text-muted-foreground">
+                  {auditIntegrity?.latest_event_hash ? `Latest hash ${shortAuditId(auditIntegrity.latest_event_hash)}` : 'Audit integrity is checked by the API.'}
+                </p>
+                <Button variant="outline" onClick={onLoadMoreAuditEvents} disabled={auditPending || !auditNextCursor}>
+                  {auditPending ? 'Loading...' : 'Load more'}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
         </TabsContent>
 
         <TabsContent value="settings" className="space-y-4">

--- a/apps/web/lib/password-manager/client.test.mjs
+++ b/apps/web/lib/password-manager/client.test.mjs
@@ -246,6 +246,64 @@ test('audit routes send empty bodies only', async () => {
   }
 })
 
+test('audit list routes use redacted read contract with filters', async () => {
+  const calls = []
+  const client = createPasswordManagerClient({
+    apiBaseUrl: 'https://ops.example.test/password-manager-api',
+    fetch: async (input, init = {}) => {
+      calls.push({
+        url: input instanceof Request ? input.url : String(input),
+        init,
+      })
+      if (String(input).endsWith('/audit-events/integrity')) {
+        return createJsonResponse(200, {
+          latest_sequence_number: 3,
+          latest_event_hash: 'abc123',
+          verified: true,
+          checked_events: 3,
+        })
+      }
+      return createJsonResponse(200, {
+        events: [
+          {
+            id: 'event-1',
+            created_at: '2026-05-05T07:30:00Z',
+            actor_user_id: 'user-1',
+            actor_email: 'user@example.test',
+            actor_display_name: 'User One',
+            event_type: 'entry.copied',
+            object_type: 'entry',
+            object_id: 'entry-1',
+            vault_id: 'vault-1',
+            outcome: 'success',
+            summary: 'User One copied a secret field.',
+            metadata: { field_type: 'password' },
+          },
+        ],
+        next_cursor: '3',
+      })
+    },
+  })
+
+  const events = await client.listAuditEvents({
+    vaultId: 'vault-1',
+    eventType: 'entry.copied',
+    outcome: 'success',
+    limit: 25,
+  })
+  const integrity = await client.getAuditIntegrityStatus()
+
+  assert.equal(events.events[0].summary, 'User One copied a secret field.')
+  assert.equal(events.next_cursor, '3')
+  assert.equal(integrity.verified, true)
+  assert.equal(calls[0].init.method, 'GET')
+  assert.equal(calls[0].init.credentials, 'include')
+  assert.match(calls[0].url, /\/audit-events\?/)
+  assert.match(calls[0].url, /vault_id=vault-1/)
+  assert.match(calls[0].url, /event_type=entry\.copied/)
+  assert.equal(calls[1].url, 'https://ops.example.test/password-manager-api/audit-events/integrity')
+})
+
 test('request payload helpers reject plaintext-shaped fields', () => {
   assert.throws(
     () =>

--- a/apps/web/lib/password-manager/client.ts
+++ b/apps/web/lib/password-manager/client.ts
@@ -42,6 +42,8 @@ export const PASSWORD_MANAGER_CLIENT_ROUTE_SPECS = {
   auditCopy: { method: 'POST', path: '/vaults/{vaultID}/entries/{entryID}/copy-audit' },
   auditReveal: { method: 'POST', path: '/vaults/{vaultID}/entries/{entryID}/reveal-audit' },
   auditExport: { method: 'POST', path: '/vaults/{vaultID}/export-audit' },
+  listAuditEvents: { method: 'GET', path: '/audit-events' },
+  getAuditIntegrity: { method: 'GET', path: '/audit-events/integrity' },
   listMembers: { method: 'GET', path: '/vaults/{vaultID}/members' },
   lookupMemberRecipients: { method: 'POST', path: '/vaults/{vaultID}/member-recipients' },
   addMember: { method: 'POST', path: '/vaults/{vaultID}/members' },
@@ -127,6 +129,45 @@ export interface KeyEpochRecord {
   created_at: string
 }
 
+export interface AuditEventRecord {
+  id: string
+  created_at: string
+  actor_user_id: string
+  actor_email: string
+  actor_display_name: string
+  event_type: string
+  object_type: string
+  object_id: string
+  vault_id: string
+  outcome: string
+  summary: string
+  metadata: JsonObject
+}
+
+export interface AuditEventsResponse {
+  events: AuditEventRecord[]
+  next_cursor: string
+}
+
+export interface AuditIntegrityStatus {
+  latest_sequence_number: number
+  latest_event_hash: string
+  verified: boolean
+  checked_events: number
+}
+
+export interface AuditEventFilters {
+  vaultId?: string
+  actorUserId?: string
+  eventType?: string
+  objectType?: string
+  outcome?: string
+  from?: string
+  to?: string
+  cursor?: string
+  limit?: number
+}
+
 function normalizeApiBaseUrl(value: string): string {
   const trimmed = value.trim()
   if (!trimmed) {
@@ -141,6 +182,16 @@ function resolvePath(template: string, params: Record<string, string> = {}): str
     resolved = resolved.replace(`{${key}}`, encodeURIComponent(value))
   }
   return resolved
+}
+
+function queryString(params: Record<string, string | number | undefined>): string {
+  const searchParams = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === '') continue
+    searchParams.set(key, String(value))
+  }
+  const encoded = searchParams.toString()
+  return encoded ? `?${encoded}` : ''
 }
 
 function assertNoPlaintextLikeKeys(value: JsonValue, path = '$'): void {
@@ -639,6 +690,28 @@ export function createPasswordManagerClient(options: PasswordManagerClientOption
           vaultID: requireNonEmptyString(input.vaultId, 'vaultId'),
         },
       })
+    },
+
+    async listAuditEvents(filters: AuditEventFilters = {}): Promise<AuditEventsResponse> {
+      const route = PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.listAuditEvents
+      return requestJson<AuditEventsResponse>(fetchImpl, apiBaseUrl, {
+        ...route,
+        path: `${route.path}${queryString({
+          vault_id: filters.vaultId,
+          actor_user_id: filters.actorUserId,
+          event_type: filters.eventType,
+          object_type: filters.objectType,
+          outcome: filters.outcome,
+          from: filters.from,
+          to: filters.to,
+          cursor: filters.cursor,
+          limit: filters.limit,
+        })}`,
+      })
+    },
+
+    async getAuditIntegrityStatus(): Promise<AuditIntegrityStatus> {
+      return requestJson<AuditIntegrityStatus>(fetchImpl, apiBaseUrl, PASSWORD_MANAGER_CLIENT_ROUTE_SPECS.getAuditIntegrity)
     },
   }
 }

--- a/apps/web/tests/e2e/fixtures/password-manager.ts
+++ b/apps/web/tests/e2e/fixtures/password-manager.ts
@@ -330,6 +330,53 @@ export async function createPasswordManagerMock(context: BrowserContext): Promis
 
     if (!await ensureSession()) return
 
+    if (method === 'GET' && path === '/audit-events') {
+      await fulfillJson(route, 200, {
+        events: [
+          {
+            id: 'audit-event-1',
+            created_at: nowIso(),
+            actor_user_id: state.currentUserId,
+            actor_email: TEST_USER.email,
+            actor_display_name: TEST_USER.name,
+            event_type: 'entry.copied',
+            object_type: 'entry',
+            object_id: 'entry-2',
+            vault_id: 'vault-1',
+            outcome: 'success',
+            summary: `${TEST_USER.name} copied a secret field.`,
+            metadata: { field_type: 'password' },
+          },
+          {
+            id: 'audit-event-2',
+            created_at: nowIso(),
+            actor_user_id: state.currentUserId,
+            actor_email: TEST_USER.email,
+            actor_display_name: TEST_USER.name,
+            event_type: 'vault.member_added',
+            object_type: 'vault_member',
+            object_id: state.currentUserId,
+            vault_id: 'vault-1',
+            outcome: 'success',
+            summary: `${TEST_USER.name} added a vault member.`,
+            metadata: { role: 'viewer' },
+          },
+        ],
+        next_cursor: '',
+      })
+      return
+    }
+
+    if (method === 'GET' && path === '/audit-events/integrity') {
+      await fulfillJson(route, 200, {
+        latest_sequence_number: 2,
+        latest_event_hash: 'abcdef1234567890',
+        verified: true,
+        checked_events: 2,
+      })
+      return
+    }
+
     if (method === 'GET' && path === '/vaults') {
       await fulfillJson(route, 200, {
         vaults: Array.from(state.vaults.values()).map((vault) => vault.record),

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -308,6 +308,17 @@ test('hosted password manager flow keeps plaintext and key material inside the b
   await page.getByRole('button', { name: 'Delete vault permanently' }).click()
   await expect(page.getByTestId('password-manager-vault-vault-1')).toHaveCount(0)
 
+  await page.getByRole('tab', { name: 'Audit' }).click()
+  await expect(page.getByTestId('password-manager-audit-table')).toBeVisible()
+  await expect(page.getByText('Verified 2')).toBeVisible()
+  await expect(page.getByTestId('password-manager-audit-table')).toContainText('Copied')
+  await expect(page.getByTestId('password-manager-audit-table')).not.toContainText('request_ip')
+  await expect(page.getByTestId('password-manager-audit-table')).not.toContainText('user_agent')
+  await expect(page.getByTestId('password-manager-audit-table')).not.toContainText('session_id')
+  await expect(page.getByTestId('password-manager-audit-table')).not.toContainText('ciphertext')
+  await expect(page.getByTestId('password-manager-audit-table')).not.toContainText('wrapped_vault_key_envelope')
+  await expect(page.getByTestId('password-manager-audit-table')).not.toContainText('private_key')
+
   await passwordManagerMock.switchAuthenticatedInstance()
   await page.reload()
   await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()

--- a/deploy/password-manager-release.json
+++ b/deploy/password-manager-release.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "repository": "carrtech-dev/ct-password-manager",
-  "git_tag": "api/v0.1.3",
-  "source_commit_sha": "74cc8d1840efec5da00f8d90afbd2ed2969de987",
+  "git_tag": "api/v0.1.4",
+  "source_commit_sha": "ee39b8af473f7ea791ac2d3c0932602d577345d8",
   "image_repository": "ghcr.io/carrtech-dev/ct-password-manager/api",
-  "image_digest": "sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7",
-  "digest_reference": "ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7",
+  "image_digest": "sha256:6f5cc00a33d5df59cbca9968b178675ea45afff9b8f9c2394c2b3ae0a7d09220",
+  "digest_reference": "ghcr.io/carrtech-dev/ct-password-manager/api@sha256:6f5cc00a33d5df59cbca9968b178675ea45afff9b8f9c2394c2b3ae0a7d09220",
   "api_contract_version": "1.0.0",
-  "api_contract_checksum_sha256": "bbb7dc110d36a9239784945a0fff85dccff3e8cc7f43178a0b05031585239dde"
+  "api_contract_checksum_sha256": "489965787cee120475f2231dee036d3eb95add8c8d77b5b114a5ec8b9ef25f85"
 }

--- a/deploy/scripts/test-password-manager-release-contract.sh
+++ b/deploy/scripts/test-password-manager-release-contract.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 DESCRIPTOR="${REPO_ROOT}/deploy/password-manager-release.json"
 CLIENT_TEST="${REPO_ROOT}/apps/web/lib/password-manager/client.test.mjs"
 
-expected_ref="ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7"
+expected_ref="ghcr.io/carrtech-dev/ct-password-manager/api@sha256:6f5cc00a33d5df59cbca9968b178675ea45afff9b8f9c2394c2b3ae0a7d09220"
 
 python3 "${REPO_ROOT}/deploy/scripts/validate-password-manager-release.py" "$DESCRIPTOR" >/dev/null
 

--- a/docker-compose.single.yml
+++ b/docker-compose.single.yml
@@ -34,7 +34,7 @@ services:
       start_period: 10s
 
   password-manager-migrate:
-    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7
+    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:6f5cc00a33d5df59cbca9968b178675ea45afff9b8f9c2394c2b3ae0a7d09220
     restart: "no"
     depends_on:
       password-manager-db:
@@ -52,7 +52,7 @@ services:
     command: ["-action", "up"]
 
   password-manager-api:
-    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:91c7e5fa77e4bf26115c0f071713856571a8873c4b4e1ab600c53ba78f80fee7
+    image: ghcr.io/carrtech-dev/ct-password-manager/api@sha256:6f5cc00a33d5df59cbca9968b178675ea45afff9b8f9c2394c2b3ae0a7d09220
     restart: unless-stopped
     depends_on:
       password-manager-db:


### PR DESCRIPTION
## Summary
- add Password Manager client support for redacted tenant audit event listing and integrity status
- add an Audit tab with tenant-wide filters and public-safe event details
- update the bundled Password Manager API pin to api/v0.1.4
- extend E2E mock/assertions for audit visibility and secret-field redaction

## Validation
- PASSWORD_MANAGER_OPENAPI_CONTRACT_PATH=/Volumes/MacBookStorage-Dev/dev/carrtech/ct-password-manager-audit-view/docs/api-contract/openapi.json node --experimental-strip-types --test apps/web/lib/password-manager/client.test.mjs
- python3 deploy/scripts/validate-password-manager-release.py deploy/password-manager-release.json
- bash deploy/scripts/test-password-manager-release-contract.sh
- bash deploy/scripts/test-password-manager-compose.sh
- bash deploy/scripts/test-password-manager-nginx.sh
- bash deploy/scripts/test-password-manager-startup.sh
- pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'lib/password-manager/client.ts' 'lib/password-manager/client.test.mjs' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts
- BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret DATABASE_URL=postgres://test:test@localhost:5432/ctops_test pnpm --dir apps/web build

## Local validation blocked
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts: local testcontainers could not find a working container runtime