### PR TITLE
fix(automation): hide ansible controls when disabled

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -91,6 +91,7 @@ interface Props {
   currentUserId: string
   userRole: string
   latestAgentVersion: string
+  ansibleAutomationEnabled: boolean
 }
 
 /**
@@ -255,7 +256,14 @@ function TabButton({
   )
 }
 
-export function HostDetailClient({ host: initialHost, scopeId, currentUserId, userRole, latestAgentVersion }: Props) {
+export function HostDetailClient({
+  host: initialHost,
+  scopeId,
+  currentUserId,
+  userRole,
+  latestAgentVersion,
+  ansibleAutomationEnabled,
+}: Props) {
   const canManageHost = canAccessTooling({ role: userRole })
   const canRunHostTasks = userRole === 'org_admin' || userRole === 'super_admin'
   const [activeParentTab, setActiveParentTab] = useState<ParentTabId>('overview')
@@ -1289,7 +1297,11 @@ export function HostDetailClient({ host: initialHost, scopeId, currentUserId, us
 
       {/* Tasks Tab */}
       {activeTab === 'tasks' && (
-        <TasksTab host={host} canRunTasks={canRunHostTasks} />
+        <TasksTab
+          host={host}
+          canRunTasks={canRunHostTasks}
+          ansibleAutomationEnabled={ansibleAutomationEnabled}
+        />
       )}
 
       {/* Logs Tab */}

--- a/apps/web/app/(dashboard)/hosts/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getRequiredSession } from '@/lib/auth/session'
 import { getHost } from '@/lib/actions/agents'
 import { resolveCurrentActionScope } from '@/lib/actions/action-scope'
 import { REQUIRED_AGENT_VERSION } from '@/lib/agent/version'
+import { getAnsibleAutomationAvailability } from '@/lib/actions/automation'
 import { HostDetailClient } from './host-detail-client'
 
 export const metadata: Metadata = {
@@ -19,7 +20,10 @@ export default async function HostDetailPage({ params }: Props) {
   const session = await getRequiredSession()
   const scopeId = resolveCurrentActionScope(session)
 
-  const host = await getHost(id)
+  const [host, ansibleAutomation] = await Promise.all([
+    getHost(id),
+    getAnsibleAutomationAvailability(),
+  ])
   if (!host) notFound()
 
   return (
@@ -29,6 +33,7 @@ export default async function HostDetailPage({ params }: Props) {
       currentUserId={session.user.id}
       userRole={session.user.role}
       latestAgentVersion={REQUIRED_AGENT_VERSION}
+      ansibleAutomationEnabled={ansibleAutomation.enabled}
     />
   )
 }

--- a/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/tasks-tab.tsx
@@ -68,6 +68,7 @@ import { useRouter } from 'next/navigation'
 interface Props {
   host: HostWithAgent
   canRunTasks: boolean
+  ansibleAutomationEnabled: boolean
 }
 
 type AgentQueryPollResponse = {
@@ -181,10 +182,11 @@ function TaskDetailsCell({ run, hostId }: { run: TaskRunWithHosts; hostId: strin
   return <span className="text-sm text-muted-foreground">—</span>
 }
 
-export function TasksTab({ host, canRunTasks }: Props) {
+export function TasksTab({ host, canRunTasks, ansibleAutomationEnabled }: Props) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const isLinux = host.os?.toLowerCase() === 'linux'
+  const canUseAnsible = canRunTasks && ansibleAutomationEnabled
 
   // Patch dialog state
   const [patchOpen, setPatchOpen] = useState(false)
@@ -221,7 +223,7 @@ export function TasksTab({ host, canRunTasks }: Props) {
   const { data: ansibleCredentials = [] } = useQuery<AnsibleCredentialProfileSummary[]>({
     queryKey: ['ansible-credential-profiles'],
     queryFn: () => listAnsibleCredentialProfiles(),
-    enabled: canRunTasks && ansibleOpen,
+    enabled: canUseAnsible && ansibleOpen,
   })
 
   // Service autocomplete query polling
@@ -335,10 +337,12 @@ export function TasksTab({ host, canRunTasks }: Props) {
             </Button>
             {isLinux && (
               <>
-                <Button variant="outline" size="sm" onClick={() => setAnsibleOpen(true)}>
-                  <KeyRound className="size-4 mr-1.5" />
-                  Ansible Ping
-                </Button>
+                {canUseAnsible && (
+                  <Button variant="outline" size="sm" onClick={() => setAnsibleOpen(true)}>
+                    <KeyRound className="size-4 mr-1.5" />
+                    Ansible Ping
+                  </Button>
+                )}
                 <Button variant="outline" size="sm" onClick={() => setServiceOpen(true)}>
                   <Power className="size-4 mr-1.5" />
                   Service
@@ -442,8 +446,9 @@ export function TasksTab({ host, canRunTasks }: Props) {
         </div>
       )}
 
-      {/* Patch dialog */}
-      <Dialog open={ansibleOpen} onOpenChange={setAnsibleOpen}>
+      {/* Ansible dialog */}
+      {canUseAnsible && (
+        <Dialog open={ansibleOpen} onOpenChange={setAnsibleOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Run Ansible Ping</DialogTitle>
@@ -500,7 +505,8 @@ export function TasksTab({ host, canRunTasks }: Props) {
             </Button>
           </DialogFooter>
         </DialogContent>
-      </Dialog>
+        </Dialog>
+      )}
 
       {/* Patch dialog */}
       <Dialog open={patchOpen} onOpenChange={setPatchOpen}>

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx
@@ -102,6 +102,7 @@ interface Props {
   userRole: string
   initialGroup: HostGroupWithMembers
   initialAllHosts: HostWithAgent[]
+  ansibleAutomationEnabled: boolean
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -170,10 +171,17 @@ function RunStatusBadge({ status }: { status: string }) {
   }
 }
 
-export function GroupDetailClient({ scopeId, userRole, initialGroup, initialAllHosts }: Props) {
+export function GroupDetailClient({
+  scopeId,
+  userRole,
+  initialGroup,
+  initialAllHosts,
+  ansibleAutomationEnabled,
+}: Props) {
   const queryClient = useQueryClient()
   const router = useRouter()
   const canRunTasks = userRole === 'org_admin' || userRole === 'super_admin'
+  const canUseAnsible = canRunTasks && ansibleAutomationEnabled
   const [addOpen, setAddOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [removeTarget, setRemoveTarget] = useState<Host | null>(null)
@@ -229,7 +237,7 @@ export function GroupDetailClient({ scopeId, userRole, initialGroup, initialAllH
   const { data: ansibleCredentials = [] } = useQuery<AnsibleCredentialProfileSummary[]>({
     queryKey: ['ansible-credential-profiles'],
     queryFn: () => listAnsibleCredentialProfiles(),
-    enabled: canRunTasks && ansibleOpen,
+    enabled: canUseAnsible && ansibleOpen,
   })
 
   const { mutate: doAdd, isPending: isAdding } = useMutation({
@@ -338,10 +346,12 @@ export function GroupDetailClient({ scopeId, userRole, initialGroup, initialAllH
           <div className="flex items-center gap-2">
             {canRunTasks && (
               <>
-                <Button variant="outline" onClick={() => setAnsibleOpen(true)}>
-                  <KeyRound className="size-4 mr-1" />
-                  Ansible Ping
-                </Button>
+                {canUseAnsible && (
+                  <Button variant="outline" onClick={() => setAnsibleOpen(true)}>
+                    <KeyRound className="size-4 mr-1" />
+                    Ansible Ping
+                  </Button>
+                )}
                 <Button variant="outline" onClick={() => setScriptOpen(true)}>
                   <Terminal className="size-4 mr-1" />
                   Run Script
@@ -624,7 +634,8 @@ export function GroupDetailClient({ scopeId, userRole, initialGroup, initialAllH
       </div>
 
       {/* Ansible Group Dialog */}
-      <Dialog open={ansibleOpen} onOpenChange={setAnsibleOpen}>
+      {canUseAnsible && (
+        <Dialog open={ansibleOpen} onOpenChange={setAnsibleOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Ansible Ping &quot;{group.name}&quot;</DialogTitle>
@@ -706,7 +717,8 @@ export function GroupDetailClient({ scopeId, userRole, initialGroup, initialAllH
             </Button>
           </DialogFooter>
         </DialogContent>
-      </Dialog>
+        </Dialog>
+      )}
 
       {/* Script Group Dialog */}
       <Dialog open={scriptOpen} onOpenChange={setScriptOpen}>

--- a/apps/web/app/(dashboard)/hosts/groups/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/hosts/groups/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import { getRequiredSession } from '@/lib/auth/session'
 import { getGroup } from '@/lib/actions/host-groups'
 import { listHosts } from '@/lib/actions/agents'
+import { getAnsibleAutomationAvailability } from '@/lib/actions/automation'
 import { GroupDetailClient } from './group-detail-client'
 
 export const metadata: Metadata = {
@@ -18,9 +19,10 @@ export default async function GroupDetailPage({ params }: Props) {
   const session = await getRequiredSession()
   const instanceId = session.user.instanceId!
 
-  const [group, allHosts] = await Promise.all([
+  const [group, allHosts, ansibleAutomation] = await Promise.all([
     getGroup(instanceId, id),
     listHosts(instanceId),
+    getAnsibleAutomationAvailability(),
   ])
 
   if (!group) notFound()
@@ -31,6 +33,7 @@ export default async function GroupDetailPage({ params }: Props) {
       userRole={session.user.role}
       initialGroup={group}
       initialAllHosts={allHosts}
+      ansibleAutomationEnabled={ansibleAutomation.enabled}
     />
   )
 }

--- a/apps/web/app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx
@@ -174,7 +174,8 @@ export function AutomationSettingsClient({ initialSettings, initialCredentialPro
         </CardContent>
       </Card>
 
-      <Card>
+      {enabled && (
+        <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <KeyRound className="h-4 w-4" />
@@ -259,7 +260,8 @@ export function AutomationSettingsClient({ initialSettings, initialCredentialPro
             )}
           </div>
         </CardContent>
-      </Card>
+        </Card>
+      )}
     </div>
   )
 }

--- a/apps/web/lib/actions/automation.ts
+++ b/apps/web/lib/actions/automation.ts
@@ -11,6 +11,7 @@ import { checkAnsibleApiHealth } from '@/lib/automation/ansible-api'
 import { validateSshPrivateKey } from '@/lib/automation/ansible-runner'
 import {
   buildAutomationSettingsSnapshot,
+  isAnsibleAutomationEnabled,
   nextAutomationMetadata,
   type AutomationStatus,
 } from '@/lib/automation/settings-core'
@@ -36,6 +37,10 @@ export interface AnsibleCredentialProfileSummary {
   username: string
   createdAt: Date
   updatedAt: Date
+}
+
+export interface AnsibleAutomationAvailability {
+  enabled: boolean
 }
 
 const credentialInputSchema = z.object({
@@ -65,7 +70,7 @@ export async function getAutomationSettings(): Promise<AutomationSettingsResult>
   const metadata = parseInstanceMetadata(row?.metadata)
   const snapshot = buildAutomationSettingsSnapshot(metadata)
 
-  if (!snapshot.ansibleFeatureEnabled || snapshot.provider !== 'ansible') {
+  if (!isAnsibleAutomationEnabled(snapshot)) {
     return {
       ...snapshot,
       ansibleDescription: FEATURE_FLAG_REGISTRY['automation.ansible'].description,
@@ -91,6 +96,20 @@ export async function getAutomationSettings(): Promise<AutomationSettingsResult>
     status: 'unavailable',
     statusMessage: 'Ansible automation is enabled. Run ./start.sh on the host to start the optional Ansible service.',
   }
+}
+
+export async function getAnsibleAutomationAvailability(): Promise<AnsibleAutomationAvailability> {
+  const session = await getRequiredSession()
+  const instanceId = resolveCurrentActionScope(session)
+
+  const row = await db.query.instanceSettings.findFirst({
+    where: eq(instanceSettings.id, instanceId),
+    columns: { metadata: true },
+  })
+  const metadata = parseInstanceMetadata(row?.metadata)
+  const snapshot = buildAutomationSettingsSnapshot(metadata)
+
+  return { enabled: isAnsibleAutomationEnabled(snapshot) }
 }
 
 export async function updateAnsibleAutomationSettings(

--- a/apps/web/lib/automation/ansible-ui-gating.test.mjs
+++ b/apps/web/lib/automation/ansible-ui-gating.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+function source(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('host and group Ansible task controls are gated by automation availability', () => {
+  const hostPage = source('app/(dashboard)/hosts/[id]/page.tsx')
+  const hostClient = source('app/(dashboard)/hosts/[id]/host-detail-client.tsx')
+  const tasksTab = source('app/(dashboard)/hosts/[id]/tasks-tab.tsx')
+  const groupPage = source('app/(dashboard)/hosts/groups/[id]/page.tsx')
+  const groupClient = source('app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx')
+
+  assert.match(hostPage, /getAnsibleAutomationAvailability\(\)/)
+  assert.match(hostPage, /ansibleAutomationEnabled=\{ansibleAutomation\.enabled\}/)
+  assert.match(hostClient, /ansibleAutomationEnabled: boolean/)
+  assert.match(hostClient, /<TasksTab[\s\S]*ansibleAutomationEnabled=\{ansibleAutomationEnabled\}/)
+  assert.match(tasksTab, /ansibleAutomationEnabled: boolean/)
+  assert.match(tasksTab, /const canUseAnsible = canRunTasks && ansibleAutomationEnabled/)
+  assert.match(tasksTab, /enabled: canUseAnsible && ansibleOpen/)
+  assert.match(tasksTab, /\{canUseAnsible && \([\s\S]*Ansible Ping/)
+
+  assert.match(groupPage, /getAnsibleAutomationAvailability\(\)/)
+  assert.match(groupPage, /ansibleAutomationEnabled=\{ansibleAutomation\.enabled\}/)
+  assert.match(groupClient, /ansibleAutomationEnabled: boolean/)
+  assert.match(groupClient, /const canUseAnsible = canRunTasks && ansibleAutomationEnabled/)
+  assert.match(groupClient, /enabled: canUseAnsible && ansibleOpen/)
+  assert.match(groupClient, /\{canUseAnsible && \([\s\S]*Ansible Ping/)
+})
+
+test('automation settings hide Ansible credential management while disabled', () => {
+  const settingsClient = source('app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx')
+
+  assert.match(settingsClient, /const enabled = settings\.ansibleFeatureEnabled && settings\.provider === 'ansible'/)
+  assert.match(settingsClient, /\{enabled && \([\s\S]*Ansible SSH credentials/)
+})

--- a/apps/web/lib/automation/settings-core.test.mjs
+++ b/apps/web/lib/automation/settings-core.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   buildAutomationSettingsSnapshot,
   getStoredAutomationProvider,
+  isAnsibleAutomationEnabled,
   nextAutomationMetadata,
 } from './settings-core.ts'
 
@@ -28,6 +29,24 @@ test('valid ansible metadata enables the provider snapshot', () => {
 
 test('getStoredAutomationProvider rejects malformed providers', () => {
   assert.equal(getStoredAutomationProvider({ provider: 'bad' }), 'none')
+})
+
+test('isAnsibleAutomationEnabled requires both the flag and provider', () => {
+  assert.equal(isAnsibleAutomationEnabled({
+    provider: 'ansible',
+    ansibleFeatureEnabled: true,
+    ansibleAdminConfigurable: true,
+  }), true)
+  assert.equal(isAnsibleAutomationEnabled({
+    provider: 'ansible',
+    ansibleFeatureEnabled: false,
+    ansibleAdminConfigurable: true,
+  }), false)
+  assert.equal(isAnsibleAutomationEnabled({
+    provider: 'none',
+    ansibleFeatureEnabled: true,
+    ansibleAdminConfigurable: true,
+  }), false)
 })
 
 test('nextAutomationMetadata writes explicit feature flag and provider choices', () => {

--- a/apps/web/lib/automation/settings-core.ts
+++ b/apps/web/lib/automation/settings-core.ts
@@ -29,6 +29,10 @@ export function buildAutomationSettingsSnapshot(input: {
   }
 }
 
+export function isAnsibleAutomationEnabled(snapshot: AutomationSettingsSnapshot): boolean {
+  return snapshot.ansibleFeatureEnabled && snapshot.provider === 'ansible'
+}
+
 export function nextAutomationMetadata(input: {
   featureFlags?: FeatureFlagOverrides
   enableAnsible: boolean


### PR DESCRIPTION
## Summary
- gate host and host group Ansible Ping actions on the stored Ansible automation flag/provider state
- hide Ansible SSH credential management while the provider is disabled
- add regression coverage for Ansible UI gating and shared enabled-state logic

## Validation
- pnpm --dir apps/web type-check
- pnpm --dir apps/web exec eslint 'app/(dashboard)/hosts/[id]/page.tsx' 'app/(dashboard)/hosts/[id]/host-detail-client.tsx' 'app/(dashboard)/hosts/[id]/tasks-tab.tsx' 'app/(dashboard)/hosts/groups/[id]/page.tsx' 'app/(dashboard)/hosts/groups/[id]/group-detail-client.tsx' 'app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx' lib/actions/automation.ts lib/automation/settings-core.ts lib/automation/settings-core.test.mjs lib/automation/ansible-ui-gating.test.mjs
- pnpm --dir apps/web exec node --experimental-strip-types --test lib/automation/ansible-ui-gating.test.mjs lib/automation/settings-core.test.mjs
- pnpm --dir apps/web test:unit (fails only lib/integrations/ct-cve/db-nonce-store.test.mjs: Could not find a working container runtime strategy)