### PR TITLE
feat(agent): report Docker runtime status

### DIFF
--- a/agent/internal/heartbeat/docker_status.go
+++ b/agent/internal/heartbeat/docker_status.go
@@ -1,0 +1,124 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+const (
+	defaultDockerSocketPath   = "/var/run/docker.sock"
+	dockerStatusProbeTimeout  = 2 * time.Second
+	maxDockerStatusErrorBytes = 512
+)
+
+type dockerVersionInfo struct {
+	Version    string `json:"Version"`
+	APIVersion string `json:"ApiVersion"`
+}
+
+type dockerVersionProbe func(context.Context, string) (dockerVersionInfo, error)
+
+func detectDockerStatus(ctx context.Context, socketPath string) *agentv1.DockerStatus {
+	return detectDockerStatusWithProbe(ctx, socketPath, probeDockerVersion)
+}
+
+func detectDockerStatusWithProbe(ctx context.Context, socketPath string, probe dockerVersionProbe) *agentv1.DockerStatus {
+	status := &agentv1.DockerStatus{
+		CheckedAtUnix: time.Now().Unix(),
+	}
+
+	if _, err := os.Stat(socketPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			status.Status = agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_NOT_INSTALLED
+			return status
+		}
+		if errors.Is(err, os.ErrPermission) {
+			status.Status = agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_PERMISSION_DENIED
+			status.ErrorMessage = boundDockerStatusError(err)
+			return status
+		}
+		status.Status = agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_ERROR
+		status.ErrorMessage = boundDockerStatusError(err)
+		return status
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, dockerStatusProbeTimeout)
+	defer cancel()
+	version, err := probe(probeCtx, socketPath)
+	if err != nil {
+		status.Status = classifyDockerProbeError(err)
+		status.ErrorMessage = boundDockerStatusError(err)
+		return status
+	}
+
+	status.Status = agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_INSTALLED
+	status.RuntimeVersion = truncateUTF8(version.Version, 64)
+	status.ApiVersion = truncateUTF8(version.APIVersion, 32)
+	return status
+}
+
+func probeDockerVersion(ctx context.Context, socketPath string) (dockerVersionInfo, error) {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}
+	defer transport.CloseIdleConnections()
+
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://docker/version", nil)
+	if err != nil {
+		return dockerVersionInfo{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return dockerVersionInfo{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return dockerVersionInfo{}, os.ErrPermission
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return dockerVersionInfo{}, fmt.Errorf("docker version endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	var version dockerVersionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&version); err != nil {
+		return dockerVersionInfo{}, err
+	}
+	return version, nil
+}
+
+func classifyDockerProbeError(err error) agentv1.DockerRuntimeStatus {
+	if errors.Is(err, os.ErrPermission) {
+		return agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_PERMISSION_DENIED
+	}
+	if errors.Is(err, context.DeadlineExceeded) || strings.Contains(strings.ToLower(err.Error()), "connection refused") {
+		return agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_UNREACHABLE
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_UNREACHABLE
+	}
+	return agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_ERROR
+}
+
+func boundDockerStatusError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return truncateUTF8(err.Error(), maxDockerStatusErrorBytes)
+}

--- a/agent/internal/heartbeat/docker_status_test.go
+++ b/agent/internal/heartbeat/docker_status_test.go
@@ -1,0 +1,97 @@
+package heartbeat
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+func TestDetectDockerStatusReportsNotInstalledWhenSocketMissing(t *testing.T) {
+	status := detectDockerStatus(context.Background(), filepath.Join(t.TempDir(), "docker.sock"))
+
+	if status.Status != agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_NOT_INSTALLED {
+		t.Fatalf("status = %v, want not installed", status.Status)
+	}
+	if status.CheckedAtUnix == 0 {
+		t.Fatal("checked_at_unix was not set")
+	}
+}
+
+func TestDetectDockerStatusReportsPermissionDenied(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	probe := func(context.Context, string) (dockerVersionInfo, error) {
+		return dockerVersionInfo{}, &os.PathError{Op: "dial", Path: socketPath, Err: os.ErrPermission}
+	}
+
+	status := detectDockerStatusWithProbe(context.Background(), socketPath, probe)
+
+	if status.Status != agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_PERMISSION_DENIED {
+		t.Fatalf("status = %v, want permission denied", status.Status)
+	}
+}
+
+func TestDetectDockerStatusReportsUnreachable(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	probe := func(context.Context, string) (dockerVersionInfo, error) {
+		return dockerVersionInfo{}, &net.OpError{Op: "dial", Net: "unix", Err: errors.New("connection refused")}
+	}
+
+	status := detectDockerStatusWithProbe(context.Background(), socketPath, probe)
+
+	if status.Status != agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_UNREACHABLE {
+		t.Fatalf("status = %v, want unreachable", status.Status)
+	}
+}
+
+func TestDetectDockerStatusReportsInstalledWithVersionInfo(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	probe := func(context.Context, string) (dockerVersionInfo, error) {
+		return dockerVersionInfo{Version: "26.1.4", APIVersion: "1.45"}, nil
+	}
+
+	status := detectDockerStatusWithProbe(context.Background(), socketPath, probe)
+
+	if status.Status != agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_INSTALLED {
+		t.Fatalf("status = %v, want installed", status.Status)
+	}
+	if status.RuntimeVersion != "26.1.4" {
+		t.Fatalf("runtime_version = %q, want 26.1.4", status.RuntimeVersion)
+	}
+	if status.ApiVersion != "1.45" {
+		t.Fatalf("api_version = %q, want 1.45", status.ApiVersion)
+	}
+}
+
+func TestDetectDockerStatusBoundsErrorMessage(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	probe := func(context.Context, string) (dockerVersionInfo, error) {
+		return dockerVersionInfo{}, errors.New(strings.Repeat("x", maxDockerStatusErrorBytes+32))
+	}
+
+	status := detectDockerStatusWithProbe(context.Background(), socketPath, probe)
+
+	if status.Status != agentv1.DockerRuntimeStatus_DOCKER_RUNTIME_STATUS_ERROR {
+		t.Fatalf("status = %v, want error", status.Status)
+	}
+	if len(status.ErrorMessage) > maxDockerStatusErrorBytes {
+		t.Fatalf("error_message length = %d, want <= %d", len(status.ErrorMessage), maxDockerStatusErrorBytes)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -761,13 +761,14 @@ func minInt(a, b int) int {
 
 // hostMetricsSnapshot holds a point-in-time snapshot of system metrics.
 type hostMetricsSnapshot struct {
-	cpu       float32
-	memory    float32
-	disk      float32
-	uptime    int64
-	osVersion string
-	disks     []*agentv1.DiskInfo
-	nets      []*agentv1.NetworkInterface
+	cpu          float32
+	memory       float32
+	disk         float32
+	uptime       int64
+	osVersion    string
+	disks        []*agentv1.DiskInfo
+	nets         []*agentv1.NetworkInterface
+	dockerStatus *agentv1.DockerStatus
 }
 
 // refreshMetrics collects fresh system metrics and stores them in the cache.
@@ -778,13 +779,14 @@ type hostMetricsSnapshot struct {
 func (r *Runner) refreshMetrics() {
 	cpu, mem, disk, uptime, osVersion, disks, nets := r.collectMetrics()
 	r.cachedMetrics = hostMetricsSnapshot{
-		cpu:       cpu,
-		memory:    mem,
-		disk:      disk,
-		uptime:    uptime,
-		osVersion: osVersion,
-		disks:     disks,
-		nets:      nets,
+		cpu:          cpu,
+		memory:       mem,
+		disk:         disk,
+		uptime:       uptime,
+		osVersion:    osVersion,
+		disks:        disks,
+		nets:         nets,
+		dockerStatus: detectDockerStatus(context.Background(), defaultDockerSocketPath),
 	}
 }
 
@@ -813,6 +815,7 @@ func (r *Runner) sendHeartbeatWithAgentID(stream agentv1.IngestService_Heartbeat
 		TaskResults:                 r.drainTaskResults(),
 		PinnedServerCertFingerprint: r.currentPinnedFingerprint(),
 		SshHostKeys:                 collectSSHHostKeys(),
+		DockerStatus:                m.dockerStatus,
 	}
 
 	if err := stream.Send(req); err != nil {

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -154,7 +154,7 @@ Purpose: prove the agent-to-ingest-to-UI path before adding high-volume telemetr
 
 | Task | Owner | Status | Files / Areas | Dependencies | Acceptance Criteria | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Add agent Docker capability detection | unclaimed | pending | `agent/internal/...`, agent tests | Phase 0 protobuf contract | Agent reports Docker status without shelling out where possible and sends no container metrics when Docker is unavailable. | TBD | Statuses: `not_installed`, `installed`, `permission_denied`, `unreachable`, `error`. |
+| Add agent Docker capability detection | Codex | in_progress | `agent/internal/...`, agent tests | Phase 0 protobuf contract | Agent reports Docker status without shelling out where possible and sends no container metrics when Docker is unavailable. | TBD | Statuses: `not_installed`, `installed`, `permission_denied`, `unreachable`, `error`. |
 | Persist Docker capability status | unclaimed | pending | `apps/ingest/internal/...`, DB queries, tests | Agent status contract | Ingest validates and stores Docker status by host without breaking old agents. | TBD | Include last checked timestamp and optional error message with bounded length. |
 | Display Docker status in host UI | unclaimed | pending | `apps/web/app/(dashboard)/hosts/...`, components, tests | Persisted status | Host detail shows clear Docker status and empty states. | TBD | Avoid implying Docker is installed when status is unknown. |
 

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -154,7 +154,7 @@ Purpose: prove the agent-to-ingest-to-UI path before adding high-volume telemetr
 
 | Task | Owner | Status | Files / Areas | Dependencies | Acceptance Criteria | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Add agent Docker capability detection | Codex | in_progress | `agent/internal/...`, agent tests | Phase 0 protobuf contract | Agent reports Docker status without shelling out where possible and sends no container metrics when Docker is unavailable. | TBD | Statuses: `not_installed`, `installed`, `permission_denied`, `unreachable`, `error`. |
+| Add agent Docker capability detection | Codex | review | `agent/internal/...`, agent tests | Phase 0 protobuf contract | Agent reports Docker status without shelling out where possible and sends no container metrics when Docker is unavailable. | [#1342](https://github.com/carrtech-dev/ct-ops/pull/1342) | Reports Docker socket status on heartbeat via `/version`; statuses: `not_installed`, `installed`, `permission_denied`, `unreachable`, `error`. |
 | Persist Docker capability status | unclaimed | pending | `apps/ingest/internal/...`, DB queries, tests | Agent status contract | Ingest validates and stores Docker status by host without breaking old agents. | TBD | Include last checked timestamp and optional error message with bounded length. |
 | Display Docker status in host UI | unclaimed | pending | `apps/web/app/(dashboard)/hosts/...`, components, tests | Persisted status | Host detail shows clear Docker status and empty states. | TBD | Avoid implying Docker is installed when status is unknown. |
 


### PR DESCRIPTION
## Summary
- add Docker Unix socket status detection for agent heartbeats
- report installed, not installed, permission denied, unreachable, and error states with bounded diagnostics
- mark the Phase 1 agent detection task as in progress in the Docker telemetry plan

## Tests
- go test ./internal/heartbeat -run 'TestDetectDockerStatus'
- go test ./internal/heartbeat
- go test ./agent/...
