### PR TITLE
fix(bundle): resolve released image version tags

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -179,14 +179,19 @@ jobs:
           resolve_released_image_ref() {
             local component="$1"
             local version="$2"
+            local image_tag
             local digest
             if [ -z "$version" ] || [ "$version" = "null" ]; then
               echo "ERROR: missing release-please manifest version for ${component}" >&2
               exit 1
             fi
-            digest="$(docker buildx imagetools inspect "ghcr.io/carrtech-dev/ct-ops/${component}:${version}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+            image_tag="${version}"
+            if [[ "$image_tag" != v* ]]; then
+              image_tag="v${image_tag}"
+            fi
+            digest="$(docker buildx imagetools inspect "ghcr.io/carrtech-dev/ct-ops/${component}:${image_tag}" --format '{{json .Manifest.Digest}}' | tr -d '"')"
             if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-              echo "ERROR: could not resolve digest for ${component}:${version}" >&2
+              echo "ERROR: could not resolve digest for ${component}:${image_tag}" >&2
               exit 1
             fi
             printf 'ghcr.io/carrtech-dev/ct-ops/%s@%s\n' "$component" "$digest"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -25,7 +25,9 @@
   Password Manager metadata, and bundle SBOM assets to the bundle release.
 - Kept customer defaults digest-pinned by using same-run image build outputs
   when available, otherwise resolving the latest released component version
-  tags for `WEB_IMAGE`, `INGEST_IMAGE`, and `ANSIBLE_API_IMAGE`.
+  tags for `WEB_IMAGE`, `INGEST_IMAGE`, and `ANSIBLE_API_IMAGE`. The fallback
+  resolver normalizes release-please manifest versions to the published
+  `v<version>` image tags before reading manifest digests.
 - Updated installer and upgrade scripts to download the latest bundle release,
   refresh all three CT-Ops runtime image env refs, and preserve custom operator
   overrides with explicit warnings.

--- a/deploy/scripts/test-agent-release-bundle.sh
+++ b/deploy/scripts/test-agent-release-bundle.sh
@@ -45,6 +45,7 @@ assert_contains "$WORKFLOW" "needs.release-please.outputs.bundle_release_created
 assert_contains "$WORKFLOW" "ref: \${{ needs.release-please.outputs.bundle_tag_name }}"
 assert_contains "$WORKFLOW" "tag_name: \${{ needs.release-please.outputs.bundle_tag_name }}"
 assert_contains "$WORKFLOW" "VERSION=\"\${TAG#bundle/}\""
+assert_contains "$WORKFLOW" "image_tag=\"v\${image_tag}\""
 
 assert_contains "$WORKFLOW" "resolve_released_image_ref web \"\$WEB_VERSION\""
 assert_contains "$WORKFLOW" "resolve_released_image_ref ingest \"\$INGEST_VERSION\""


### PR DESCRIPTION
## Summary
- normalize release-please manifest versions to the published v-prefixed image tags before resolving fallback digests
- extend the bundle workflow regression check for this behavior

## Validation
- bash -n deploy/scripts/test-agent-release-bundle.sh
- bash deploy/scripts/test-agent-release-bundle.sh
- ruby YAML parse for .github/workflows/agent-release.yml
- python3 -m json.tool release-please-config.json
- python3 -m json.tool .release-please-manifest.json
- docker buildx imagetools inspect ghcr.io/carrtech-dev/ct-ops/web:v0.136.0
- docker buildx imagetools inspect ghcr.io/carrtech-dev/ct-ops/ingest:v0.9.7
- docker buildx imagetools inspect ghcr.io/carrtech-dev/ct-ops/ansible-api:v0.3.1
- bash -n install.sh deploy/customer-bundle/upgrade.sh deploy/customer-bundle/start.sh deploy/scripts/test-install.sh deploy/scripts/test-upgrade.sh deploy/scripts/test-agent-release-bundle.sh
- git diff --check