### PR TITLE
fix(bundle): verify ansible profile image pin

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -635,7 +635,7 @@ jobs:
           PASSWORD_MANAGER_API_IMAGE_REF="$(python3 -c 'import json; print(json.load(open("deploy/password-manager-release.json", encoding="utf-8"))["digest_reference"])')"
           export BETTER_AUTH_SECRET=verify-placeholder
           export POSTGRES_PASSWORD=verify-placeholder
-          refs="$(docker compose -f dist/ct-ops/docker-compose.yml --env-file dist/ct-ops/.env.example config --images)"
+          refs="$(docker compose -f dist/ct-ops/docker-compose.yml --env-file dist/ct-ops/.env.example --profile ansible config --images)"
           echo "$refs"
           ! grep -q '^PASSWORD_MANAGER_API_IMAGE=' dist/ct-ops/.env.example
           ! grep -q 'PASSWORD_MANAGER_API_IMAGE' dist/ct-ops/docker-compose.yml

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -27,7 +27,9 @@
   when available, otherwise resolving the latest released component version
   tags for `WEB_IMAGE`, `INGEST_IMAGE`, and `ANSIBLE_API_IMAGE`. The fallback
   resolver normalizes release-please manifest versions to the published
-  `v<version>` image tags before reading manifest digests.
+  `v<version>` image tags before reading manifest digests, and the release
+  verification renders the ansible Compose profile so the optional
+  `ANSIBLE_API_IMAGE` pin is checked.
 - Updated installer and upgrade scripts to download the latest bundle release,
   refresh all three CT-Ops runtime image env refs, and preserve custom operator
   overrides with explicit warnings.

--- a/deploy/scripts/test-agent-release-bundle.sh
+++ b/deploy/scripts/test-agent-release-bundle.sh
@@ -10,7 +10,7 @@ MANIFEST="${REPO_ROOT}/.release-please-manifest.json"
 assert_contains() {
   local file="$1"
   local needle="$2"
-  if ! grep -Fq "$needle" "$file"; then
+  if ! grep -Fq -- "$needle" "$file"; then
     echo "expected ${file} to contain: ${needle}" >&2
     exit 1
   fi
@@ -19,7 +19,7 @@ assert_contains() {
 assert_not_contains() {
   local file="$1"
   local needle="$2"
-  if grep -Fq "$needle" "$file"; then
+  if grep -Fq -- "$needle" "$file"; then
     echo "expected ${file} not to contain: ${needle}" >&2
     exit 1
   fi
@@ -60,6 +60,7 @@ assert_contains "$WORKFLOW" "ANSIBLE_API_IMAGE_REF="
 assert_contains "$WORKFLOW" "grep -Fxq \"\${WEB_IMAGE_REF}\" <<< \"\$refs\""
 assert_contains "$WORKFLOW" "grep -Fxq \"\${INGEST_IMAGE_REF}\" <<< \"\$refs\""
 assert_contains "$WORKFLOW" "grep -Fxq \"\${ANSIBLE_API_IMAGE_REF}\" <<< \"\$refs\""
+assert_contains "$WORKFLOW" "--profile ansible config --images"
 assert_not_contains "$WORKFLOW" "imagetools inspect ghcr.io/carrtech-dev/ct-ops/ingest:latest"
 assert_not_contains "$WORKFLOW" "imagetools inspect ghcr.io/carrtech-dev/ct-ops/ansible-api:latest"
 


### PR DESCRIPTION
## Summary
- render the ansible Compose profile in release bundle verification so ANSIBLE_API_IMAGE is present and checked
- make the static workflow regression helper handle needles that begin with '-'

## Validation
- bash -n deploy/scripts/test-agent-release-bundle.sh
- bash deploy/scripts/test-agent-release-bundle.sh
- ruby YAML parse for .github/workflows/agent-release.yml
- local docker compose render with --profile ansible confirmed WEB_IMAGE, INGEST_IMAGE, and ANSIBLE_API_IMAGE digests from the release run
- git diff --check