### PR TITLE
fix(ansible): scope ping logs by host name

### DIFF
--- a/apps/ansible-api/server.py
+++ b/apps/ansible-api/server.py
@@ -260,7 +260,7 @@ def run_ansible_ping(payload: dict[str, Any]) -> dict[str, Any]:
     request = validate_ansible_ping_request(payload)
     command = run_ansible_ping_command(request)
     results = []
-    host_ids = {host["id"] for host in request["hosts"]}
+    host_names = {host["name"] for host in request["hosts"]}
 
     for host in request["hosts"]:
         succeeded = _host_succeeded_from_json(command.stdout, host["name"])
@@ -271,8 +271,8 @@ def run_ansible_ping(payload: dict[str, Any]) -> dict[str, Any]:
             "name": host["name"],
             "status": "success" if succeeded else "failed",
             "exitCode": 0 if succeeded else (command.returncode or 1),
-            "stdout": _host_stdout(command.stdout, host["id"], host_ids),
-            "stderr": _host_stderr(command.stderr, host["id"], host_ids),
+            "stdout": _host_stdout(command.stdout, host["name"], host_names),
+            "stderr": _host_stderr(command.stderr, host["name"], host_names),
         })
 
     return {

--- a/apps/ansible-api/tests/test_contract.py
+++ b/apps/ansible-api/tests/test_contract.py
@@ -127,6 +127,47 @@ class AnsibleApiContractTests(unittest.TestCase):
         self.assertIn("Host 'host-2'", payload["hosts"][1]["stderr"])
         self.assertNotIn("Host 'host-1'", payload["hosts"][1]["stderr"])
 
+    @mock.patch("server.run_ansible_ping_command")
+    def test_run_ansible_ping_scopes_output_by_ansible_host_name_when_id_differs(self, run_command):
+        run_command.return_value = server.CommandResult(
+            returncode=0,
+            stdout=json.dumps({
+                "plays": [{
+                    "tasks": [{
+                        "hosts": {
+                            "ct-portal": {"ping": "pong", "changed": False},
+                            "ct-ops": {"ping": "pong", "changed": False},
+                        },
+                    }],
+                }],
+            }),
+            stderr="\n".join([
+                "[WARNING]: Host 'ct-portal' is using the discovered Python interpreter at '/usr/bin/python3.12'",
+                "[WARNING]: Host 'ct-ops' is using the discovered Python interpreter at '/usr/bin/python3.12'",
+            ]),
+            elapsedMs=25,
+        )
+
+        payload = server.run_ansible_ping({
+            "credential": {
+                "username": "deploy",
+                "privateKey": private_key_block(),
+            },
+            "hosts": [
+                {"id": "host-db-id-1", "name": "ct-portal", "address": "10.0.0.10", "port": 22},
+                {"id": "host-db-id-2", "name": "ct-ops", "address": "10.0.0.11", "port": 22},
+            ],
+        })
+
+        self.assertIn("ct-portal", payload["hosts"][0]["stdout"])
+        self.assertNotIn("ct-ops", payload["hosts"][0]["stdout"])
+        self.assertIn("Host 'ct-portal'", payload["hosts"][0]["stderr"])
+        self.assertNotIn("Host 'ct-ops'", payload["hosts"][0]["stderr"])
+        self.assertIn("ct-ops", payload["hosts"][1]["stdout"])
+        self.assertNotIn("ct-portal", payload["hosts"][1]["stdout"])
+        self.assertIn("Host 'ct-ops'", payload["hosts"][1]["stderr"])
+        self.assertNotIn("Host 'ct-portal'", payload["hosts"][1]["stderr"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- scope per-host Ansible stdout/stderr filtering by the inventory host name emitted by Ansible instead of the database host ID
- add a regression test for hosts whose DB IDs differ from Ansible aliases

## Validation
- PYTHONPATH=apps/ansible-api python3 -m unittest discover -s apps/ansible-api/tests
- docker build -q -f apps/ansible-api/Dockerfile apps/ansible-api (blocked locally: Docker daemon is not running)