### PR TITLE
fix(ansible-api): report hostnames in ping output

### DIFF
--- a/apps/ansible-api/server.py
+++ b/apps/ansible-api/server.py
@@ -148,7 +148,7 @@ def inventory_text(hosts: list[dict[str, Any]], username: str) -> str:
     lines = ["[ct_ops_targets]"]
     for host in hosts:
         lines.append(
-            f"{host['id']} ansible_host={host['address']} ansible_user={username} ansible_port={host['port']}"
+            f"{host['name']} ansible_host={host['address']} ansible_user={username} ansible_port={host['port']}"
         )
     return "\n".join(lines) + "\n"
 
@@ -221,7 +221,7 @@ def run_ansible_ping(payload: dict[str, Any]) -> dict[str, Any]:
     results = []
 
     for host in request["hosts"]:
-        succeeded = _host_succeeded_from_json(command.stdout, host["id"])
+        succeeded = _host_succeeded_from_json(command.stdout, host["name"])
         if succeeded is None:
             succeeded = command.returncode == 0
         results.append({

--- a/apps/ansible-api/tests/test_contract.py
+++ b/apps/ansible-api/tests/test_contract.py
@@ -46,11 +46,27 @@ class AnsibleApiContractTests(unittest.TestCase):
                 "hosts": [],
             })
 
+    def test_inventory_text_uses_hostname_as_ansible_alias(self):
+        inventory = server.inventory_text([
+            {
+                "id": "faspa3cinwzc10930aa1rqra",
+                "name": "web-01.example.test",
+                "address": "10.0.0.10",
+                "port": 2222,
+            }
+        ], "deploy")
+
+        self.assertIn(
+            "web-01.example.test ansible_host=10.0.0.10 ansible_user=deploy ansible_port=2222",
+            inventory,
+        )
+        self.assertNotIn("faspa3cinwzc10930aa1rqra ansible_host=", inventory)
+
     @mock.patch("server.run_ansible_ping_command")
     def test_run_ansible_ping_shapes_per_host_results(self, run_command):
         run_command.return_value = server.CommandResult(
-            returncode=0,
-            stdout='{"plays":[{"tasks":[{"hosts":{"host-1":{"ok":1,"failed":0}}}]}]}',
+            returncode=1,
+            stdout='{"plays":[{"tasks":[{"hosts":{"server-1.example.test":{"ok":1,"failed":0}}}]}]}',
             stderr="",
             elapsedMs=25,
         )
@@ -60,11 +76,12 @@ class AnsibleApiContractTests(unittest.TestCase):
                 "username": "deploy",
                 "privateKey": private_key_block(),
             },
-            "hosts": [{"id": "host-1", "name": "host-1", "address": "10.0.0.10", "port": 22}],
+            "hosts": [{"id": "host-1", "name": "server-1.example.test", "address": "10.0.0.10", "port": 22}],
         })
 
         self.assertEqual(payload["ok"], True)
         self.assertEqual(payload["hosts"][0]["id"], "host-1")
+        self.assertEqual(payload["hosts"][0]["name"], "server-1.example.test")
         self.assertEqual(payload["hosts"][0]["status"], "success")
         self.assertEqual(payload["hosts"][0]["exitCode"], 0)
         self.assertEqual(payload["elapsedMs"], 25)


### PR DESCRIPTION
## Summary
- use the host hostname as the Ansible inventory alias so Ansible stdout reports hostnames instead of CT-Ops host ids
- keep CT-Ops host ids in the API response while parsing Ansible JSON callback results by hostname
- add Ansible API contract coverage for hostname-based inventory aliases

Fixes #1316

## Tests
- python3 -m unittest discover tests (from apps/ansible-api)

## Notes
- Tried running the web unit test command, but pnpm is not available on this shell's PATH.