### PR TITLE
fix(password-manager): hide vault mutation UI for read-only roles

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,24 @@
 
 ## What Has Been Built
 
+### Session 131 — Password Manager vault role UI gates
+
+**Read-only vault workspace controls** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/tests/e2e/fixtures/password-manager.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)
+- Gated vault mutation affordances from the selected vault role returned by the
+  Password Manager API: only `owner` and `manager` roles can open Settings,
+  create entries, choose entry templates, or open edit-entry forms.
+- Kept read-only vault use intact for restricted roles by leaving vault
+  selection, entry listing, reveal, copy, export, and Audit available.
+- Added a hosted Password Manager E2E regression that downgrades the selected
+  vault to `viewer` and asserts Settings, New entry, template selection, and
+  entry edit controls are hidden.
+
+**Validation**
+- `pnpm --dir apps/web lint 'app/(dashboard)/password-manager/password-manager-client.tsx' 'tests/e2e/fixtures/password-manager.ts' 'tests/e2e/tooling/password-manager.spec.ts'`
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts`
+- `pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts --grep "read-only vault roles"` (blocked locally: `testcontainers` could not find a working container runtime)
+
 ### Session 130 — Password Manager tenant audit view
 
 **Standards-oriented audit visibility** (`apps/web/app/(dashboard)/password-manager/password-manager-client.tsx`, `apps/web/lib/password-manager/client.ts`, `apps/web/tests/e2e/fixtures/password-manager.ts`, `apps/web/tests/e2e/tooling/password-manager.spec.ts`)

--- a/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
+++ b/apps/web/app/(dashboard)/password-manager/password-manager-client.tsx
@@ -3057,6 +3057,7 @@ function PasswordManagerWorkspace({
   const [sshKeyGenerationPending, setSshKeyGenerationPending] = useState(false)
   const [sshKeyGenerationError, setSshKeyGenerationError] = useState<string | null>(null)
   const [visibleEntryPasswordFields, setVisibleEntryPasswordFields] = useState<Record<string, boolean>>({})
+  const [workspaceTab, setWorkspaceTab] = useState('passwords')
   const memberIds = new Set(members.map((member) => member.user_id))
   const selectedInstanceUser = instanceUsers.find((user) => user.id === memberUserId) ?? null
   const selectedRecipient = memberUserId ? memberRecipients[memberUserId] : undefined
@@ -3069,9 +3070,16 @@ function PasswordManagerWorkspace({
   }, [memberRecipients])
   const activeEntryTemplate = getPasswordManagerEntryTemplate(entryTemplateId)
   const isViewingEntry = entryDialogMode === 'view'
+  const canManageSelectedVault = !!selectedVault && canManageVaultRole(selectedVault.role)
   const selectedMemberLabel = selectedInstanceUser
     ? `${selectedInstanceUser.name || selectedInstanceUser.email} (${selectedInstanceUser.email})`
     : 'Select user'
+
+  useEffect(() => {
+    if (workspaceTab === 'settings' && !canManageSelectedVault) {
+      setWorkspaceTab('passwords')
+    }
+  }, [canManageSelectedVault, workspaceTab])
 
   async function handleCreateVaultFromDialog() {
     await onCreateVault()
@@ -3081,6 +3089,9 @@ function PasswordManagerWorkspace({
   }
 
   function handleStartCreateEntryDialog() {
+    if (!canManageSelectedVault) {
+      return
+    }
     onStartCreateEntry()
     setEntryDialogMode('create')
     setVisibleEntryPasswordFields({})
@@ -3090,6 +3101,9 @@ function PasswordManagerWorkspace({
   }
 
   function handleStartEditEntryDialog(entry: PasswordManagerEntrySummary) {
+    if (!canManageSelectedVault) {
+      return
+    }
     onSelectEntry(entry.id)
     onStartEditEntry(entry)
     setEntryDialogMode('edit')
@@ -3337,10 +3351,15 @@ function PasswordManagerWorkspace({
       </Dialog>
 
       <Tabs
-        defaultValue="passwords"
+        value={workspaceTab}
         className="gap-4"
         onValueChange={(value) => {
-          if (value === 'settings') {
+          if (value === 'settings' && !canManageSelectedVault) {
+            setWorkspaceTab('passwords')
+            return
+          }
+          setWorkspaceTab(value)
+          if (value === 'settings' && canManageSelectedVault) {
             onMemberRecipientLookupRequest()
           }
         }}
@@ -3354,10 +3373,12 @@ function PasswordManagerWorkspace({
             <ScrollText className="size-4" />
             Audit
           </TabsTrigger>
-          <TabsTrigger value="settings">
-            <Settings className="size-4" />
-            Settings
-          </TabsTrigger>
+          {canManageSelectedVault ? (
+            <TabsTrigger value="settings">
+              <Settings className="size-4" />
+              Settings
+            </TabsTrigger>
+          ) : null}
         </TabsList>
 
         <TabsContent value="passwords" className="space-y-4">
@@ -3377,46 +3398,48 @@ function PasswordManagerWorkspace({
                     <Download className="mr-2 size-4" />
                     Export vault
                   </Button>
-                  <div className="inline-flex rounded-md shadow-xs">
-                    <Button
-                      variant="outline"
-                      className="rounded-r-none border-r-0"
-                      onClick={handleStartCreateEntryDialog}
-                      disabled={!selectedVault || workspacePending}
-                    >
-                      <Plus className="mr-2 size-4" />
-                      New entry
-                    </Button>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          className="rounded-l-none px-2"
-                          aria-label="Choose entry template"
-                          data-testid="password-manager-entry-template-menu"
-                          disabled={!selectedVault || workspacePending}
-                        >
-                          <ChevronsUpDown className="size-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-64">
-                        <DropdownMenuLabel>Entry template</DropdownMenuLabel>
-                        <DropdownMenuRadioGroup
-                          value={selectedEntryTemplateId}
-                          onValueChange={(value) => onEntryTemplateChange(value as PasswordManagerEntryTemplateId)}
-                        >
-                          {PASSWORD_MANAGER_ENTRY_TEMPLATES.map((template) => (
-                            <DropdownMenuRadioItem key={template.id} value={template.id}>
-                              <div className="grid gap-0.5">
-                                <span>{template.label}</span>
-                                <span className="text-xs text-muted-foreground">{template.description}</span>
-                              </div>
-                            </DropdownMenuRadioItem>
-                          ))}
-                        </DropdownMenuRadioGroup>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
+                  {canManageSelectedVault ? (
+                    <div className="inline-flex rounded-md shadow-xs">
+                      <Button
+                        variant="outline"
+                        className="rounded-r-none border-r-0"
+                        onClick={handleStartCreateEntryDialog}
+                        disabled={!selectedVault || workspacePending}
+                      >
+                        <Plus className="mr-2 size-4" />
+                        New entry
+                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className="rounded-l-none px-2"
+                            aria-label="Choose entry template"
+                            data-testid="password-manager-entry-template-menu"
+                            disabled={!selectedVault || workspacePending}
+                          >
+                            <ChevronsUpDown className="size-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-64">
+                          <DropdownMenuLabel>Entry template</DropdownMenuLabel>
+                          <DropdownMenuRadioGroup
+                            value={selectedEntryTemplateId}
+                            onValueChange={(value) => onEntryTemplateChange(value as PasswordManagerEntryTemplateId)}
+                          >
+                            {PASSWORD_MANAGER_ENTRY_TEMPLATES.map((template) => (
+                              <DropdownMenuRadioItem key={template.id} value={template.id}>
+                                <div className="grid gap-0.5">
+                                  <span>{template.label}</span>
+                                  <span className="text-xs text-muted-foreground">{template.description}</span>
+                                </div>
+                              </DropdownMenuRadioItem>
+                            ))}
+                          </DropdownMenuRadioGroup>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </CardHeader>
@@ -3548,20 +3571,22 @@ function PasswordManagerWorkspace({
                           <TooltipContent>View entry</TooltipContent>
                         </Tooltip>
                       ) : null}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="icon-sm"
-                            onClick={() => handleStartEditEntryDialog(entry)}
-                            aria-label="Edit entry"
-                            title="Edit entry"
-                          >
-                            <Pencil className="size-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Edit entry</TooltipContent>
-                      </Tooltip>
+                      {canManageSelectedVault ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon-sm"
+                              onClick={() => handleStartEditEntryDialog(entry)}
+                              aria-label="Edit entry"
+                              title="Edit entry"
+                            >
+                              <Pencil className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Edit entry</TooltipContent>
+                        </Tooltip>
+                      ) : null}
                       </div>
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
@@ -3588,10 +3613,12 @@ function PasswordManagerWorkspace({
                               View
                             </DropdownMenuItem>
                           ) : null}
-                          <DropdownMenuItem onSelect={() => handleStartEditEntryDialog(entry)}>
-                            <Pencil className="size-4" />
-                            Edit
-                          </DropdownMenuItem>
+                          {canManageSelectedVault ? (
+                            <DropdownMenuItem onSelect={() => handleStartEditEntryDialog(entry)}>
+                              <Pencil className="size-4" />
+                              Edit
+                            </DropdownMenuItem>
+                          ) : null}
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </TableCell>
@@ -4137,7 +4164,8 @@ function PasswordManagerWorkspace({
           </Card>
         </TabsContent>
 
-        <TabsContent value="settings" className="space-y-4">
+        {canManageSelectedVault ? (
+          <TabsContent value="settings" className="space-y-4">
           {selectedVault ? (
             <Card className="border-border/60 shadow-xs">
               <CardHeader>
@@ -4474,7 +4502,8 @@ function PasswordManagerWorkspace({
               ) : null}
             </CardContent>
           </Card>
-        </TabsContent>
+          </TabsContent>
+        ) : null}
       </Tabs>
     </div>
   )

--- a/apps/web/tests/e2e/fixtures/password-manager.ts
+++ b/apps/web/tests/e2e/fixtures/password-manager.ts
@@ -48,6 +48,7 @@ interface PasswordManagerMockState {
 export interface PasswordManagerMockController {
   getMemberEnvelope(userId: string): PasswordManagerMemberEnvelope
   failNextRefreshWithSessionExpiry(): void
+  setVaultRole(vaultId: string, role: string): void
   switchAuthenticatedInstance(): Promise<void>
   launchAssertions(): string[]
   requestsFor(method: string, path: string): PasswordManagerMockRequest[]
@@ -658,6 +659,17 @@ export async function createPasswordManagerMock(context: BrowserContext): Promis
     },
     failNextRefreshWithSessionExpiry() {
       state.failNextRefresh = true
+    },
+    setVaultRole(vaultId: string, role: string) {
+      const vault = state.vaults.get(vaultId)
+      if (!vault) {
+        throw new Error(`Password Manager mock vault not found: ${vaultId}`)
+      }
+      vault.record.role = role
+      const currentMember = vault.members.get(state.currentUserId)
+      if (currentMember) {
+        currentMember.role = role
+      }
     },
     async switchAuthenticatedInstance() {
       const sql = getTestDb()

--- a/apps/web/tests/e2e/tooling/password-manager.spec.ts
+++ b/apps/web/tests/e2e/tooling/password-manager.spec.ts
@@ -422,3 +422,51 @@ test('hosted password manager flow keeps plaintext and key material inside the b
     expect(request.body).not.toContain(generatedRsaPrivateKey)
   }
 })
+
+test('hosted password manager hides vault mutation UI for read-only vault roles', async ({
+  authenticatedPage: page,
+  passwordManagerMock,
+}) => {
+  const setupPassword = 'LocalUnlockPassword!42'
+
+  await page.goto('/password-manager')
+  await expect(page.getByTestId('password-manager-state-setup-required')).toBeVisible()
+
+  await page.getByLabel('Unlock password', { exact: true }).fill(setupPassword)
+  await page.getByLabel('Confirm unlock password', { exact: true }).fill(setupPassword)
+  await page.getByRole('button', { name: 'Create unlock profile' }).click()
+
+  await page.getByRole('button', { name: 'Create vault' }).click()
+  await page.getByLabel('Vault name').fill('Shared production')
+  await page.getByRole('button', { name: 'Create encrypted vault' }).click()
+
+  await page.getByRole('button', { name: 'New entry' }).click()
+  await expect(page.getByRole('dialog', { name: 'New login' })).toBeVisible()
+  await page.getByLabel('Title').fill('Grafana admin')
+  await page.getByLabel('Username').fill('ops-admin')
+  await page.getByLabel('Password', { exact: true }).fill('SuperSecretPassword!99')
+  await page.getByRole('button', { name: 'Create encrypted entry' }).click()
+  await expect(page.getByTestId('password-manager-entry-entry-1')).toContainText('Grafana admin')
+
+  passwordManagerMock.setVaultRole('vault-1', 'viewer')
+  await page.reload()
+  await expect(page.getByTestId('password-manager-state-locked')).toBeVisible()
+  await page.getByLabel('Unlock password', { exact: true }).fill(setupPassword)
+  await page.getByRole('button', { name: 'Unlock' }).click()
+
+  await expect(page.getByTestId('password-manager-workspace')).toBeVisible()
+  await expect(page.getByTestId('password-manager-vault-vault-1')).toContainText('Shared production')
+  await expect(page.getByText('viewer')).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Settings' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'New entry' })).toHaveCount(0)
+  await expect(page.getByTestId('password-manager-entry-template-menu')).toHaveCount(0)
+
+  const entryCard = page.getByTestId('password-manager-entry-entry-1')
+  await expect(entryCard).toContainText('Grafana admin')
+  await expect(entryCard.getByRole('button', { name: 'Reveal password' })).toBeVisible()
+  await expect(entryCard.getByRole('button', { name: 'Copy password' })).toBeVisible()
+  await expect(entryCard.getByRole('button', { name: 'Edit entry' })).toHaveCount(0)
+
+  expect(passwordManagerMock.requestsFor('POST', '/vaults/vault-1/entries')).toHaveLength(1)
+  expect(passwordManagerMock.requestsFor('PATCH', '/vaults/vault-1')).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- Gate Password Manager Settings, entry creation, template selection, and entry edit controls to vault roles that can manage the vault: owner and manager.
- Keep read-only vault use available for restricted roles: entry list, reveal/copy, export, and audit remain visible.
- Add a hosted Password Manager E2E regression for a viewer vault role.

## Validation
- pnpm --dir apps/web lint app/(dashboard)/password-manager/password-manager-client.tsx tests/e2e/fixtures/password-manager.ts tests/e2e/tooling/password-manager.spec.ts
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec playwright test --list tests/e2e/tooling/password-manager.spec.ts
- pnpm --dir apps/web exec node tests/e2e/runner.mjs tests/e2e/tooling/password-manager.spec.ts --grep "read-only vault roles" (blocked locally: testcontainers could not find a working container runtime)