### PR TITLE
fix(web): cover customer start script query regression

### DIFF
--- a/apps/web/lib/deploy-start-script.test.mjs
+++ b/apps/web/lib/deploy-start-script.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const repoFile = (path) => new URL(`../../../${path}`, import.meta.url)
+
+test('start scripts send the Ansible settings query to psql stdin', () => {
+  for (const path of ['start.sh', 'deploy/customer-bundle/start.sh']) {
+    const script = readFileSync(repoFile(path), 'utf8')
+
+    assert.match(script, /should_start_ansible_profile\(\)/)
+    assert.match(script, /<<'SQL'/)
+    assert.doesNotMatch(script, /-c "SELECT CASE WHEN EXISTS/)
+    assert.match(script, /WHERE id = :'instance_id'/)
+    assert.match(script, /metadata->'featureFlags'->>'automation\.ansible'/)
+  }
+})


### PR DESCRIPTION
## Summary
- add a web unit regression test that checks both start scripts send the Ansible settings query to psql via stdin
- this keeps the deployment-script fix covered from the web package and triggers a web patch release containing PR #1303

## Validation
- node --experimental-strip-types --test apps/web/lib/deploy-start-script.test.mjs
- bash deploy/scripts/test-ansible-profile-wiring.sh
- bash deploy/scripts/test-start.sh
- pnpm --filter web test:unit (fails only on existing Testcontainers runtime requirement: Could not find a working container runtime strategy)