### PR TITLE
fix(ansible): scope ping output per host

### DIFF
--- a/apps/ansible-api/server.py
+++ b/apps/ansible-api/server.py
@@ -196,7 +196,7 @@ def run_ansible_ping_command(payload: dict[str, Any]) -> CommandResult:
     )
 
 
-def _host_succeeded_from_json(stdout: str, host_id: str) -> bool | None:
+def _host_result_from_json(stdout: str, host_id: str) -> dict[str, Any] | None:
     try:
         data = json.loads(stdout)
     except Exception:
@@ -211,14 +211,56 @@ def _host_succeeded_from_json(stdout: str, host_id: str) -> bool | None:
                 continue
             result = hosts[host_id]
             if isinstance(result, dict):
-                return bool(result.get("ping") == "pong" or result.get("ok", 0)) and not bool(result.get("failed", False))
+                return result
     return None
+
+
+def _host_succeeded_from_json(stdout: str, host_id: str) -> bool | None:
+    result = _host_result_from_json(stdout, host_id)
+    if result is None:
+        return None
+    return bool(result.get("ping") == "pong" or result.get("ok", 0)) and not bool(result.get("failed", False))
+
+
+def _host_stdout(stdout: str, host_id: str, host_ids: set[str]) -> str:
+    result = _host_result_from_json(stdout, host_id)
+    if result is not None:
+        return json.dumps({host_id: result}, indent=2, sort_keys=True) + "\n"
+
+    lines = stdout.splitlines()
+    if not lines:
+        return stdout
+
+    selected: list[str] = []
+    collecting = False
+    for line in lines:
+        starts_host_block = any(line.startswith(f"{candidate} |") for candidate in host_ids)
+        if starts_host_block:
+            collecting = line.startswith(f"{host_id} |")
+        if collecting:
+            selected.append(line)
+
+    if not selected and not any(host in stdout for host in host_ids):
+        return stdout
+    return "\n".join(selected) + ("\n" if selected else "")
+
+
+def _host_stderr(stderr: str, host_id: str, host_ids: set[str]) -> str:
+    lines = stderr.splitlines()
+    if not lines:
+        return stderr
+
+    selected = [line for line in lines if host_id in line]
+    if not selected and not any(host in stderr for host in host_ids):
+        return stderr
+    return "\n".join(selected) + ("\n" if selected else "")
 
 
 def run_ansible_ping(payload: dict[str, Any]) -> dict[str, Any]:
     request = validate_ansible_ping_request(payload)
     command = run_ansible_ping_command(request)
     results = []
+    host_ids = {host["id"] for host in request["hosts"]}
 
     for host in request["hosts"]:
         succeeded = _host_succeeded_from_json(command.stdout, host["id"])
@@ -229,8 +271,8 @@ def run_ansible_ping(payload: dict[str, Any]) -> dict[str, Any]:
             "name": host["name"],
             "status": "success" if succeeded else "failed",
             "exitCode": 0 if succeeded else (command.returncode or 1),
-            "stdout": command.stdout,
-            "stderr": command.stderr,
+            "stdout": _host_stdout(command.stdout, host["id"], host_ids),
+            "stderr": _host_stderr(command.stderr, host["id"], host_ids),
         })
 
     return {

--- a/apps/ansible-api/tests/test_contract.py
+++ b/apps/ansible-api/tests/test_contract.py
@@ -69,6 +69,47 @@ class AnsibleApiContractTests(unittest.TestCase):
         self.assertEqual(payload["hosts"][0]["exitCode"], 0)
         self.assertEqual(payload["elapsedMs"], 25)
 
+    @mock.patch("server.run_ansible_ping_command")
+    def test_run_ansible_ping_returns_host_scoped_output(self, run_command):
+        run_command.return_value = server.CommandResult(
+            returncode=0,
+            stdout=json.dumps({
+                "plays": [{
+                    "tasks": [{
+                        "hosts": {
+                            "host-1": {"ping": "pong", "changed": False},
+                            "host-2": {"ping": "pong", "changed": False},
+                        },
+                    }],
+                }],
+            }),
+            stderr="\n".join([
+                "[WARNING]: Host 'host-1' is using the discovered Python interpreter at '/usr/bin/python3.12'",
+                "[WARNING]: Host 'host-2' is using the discovered Python interpreter at '/usr/bin/python3.12'",
+            ]),
+            elapsedMs=25,
+        )
+
+        payload = server.run_ansible_ping({
+            "credential": {
+                "username": "deploy",
+                "privateKey": private_key_block(),
+            },
+            "hosts": [
+                {"id": "host-1", "name": "host-1", "address": "10.0.0.10", "port": 22},
+                {"id": "host-2", "name": "host-2", "address": "10.0.0.11", "port": 22},
+            ],
+        })
+
+        self.assertIn("host-1", payload["hosts"][0]["stdout"])
+        self.assertNotIn("host-2", payload["hosts"][0]["stdout"])
+        self.assertIn("Host 'host-1'", payload["hosts"][0]["stderr"])
+        self.assertNotIn("Host 'host-2'", payload["hosts"][0]["stderr"])
+        self.assertIn("host-2", payload["hosts"][1]["stdout"])
+        self.assertNotIn("host-1", payload["hosts"][1]["stdout"])
+        self.assertIn("Host 'host-2'", payload["hosts"][1]["stderr"])
+        self.assertNotIn("Host 'host-1'", payload["hosts"][1]["stderr"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Scope Ansible ping stdout/stderr to the matching inventory host before storing per-host task output
- Preserve command-level diagnostics when Ansible output is not host-specific
- Add a contract regression test for multi-host Ansible ping output isolation

Fixes #1315.

## Validation
- `python3 -m unittest tests/test_contract.py` from `apps/ansible-api`
- `git diff --check`

Note: `pnpm` is not available on this shell PATH, so web package tests were not run locally.