### PR TITLE
fix(ansible-api): install ssh client

### DIFF
--- a/apps/ansible-api/Dockerfile
+++ b/apps/ansible-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-alpine
 
-RUN apk add --no-cache ansible \
+RUN apk add --no-cache ansible openssh-client \
   && addgroup -S ansible \
   && adduser -S -G ansible ansible
 


### PR DESCRIPTION
## Summary
- install Alpine openssh-client in the ansible-api image so Ansible can execute SSH transport commands

## Validation
- PYTHONPATH=apps/ansible-api python3 -m unittest discover -s apps/ansible-api/tests
- gitleaks detect --no-git --source . --redact --verbose

## Notes
- Local Docker daemon was unavailable, so image-level validation is left to CI Docker image build.