### PR TITLE
fix(deploy): allow bundle restarts on occupied nginx ports

### DIFF
--- a/deploy/customer-bundle/start.sh
+++ b/deploy/customer-bundle/start.sh
@@ -702,7 +702,6 @@ start_stack() {
   check_env
   validate_password_manager_image_pin docker-compose.yml password-manager-release.json
   warn_legacy_env
-  check_ports_free
   ensure_tls_certs
 
   if [ -f "images.tar.gz" ]; then
@@ -727,6 +726,7 @@ start_stack() {
   fi
 
   docker compose down --remove-orphans >/dev/null 2>&1 || true
+  check_ports_free
 
   echo "Running database migrations..."
   if ! docker compose up --force-recreate --abort-on-container-exit --exit-code-from migrate migrate; then
@@ -745,7 +745,7 @@ start_stack() {
     exit 1
   fi
 
-  local compose_profile_args=()
+  local -a compose_profile_args=()
   if should_start_ansible_profile; then
     echo "Ansible automation is enabled; starting optional ansible-api service."
     compose_profile_args=(--profile ansible)
@@ -759,7 +759,13 @@ start_stack() {
   fi
 
   echo "Starting CT-Ops..."
-  if ! docker compose "${compose_profile_args[@]}" up -d; then
+  if ! {
+    if [ ${#compose_profile_args[@]} -gt 0 ]; then
+      docker compose "${compose_profile_args[@]}" up -d
+    else
+      docker compose up -d
+    fi
+  }; then
     echo "" >&2
     echo "ERROR: 'docker compose up' failed." >&2
     echo "Recent logs (last 50 lines per service):" >&2

--- a/deploy/scripts/test-start-restart-port-check.sh
+++ b/deploy/scripts/test-start-restart-port-check.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+START_SCRIPT="${REPO_ROOT}/deploy/customer-bundle/start.sh"
+ROOT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.single.yml"
+PASSWORD_MANAGER_RELEASE_DESCRIPTOR="${REPO_ROOT}/deploy/password-manager-release.json"
+
+make_mock_bin() {
+  local dir="$1"
+  local log_file="$2"
+
+  cat > "${dir}/docker" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "\$*" >> "${log_file}"
+
+if [ "\$#" -ge 2 ] && [ "\$1" = "compose" ] && [ "\$2" = "version" ]; then
+  exit 0
+fi
+
+if [ "\$#" -ge 3 ] && [ "\$1" = "compose" ] && [ "\$2" = "pull" ]; then
+  exit 0
+fi
+
+if [ "\$#" -ge 3 ] && [ "\$1" = "compose" ] && [ "\$2" = "down" ] && [ "\$3" = "--remove-orphans" ]; then
+  rm -f "${dir}/ports-in-use"
+  exit 0
+fi
+
+if [ "\$#" -ge 7 ] && [ "\$1" = "compose" ] && [ "\$2" = "up" ] && [ "\$3" = "--force-recreate" ] && [ "\$4" = "--abort-on-container-exit" ]; then
+  exit 0
+fi
+
+if [ "\$#" -ge 4 ] && [ "\$1" = "compose" ] && [ "\$2" = "exec" ] && [ "\$3" = "-T" ] && [ "\$4" = "db" ]; then
+  printf 'false\n'
+  exit 0
+fi
+
+if [ "\$#" -ge 3 ] && [ "\$1" = "compose" ] && [ "\$2" = "up" ] && [ "\$3" = "-d" ]; then
+  exit 0
+fi
+
+echo "unexpected docker invocation: \$*" >&2
+exit 99
+EOF
+
+  cat > "${dir}/ss" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -f "${dir}/ports-in-use" ]; then
+  cat <<'SS'
+State  Recv-Q Send-Q Local Address:Port Peer Address:Port
+LISTEN 0      4096   0.0.0.0:80       0.0.0.0:*
+LISTEN 0      4096   0.0.0.0:443      0.0.0.0:*
+SS
+else
+  cat <<'SS'
+State  Recv-Q Send-Q Local Address:Port Peer Address:Port
+SS
+fi
+EOF
+
+  chmod +x "${dir}/docker" "${dir}/ss"
+}
+
+main() {
+  local tmpdir mockbin install_dir log_file output
+  tmpdir="$(mktemp -d)"
+  trap 'chmod -R u+w "'"$tmpdir"'" 2>/dev/null || true; rm -rf "'"$tmpdir"'"' EXIT
+
+  mockbin="${tmpdir}/mockbin"
+  install_dir="${tmpdir}/ct-ops"
+  log_file="${tmpdir}/docker.log"
+  mkdir -p "$mockbin" "$install_dir/deploy/nginx" "$install_dir/deploy/dev-tls" "$install_dir/deploy/tls"
+  : > "${mockbin}/ports-in-use"
+  make_mock_bin "$mockbin" "$log_file"
+
+  cp "$START_SCRIPT" "$install_dir/start.sh"
+  cp "$ROOT_COMPOSE_FILE" "$install_dir/docker-compose.yml"
+  cp "$PASSWORD_MANAGER_RELEASE_DESCRIPTOR" "$install_dir/password-manager-release.json"
+  printf 'nginx config\n' > "$install_dir/deploy/nginx/nginx.conf"
+  printf 'dev cert\n' > "$install_dir/deploy/dev-tls/server.crt"
+  printf 'dev key\n' > "$install_dir/deploy/dev-tls/server.key"
+  printf 'live cert\n' > "$install_dir/deploy/tls/server.crt"
+  printf 'live key\n' > "$install_dir/deploy/tls/server.key"
+  cat > "$install_dir/.env" <<'EOF'
+BETTER_AUTH_URL=https://ct-ops
+BETTER_AUTH_TRUSTED_ORIGINS=https://ct-ops
+BETTER_AUTH_SECRET=test-secret
+POSTGRES_PASSWORD=test-password
+AGENT_DOWNLOAD_BASE_URL=https://ct-ops
+WEB_IMAGE=ghcr.io/carrtech-dev/ct-ops/web@sha256:1111111111111111111111111111111111111111111111111111111111111111
+INGEST_IMAGE=ghcr.io/carrtech-dev/ct-ops/ingest@sha256:2222222222222222222222222222222222222222222222222222222222222222
+EOF
+
+  output="$(
+    cd "$install_dir" &&
+      PATH="${mockbin}:/usr/bin:/bin:/usr/sbin:/sbin" ./start.sh 2>&1
+  )"
+
+  if [[ "$output" != *"CT-Ops is starting."* ]]; then
+    echo "expected start.sh to continue after restarting an existing stack, got:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  if ! grep -q '^compose down --remove-orphans$' "$log_file"; then
+    echo "expected docker compose down to be called" >&2
+    cat "$log_file" >&2
+    exit 1
+  fi
+
+  if grep -q 'the following ports are already bound on this host' <<<"$output"; then
+    echo "expected port check to ignore the stack being restarted" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  echo "start.sh restart port check test passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- move the customer-bundle nginx port check to run after 
- add a restart regression test that simulates 80/443 being occupied by the existing CT-Ops stack
- keep the check in place for genuinely foreign listeners

## Validation
- bash deploy/scripts/test-start-restart-port-check.sh
- bash deploy/scripts/test-start.sh
- bash -n deploy/customer-bundle/start.sh
- hot-patched and verified 
Created .env from .env.example.
Edit .env to set your URLs, then re-run ./start.sh. on simon@ct-ops with Ansible enabled