### PR TITLE
feat(agent): collect Docker container inventory

### DIFF
--- a/agent/internal/heartbeat/docker_inventory.go
+++ b/agent/internal/heartbeat/docker_inventory.go
@@ -1,0 +1,206 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+const (
+	dockerInventoryTimeout          = 5 * time.Second
+	defaultMaxDockerLabelBytes      = 16 * 1024
+	maxDockerContainerIDBytes       = 128
+	maxDockerContainerNameBytes     = 256
+	maxDockerContainerImageBytes    = 512
+	maxDockerContainerImageIDBytes  = 512
+	maxDockerContainerStateBytes    = 64
+	maxDockerContainerStatusBytes   = 512
+	maxDockerContainerLabelKeyBytes = 256
+)
+
+type dockerContainerListItem struct {
+	ID      string            `json:"Id"`
+	Names   []string          `json:"Names"`
+	Image   string            `json:"Image"`
+	ImageID string            `json:"ImageID"`
+	Labels  map[string]string `json:"Labels"`
+	State   string            `json:"State"`
+	Status  string            `json:"Status"`
+	Created int64             `json:"Created"`
+}
+
+type dockerContainerInspect struct {
+	RestartCount int32                       `json:"RestartCount"`
+	State        dockerContainerInspectState `json:"State"`
+}
+
+type dockerContainerInspectState struct {
+	StartedAt  string `json:"StartedAt"`
+	FinishedAt string `json:"FinishedAt"`
+}
+
+func collectDockerInventory(ctx context.Context, socketPath string, maxLabelBytes int) ([]*agentv1.DockerContainerInventory, error) {
+	ctx, cancel := context.WithTimeout(ctx, dockerInventoryTimeout)
+	defer cancel()
+	return collectDockerInventoryWithClient(ctx, dockerSocketHTTPClient(socketPath), "http://docker", maxLabelBytes)
+}
+
+func collectDockerInventoryWithClient(ctx context.Context, client *http.Client, baseURL string, maxLabelBytes int) ([]*agentv1.DockerContainerInventory, error) {
+	if maxLabelBytes <= 0 {
+		maxLabelBytes = defaultMaxDockerLabelBytes
+	}
+
+	listURL, err := url.JoinPath(baseURL, "/containers/json")
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL+"?all=1", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, os.ErrPermission
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("docker containers endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	var containers []dockerContainerListItem
+	if err := json.NewDecoder(resp.Body).Decode(&containers); err != nil {
+		return nil, err
+	}
+
+	observedAt := time.Now().Unix()
+	inventory := make([]*agentv1.DockerContainerInventory, 0, len(containers))
+	for _, container := range containers {
+		item := dockerInventoryFromListItem(container, observedAt, maxLabelBytes)
+		if inspect, err := inspectDockerContainer(ctx, client, baseURL, container.ID); err == nil {
+			item.StartedAtUnix = parseDockerTimestampUnix(inspect.State.StartedAt)
+			item.FinishedAtUnix = parseDockerTimestampUnix(inspect.State.FinishedAt)
+			item.RestartCount = inspect.RestartCount
+		}
+		inventory = append(inventory, item)
+	}
+	return inventory, nil
+}
+
+func dockerInventoryFromListItem(container dockerContainerListItem, observedAt int64, maxLabelBytes int) *agentv1.DockerContainerInventory {
+	return &agentv1.DockerContainerInventory{
+		DockerContainerId: truncateUTF8(strings.TrimSpace(container.ID), maxDockerContainerIDBytes),
+		Names:             normalizeDockerNames(container.Names),
+		Image:             truncateUTF8(strings.TrimSpace(container.Image), maxDockerContainerImageBytes),
+		ImageId:           truncateUTF8(strings.TrimSpace(container.ImageID), maxDockerContainerImageIDBytes),
+		Labels:            boundedDockerLabels(container.Labels, maxLabelBytes),
+		State:             truncateUTF8(strings.TrimSpace(container.State), maxDockerContainerStateBytes),
+		Status:            truncateUTF8(strings.TrimSpace(container.Status), maxDockerContainerStatusBytes),
+		CreatedAtUnix:     container.Created,
+		ObservedAtUnix:    observedAt,
+	}
+}
+
+func inspectDockerContainer(ctx context.Context, client *http.Client, baseURL, containerID string) (dockerContainerInspect, error) {
+	inspectURL, err := url.JoinPath(baseURL, "/containers", containerID, "json")
+	if err != nil {
+		return dockerContainerInspect{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, inspectURL, nil)
+	if err != nil {
+		return dockerContainerInspect{}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return dockerContainerInspect{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return dockerContainerInspect{}, os.ErrPermission
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return dockerContainerInspect{}, fmt.Errorf("docker inspect endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	var inspect dockerContainerInspect
+	if err := json.NewDecoder(resp.Body).Decode(&inspect); err != nil {
+		return dockerContainerInspect{}, err
+	}
+	return inspect, nil
+}
+
+func dockerSocketHTTPClient(socketPath string) *http.Client {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}
+	return &http.Client{Transport: transport}
+}
+
+func normalizeDockerNames(names []string) []string {
+	normalized := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(strings.TrimPrefix(name, "/"))
+		if name == "" {
+			continue
+		}
+		normalized = append(normalized, truncateUTF8(name, maxDockerContainerNameBytes))
+	}
+	return normalized
+}
+
+func boundedDockerLabels(labels map[string]string, maxBytes int) []*agentv1.DockerContainerLabel {
+	if maxBytes <= 0 || len(labels) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	out := make([]*agentv1.DockerContainerLabel, 0, len(keys))
+	used := 0
+	for _, originalKey := range keys {
+		key := truncateUTF8(strings.TrimSpace(originalKey), maxDockerContainerLabelKeyBytes)
+		if key == "" {
+			continue
+		}
+		remaining := maxBytes - used - len(key)
+		if remaining < 0 {
+			break
+		}
+		value := truncateUTF8(labels[originalKey], remaining)
+		out = append(out, &agentv1.DockerContainerLabel{Key: key, Value: value})
+		used += len(key) + len(value)
+		if used >= maxBytes {
+			break
+		}
+	}
+	return out
+}
+
+func parseDockerTimestampUnix(value string) int64 {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.HasPrefix(value, "0001-01-01T00:00:00") {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return 0
+	}
+	return t.Unix()
+}

--- a/agent/internal/heartbeat/docker_inventory_test.go
+++ b/agent/internal/heartbeat/docker_inventory_test.go
@@ -1,0 +1,125 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	agentv1 "github.com/carrtech-dev/ct-ops/proto/agent/v1"
+)
+
+func TestCollectDockerInventoryIncludesContainerDetails(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/containers/json", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("all") != "1" {
+			t.Fatalf("all query = %q, want 1", r.URL.Query().Get("all"))
+		}
+		_ = json.NewEncoder(w).Encode([]dockerContainerListItem{
+			{
+				ID:      "abcdef123456",
+				Names:   []string{"/web", "worker"},
+				Image:   "nginx:1.27",
+				ImageID: "sha256:image",
+				Labels:  map[string]string{"com.example.role": "frontend", "tier": "edge"},
+				State:   "running",
+				Status:  "Up 2 minutes",
+				Created: 1_778_611_200,
+			},
+		})
+	})
+	handler.HandleFunc("/containers/abcdef123456/json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(dockerContainerInspect{
+			RestartCount: 3,
+			State: dockerContainerInspectState{
+				StartedAt:  "2026-05-12T20:00:05.123456789Z",
+				FinishedAt: "0001-01-01T00:00:00Z",
+			},
+		})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	inventory, err := collectDockerInventoryWithClient(context.Background(), server.Client(), server.URL, 1024)
+	if err != nil {
+		t.Fatalf("collectDockerInventoryWithClient() error = %v", err)
+	}
+	if len(inventory) != 1 {
+		t.Fatalf("inventory length = %d, want 1", len(inventory))
+	}
+
+	got := inventory[0]
+	if got.DockerContainerId != "abcdef123456" {
+		t.Fatalf("docker_container_id = %q", got.DockerContainerId)
+	}
+	if got.Names[0] != "web" || got.Names[1] != "worker" {
+		t.Fatalf("names = %#v, want normalized names", got.Names)
+	}
+	if got.Image != "nginx:1.27" || got.ImageId != "sha256:image" {
+		t.Fatalf("image fields = %q/%q", got.Image, got.ImageId)
+	}
+	if got.State != "running" || got.Status != "Up 2 minutes" {
+		t.Fatalf("state/status = %q/%q", got.State, got.Status)
+	}
+	if got.CreatedAtUnix != 1_778_611_200 {
+		t.Fatalf("created_at_unix = %d", got.CreatedAtUnix)
+	}
+	if got.StartedAtUnix != 1_778_616_005 {
+		t.Fatalf("started_at_unix = %d", got.StartedAtUnix)
+	}
+	if got.FinishedAtUnix != 0 {
+		t.Fatalf("finished_at_unix = %d, want zero for Docker zero time", got.FinishedAtUnix)
+	}
+	if got.ObservedAtUnix == 0 {
+		t.Fatal("observed_at_unix was not set")
+	}
+	if got.RestartCount != 3 {
+		t.Fatalf("restart_count = %d, want 3", got.RestartCount)
+	}
+	assertDockerLabel(t, got, "com.example.role", "frontend")
+	assertDockerLabel(t, got, "tier", "edge")
+}
+
+func TestCollectDockerInventoryBoundsLabels(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/containers/json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]dockerContainerListItem{
+			{
+				ID:     "abcdef123456",
+				Labels: map[string]string{"aaa": "12345", "bbb": "1234567890", "ccc": "ignored"},
+			},
+		})
+	})
+	handler.HandleFunc("/containers/abcdef123456/json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(dockerContainerInspect{})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	inventory, err := collectDockerInventoryWithClient(context.Background(), server.Client(), server.URL, 12)
+	if err != nil {
+		t.Fatalf("collectDockerInventoryWithClient() error = %v", err)
+	}
+
+	labels := inventory[0].Labels
+	if len(labels) != 2 {
+		t.Fatalf("labels length = %d, want 2 labels within byte budget", len(labels))
+	}
+	if labels[0].Key != "aaa" || labels[0].Value != "12345" {
+		t.Fatalf("first label = %#v", labels[0])
+	}
+	if labels[1].Key != "bbb" || labels[1].Value != "1" {
+		t.Fatalf("second label = %#v, want truncated value", labels[1])
+	}
+}
+
+func assertDockerLabel(t *testing.T, inventory *agentv1.DockerContainerInventory, key, value string) {
+	t.Helper()
+	for _, label := range inventory.Labels {
+		if label.Key == key && label.Value == value {
+			return
+		}
+	}
+	t.Fatalf("missing label %q=%q in %#v", key, value, inventory.Labels)
+}

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -164,7 +164,7 @@ Purpose: list containers per host and track their lifecycle before storing high-
 
 | Task | Owner | Status | Files / Areas | Dependencies | Acceptance Criteria | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Collect container inventory in agent | unclaimed | pending | agent Docker collector package, tests | Phase 1 agent detection | Agent reports container id, names, image, labels, state, created/started timestamps, and restart count where available. | TBD | Bound label payload size. |
+| Collect container inventory in agent | Codex | review | agent Docker collector package, tests | Phase 1 agent detection | Agent reports container id, names, image, labels, state, created/started timestamps, and restart count where available. | [#1350](https://github.com/carrtech-dev/ct-ops/pull/1350) | PR #1350 adds Docker Engine API inventory collection with bounded labels. Upload remains dependent on ingest inventory upsert work. |
 | Upsert container inventory in ingest | unclaimed | pending | ingest handlers, DB queries, schema | Inventory protobuf and schema | Inventory is upserted by `host_id + docker_container_id`; missing containers are marked not currently seen rather than immediately deleted. | TBD | Preserve historical identity for charts after container exits. |
 | Add Containers tab/list UI | unclaimed | pending | host detail page/components/actions | Inventory persistence | Users can see current and recently seen containers, image, state, last seen, and restart count. | TBD | Include filters for state, image, and name if feasible in this phase. |
 


### PR DESCRIPTION
## Summary
- add Docker inventory collection from the Engine API without shelling out
- normalize container names and bound untrusted label/name/image/status payloads
- inspect containers for started/finished timestamps and restart count where available
- claim the Phase 2 agent inventory task in the Docker telemetry plan

## Tests
- go test ./... (from agent/)