### PR TITLE
feat(docker): add top container rankings

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { format, formatDistanceToNow } from 'date-fns'
-import { Box, Search, X, ShieldAlert, WifiOff, AlertTriangle, Loader2, Activity } from 'lucide-react'
+import { Box, Search, X, ShieldAlert, WifiOff, AlertTriangle, Loader2, Activity, BarChart3 } from 'lucide-react'
 import {
   CartesianGrid,
   Legend,
@@ -30,8 +30,11 @@ import {
 import {
   getHostDockerContainerMetrics,
   getHostDockerContainers,
+  getHostDockerTopContainers,
   type DockerContainerMetricPoint,
   type DockerContainerMetricsPreset,
+  type DockerTopContainerMetric,
+  type DockerTopContainerStatistic,
 } from '@/lib/actions/docker-containers'
 import type { DockerRuntimeStatus, HostDockerStatus } from '@/lib/db/schema/docker'
 
@@ -59,6 +62,18 @@ const metricRangeOptions: Array<{ value: DockerContainerMetricsPreset; label: st
   { value: '6h', label: 'Last 6h' },
   { value: '24h', label: 'Last 24h' },
   { value: '7d', label: 'Last 7 days' },
+]
+
+const topMetricOptions: Array<{ value: DockerTopContainerMetric; label: string }> = [
+  { value: 'cpu', label: 'CPU' },
+  { value: 'memory', label: 'Memory' },
+  { value: 'network', label: 'Network I/O' },
+  { value: 'block', label: 'Block I/O' },
+]
+
+const topStatisticOptions: Array<{ value: DockerTopContainerStatistic; label: string }> = [
+  { value: 'max', label: 'Max' },
+  { value: 'p95', label: 'P95' },
 ]
 
 const unavailableCopy: Record<Exclude<DisplayStatus, 'installed'>, { title: string; body: string; icon: typeof AlertTriangle }> = {
@@ -185,6 +200,13 @@ function MetricSummary({ label, value }: { label: string; value: string }) {
   )
 }
 
+function formatTopContainerValue(metric: DockerTopContainerMetric, value: number | null | undefined): string {
+  if (metric === 'network' || metric === 'block') {
+    return formatBytes(value)
+  }
+  return formatPercent(value)
+}
+
 function ContainerMetricChart({
   title,
   data,
@@ -253,6 +275,9 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
   const [image, setImage] = useState('all')
   const [selectedContainerId, setSelectedContainerId] = useState<string | null>(null)
   const [metricsRange, setMetricsRange] = useState<DockerContainerMetricsPreset>('1h')
+  const [topRange, setTopRange] = useState<DockerContainerMetricsPreset>('1h')
+  const [topMetric, setTopMetric] = useState<DockerTopContainerMetric>('cpu')
+  const [topStatistic, setTopStatistic] = useState<DockerTopContainerStatistic>('max')
   const status: DisplayStatus = dockerStatus?.status ?? 'unknown'
   const dockerUnavailable = status !== 'installed'
 
@@ -271,6 +296,16 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
     queryFn: () => getHostDockerContainerMetrics(scopeId, hostId, effectiveSelectedContainerId!, { range: metricsRange }),
     enabled: !dockerUnavailable && effectiveSelectedContainerId != null,
   })
+  const { data: topContainersData, isLoading: topContainersLoading } = useQuery({
+    queryKey: ['host-docker-top-containers', scopeId, hostId, topRange, topMetric, topStatistic],
+    queryFn: () => getHostDockerTopContainers(scopeId, hostId, {
+      range: topRange,
+      metric: topMetric,
+      statistic: topStatistic,
+    }),
+    enabled: !dockerUnavailable,
+  })
+  const topContainers = topContainersData?.containers ?? []
   const metricPoints = useMemo(() => metricsData?.points ?? [], [metricsData?.points])
   const chartData = useMemo(() => metricPoints.map((point) => ({
     time: new Date(point.recordedAt).getTime(),
@@ -355,6 +390,110 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
           )}
         </div>
       </div>
+
+      <Card data-testid="host-docker-top-containers">
+        <CardHeader className="pb-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <BarChart3 className="size-4 text-muted-foreground" />
+              Top containers
+            </CardTitle>
+            <div className="flex flex-wrap items-center gap-2">
+              <Select value={topMetric} onValueChange={(value) => setTopMetric(value as DockerTopContainerMetric)}>
+                <SelectTrigger className="w-36" data-testid="host-docker-top-metric-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {topMetricOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={topStatistic} onValueChange={(value) => setTopStatistic(value as DockerTopContainerStatistic)}>
+                <SelectTrigger className="w-28" data-testid="host-docker-top-stat-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {topStatisticOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={topRange} onValueChange={(value) => setTopRange(value as DockerContainerMetricsPreset)}>
+                <SelectTrigger className="w-36" data-testid="host-docker-top-range-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {metricRangeOptions.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {topContainersLoading ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
+              Loading top containers...
+            </div>
+          ) : topContainers.length === 0 ? (
+            <EmptyState title="No ranked containers" body="Rankings will appear after the agent uploads container metrics for this range." icon={BarChart3} />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-12">Rank</TableHead>
+                  <TableHead>Container</TableHead>
+                  <TableHead>Image</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead className="text-right">{topStatistic === 'p95' ? 'P95' : 'Max'}</TableHead>
+                  <TableHead className="text-right">Samples</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {topContainers.map((container, index) => (
+                  <TableRow
+                    key={container.dockerContainerId}
+                    data-testid={`host-docker-top-container-row-${container.dockerContainerId}`}
+                    className={container.dockerContainerId === effectiveSelectedContainerId ? 'bg-muted/50' : 'cursor-pointer'}
+                    onClick={() => setSelectedContainerId(container.dockerContainerId)}
+                  >
+                    <TableCell className="text-sm text-muted-foreground">{index + 1}</TableCell>
+                    <TableCell>
+                      <div className="font-medium text-foreground">
+                        {container.primaryName || container.dockerContainerId.slice(0, 12)}
+                      </div>
+                      <div className="font-mono text-xs text-muted-foreground">
+                        {container.dockerContainerId.slice(0, 12)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="max-w-[260px] truncate text-sm">
+                      {container.image || '-'}
+                    </TableCell>
+                    <TableCell>
+                      <ContainerStateBadge state={container.state} present={container.isPresent} />
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-semibold tabular-nums">
+                      {formatTopContainerValue(topMetric, container.value)}
+                    </TableCell>
+                    <TableCell className="text-right text-sm tabular-nums text-muted-foreground">
+                      {container.sampleCount.toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader className="pb-3">

--- a/apps/web/lib/actions/docker-containers.ts
+++ b/apps/web/lib/actions/docker-containers.ts
@@ -52,6 +52,30 @@ export interface HostDockerContainerMetricsResult {
   points: DockerContainerMetricPoint[]
 }
 
+export type DockerTopContainerMetric = 'cpu' | 'memory' | 'network' | 'block'
+export type DockerTopContainerStatistic = 'max' | 'p95'
+
+export interface DockerTopContainersQuery {
+  range?: DockerContainerMetricsPreset
+  metric?: DockerTopContainerMetric
+  statistic?: DockerTopContainerStatistic
+}
+
+export interface DockerTopContainerRow {
+  dockerContainerId: string
+  primaryName: string | null
+  image: string | null
+  state: string | null
+  isPresent: boolean
+  lastSeenAt: Date | null
+  value: number | null
+  sampleCount: number
+}
+
+export interface HostDockerTopContainersResult {
+  containers: DockerTopContainerRow[]
+}
+
 function cleanFilter(value: string | undefined): string | undefined {
   const trimmed = value?.trim()
   if (!trimmed || trimmed === 'all') return undefined
@@ -75,6 +99,34 @@ function resolveMetricRange(range: DockerContainerMetricsPreset | undefined): { 
   const to = new Date()
   const from = new Date(to.getTime() - hours[selected] * 3_600_000)
   return { from, to, bucketInterval: bucketIntervals[selected] }
+}
+
+function resolveTopMetric(metric: DockerTopContainerMetric | undefined): DockerTopContainerMetric {
+  return metric === 'memory' || metric === 'network' || metric === 'block' ? metric : 'cpu'
+}
+
+function resolveTopStatistic(statistic: DockerTopContainerStatistic | undefined): DockerTopContainerStatistic {
+  return statistic === 'p95' ? 'p95' : 'max'
+}
+
+function topMetricExpression(metric: DockerTopContainerMetric): string {
+  switch (metric) {
+    case 'memory':
+      return 'm.memory_percent'
+    case 'network':
+      return `CASE
+        WHEN m.network_rx_bytes IS NULL AND m.network_tx_bytes IS NULL THEN NULL
+        ELSE COALESCE(m.network_rx_bytes, 0) + COALESCE(m.network_tx_bytes, 0)
+      END`
+    case 'block':
+      return `CASE
+        WHEN m.block_read_bytes IS NULL AND m.block_write_bytes IS NULL THEN NULL
+        ELSE COALESCE(m.block_read_bytes, 0) + COALESCE(m.block_write_bytes, 0)
+      END`
+    case 'cpu':
+    default:
+      return 'm.cpu_percent'
+  }
 }
 
 export async function getHostDockerContainers(
@@ -235,6 +287,87 @@ export async function getHostDockerContainerMetrics(
       blockWriteMax: row.block_write_max,
       pidsAvg: row.pids_avg,
       pidsMax: row.pids_max,
+    })),
+  }
+}
+
+export async function getHostDockerTopContainers(
+  instanceId: string,
+  hostId: string,
+  query: DockerTopContainersQuery = {},
+): Promise<HostDockerTopContainersResult> {
+  await requireInstanceAccess(instanceId)
+
+  const host = await db.query.hosts.findFirst({
+    columns: { id: true },
+    where: and(eq(hosts.id, hostId), eq(hosts.instanceId, instanceId), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { containers: [] }
+
+  const range = resolveMetricRange(query.range)
+  const metric = resolveTopMetric(query.metric)
+  const statistic = resolveTopStatistic(query.statistic)
+  const metricSql = topMetricExpression(metric)
+  const aggregateSql = statistic === 'p95'
+    ? `(percentile_cont(0.95) WITHIN GROUP (ORDER BY metric_value))::double precision`
+    : `MAX(metric_value)::double precision`
+
+  const rows = await db.execute<{
+    docker_container_id: string
+    primary_name: string | null
+    image: string | null
+    state: string | null
+    is_present: boolean
+    last_seen_at: Date | null
+    value: number | null
+    sample_count: number
+  }>(sql`
+    WITH metric_values AS (
+      SELECT
+        dc.docker_container_id,
+        dc.primary_name,
+        dc.image,
+        dc.state,
+        dc.is_present,
+        dc.last_seen_at,
+        ${sql.raw(metricSql)}::double precision AS metric_value
+      FROM docker_container_metrics m
+      INNER JOIN docker_containers dc
+        ON dc.id = m.docker_container_row_id
+       AND dc.instance_id = m.instance_id
+       AND dc.host_id = m.host_id
+       AND dc.docker_container_id = m.docker_container_id
+      WHERE m.instance_id = ${instanceId}
+        AND m.host_id = ${hostId}
+        AND m.recorded_at >= ${range.from.toISOString()}
+        AND m.recorded_at <= ${range.to.toISOString()}
+    )
+    SELECT
+      docker_container_id,
+      primary_name,
+      image,
+      state,
+      is_present,
+      last_seen_at,
+      ${sql.raw(aggregateSql)} AS value,
+      COUNT(metric_value)::integer AS sample_count
+    FROM metric_values
+    WHERE metric_value IS NOT NULL
+    GROUP BY docker_container_id, primary_name, image, state, is_present, last_seen_at
+    ORDER BY value DESC NULLS LAST, primary_name ASC NULLS LAST, docker_container_id ASC
+    LIMIT 10
+  `)
+
+  return {
+    containers: Array.from(rows).map((row) => ({
+      dockerContainerId: row.docker_container_id,
+      primaryName: row.primary_name,
+      image: row.image,
+      state: row.state,
+      isPresent: row.is_present,
+      lastSeenAt: row.last_seen_at ? new Date(row.last_seen_at) : null,
+      value: row.value,
+      sampleCount: row.sample_count,
     })),
   }
 }

--- a/apps/web/tests/e2e/hosts/docker-containers.spec.ts
+++ b/apps/web/tests/e2e/hosts/docker-containers.spec.ts
@@ -263,6 +263,78 @@ test('host Containers tab shows per-container metric charts with max spike value
   await expect(metrics.getByText('Block I/O')).toBeVisible()
 })
 
+test('host Containers tab ranks top containers by selected metric and statistic', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-top-containers-host')
+  await seedDockerStatus(sql, instanceId, 'docker-top-containers-host', 'installed')
+
+  await sql`
+    INSERT INTO docker_containers (
+      id,
+      instance_id,
+      host_id,
+      docker_container_id,
+      primary_name,
+      names_json,
+      image,
+      image_id,
+      labels_json,
+      state,
+      status,
+      first_seen_at,
+      last_seen_at,
+      last_inventory_at,
+      restart_count,
+      is_present
+    )
+    VALUES
+      ('docker-top-api-row', ${instanceId}, 'docker-top-containers-host', 'top-api-container-id', 'api', '["api"]'::jsonb, 'api:latest', 'sha256:api', '{}'::jsonb, 'running', 'Up 9 minutes', NOW() - INTERVAL '20 minutes', NOW() - INTERVAL '30 seconds', NOW() - INTERVAL '30 seconds', 0, true),
+      ('docker-top-worker-row', ${instanceId}, 'docker-top-containers-host', 'top-worker-container-id', 'worker', '["worker"]'::jsonb, 'worker:latest', 'sha256:worker', '{}'::jsonb, 'running', 'Up 9 minutes', NOW() - INTERVAL '20 minutes', NOW() - INTERVAL '30 seconds', NOW() - INTERVAL '30 seconds', 0, true)
+  `
+
+  await sql`
+    INSERT INTO docker_container_metrics (
+      id,
+      instance_id,
+      host_id,
+      docker_container_row_id,
+      docker_container_id,
+      recorded_at,
+      cpu_percent,
+      memory_usage_bytes,
+      memory_limit_bytes,
+      memory_percent,
+      network_rx_bytes,
+      network_tx_bytes,
+      block_read_bytes,
+      block_write_bytes,
+      pids_current,
+      restart_count
+    )
+    VALUES
+      ('docker-top-api-sample-1', ${instanceId}, 'docker-top-containers-host', 'docker-top-api-row', 'top-api-container-id', NOW() - INTERVAL '15 minutes', 55.0, 1000, 4000, 25.0, 1000, 1200, 100, 200, 4, 0),
+      ('docker-top-api-sample-2', ${instanceId}, 'docker-top-containers-host', 'docker-top-api-row', 'top-api-container-id', NOW() - INTERVAL '10 minutes', 82.4, 2400, 4000, 60.0, 8000, 7000, 300, 500, 6, 0),
+      ('docker-top-worker-sample-1', ${instanceId}, 'docker-top-containers-host', 'docker-top-worker-row', 'top-worker-container-id', NOW() - INTERVAL '15 minutes', 12.0, 3200, 4000, 80.0, 1200, 1400, 9000, 8000, 3, 0),
+      ('docker-top-worker-sample-2', ${instanceId}, 'docker-top-containers-host', 'docker-top-worker-row', 'top-worker-container-id', NOW() - INTERVAL '10 minutes', 16.0, 3600, 4000, 90.0, 1800, 1800, 12000, 11000, 4, 0)
+  `
+
+  await page.goto('/hosts/docker-top-containers-host')
+  await page.getByTestId('host-parent-tab-containers').click()
+
+  const topContainers = page.getByTestId('host-docker-top-containers')
+  await expect(topContainers).toContainText('Top containers')
+  await expect(page.getByTestId('host-docker-top-container-row-top-api-container-id')).toContainText('82.4%')
+
+  await page.getByTestId('host-docker-top-metric-select').click()
+  await page.getByRole('option', { name: 'Memory' }).click()
+  await expect(page.getByTestId('host-docker-top-container-row-top-worker-container-id')).toContainText('90.0%')
+
+  await page.getByTestId('host-docker-top-stat-select').click()
+  await page.getByRole('option', { name: 'P95' }).click()
+  await expect(topContainers).toContainText('P95')
+})
+
 test('host Containers tab explains Docker unavailable states', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const instanceId = await getOrgId(sql)

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -197,7 +197,7 @@ Purpose: make the feature operationally useful beyond basic charts.
 
 | Task | Owner | Status | Files / Areas | Dependencies | Acceptance Criteria | PR | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Add top containers views | unclaimed | pending | web actions/components | Phase 3 metrics | Users can rank containers by CPU, memory, network, and block I/O over a selected time range. | TBD | Use max and p95 as ranking options. |
+| Add top containers views | Codex | review | web actions/components | Phase 3 metrics | Users can rank containers by CPU, memory, network, and block I/O over a selected time range. | [#1379](https://github.com/carrtech-dev/ct-ops/pull/1379) | Uses max and p95 ranking options across CPU, memory, network I/O, and block I/O. E2E spec added; local E2E run blocked by unavailable container runtime. |
 | Add container lifecycle timeline | unclaimed | pending | agent/inventory ingest/UI | Phase 2 inventory | Users can see starts, stops, restarts, and disappeared containers over time. | TBD | Could begin with inferred events from inventory changes. |
 | Add alert rules for containers | unclaimed | pending | alert schema/evaluator/UI | Phase 3 metrics | Alerts cover restart loop, memory near limit, sustained CPU, container missing, and high network I/O. | TBD | Avoid alerting on short one-sample noise by default. |
 | Add fleet/container search | unclaimed | pending | web routes/actions/components | Phase 2 inventory | Users can search across hosts by container name, image, label, and state. | TBD | Useful for finding where a workload is running. |


### PR DESCRIPTION
## Summary
- add a host Containers tab Top containers card with metric, statistic, and range selectors
- add an authorized server action that ranks containers by CPU, memory, network I/O, or block I/O using max or p95
- add E2E coverage for switching the top-container metric/statistic controls
- update the Docker telemetry implementation plan to mark the task in progress

## Validation
- `node /tmp/codex-pnpm-10.6.5/bin/pnpm.cjs --filter web type-check`
- `node /tmp/codex-pnpm-10.6.5/bin/pnpm.cjs --filter web lint` (passes with existing warnings)
- `git diff --check`

## Not run
- `node /tmp/codex-pnpm-10.6.5/bin/pnpm.cjs --filter web test:e2e -- tests/e2e/hosts/docker-containers.spec.ts` (blocked locally: testcontainers could not find a working container runtime strategy)
