### PR TITLE
fix(web): remove auth secrets from Docker build args

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -74,10 +74,8 @@ COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Build the app (DATABASE_URL not needed at build time — only for drizzle-kit)
+# Build the app (DATABASE_URL is only needed if build-time code imports db config).
 ARG DATABASE_URL=postgresql://placeholder:placeholder@placeholder:5432/placeholder
-ARG BETTER_AUTH_SECRET=build-time-placeholder-not-used-at-runtime
-ARG BETTER_AUTH_URL=https://build-time-placeholder.invalid
 
 WORKDIR /app/apps/web
 RUN pnpm run build

--- a/apps/web/lib/auth/env.test.mjs
+++ b/apps/web/lib/auth/env.test.mjs
@@ -21,6 +21,14 @@ test('getBetterAuthUrl rejects missing or invalid values', () => {
   )
 })
 
+test('Better Auth env uses deterministic placeholders during production builds only', () => {
+  const buildEnv = { NEXT_PHASE: 'phase-production-build' }
+
+  assert.equal(getBetterAuthSecret(buildEnv).length, 32)
+  assert.equal(getBetterAuthUrl(buildEnv), 'https://build-time-placeholder.invalid/')
+  assert.equal(getBetterAuthOrigin(buildEnv), 'https://build-time-placeholder.invalid')
+})
+
 test('getBetterAuthOrigin normalises BETTER_AUTH_URL to an origin', () => {
   assert.equal(
     getBetterAuthOrigin({ BETTER_AUTH_URL: 'https://ct-ops.example.com/login?next=%2Fdashboard' }),

--- a/apps/web/lib/auth/env.ts
+++ b/apps/web/lib/auth/env.ts
@@ -1,5 +1,13 @@
 type EnvLike = Record<string, string | undefined>
 
+const PRODUCTION_BUILD_PHASE = 'phase-production-build'
+const BUILD_TIME_AUTH_SECRET = 'build-time-placeholder-000000000'
+const BUILD_TIME_AUTH_URL = 'https://build-time-placeholder.invalid'
+
+function isProductionBuildPhase(env: EnvLike): boolean {
+  return env['NEXT_PHASE'] === PRODUCTION_BUILD_PHASE
+}
+
 function readBooleanEnv(env: EnvLike, name: string, fallback: boolean): boolean {
   const value = env[name]?.trim().toLowerCase()
   if (!value) return fallback
@@ -10,10 +18,16 @@ function readBooleanEnv(env: EnvLike, name: string, fallback: boolean): boolean 
 
 function readRequiredEnv(env: EnvLike, name: 'BETTER_AUTH_SECRET' | 'BETTER_AUTH_URL'): string {
   const value = env[name]?.trim()
-  if (!value) {
-    throw new Error(`${name} must be set`)
+  if (value) {
+    return value
   }
-  return value
+
+  if (isProductionBuildPhase(env)) {
+    if (name === 'BETTER_AUTH_SECRET') return BUILD_TIME_AUTH_SECRET
+    return BUILD_TIME_AUTH_URL
+  }
+
+  throw new Error(`${name} must be set`)
 }
 
 export function getBetterAuthSecret(env: EnvLike = process.env): string {

--- a/apps/web/lib/dockerfile.test.mjs
+++ b/apps/web/lib/dockerfile.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const dockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8')
+
+test('web Dockerfile does not declare secret-shaped auth build variables', () => {
+  assert.doesNotMatch(dockerfile, /^\s*(ARG|ENV)\s+BETTER_AUTH_SECRET\b/m)
+  assert.doesNotMatch(dockerfile, /^\s*(ARG|ENV)\s+BETTER_AUTH_URL\b/m)
+})

--- a/apps/web/lib/security/trusted-origins.test.mjs
+++ b/apps/web/lib/security/trusted-origins.test.mjs
@@ -25,6 +25,13 @@ test('getTrustedOrigins rejects missing BETTER_AUTH_URL instead of silently usin
   assert.throws(() => getTrustedOrigins({}), /BETTER_AUTH_URL must be set/)
 })
 
+test('getTrustedOriginHosts uses deterministic placeholder origin during production builds only', () => {
+  assert.deepEqual(
+    getTrustedOriginHosts({ NEXT_PHASE: 'phase-production-build' }),
+    ['build-time-placeholder.invalid'],
+  )
+})
+
 test('getTrustedOriginHosts keeps the host:port values expected by Next serverActions.allowedOrigins', () => {
   const env = {
     BETTER_AUTH_URL: 'https://ct-ops.example.com',

--- a/apps/web/lib/security/trusted-origins.ts
+++ b/apps/web/lib/security/trusted-origins.ts
@@ -1,5 +1,8 @@
 type EnvLike = Record<string, string | undefined>
 
+const PRODUCTION_BUILD_PHASE = 'phase-production-build'
+const BUILD_TIME_AUTH_URL = 'https://build-time-placeholder.invalid'
+
 function normaliseOrigin(value: string): string | null {
   try {
     return new URL(value).origin
@@ -10,6 +13,10 @@ function normaliseOrigin(value: string): string | null {
 
 function getConfiguredAuthUrl(env: EnvLike): string {
   const value = env['BETTER_AUTH_URL']?.trim()
+  if (!value && env['NEXT_PHASE'] === PRODUCTION_BUILD_PHASE) {
+    return BUILD_TIME_AUTH_URL
+  }
+
   if (!value) {
     throw new Error('BETTER_AUTH_URL must be set')
   }


### PR DESCRIPTION
## Summary
- remove BETTER_AUTH_SECRET and BETTER_AUTH_URL from the web Docker build args
- provide deterministic auth placeholders only during Next production builds
- add regression coverage for Dockerfile secret-shaped build variables and build-phase placeholders

Closes #1322

## Tests
- node --experimental-strip-types --test apps/web/lib/dockerfile.test.mjs apps/web/lib/auth/env.test.mjs apps/web/lib/security/trusted-origins.test.mjs

## Notes
- Docker build check was not run locally because the Docker daemon is not running in this environment.