### PR TITLE
feat(hosts): display docker runtime status

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -57,6 +57,7 @@ import type { HeartbeatPoint, HostWithAgent, MetricsPreset, MetricsQuery } from 
 import { useHostStream } from '@/hooks/use-host-stream'
 import { useChartZoom } from '@/hooks/use-chart-zoom'
 import type { DiskInfo, NetworkInterface } from '@/lib/db/schema'
+import type { DockerRuntimeStatus, HostDockerStatus } from '@/lib/db/schema/docker'
 import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { ChecksTab } from './checks-tab'
 import { AlertsTab } from './alerts-tab'
@@ -227,6 +228,125 @@ function VulnerabilityStatusBadge({ status }: { status: HostVulnerabilityAssessm
       <AlertTriangle className="size-3 mr-1" />
       Not assessed
     </Badge>
+  )
+}
+
+type DockerDisplayStatus = DockerRuntimeStatus | 'unknown'
+
+const dockerStatusCopy: Record<
+  DockerDisplayStatus,
+  { label: string; description: string; badgeClass: string; icon: typeof CheckCircle }
+> = {
+  unknown: {
+    label: 'Unknown',
+    description: 'No Docker status has been reported yet.',
+    badgeClass: 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-100',
+    icon: AlertTriangle,
+  },
+  installed: {
+    label: 'Installed',
+    description: 'Docker Engine is available on this host.',
+    badgeClass: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100',
+    icon: CheckCircle,
+  },
+  not_installed: {
+    label: 'Not installed',
+    description: 'Docker Engine is not installed or was not found.',
+    badgeClass: 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-100',
+    icon: WifiOff,
+  },
+  permission_denied: {
+    label: 'Permission denied',
+    description: 'The agent found Docker but cannot access it.',
+    badgeClass: 'bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100',
+    icon: ShieldAlert,
+  },
+  unreachable: {
+    label: 'Unreachable',
+    description: 'Docker was detected but did not respond to the agent.',
+    badgeClass: 'bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100',
+    icon: AlertTriangle,
+  },
+  error: {
+    label: 'Error',
+    description: 'The agent hit an unexpected Docker status check error.',
+    badgeClass: 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100',
+    icon: XCircle,
+  },
+}
+
+function sanitiseDockerDiagnostic(message: string | null | undefined): string | null {
+  if (!message) return null
+  const withoutPaths = message
+    .replace(/\bunix:\/\/\/\S+/g, 'Docker socket')
+    .replace(/\b\/[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+/g, 'host path')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!withoutPaths) return null
+  return withoutPaths.length > 160 ? `${withoutPaths.slice(0, 157)}...` : withoutPaths
+}
+
+function DockerStatusBadge({ status }: { status: DockerDisplayStatus }) {
+  const copy = dockerStatusCopy[status]
+  const Icon = copy.icon
+  return (
+    <Badge className={copy.badgeClass}>
+      <Icon className="size-3 mr-1" />
+      {copy.label}
+    </Badge>
+  )
+}
+
+function DockerStatusCard({ dockerStatus }: { dockerStatus?: HostDockerStatus | null }) {
+  const status: DockerDisplayStatus = dockerStatus?.status ?? 'unknown'
+  const copy = dockerStatusCopy[status]
+  const diagnostic = sanitiseDockerDiagnostic(dockerStatus?.errorMessage)
+  const hasVersionDetails = dockerStatus?.runtimeVersion || dockerStatus?.apiVersion
+
+  return (
+    <Card data-testid="host-docker-status-card">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Layers className="size-4 text-muted-foreground" />
+          Docker Runtime
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <DockerStatusBadge status={status} />
+          <span className="text-sm text-muted-foreground">{copy.description}</span>
+        </div>
+
+        <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-muted-foreground">Last checked</dt>
+            <dd className="font-medium text-foreground">
+              {dockerStatus?.checkedAt ? formatOptionalDate(dockerStatus.checkedAt) : 'Never'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Runtime</dt>
+            <dd className="font-medium text-foreground">
+              {dockerStatus?.runtimeVersion ? `Runtime ${dockerStatus.runtimeVersion}` : '-'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">API</dt>
+            <dd className="font-medium text-foreground">
+              {dockerStatus?.apiVersion ? `API ${dockerStatus.apiVersion}` : '-'}
+            </dd>
+          </div>
+        </dl>
+
+        {diagnostic ? (
+          <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            {diagnostic}
+          </p>
+        ) : !hasVersionDetails && status !== 'unknown' ? (
+          <p className="text-sm text-muted-foreground">No diagnostic details were reported.</p>
+        ) : null}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -673,6 +793,8 @@ export function HostDetailClient({
               )}
             </CardContent>
           </Card>
+
+          <DockerStatusCard dockerStatus={host.dockerStatus} />
 
           {/* Info cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/apps/web/lib/actions/agents-core.ts
+++ b/apps/web/lib/actions/agents-core.ts
@@ -11,6 +11,7 @@ import {
   agentEnrolmentTokens,
   revokedCertificates,
   hosts,
+  hostDockerStatus,
   hostMetrics,
   hostGroupMembers,
   checks,
@@ -38,7 +39,7 @@ import {
   pendingCertSignings,
 } from '@/lib/db/schema'
 import { eq, and, isNull, gt, gte, lte, asc, desc, sql, inArray, ilike, or, count } from 'drizzle-orm'
-import type { Agent, AgentEnrolmentToken, Host, HostMetric } from '@/lib/db/schema'
+import type { Agent, AgentEnrolmentToken, Host, HostDockerStatus, HostMetric } from '@/lib/db/schema'
 import { HOST_HIGH_USAGE_THRESHOLD, HOST_STALE_MINUTES } from '@/lib/db/schema/hosts'
 import { applyGlobalDefaultsToHost } from '@/lib/actions/alerts'
 import { escapeLikePattern } from '@/lib/utils'
@@ -330,7 +331,7 @@ export async function rejectAgent(
   }
 }
 
-export type HostWithAgent = Host & { agent: Agent | null }
+export type HostWithAgent = Host & { agent: Agent | null; dockerStatus?: HostDockerStatus | null }
 
 export async function listHosts(instanceId?: string): Promise<HostWithAgent[]> {
   const currentScope = instanceId ?? await resolveCurrentActionScope()
@@ -1051,9 +1052,20 @@ export async function getHeartbeatHistory(
 export async function getHost(instanceId: string, hostId: string): Promise<HostWithAgent | null> {
   await requireInstanceAccess(instanceId)
   const rows = await db
-    .select()
+    .select({
+      host: hosts,
+      agent: agents,
+      dockerStatus: hostDockerStatus,
+    })
     .from(hosts)
     .leftJoin(agents, eq(hosts.agentId, agents.id))
+    .leftJoin(
+      hostDockerStatus,
+      and(
+        eq(hostDockerStatus.hostId, hosts.id),
+        eq(hostDockerStatus.instanceId, hosts.instanceId),
+      ),
+    )
     .where(
       and(
         eq(hosts.id, hostId),
@@ -1066,8 +1078,9 @@ export async function getHost(instanceId: string, hostId: string): Promise<HostW
   if (rows.length === 0) return null
   const row = rows[0]!
   return {
-    ...row.hosts,
-    agent: row.agents ?? null,
+    ...row.host,
+    agent: row.agent ?? null,
+    dockerStatus: row.dockerStatus ?? null,
   }
 }
 

--- a/apps/web/tests/e2e/hosts/docker-status.spec.ts
+++ b/apps/web/tests/e2e/hosts/docker-status.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM instance_settings
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+async function seedHost(sql: ReturnType<typeof getTestDb>, instanceId: string, hostId: string) {
+  await sql`
+    INSERT INTO hosts (
+      id,
+      instance_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      ${hostId},
+      ${instanceId},
+      ${`${hostId}.example.test`},
+      ${`Docker ${hostId}`},
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.80.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+}
+
+test('host overview shows unknown Docker status for older agents', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-status-unknown')
+
+  await page.goto('/hosts/docker-status-unknown')
+
+  const card = page.getByTestId('host-docker-status-card')
+  await expect(card).toBeVisible()
+  await expect(card).toContainText('Unknown')
+  await expect(card).toContainText('No Docker status has been reported yet.')
+})
+
+test('host overview shows installed Docker status with version details', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-status-installed')
+
+  await sql`
+    INSERT INTO host_docker_status (
+      instance_id,
+      host_id,
+      status,
+      checked_at,
+      runtime_version,
+      api_version
+    )
+    VALUES (
+      ${instanceId},
+      'docker-status-installed',
+      'installed',
+      NOW() - INTERVAL '2 minutes',
+      '25.0.5',
+      '1.45'
+    )
+  `
+
+  await page.goto('/hosts/docker-status-installed')
+
+  const card = page.getByTestId('host-docker-status-card')
+  await expect(card).toContainText('Installed')
+  await expect(card).toContainText('Runtime 25.0.5')
+  await expect(card).toContainText('API 1.45')
+  await expect(card).toContainText('Last checked')
+})
+
+test('host overview distinguishes Docker permission denied from not installed', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-status-denied')
+  await seedHost(sql, instanceId, 'docker-status-missing')
+
+  await sql`
+    INSERT INTO host_docker_status (
+      instance_id,
+      host_id,
+      status,
+      checked_at,
+      error_message
+    )
+    VALUES
+      (
+        ${instanceId},
+        'docker-status-denied',
+        'permission_denied',
+        NOW() - INTERVAL '5 minutes',
+        'Docker socket access denied'
+      ),
+      (
+        ${instanceId},
+        'docker-status-missing',
+        'not_installed',
+        NOW() - INTERVAL '7 minutes',
+        NULL
+      )
+  `
+
+  await page.goto('/hosts/docker-status-denied')
+  const deniedCard = page.getByTestId('host-docker-status-card')
+  await expect(deniedCard).toContainText('Permission denied')
+  await expect(deniedCard).toContainText('Docker socket access denied')
+
+  await page.goto('/hosts/docker-status-missing')
+  const missingCard = page.getByTestId('host-docker-status-card')
+  await expect(missingCard).toContainText('Not installed')
+  await expect(missingCard).toContainText('Docker Engine is not installed or was not found.')
+  await expect(missingCard).not.toContainText('Permission denied')
+})

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -156,7 +156,7 @@ Purpose: prove the agent-to-ingest-to-UI path before adding high-volume telemetr
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Add agent Docker capability detection | Codex | done | `agent/internal/...`, agent tests | Phase 0 protobuf contract | Agent reports Docker status without shelling out where possible and sends no container metrics when Docker is unavailable. | [#1342](https://github.com/carrtech-dev/ct-ops/pull/1342) | Merged in #1342. Reports Docker socket status on heartbeat via `/version`; statuses: `not_installed`, `installed`, `permission_denied`, `unreachable`, `error`. |
 | Persist Docker capability status | Codex | done | `apps/ingest/internal/...`, DB queries, tests | Agent status contract | Ingest validates and stores Docker status by host without breaking old agents. | [#1345](https://github.com/carrtech-dev/ct-ops/pull/1345) | Merged in #1345. Stores last checked timestamp and bounded optional error message. |
-| Display Docker status in host UI | unclaimed | pending | `apps/web/app/(dashboard)/hosts/...`, components, tests | Persisted status | Host detail shows clear Docker status and empty states. | TBD | Avoid implying Docker is installed when status is unknown. |
+| Display Docker status in host UI | Codex | in_progress | `apps/web/app/(dashboard)/hosts/...`, components, tests | Persisted status | Host detail shows clear Docker status and empty states. | TBD | Avoid implying Docker is installed when status is unknown. Claimed 2026-05-12 for docker-project automation. |
 
 ## Phase 2: Container Inventory
 


### PR DESCRIPTION
## Summary
- add Docker runtime status to the host detail payload
- render a Docker Runtime overview card with unknown, installed, not installed, permission denied, unreachable, and error states
- add E2E coverage for unknown, installed, permission denied, and not installed states
- update the Docker telemetry coordination plan with the claimed UI task

## Validation
- PASS: PATH="/Users/simoncarr/.nvm/versions/node/v22.14.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/simoncarr/.local/bin:/Users/simoncarr/.codex/tmp/arg0/codex-arg0WiLUL7:/Applications/Codex.app/Contents/Resources:/Users/simoncarr/.codex/bin:/Users/simoncarr/Library/Python/3.9/bin/:/Users/simoncarr/.local/bin" pnpm --dir apps/web type-check
- PASS: PATH="/Users/simoncarr/.nvm/versions/node/v22.14.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/simoncarr/.local/bin:/Users/simoncarr/.codex/tmp/arg0/codex-arg0WiLUL7:/Applications/Codex.app/Contents/Resources:/Users/simoncarr/.codex/bin:/Users/simoncarr/Library/Python/3.9/bin/:/Users/simoncarr/.local/bin" pnpm --dir apps/web lint (existing warnings only)
- BLOCKED: PATH="/Users/simoncarr/.nvm/versions/node/v22.14.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/simoncarr/.local/bin:/Users/simoncarr/.codex/tmp/arg0/codex-arg0WiLUL7:/Applications/Codex.app/Contents/Resources:/Users/simoncarr/.codex/bin:/Users/simoncarr/Library/Python/3.9/bin/:/Users/simoncarr/.local/bin" pnpm --dir apps/web test:e2e tests/e2e/hosts/docker-status.spec.ts (Testcontainers could not find a working container runtime strategy)