### PR TITLE
docs(docker): mark status ui complete

### DIFF
--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -156,7 +156,7 @@ Purpose: prove the agent-to-ingest-to-UI path before adding high-volume telemetr
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Add agent Docker capability detection | Codex | done | `agent/internal/...`, agent tests | Phase 0 protobuf contract | Agent reports Docker status without shelling out where possible and sends no container metrics when Docker is unavailable. | [#1342](https://github.com/carrtech-dev/ct-ops/pull/1342) | Merged in #1342. Reports Docker socket status on heartbeat via `/version`; statuses: `not_installed`, `installed`, `permission_denied`, `unreachable`, `error`. |
 | Persist Docker capability status | Codex | done | `apps/ingest/internal/...`, DB queries, tests | Agent status contract | Ingest validates and stores Docker status by host without breaking old agents. | [#1345](https://github.com/carrtech-dev/ct-ops/pull/1345) | Merged in #1345. Stores last checked timestamp and bounded optional error message. |
-| Display Docker status in host UI | Codex | in_progress | `apps/web/app/(dashboard)/hosts/...`, components, tests | Persisted status | Host detail shows clear Docker status and empty states. | TBD | Avoid implying Docker is installed when status is unknown. Claimed 2026-05-12 for docker-project automation. |
+| Display Docker status in host UI | Codex | done | `apps/web/app/(dashboard)/hosts/...`, components, tests | Persisted status | Host detail shows clear Docker status and empty states. | [#1347](https://github.com/carrtech-dev/ct-ops/pull/1347) | Merged in #1347. Host overview now shows Docker runtime status with unknown, installed, not installed, permission denied, unreachable, and error states. |
 
 ## Phase 2: Container Inventory
 


### PR DESCRIPTION
## Summary
- mark the Docker status UI task complete in the telemetry implementation plan
- link the merged implementation PR #1347

## Validation
- PASS: git diff --check