### PR TITLE
fix(upgrade): avoid self-overwriting running script

### DIFF
--- a/deploy/customer-bundle/upgrade.sh
+++ b/deploy/customer-bundle/upgrade.sh
@@ -15,6 +15,19 @@ REPO_NAME="ct-ops"
 RELEASE_MANIFEST_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/.release-please-manifest.json"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -n "${CT_OPS_UPGRADE_SCRIPT_DIR:-}" ]; then
+  SCRIPT_DIR="$CT_OPS_UPGRADE_SCRIPT_DIR"
+fi
+
+if [ -z "${CT_OPS_UPGRADE_SCRIPT_SNAPSHOT:-}" ]; then
+  SCRIPT_SNAPSHOT="$(mktemp -t ct-ops-upgrade.XXXXXX.sh)"
+  cp "${BASH_SOURCE[0]}" "$SCRIPT_SNAPSHOT"
+  chmod +x "$SCRIPT_SNAPSHOT"
+  CT_OPS_UPGRADE_SCRIPT_SNAPSHOT=1 \
+    CT_OPS_UPGRADE_SCRIPT_DIR="$SCRIPT_DIR" \
+    CT_OPS_UPGRADE_SCRIPT_SNAPSHOT_PATH="$SCRIPT_SNAPSHOT" \
+    exec bash "$SCRIPT_SNAPSHOT" "$@"
+fi
 cd "$SCRIPT_DIR"
 
 FROM_ZIP=""
@@ -369,6 +382,9 @@ BUNDLE_ZIP=""
 BACKUP_FILE=""
 UNPACK_DIR=""
 NEW_BUNDLE_DIR=""
+if [ -n "${CT_OPS_UPGRADE_SCRIPT_SNAPSHOT_PATH:-}" ]; then
+  TEMP_FILES+=("$CT_OPS_UPGRADE_SCRIPT_SNAPSHOT_PATH")
+fi
 trap cleanup EXIT
 
 require_existing_bundle

--- a/deploy/scripts/test-upgrade.sh
+++ b/deploy/scripts/test-upgrade.sh
@@ -136,6 +136,15 @@ EOF
     "${dir}/ct-ops/upgrade.sh"
 }
 
+write_replacement_upgrade_script() {
+  local path="$1"
+  local version="$2"
+
+  printf '#!/usr/bin/env bash\n' > "$path"
+  printf 'echo replacement upgrade helper %s\n' "$version" >> "$path"
+  chmod +x "$path"
+}
+
 main() {
   local tmpdir mockbin old_install new_src backup_dir bundle_zip docker_log
   tmpdir="$(mktemp -d)"
@@ -166,6 +175,7 @@ main() {
   chmod 500 "${old_install}/licence-keys"
 
   write_bundle "$new_src" "v9.9.9"
+  write_replacement_upgrade_script "${new_src}/ct-ops/upgrade.sh" "v9.9.9"
   (cd "$new_src" && zip -qr "$bundle_zip" ct-ops)
 
   (
@@ -186,6 +196,7 @@ main() {
   grep -q 'tls-cert' "${old_install}/deploy/tls/server.crt"
   grep -q 'dev-cert' "${old_install}/deploy/dev-tls/server.crt"
   grep -q 'public-key-v9.9.9' "${old_install}/licence-keys/current.pem"
+  grep -q 'replacement upgrade helper v9.9.9' "${old_install}/upgrade.sh"
   test -w "${old_install}/licence-keys"
   test ! -f "${old_install}/images.tar.gz"
   grep -q 'docker compose down' "$docker_log"


### PR DESCRIPTION
## Summary
- run upgrade.sh from a temporary snapshot so the install step can safely replace the on-disk helper
- add a regression fixture that installs a different replacement upgrade helper while the upgrade is still running

## Validation
- bash -n deploy/customer-bundle/upgrade.sh
- bash -n deploy/scripts/test-upgrade.sh
- deploy/scripts/test-upgrade.sh