### PR TITLE
feat(web): add host docker retention override

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/settings-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/settings-tab.tsx
@@ -2,14 +2,20 @@
 
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { AlertTriangle, KeyRound, Settings, Users, Cpu, HardDrive, MemoryStick, Plus, X, TerminalSquare, Tag as TagIcon } from 'lucide-react'
+import { AlertTriangle, KeyRound, Settings, Users, Cpu, HardDrive, MemoryStick, Plus, X, TerminalSquare, Tag as TagIcon, Boxes } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { CheckCircle2 } from 'lucide-react'
-import { getHostCollectionSettings, updateHostCollectionSettings } from '@/lib/actions/host-settings'
+import {
+  getHostCollectionSettings,
+  getHostDockerRetentionSettings,
+  updateHostCollectionSettings,
+  updateHostDockerRetentionOverride,
+} from '@/lib/actions/host-settings'
 import { getHostTerminalSettings, trustPendingSshHostKeys, updateHostTerminalSettings } from '@/lib/actions/terminal'
 import type { HostTerminalSettings } from '@/lib/actions/terminal-core'
 import { getOrgUsers } from '@/lib/actions/users'
@@ -22,10 +28,22 @@ interface SettingsTabProps {
   isAdmin: boolean
 }
 
+const RETENTION_OPTIONS = [
+  { value: '7', label: '7 days' },
+  { value: '14', label: '14 days' },
+  { value: '30', label: '30 days' },
+  { value: '60', label: '60 days' },
+  { value: '90', label: '90 days' },
+  { value: '180', label: '180 days' },
+  { value: '365', label: '1 year' },
+]
+
 export function SettingsTab({ hostId, isAdmin }: SettingsTabProps) {
   const queryClient = useQueryClient()
   const [saveSuccess, setSaveSuccess] = useState(false)
   const [newUsername, setNewUsername] = useState('')
+  const [dockerRetentionSaveSuccess, setDockerRetentionSaveSuccess] = useState(false)
+  const [localDockerRetentionOverride, setLocalDockerRetentionOverride] = useState<number | null | undefined>(undefined)
 
   // Terminal settings state
   const [terminalSaveSuccess, setTerminalSaveSuccess] = useState(false)
@@ -39,6 +57,11 @@ export function SettingsTab({ hostId, isAdmin }: SettingsTabProps) {
   const { data: terminalSettings } = useQuery({
     queryKey: ['host-terminal-settings', hostId],
     queryFn: () => getHostTerminalSettings(hostId),
+  })
+
+  const { data: dockerRetentionSettings } = useQuery({
+    queryKey: ['host-docker-retention-settings', hostId],
+    queryFn: () => getHostDockerRetentionSettings(hostId),
   })
 
   const { data: orgUsers } = useQuery({
@@ -141,6 +164,17 @@ export function SettingsTab({ hostId, isAdmin }: SettingsTabProps) {
     },
   })
 
+  const dockerRetentionMutation = useMutation({
+    mutationFn: (days: number | null) => updateHostDockerRetentionOverride(hostId, days),
+    onSuccess: (result) => {
+      if ('error' in result) return
+      setDockerRetentionSaveSuccess(true)
+      setLocalDockerRetentionOverride(undefined)
+      queryClient.invalidateQueries({ queryKey: ['host-docker-retention-settings', hostId] })
+      setTimeout(() => setDockerRetentionSaveSuccess(false), 3000)
+    },
+  })
+
   function updateSetting(patch: Partial<HostCollectionSettings>) {
     const base = currentSettings ?? { cpu: true, memory: true, disk: true, localUsers: false }
     setLocalSettings({ ...base, ...patch })
@@ -182,6 +216,16 @@ export function SettingsTab({ hostId, isAdmin }: SettingsTabProps) {
   }
 
   const isDirty = localSettings !== null
+  const currentDockerRetentionOverride =
+    localDockerRetentionOverride === undefined
+      ? dockerRetentionSettings?.retentionDaysOverride ?? null
+      : localDockerRetentionOverride
+  const dockerRetentionValue = currentDockerRetentionOverride === null ? 'inherit' : String(currentDockerRetentionOverride)
+  const dockerRetentionDirty =
+    localDockerRetentionOverride !== undefined &&
+    localDockerRetentionOverride !== (dockerRetentionSettings?.retentionDaysOverride ?? null)
+  const effectiveDockerRetentionDays =
+    currentDockerRetentionOverride ?? dockerRetentionSettings?.globalRetentionDays ?? 30
 
   return (
     <div className="space-y-6">
@@ -378,6 +422,94 @@ export function SettingsTab({ hostId, isAdmin }: SettingsTabProps) {
           </div>
         </CardContent>
       </Card>
+
+      {dockerRetentionSettings && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Boxes className="size-4 text-muted-foreground" />
+              Docker Retention
+            </CardTitle>
+            <CardDescription>
+              Override how long Docker container metrics are kept for this host.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div>
+                <p className="text-xs text-muted-foreground">Inherited default</p>
+                <p className="text-sm font-medium" data-testid="settings-docker-retention-inherited">
+                  {dockerRetentionSettings.globalRetentionDays} days
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Host override</p>
+                <p className="text-sm font-medium">
+                  {currentDockerRetentionOverride === null ? 'None' : `${currentDockerRetentionOverride} days`}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Effective retention</p>
+                <p className="text-sm font-medium">{effectiveDockerRetentionDays} days</p>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="docker-retention-override-select">Retention override</Label>
+              <Select
+                value={dockerRetentionValue}
+                onValueChange={(value) =>
+                  setLocalDockerRetentionOverride(value === 'inherit' ? null : Number(value))
+                }
+                disabled={dockerRetentionMutation.isPending}
+              >
+                <SelectTrigger
+                  id="docker-retention-override-select"
+                  className="w-56"
+                  data-testid="settings-docker-retention-override-select"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="inherit">Inherit default</SelectItem>
+                  {RETENTION_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-3 pt-2 border-t">
+              <Button
+                size="sm"
+                disabled={!dockerRetentionDirty || dockerRetentionMutation.isPending}
+                onClick={() => dockerRetentionMutation.mutate(currentDockerRetentionOverride)}
+                data-testid="settings-docker-retention-save"
+              >
+                {dockerRetentionMutation.isPending ? 'Saving...' : 'Save'}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={currentDockerRetentionOverride === null || dockerRetentionMutation.isPending}
+                onClick={() => dockerRetentionMutation.mutate(null)}
+                data-testid="settings-docker-retention-clear"
+              >
+                Clear override
+              </Button>
+              {dockerRetentionSaveSuccess && (
+                <span className="flex items-center gap-1 text-sm text-green-700" data-testid="settings-docker-retention-success">
+                  <CheckCircle2 className="size-4" />
+                  Saved
+                </span>
+              )}
+              {dockerRetentionMutation.isError && (
+                <span className="text-sm text-destructive">Failed to save Docker retention</span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Tags Card */}
       <Card>

--- a/apps/web/lib/actions/host-docker-retention.test.mjs
+++ b/apps/web/lib/actions/host-docker-retention.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const source = readFileSync(path.join(here, 'host-settings.ts'), 'utf8')
+
+function getActionSegment(action) {
+  const start = source.indexOf(`export async function ${action}`)
+  assert.notEqual(start, -1, `expected ${action} to exist in host-settings.ts`)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? undefined : next)
+}
+
+test('host Docker retention reads inherited and effective retention values', () => {
+  const segment = getActionSegment('getHostDockerRetentionSettings')
+
+  assert.match(segment, /parseHostMetadata\(host\?\.metadata\)/)
+  assert.match(segment, /org\?\.dockerMetricRetentionDays \?\? 30/)
+  assert.match(segment, /retentionDaysOverride \?\? globalRetentionDays/)
+})
+
+test('host Docker retention override requires write access and supports clearing', () => {
+  const segment = getActionSegment('updateHostDockerRetentionOverride')
+
+  assert.match(segment, /await requireInstanceWriteAccess\(currentScope\)/)
+  assert.match(source, /days: z\.number\(\)\.int\(\)\.min\(1\)\.max\(365\)\.nullable\(\)/)
+  assert.match(segment, /retentionDaysOverride: parsed\.data\.days/)
+})

--- a/apps/web/lib/actions/host-settings.ts
+++ b/apps/web/lib/actions/host-settings.ts
@@ -4,6 +4,7 @@ import { logError } from '@/lib/logging'
 import { requireInstanceAccess, requireInstanceAdminAccess, requireInstanceWriteAccess } from '@/lib/actions/action-auth'
 import { getRequiredSession } from '@/lib/auth/session'
 
+import { z } from 'zod'
 import { db } from '@/lib/db'
 import { hosts, instanceSettings, checks } from '@/lib/db/schema'
 import { eq, and, isNull } from 'drizzle-orm'
@@ -13,6 +14,16 @@ import { parseHostMetadata } from '@/lib/db/schema/hosts'
 import { parseInstanceMetadata } from '@/lib/db/schema/instance-settings'
 import { resolveCurrentActionScope } from './action-scope'
 import { createCheck, updateCheck } from '@/lib/actions/checks'
+
+export interface HostDockerRetentionSettings {
+  globalRetentionDays: number
+  retentionDaysOverride: number | null
+  effectiveRetentionDays: number
+}
+
+const hostDockerRetentionOverrideSchema = z.object({
+  days: z.number().int().min(1).max(365).nullable(),
+})
 
 export async function getHostCollectionSettings(
   ...args: [string] | [string, string]
@@ -66,6 +77,77 @@ export async function updateHostCollectionSettings(
     return { success: true }
   } catch (err) {
     logError('Failed to update host collection settings:', err)
+    return { error: 'An unexpected error occurred' }
+  }
+}
+
+export async function getHostDockerRetentionSettings(
+  ...args: [string] | [string, string]
+): Promise<HostDockerRetentionSettings> {
+  const session = await getRequiredSession()
+  const [currentScope, hostId] =
+    args.length === 2 ? args : [resolveCurrentActionScope(session), args[0]]
+  await requireInstanceAccess(currentScope)
+
+  const [host, org] = await Promise.all([
+    db.query.hosts.findFirst({
+      where: and(eq(hosts.id, hostId), eq(hosts.instanceId, currentScope), isNull(hosts.deletedAt)),
+      columns: { metadata: true },
+    }),
+    db.query.instanceSettings.findFirst({
+      where: eq(instanceSettings.id, currentScope),
+      columns: { dockerMetricRetentionDays: true },
+    }),
+  ])
+
+  const metadata = parseHostMetadata(host?.metadata)
+  const globalRetentionDays = org?.dockerMetricRetentionDays ?? 30
+  const retentionDaysOverride = metadata.dockerSettings?.retentionDaysOverride ?? null
+
+  return {
+    globalRetentionDays,
+    retentionDaysOverride,
+    effectiveRetentionDays: retentionDaysOverride ?? globalRetentionDays,
+  }
+}
+
+export async function updateHostDockerRetentionOverride(
+  ...args: [string, number | null] | [string, string, number | null]
+): Promise<{ success: true } | { error: string }> {
+  const session = await getRequiredSession()
+  const [currentScope, hostId, days] =
+    args.length === 3 ? args : [resolveCurrentActionScope(session), args[0], args[1]]
+  await requireInstanceWriteAccess(currentScope)
+
+  const parsed = hostDockerRetentionOverrideSchema.safeParse({ days })
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid value' }
+  }
+
+  try {
+    const host = await db.query.hosts.findFirst({
+      where: and(eq(hosts.id, hostId), eq(hosts.instanceId, currentScope), isNull(hosts.deletedAt)),
+      columns: { id: true, metadata: true },
+    })
+    if (!host) return { error: 'Host not found' }
+
+    const currentMetadata = parseHostMetadata(host.metadata)
+    const updatedMetadata = {
+      ...currentMetadata,
+      dockerSettings: {
+        ...(currentMetadata.dockerSettings ?? {}),
+        retentionDaysOverride: parsed.data.days,
+      },
+    }
+
+    await db
+      .update(hosts)
+      .set({ metadata: updatedMetadata, updatedAt: new Date() })
+      .where(and(eq(hosts.id, hostId), eq(hosts.instanceId, currentScope)))
+
+    return { success: true }
+  } catch (err) {
+    logError('Failed to update host Docker retention override:', err)
     return { error: 'An unexpected error occurred' }
   }
 }

--- a/apps/web/lib/db/schema/hosts.ts
+++ b/apps/web/lib/db/schema/hosts.ts
@@ -37,6 +37,10 @@ export interface SshHostKeyMetadata {
   fingerprintSha256: string
 }
 
+export interface HostDockerSettings {
+  retentionDaysOverride?: number | null
+}
+
 export const DEFAULT_COLLECTION_SETTINGS: HostCollectionSettings = {
   cpu: true,
   memory: true,
@@ -64,6 +68,10 @@ const networkInterfaceSchema = z.object({
 const tagPairSchema = z.object({
   key: z.string(),
   value: z.string(),
+}).strip()
+
+const hostDockerSettingsSchema = z.object({
+  retentionDaysOverride: z.number().int().min(1).max(365).nullable().optional().catch(undefined),
 }).strip()
 
 export const hostCollectionSettingsSchema = z.object({
@@ -96,6 +104,7 @@ export const hostMetadataSchema = z.object({
   sshHostKeyChangedAt: z.string().optional().catch(undefined),
   lastSoftwareScanAt: z.string().optional().catch(undefined),
   pendingTags: z.array(tagPairSchema).catch([]).optional(),
+  dockerSettings: hostDockerSettingsSchema.optional().catch(undefined),
 }).strip()
 
 const defaultHostMetadata: HostMetadata = {
@@ -129,6 +138,7 @@ export interface HostMetadata {
   sshHostKeyStatus?: 'changed'
   sshHostKeyChangedAt?: string
   lastSoftwareScanAt?: string    // ISO timestamp; avoid Date in JSONB (use .toISOString())
+  dockerSettings?: HostDockerSettings
   // Tags supplied via the agent CLI --tag flag / token metadata at register
   // time. Stashed here until approveAgent merges them with org defaults and
   // writes canonical rows into resource_tags.

--- a/apps/web/lib/db/schema/metadata-validation.test.mjs
+++ b/apps/web/lib/db/schema/metadata-validation.test.mjs
@@ -34,6 +34,10 @@ test('parseHostMetadata strips unknown fields and falls back on malformed values
         extra: true,
       },
     },
+    dockerSettings: {
+      retentionDaysOverride: 45,
+      extra: true,
+    },
     injected: { admin: true },
   })
 
@@ -58,7 +62,22 @@ test('parseHostMetadata strips unknown fields and falls back on malformed values
       selectedUsernames: ['alice'],
     },
   })
+  assert.deepEqual(parsed.dockerSettings, {
+    retentionDaysOverride: 45,
+  })
   assert.equal('injected' in parsed, false)
+})
+
+test('parseHostMetadata preserves a cleared Docker retention override', () => {
+  const parsed = parseHostMetadata({
+    dockerSettings: {
+      retentionDaysOverride: null,
+    },
+  })
+
+  assert.deepEqual(parsed.dockerSettings, {
+    retentionDaysOverride: null,
+  })
 })
 
 test('parseInstanceMetadata preserves valid settings and drops malformed nested metadata', () => {

--- a/apps/web/lib/hosts/host-docker-retention-ui.test.mjs
+++ b/apps/web/lib/hosts/host-docker-retention-ui.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const source = readFileSync(
+  path.join(repoRoot, 'app/(dashboard)/hosts/[id]/settings-tab.tsx'),
+  'utf8',
+)
+
+test('host settings tab exposes Docker retention override controls', () => {
+  assert.match(source, /getHostDockerRetentionSettings/)
+  assert.match(source, /updateHostDockerRetentionOverride/)
+  assert.match(source, /settings-docker-retention-override-select/)
+  assert.match(source, /settings-docker-retention-inherited/)
+  assert.match(source, /settings-docker-retention-clear/)
+})

--- a/apps/web/tests/e2e/hosts/docker-retention.spec.ts
+++ b/apps/web/tests/e2e/hosts/docker-retention.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG } from '../fixtures/seed'
+
+async function getOrgId(sql: ReturnType<typeof getTestDb>): Promise<string> {
+  const rows = await sql<Array<{ id: string }>>`
+    SELECT id
+    FROM instance_settings
+    WHERE slug = ${TEST_ORG.slug}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return rows[0]!.id
+}
+
+test('admin can set and clear a host Docker retention override', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+
+  await sql`
+    UPDATE instance_settings
+    SET docker_metric_retention_days = 30
+    WHERE id = ${instanceId}
+  `
+
+  await sql`
+    INSERT INTO hosts (
+      id,
+      instance_id,
+      hostname,
+      display_name,
+      os,
+      arch,
+      ip_addresses,
+      status,
+      last_seen_at
+    )
+    VALUES (
+      'docker-retention-host',
+      ${instanceId},
+      'docker-retention-node',
+      'Docker Retention Node',
+      'Linux',
+      'x86_64',
+      '["10.60.0.10"]'::jsonb,
+      'online',
+      NOW()
+    )
+  `
+
+  await page.goto('/hosts/docker-retention-host')
+  await page.getByTestId('host-parent-tab-management').click()
+  await page.getByTestId('host-tab-settings').click()
+  await expect(page.getByTestId('settings-docker-retention-inherited')).toContainText('30 days')
+
+  await page.getByTestId('settings-docker-retention-override-select').click()
+  await page.getByRole('option', { name: '90 days' }).click()
+  await page.getByTestId('settings-docker-retention-save').click()
+  await expect(page.getByTestId('settings-docker-retention-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ override: string | null }>>`
+        SELECT metadata #>> '{dockerSettings,retentionDaysOverride}' AS override
+        FROM hosts
+        WHERE id = 'docker-retention-host'
+        LIMIT 1
+      `
+      return rows[0]?.override ?? null
+    })
+    .toBe('90')
+
+  await page.getByTestId('settings-docker-retention-clear').click()
+  await expect(page.getByTestId('settings-docker-retention-success')).toHaveText('Saved')
+
+  await expect
+    .poll(async () => {
+      const rows = await sql<Array<{ override_type: string | null }>>`
+        SELECT jsonb_typeof(metadata #> '{dockerSettings,retentionDaysOverride}') AS override_type
+        FROM hosts
+        WHERE id = 'docker-retention-host'
+        LIMIT 1
+      `
+      return rows[0]?.override_type ?? null
+    })
+    .toBe('null')
+})

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -187,7 +187,7 @@ Purpose: support 30-day default retention with global and per-host controls.
 | Task | Owner | Status | Files / Areas | Dependencies | Acceptance Criteria | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Add global Docker retention setting | Codex | done | Administration/settings UI and actions | Phase 0 settings contract | Admin can configure Docker metric retention days; default is 30. | [#1368](https://github.com/carrtech-dev/ct-ops/pull/1368) | Merged in #1368 and released. Adds Docker-specific `dockerMetricRetentionDays` setting per Phase 0 contract. |
-| Add host retention override | unclaimed | pending | host settings UI/actions/schema | Global setting | Host settings can set or clear a local Docker retention override. | TBD | Display effective value and inherited/default state. |
+| Add host retention override | Codex | in_progress | host settings UI/actions/schema | Global setting | Host settings can set or clear a local Docker retention override. | TBD | Implementing nullable `HostMetadata.dockerSettings.retentionDaysOverride` with inherited/default/effective display. |
 | Implement retention sweeper | unclaimed | pending | ingest sweeper or web maintenance job, tests | Global and host settings | Rows are deleted according to each host's effective retention. | TBD | Timescale table retention alone cannot express per-host overrides. |
 | Document retention behavior | unclaimed | pending | docs site, feature docs | Retention implementation | Docs explain defaults, overrides, storage impact, and cleanup timing. | TBD | Include sizing caveats for large fleets. |
 

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -187,7 +187,7 @@ Purpose: support 30-day default retention with global and per-host controls.
 | Task | Owner | Status | Files / Areas | Dependencies | Acceptance Criteria | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Add global Docker retention setting | Codex | done | Administration/settings UI and actions | Phase 0 settings contract | Admin can configure Docker metric retention days; default is 30. | [#1368](https://github.com/carrtech-dev/ct-ops/pull/1368) | Merged in #1368 and released. Adds Docker-specific `dockerMetricRetentionDays` setting per Phase 0 contract. |
-| Add host retention override | Codex | in_progress | host settings UI/actions/schema | Global setting | Host settings can set or clear a local Docker retention override. | TBD | Implementing nullable `HostMetadata.dockerSettings.retentionDaysOverride` with inherited/default/effective display. |
+| Add host retention override | Codex | review | host settings UI/actions/schema | Global setting | Host settings can set or clear a local Docker retention override. | [#1372](https://github.com/carrtech-dev/ct-ops/pull/1372) | Implements nullable `HostMetadata.dockerSettings.retentionDaysOverride` with inherited/default/effective display. |
 | Implement retention sweeper | unclaimed | pending | ingest sweeper or web maintenance job, tests | Global and host settings | Rows are deleted according to each host's effective retention. | TBD | Timescale table retention alone cannot express per-host overrides. |
 | Document retention behavior | unclaimed | pending | docs site, feature docs | Retention implementation | Docs explain defaults, overrides, storage impact, and cleanup timing. | TBD | Include sizing caveats for large fleets. |
 


### PR DESCRIPTION
## Summary
- add host metadata support for nullable Docker retention overrides
- add host settings actions to read inherited/default/effective Docker retention and set or clear overrides
- add a Docker Retention card to the host Settings tab
- add source-level action/UI tests, metadata parser coverage, and an E2E spec for set/clear behavior

## Validation
- /Applications/Codex.app/Contents/Resources/node --experimental-strip-types --test lib/actions/host-docker-retention.test.mjs lib/hosts/host-docker-retention-ui.test.mjs
- git diff --check

## Notes
- Full web package scripts and the parser test could not be run locally because npm/pnpm/yarn/corepack and installed node_modules are unavailable in this environment.