### PR TITLE
feat(hosts): add docker containers tab

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
@@ -1,0 +1,277 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { formatDistanceToNow } from 'date-fns'
+import { Box, Search, X, ShieldAlert, WifiOff, AlertTriangle, Loader2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { getHostDockerContainers } from '@/lib/actions/docker-containers'
+import type { DockerRuntimeStatus, HostDockerStatus } from '@/lib/db/schema/docker'
+
+interface Props {
+  scopeId: string
+  hostId: string
+  dockerStatus?: HostDockerStatus | null
+}
+
+type DisplayStatus = DockerRuntimeStatus | 'unknown'
+
+const stateOptions = [
+  { value: 'all', label: 'All states' },
+  { value: 'running', label: 'Running' },
+  { value: 'exited', label: 'Exited' },
+  { value: 'created', label: 'Created' },
+  { value: 'paused', label: 'Paused' },
+  { value: 'restarting', label: 'Restarting' },
+  { value: 'removing', label: 'Removing' },
+  { value: 'dead', label: 'Dead' },
+]
+
+const unavailableCopy: Record<Exclude<DisplayStatus, 'installed'>, { title: string; body: string; icon: typeof AlertTriangle }> = {
+  unknown: {
+    title: 'Docker status unknown',
+    body: 'No Docker runtime status has been reported for this host yet.',
+    icon: AlertTriangle,
+  },
+  not_installed: {
+    title: 'Docker not installed',
+    body: 'Docker Engine is not installed or was not found on this host.',
+    icon: WifiOff,
+  },
+  permission_denied: {
+    title: 'Permission denied',
+    body: 'The agent found Docker but cannot read container inventory.',
+    icon: ShieldAlert,
+  },
+  unreachable: {
+    title: 'Docker unreachable',
+    body: 'Docker was detected but did not respond to the agent.',
+    icon: AlertTriangle,
+  },
+  error: {
+    title: 'Docker status error',
+    body: 'The agent hit an unexpected Docker status check error.',
+    icon: AlertTriangle,
+  },
+}
+
+function formatRelative(date: Date | string | null | undefined): string {
+  if (!date) return '-'
+  return formatDistanceToNow(new Date(date), { addSuffix: true })
+}
+
+function formatAbsolute(date: Date | string | null | undefined): string {
+  if (!date) return '-'
+  return new Date(date).toLocaleString()
+}
+
+function ContainerStateBadge({ state, present }: { state: string | null; present: boolean }) {
+  if (!present) {
+    return (
+      <Badge className="bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-100">
+        Not present
+      </Badge>
+    )
+  }
+  if (state === 'running') {
+    return (
+      <Badge className="bg-green-100 text-green-800 border-green-200 hover:bg-green-100">
+        Running
+      </Badge>
+    )
+  }
+  if (state === 'exited' || state === 'dead') {
+    return (
+      <Badge className="bg-gray-100 text-gray-700 border-gray-200 hover:bg-gray-100">
+        {state === 'dead' ? 'Dead' : 'Exited'}
+      </Badge>
+    )
+  }
+  if (state === 'restarting' || state === 'paused') {
+    return (
+      <Badge className="bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100">
+        {state === 'restarting' ? 'Restarting' : 'Paused'}
+      </Badge>
+    )
+  }
+  return (
+    <Badge className="bg-slate-100 text-slate-700 border-slate-200 hover:bg-slate-100">
+      {state || 'Unknown'}
+    </Badge>
+  )
+}
+
+function EmptyState({ title, body, icon: Icon = Box }: { title: string; body: string; icon?: typeof Box }) {
+  return (
+    <div className="rounded-lg border border-dashed p-12 text-center">
+      <Icon className="size-8 mx-auto text-muted-foreground mb-3" />
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <p className="text-xs text-muted-foreground mt-1">{body}</p>
+    </div>
+  )
+}
+
+export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
+  const [search, setSearch] = useState('')
+  const [state, setState] = useState('all')
+  const [image, setImage] = useState('all')
+  const status: DisplayStatus = dockerStatus?.status ?? 'unknown'
+  const dockerUnavailable = status !== 'installed'
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['host-docker-containers', scopeId, hostId, search, state, image],
+    queryFn: () => getHostDockerContainers(scopeId, hostId, { search, state, image }),
+    enabled: !dockerUnavailable,
+  })
+
+  const containers = data?.containers ?? []
+  const imageOptions = data?.imageOptions ?? []
+  const hasActiveFilters = search.trim() !== '' || state !== 'all' || image !== 'all'
+  const clearFilters = () => {
+    setSearch('')
+    setState('all')
+    setImage('all')
+  }
+
+  if (dockerUnavailable) {
+    const copy = unavailableCopy[status]
+    return (
+      <div data-testid="host-containers-tab">
+        <EmptyState title={copy.title} body={copy.body} icon={copy.icon} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4" data-testid="host-containers-tab">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          {isLoading ? 'Loading containers...' : `${containers.length} container${containers.length === 1 ? '' : 's'}`}
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[220px]">
+            <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search name, image or ID"
+              className="pl-8"
+              data-testid="host-containers-search"
+            />
+          </div>
+          <Select value={state} onValueChange={setState}>
+            <SelectTrigger className="w-36" data-testid="host-containers-state-filter">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {stateOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={image} onValueChange={setImage}>
+            <SelectTrigger className="w-48" data-testid="host-containers-image-filter">
+              <SelectValue placeholder="Image" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All images</SelectItem>
+              {imageOptions.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {hasActiveFilters && (
+            <Button variant="ghost" size="sm" onClick={clearFilters} className="gap-1">
+              <X className="size-3.5" />
+              Clear
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Box className="size-4 text-muted-foreground" />
+            Container Inventory
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
+              Loading containers...
+            </div>
+          ) : containers.length === 0 ? (
+            hasActiveFilters ? (
+              <EmptyState title="No containers match your filters" body="Clear the current filters to see all known Docker containers for this host." />
+            ) : (
+              <EmptyState title="No containers reported" body="Docker is installed, but no current or recently seen containers have been reported yet." />
+            )
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Image</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last seen</TableHead>
+                  <TableHead>Started</TableHead>
+                  <TableHead className="text-right">Restarts</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {containers.map((container) => (
+                  <TableRow
+                    key={container.id}
+                    data-testid={`host-docker-container-row-${container.dockerContainerId}`}
+                  >
+                    <TableCell>
+                      <div className="font-medium text-foreground">
+                        {container.primaryName || container.namesJson[0] || container.dockerContainerId.slice(0, 12)}
+                      </div>
+                      <div className="font-mono text-xs text-muted-foreground">
+                        {container.dockerContainerId.slice(0, 12)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="max-w-[260px] truncate text-sm">
+                      {container.image || '-'}
+                    </TableCell>
+                    <TableCell>
+                      <ContainerStateBadge state={container.state} present={container.isPresent} />
+                    </TableCell>
+                    <TableCell className="max-w-[280px] truncate text-sm text-muted-foreground">
+                      {container.status || '-'}
+                    </TableCell>
+                    <TableCell className="text-sm">{formatRelative(container.lastSeenAt)}</TableCell>
+                    <TableCell className="text-sm">{formatAbsolute(container.startedAtSource)}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {container.restartCount ?? '-'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -67,6 +67,7 @@ import { LocalUsersTab } from './local-users-tab'
 import { TasksTab } from './tasks-tab'
 import { LogsTab } from './logs-tab'
 import { InventoryTab } from './inventory-tab'
+import { ContainersTab } from './containers-tab'
 import { PatchStatusTab } from './patch-status-tab'
 import { VulnerabilitiesTab } from './vulnerabilities-tab'
 import { HostTerminalLauncher } from './host-terminal-launcher'
@@ -1401,6 +1402,11 @@ export function HostDetailClient({
       {/* Inventory Tab */}
       {activeTab === 'packages' && (
         <InventoryTab scopeId={scopeId} hostId={initialHost.id} />
+      )}
+
+      {/* Containers Tab */}
+      {activeTab === 'containers' && (
+        <ContainersTab scopeId={scopeId} hostId={initialHost.id} dockerStatus={host.dockerStatus} />
       )}
 
       {/* Vulnerabilities Tab */}

--- a/apps/web/lib/actions/docker-containers.ts
+++ b/apps/web/lib/actions/docker-containers.ts
@@ -1,0 +1,91 @@
+'use server'
+
+import { and, asc, desc, eq, ilike, isNull, or, sql } from 'drizzle-orm'
+import { requireInstanceAccess } from '@/lib/actions/action-auth'
+import { db } from '@/lib/db'
+import { dockerContainers, hosts, type DockerContainer } from '@/lib/db/schema'
+import { escapeLikePattern } from '@/lib/utils'
+
+export interface HostDockerContainerFilters {
+  search?: string
+  state?: string
+  image?: string
+}
+
+export interface HostDockerContainersResult {
+  containers: DockerContainer[]
+  imageOptions: string[]
+}
+
+const MAX_CONTAINER_ROWS = 200
+const MAX_FILTER_LENGTH = 256
+
+function cleanFilter(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed || trimmed === 'all') return undefined
+  return trimmed.slice(0, MAX_FILTER_LENGTH)
+}
+
+export async function getHostDockerContainers(
+  instanceId: string,
+  hostId: string,
+  filters: HostDockerContainerFilters = {},
+): Promise<HostDockerContainersResult> {
+  await requireInstanceAccess(instanceId)
+
+  const host = await db.query.hosts.findFirst({
+    columns: { id: true },
+    where: and(eq(hosts.id, hostId), eq(hosts.instanceId, instanceId), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { containers: [], imageOptions: [] }
+
+  const search = cleanFilter(filters.search)
+  const state = cleanFilter(filters.state)
+  const image = cleanFilter(filters.image)
+
+  const conditions = [
+    eq(dockerContainers.instanceId, instanceId),
+    eq(dockerContainers.hostId, hostId),
+  ]
+
+  if (state) {
+    conditions.push(eq(dockerContainers.state, state))
+  }
+  if (image) {
+    conditions.push(eq(dockerContainers.image, image))
+  }
+  if (search) {
+    const pattern = `%${escapeLikePattern(search)}%`
+    const searchClause = or(
+      ilike(dockerContainers.primaryName, pattern),
+      ilike(dockerContainers.image, pattern),
+      ilike(dockerContainers.dockerContainerId, pattern),
+      sql`${dockerContainers.namesJson}::text ILIKE ${pattern}`,
+    )
+    if (searchClause) conditions.push(searchClause)
+  }
+
+  const [rows, images] = await Promise.all([
+    db.query.dockerContainers.findMany({
+      where: and(...conditions),
+      orderBy: [
+        desc(dockerContainers.isPresent),
+        desc(dockerContainers.lastSeenAt),
+        asc(dockerContainers.primaryName),
+      ],
+      limit: MAX_CONTAINER_ROWS,
+    }),
+    db.query.dockerContainers.findMany({
+      columns: { image: true },
+      where: and(eq(dockerContainers.instanceId, instanceId), eq(dockerContainers.hostId, hostId)),
+      orderBy: [asc(dockerContainers.image)],
+    }),
+  ])
+
+  return {
+    containers: rows,
+    imageOptions: Array.from(new Set(images
+      .map((row) => row.image)
+      .filter((value): value is string => Boolean(value)))),
+  }
+}

--- a/apps/web/lib/hosts/host-detail-tabs.test.mjs
+++ b/apps/web/lib/hosts/host-detail-tabs.test.mjs
@@ -12,3 +12,13 @@ test('host network membership tab belongs under infrastructure', () => {
   assert.ok(infrastructure.children?.includes('host-networks'))
   assert.equal(management.children?.includes('host-networks'), false)
 })
+
+test('container inventory is available as a top-level host tab', () => {
+  const containers = PARENT_TABS.find((tab) => tab.id === 'containers')
+  const inventory = PARENT_TABS.find((tab) => tab.id === 'inventory')
+
+  assert.ok(containers)
+  assert.equal(containers.defaultTab, 'containers')
+  assert.equal(containers.children, null)
+  assert.equal(inventory?.children?.includes('containers'), false)
+})

--- a/apps/web/lib/hosts/host-detail-tabs.ts
+++ b/apps/web/lib/hosts/host-detail-tabs.ts
@@ -3,6 +3,7 @@ export type ParentTabId =
   | 'monitoring'
   | 'infrastructure'
   | 'inventory'
+  | 'containers'
   | 'notes'
   | 'management'
   | 'tools'
@@ -24,6 +25,7 @@ export type Tab =
   | 'logs'
   | 'terminal'
   | 'packages'
+  | 'containers'
   | 'notes'
 
 export const TAB_LABELS: Record<Tab, string> = {
@@ -43,6 +45,7 @@ export const TAB_LABELS: Record<Tab, string> = {
   logs: 'Logs',
   terminal: 'Terminal',
   packages: 'Packages',
+  containers: 'Containers',
   notes: 'Notes',
 }
 
@@ -56,6 +59,7 @@ export const PARENT_TABS: Array<{
   { id: 'monitoring', label: 'Monitoring', defaultTab: 'metrics', children: ['metrics', 'checks', 'alerts'] },
   { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network', 'host-networks', 'patch-status'] },
   { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages', 'vulnerabilities'] },
+  { id: 'containers', label: 'Containers', defaultTab: 'containers', children: null },
   { id: 'notes', label: 'Notes', defaultTab: 'notes', children: null },
   { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'settings'] },
   { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },

--- a/apps/web/tests/e2e/hosts/docker-containers.spec.ts
+++ b/apps/web/tests/e2e/hosts/docker-containers.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM instance_settings
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+async function seedHost(sql: ReturnType<typeof getTestDb>, instanceId: string, hostId: string) {
+  await sql`
+    INSERT INTO hosts (
+      id,
+      instance_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      ${hostId},
+      ${instanceId},
+      ${`${hostId}.example.test`},
+      ${`Docker ${hostId}`},
+      'Ubuntu 24.04',
+      'x86_64',
+      '["10.90.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+}
+
+async function seedDockerStatus(sql: ReturnType<typeof getTestDb>, instanceId: string, hostId: string, status: string) {
+  await sql`
+    INSERT INTO host_docker_status (
+      instance_id,
+      host_id,
+      status,
+      checked_at
+    )
+    VALUES (
+      ${instanceId},
+      ${hostId},
+      ${status},
+      NOW() - INTERVAL '1 minute'
+    )
+  `
+}
+
+test('host Containers tab lists containers and filters by name and state', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-containers-host')
+  await seedDockerStatus(sql, instanceId, 'docker-containers-host', 'installed')
+
+  await sql`
+    INSERT INTO docker_containers (
+      instance_id,
+      host_id,
+      docker_container_id,
+      primary_name,
+      names_json,
+      image,
+      image_id,
+      labels_json,
+      state,
+      status,
+      created_at_source,
+      started_at_source,
+      first_seen_at,
+      last_seen_at,
+      last_inventory_at,
+      restart_count,
+      is_present
+    )
+    VALUES
+      (
+        ${instanceId},
+        'docker-containers-host',
+        'web-container-id',
+        'web',
+        '["web","frontend"]'::jsonb,
+        'nginx:1.27',
+        'sha256:web',
+        '{"com.example.service":"web"}'::jsonb,
+        'running',
+        'Up 4 minutes',
+        NOW() - INTERVAL '10 minutes',
+        NOW() - INTERVAL '4 minutes',
+        NOW() - INTERVAL '10 minutes',
+        NOW() - INTERVAL '30 seconds',
+        NOW() - INTERVAL '30 seconds',
+        2,
+        true
+      ),
+      (
+        ${instanceId},
+        'docker-containers-host',
+        'worker-container-id',
+        'worker',
+        '["worker"]'::jsonb,
+        'redis:7',
+        'sha256:worker',
+        '{}'::jsonb,
+        'exited',
+        'Exited (0) 2 hours ago',
+        NOW() - INTERVAL '3 hours',
+        NOW() - INTERVAL '3 hours',
+        NOW() - INTERVAL '3 hours',
+        NOW() - INTERVAL '2 hours',
+        NOW() - INTERVAL '2 hours',
+        0,
+        false
+      )
+  `
+
+  await page.goto('/hosts/docker-containers-host')
+  await page.getByTestId('host-parent-tab-containers').click()
+
+  await expect(page.getByTestId('host-containers-tab')).toContainText('2 containers')
+  await expect(page.getByTestId('host-docker-container-row-web-container-id')).toContainText('web')
+  await expect(page.getByTestId('host-docker-container-row-web-container-id')).toContainText('nginx:1.27')
+  await expect(page.getByTestId('host-docker-container-row-worker-container-id')).toContainText('worker')
+  await expect(page.getByTestId('host-docker-container-row-worker-container-id')).toContainText('Not present')
+
+  await page.getByTestId('host-containers-search').fill('nginx')
+  await expect(page.getByTestId('host-docker-container-row-web-container-id')).toBeVisible()
+  await expect(page.getByTestId('host-docker-container-row-worker-container-id')).toHaveCount(0)
+
+  await page.getByTestId('host-containers-search').fill('')
+  await page.getByTestId('host-containers-state-filter').click()
+  await page.getByRole('option', { name: 'Running' }).click()
+  await expect(page.getByTestId('host-docker-container-row-web-container-id')).toBeVisible()
+  await expect(page.getByTestId('host-docker-container-row-worker-container-id')).toHaveCount(0)
+})
+
+test('host Containers tab explains Docker unavailable states', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-containers-denied')
+  await seedDockerStatus(sql, instanceId, 'docker-containers-denied', 'permission_denied')
+
+  await page.goto('/hosts/docker-containers-denied')
+  await page.getByTestId('host-parent-tab-containers').click()
+
+  const tab = page.getByTestId('host-containers-tab')
+  await expect(tab).toContainText('Permission denied')
+  await expect(tab).toContainText('The agent found Docker but cannot read container inventory.')
+})

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -166,7 +166,7 @@ Purpose: list containers per host and track their lifecycle before storing high-
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Collect container inventory in agent | Codex | done | agent Docker collector package, tests | Phase 1 agent detection | Agent reports container id, names, image, labels, state, created/started timestamps, and restart count where available. | [#1350](https://github.com/carrtech-dev/ct-ops/pull/1350) | Merged in #1350. Agent now collects Docker Engine API inventory with bounded labels. Upload remains dependent on ingest inventory upsert work. |
 | Upsert container inventory in ingest | Codex | done | ingest handlers, DB queries, schema | Inventory protobuf and schema | Inventory is upserted by `host_id + docker_container_id`; missing containers are marked not currently seen rather than immediately deleted. | [#1353](https://github.com/carrtech-dev/ct-ops/pull/1353) | Merged in #1353. Added Docker inventory schema, ingest stream handling, field bounds, and missing-container marking. |
-| Add Containers tab/list UI | unclaimed | pending | host detail page/components/actions | Inventory persistence | Users can see current and recently seen containers, image, state, last seen, and restart count. | TBD | Include filters for state, image, and name if feasible in this phase. |
+| Add Containers tab/list UI | Codex | in_progress | host detail page/components/actions | Inventory persistence | Users can see current and recently seen containers, image, state, last seen, and restart count. | TBD | Claimed 2026-05-13. Include filters for state, image, and name if feasible in this phase. |
 
 ## Phase 3: Batched Container Metrics
 

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -166,7 +166,7 @@ Purpose: list containers per host and track their lifecycle before storing high-
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Collect container inventory in agent | Codex | done | agent Docker collector package, tests | Phase 1 agent detection | Agent reports container id, names, image, labels, state, created/started timestamps, and restart count where available. | [#1350](https://github.com/carrtech-dev/ct-ops/pull/1350) | Merged in #1350. Agent now collects Docker Engine API inventory with bounded labels. Upload remains dependent on ingest inventory upsert work. |
 | Upsert container inventory in ingest | Codex | done | ingest handlers, DB queries, schema | Inventory protobuf and schema | Inventory is upserted by `host_id + docker_container_id`; missing containers are marked not currently seen rather than immediately deleted. | [#1353](https://github.com/carrtech-dev/ct-ops/pull/1353) | Merged in #1353. Added Docker inventory schema, ingest stream handling, field bounds, and missing-container marking. |
-| Add Containers tab/list UI | Codex | in_progress | host detail page/components/actions | Inventory persistence | Users can see current and recently seen containers, image, state, last seen, and restart count. | TBD | Claimed 2026-05-13. Include filters for state, image, and name if feasible in this phase. |
+| Add Containers tab/list UI | Codex | review | host detail page/components/actions | Inventory persistence | Users can see current and recently seen containers, image, state, last seen, and restart count. | [#1356](https://github.com/carrtech-dev/ct-ops/pull/1356) | PR #1356 adds the host Containers tab, scoped list action, state/image/name filters, and unavailable-state empty copy. |
 
 ## Phase 3: Batched Container Metrics
 


### PR DESCRIPTION
## Summary\n- Add a top-level host Containers tab backed by Docker inventory persistence\n- Add scoped server action for container list queries with name/image/state filters\n- Add tab unit coverage and focused Playwright coverage for list, filters, and Docker unavailable states\n\n## Validation\n- node --experimental-strip-types --test lib/hosts/host-detail-tabs.test.mjs\n- node ./node_modules/eslint/bin/eslint.js lib/hosts/host-detail-tabs.ts lib/hosts/host-detail-tabs.test.mjs lib/actions/docker-containers.ts 'app/(dashboard)/hosts/[id]/containers-tab.tsx' 'app/(dashboard)/hosts/[id]/host-detail-client.tsx' tests/e2e/hosts/docker-containers.spec.ts\n- targeted TypeScript check for new action/component files via temporary tsconfig\n\n## Not run\n- Full type-check: blocked by existing missing declarations for react-qr-code, rrule, and @xterm/xterm/css/xterm.css in this environment\n- Focused Playwright spec: blocked because testcontainers could not find a working local container runtime\n