### PR TITLE
feat(docker): add container alert rules

### DIFF
--- a/apps/ingest/internal/handlers/alerts.go
+++ b/apps/ingest/internal/handlers/alerts.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/carrtech-dev/ct-ops/ingest/internal/db/queries"
@@ -30,6 +33,15 @@ type metricThresholdConfig struct {
 	Metric    string  `json:"metric"`    // "cpu" | "memory" | "disk"
 	Operator  string  `json:"operator"`  // "gt" | "lt"
 	Threshold float64 `json:"threshold"` // 0–100
+}
+
+// dockerContainerAlertConfig is the JSONB config for docker_container alert rules.
+type dockerContainerAlertConfig struct {
+	Rule              string  `json:"rule"`
+	DockerContainerID string  `json:"dockerContainerId,omitempty"`
+	WindowMinutes     int     `json:"windowMinutes"`
+	Threshold         float64 `json:"threshold"`
+	SampleThreshold   int     `json:"sampleThreshold,omitempty"`
 }
 
 // webhookChannelConfig matches the JSONB stored in notification_channels.config for webhook channels.
@@ -111,6 +123,324 @@ func evaluateAlerts(
 			evaluateMetricThresholdRule(ctx, pool, rule, hostID, hostname, metrics, channels)
 		}
 	}
+}
+
+func evaluateDockerContainerAlerts(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	instanceID, hostID, hostname string,
+	now time.Time,
+) {
+	silenced, err := queries.IsHostSilenced(ctx, pool, instanceID, hostID)
+	if err != nil {
+		slog.Warn("evaluateDockerContainerAlerts: checking silence", "host_id", hostID, "err", err)
+	} else if silenced {
+		return
+	}
+
+	rules, err := queries.GetAlertRulesForHost(ctx, pool, instanceID, hostID)
+	if err != nil {
+		slog.Warn("evaluateDockerContainerAlerts: fetching rules", "host_id", hostID, "err", err)
+		return
+	}
+
+	webhooks, _ := queries.GetEnabledWebhookChannels(ctx, pool, instanceID)
+	smtpChs, _ := queries.GetEnabledSmtpChannels(ctx, pool, instanceID)
+	slackChs, _ := queries.GetEnabledSlackChannels(ctx, pool, instanceID)
+	telegramChs, _ := queries.GetEnabledTelegramChannels(ctx, pool, instanceID)
+	channels := notifChannels{webhooks: webhooks, smtp: smtpChs, slack: slackChs, telegram: telegramChs}
+
+	for _, rule := range rules {
+		if rule.ConditionType != "docker_container" {
+			continue
+		}
+		evaluateDockerContainerAlertRule(ctx, pool, rule, hostID, hostname, now, channels)
+	}
+}
+
+func evaluateDockerContainerAlertRule(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	rule queries.AlertRuleRow,
+	hostID, hostname string,
+	now time.Time,
+	channels notifChannels,
+) {
+	var cfg dockerContainerAlertConfig
+	if err := json.Unmarshal([]byte(rule.ConfigJSON), &cfg); err != nil {
+		slog.Warn("evaluateDockerContainerAlerts: unmarshal config", "rule_id", rule.ID, "err", err)
+		return
+	}
+	normaliseDockerContainerAlertConfig(&cfg)
+
+	conditionMet, detail, err := dockerContainerAlertCondition(ctx, pool, rule.InstanceID, hostID, cfg, now)
+	if err != nil {
+		slog.Warn("evaluateDockerContainerAlerts: evaluating rule", "rule_id", rule.ID, "err", err)
+		return
+	}
+
+	existing, err := queries.GetActiveAlertInstance(ctx, pool, rule.ID, hostID)
+	if err != nil {
+		slog.Warn("evaluateDockerContainerAlerts: checking active instance", "rule_id", rule.ID, "err", err)
+		return
+	}
+
+	if conditionMet && existing == nil {
+		message := fmt.Sprintf("%s on host %s", detail, hostname)
+		id, err := queries.InsertAlertInstance(ctx, pool, rule.ID, hostID, rule.InstanceID, rule.Severity, message, now)
+		if err != nil {
+			slog.Warn("evaluateDockerContainerAlerts: inserting alert instance", "rule_id", rule.ID, "err", err)
+			return
+		}
+		ev := AlertEvent{
+			Event:     "alert.fired",
+			Severity:  rule.Severity,
+			Host:      hostname,
+			Rule:      rule.Name,
+			Message:   message,
+			Timestamp: now.UTC().Format(time.RFC3339),
+		}
+		dispatchWebhooks(ctx, channels.webhooks, ev)
+		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, rule.InstanceID, id, "host", hostID, ev)
+		return
+	}
+
+	if !conditionMet && existing != nil {
+		if err := queries.ResolveAlertInstance(ctx, pool, existing.ID, now); err != nil {
+			slog.Warn("evaluateDockerContainerAlerts: resolving alert instance", "instance_id", existing.ID, "err", err)
+			return
+		}
+		ev := AlertEvent{
+			Event:     "alert.resolved",
+			Severity:  rule.Severity,
+			Host:      hostname,
+			Rule:      rule.Name,
+			Message:   fmt.Sprintf("Docker container condition recovered on host %s", hostname),
+			Timestamp: now.UTC().Format(time.RFC3339),
+		}
+		dispatchWebhooks(ctx, channels.webhooks, ev)
+		dispatchSmtp(channels.smtp, ev)
+		dispatchSlack(ctx, channels.slack, ev)
+		dispatchTelegram(ctx, channels.telegram, ev)
+		dispatchInApp(ctx, pool, rule.InstanceID, existing.ID, "host", hostID, ev)
+	}
+}
+
+func normaliseDockerContainerAlertConfig(cfg *dockerContainerAlertConfig) {
+	if cfg.WindowMinutes < 1 {
+		cfg.WindowMinutes = 10
+	}
+	if cfg.WindowMinutes > 1440 {
+		cfg.WindowMinutes = 1440
+	}
+	if cfg.SampleThreshold < 1 {
+		cfg.SampleThreshold = 3
+	}
+	if cfg.SampleThreshold > 1000 {
+		cfg.SampleThreshold = 1000
+	}
+	cfg.DockerContainerID = strings.TrimSpace(cfg.DockerContainerID)
+	switch cfg.Rule {
+	case "memory_near_limit", "sustained_cpu":
+		if cfg.Threshold <= 0 || cfg.Threshold > 100 {
+			cfg.Threshold = 90
+		}
+	case "high_network_io":
+		if cfg.Threshold <= 0 {
+			cfg.Threshold = 1024 * 1024
+		}
+		if cfg.Threshold > 1_000_000_000_000 {
+			cfg.Threshold = 1_000_000_000_000
+		}
+	case "container_missing":
+		if cfg.Threshold <= 0 {
+			cfg.Threshold = 5
+		}
+		if cfg.Threshold > 1440 {
+			cfg.Threshold = 1440
+		}
+	default:
+		cfg.Rule = "restart_loop"
+		if cfg.Threshold <= 0 {
+			cfg.Threshold = 3
+		}
+		if cfg.Threshold > 1000 {
+			cfg.Threshold = 1000
+		}
+	}
+}
+
+func dockerContainerAlertCondition(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	instanceID, hostID string,
+	cfg dockerContainerAlertConfig,
+	now time.Time,
+) (bool, string, error) {
+	windowStart := now.Add(-time.Duration(cfg.WindowMinutes) * time.Minute)
+	switch cfg.Rule {
+	case "restart_loop":
+		return dockerRestartLoopAlertCondition(ctx, pool, instanceID, hostID, cfg, windowStart)
+	case "memory_near_limit":
+		return dockerMetricSampleAlertCondition(ctx, pool, instanceID, hostID, cfg, windowStart, "memory_percent", "memory")
+	case "sustained_cpu":
+		return dockerSustainedCPUAlertCondition(ctx, pool, instanceID, hostID, cfg, windowStart)
+	case "container_missing":
+		return dockerContainerMissingAlertCondition(ctx, pool, instanceID, hostID, cfg, now)
+	case "high_network_io":
+		return dockerNetworkIOAlertCondition(ctx, pool, instanceID, hostID, cfg, windowStart)
+	default:
+		return false, "", nil
+	}
+}
+
+func dockerRestartLoopAlertCondition(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string, cfg dockerContainerAlertConfig, windowStart time.Time) (bool, string, error) {
+	const q = `
+		SELECT COALESCE(e.primary_name, e.docker_container_id), COUNT(*)::int
+		FROM docker_container_lifecycle_events e
+		WHERE e.instance_id = $1
+		  AND e.host_id = $2
+		  AND e.event_type = 'restarted'
+		  AND e.occurred_at >= $3
+		  AND ($4 = '' OR e.docker_container_id = $4)
+		GROUP BY e.docker_container_id, e.primary_name
+		HAVING COUNT(*) >= $5
+		ORDER BY COUNT(*) DESC, COALESCE(e.primary_name, e.docker_container_id) ASC
+		LIMIT 1
+	`
+	var name string
+	var restarts int
+	err := pool.QueryRow(ctx, q, instanceID, hostID, windowStart, cfg.DockerContainerID, int(cfg.Threshold)).Scan(&name, &restarts)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, fmt.Sprintf("Container %s restarted %d times in %d minutes", name, restarts, cfg.WindowMinutes), nil
+}
+
+func dockerMetricSampleAlertCondition(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string, cfg dockerContainerAlertConfig, windowStart time.Time, column string, label string) (bool, string, error) {
+	q := fmt.Sprintf(`
+		SELECT COALESCE(dc.primary_name, dc.docker_container_id), COUNT(*) FILTER (WHERE m.%[1]s >= $5)::int, MAX(m.%[1]s)::double precision
+		FROM docker_container_metrics m
+		INNER JOIN docker_containers dc ON dc.id = m.docker_container_row_id
+		WHERE m.instance_id = $1
+		  AND m.host_id = $2
+		  AND m.recorded_at >= $3
+		  AND ($4 = '' OR m.docker_container_id = $4)
+		GROUP BY dc.docker_container_id, dc.primary_name
+		HAVING COUNT(*) FILTER (WHERE m.%[1]s >= $5) >= $6
+		ORDER BY MAX(m.%[1]s) DESC NULLS LAST
+		LIMIT 1
+	`, column)
+	var name string
+	var samples int
+	var maxValue float64
+	err := pool.QueryRow(ctx, q, instanceID, hostID, windowStart, cfg.DockerContainerID, cfg.Threshold, cfg.SampleThreshold).Scan(&name, &samples, &maxValue)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, fmt.Sprintf("Container %s %s reached %.1f%% across %d samples", name, label, maxValue, samples), nil
+}
+
+func dockerSustainedCPUAlertCondition(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string, cfg dockerContainerAlertConfig, windowStart time.Time) (bool, string, error) {
+	const q = `
+		SELECT COALESCE(dc.primary_name, dc.docker_container_id), COUNT(*)::int, AVG(m.cpu_percent)::double precision
+		FROM docker_container_metrics m
+		INNER JOIN docker_containers dc ON dc.id = m.docker_container_row_id
+		WHERE m.instance_id = $1
+		  AND m.host_id = $2
+		  AND m.recorded_at >= $3
+		  AND ($4 = '' OR m.docker_container_id = $4)
+		GROUP BY dc.docker_container_id, dc.primary_name
+		HAVING COUNT(*) >= $6 AND AVG(m.cpu_percent) >= $5
+		ORDER BY AVG(m.cpu_percent) DESC NULLS LAST
+		LIMIT 1
+	`
+	var name string
+	var samples int
+	var avgCPU float64
+	err := pool.QueryRow(ctx, q, instanceID, hostID, windowStart, cfg.DockerContainerID, cfg.Threshold, cfg.SampleThreshold).Scan(&name, &samples, &avgCPU)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, fmt.Sprintf("Container %s averaged %.1f%% CPU across %d samples", name, avgCPU, samples), nil
+}
+
+func dockerContainerMissingAlertCondition(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string, cfg dockerContainerAlertConfig, now time.Time) (bool, string, error) {
+	if cfg.DockerContainerID == "" {
+		return false, "", nil
+	}
+	const q = `
+		SELECT COALESCE(primary_name, docker_container_id), last_seen_at
+		FROM docker_containers
+		WHERE instance_id = $1
+		  AND host_id = $2
+		  AND docker_container_id = $3
+		  AND is_present = false
+		  AND last_seen_at <= $4
+		LIMIT 1
+	`
+	missingSince := now.Add(-time.Duration(cfg.Threshold) * time.Minute)
+	var name string
+	var lastSeen time.Time
+	err := pool.QueryRow(ctx, q, instanceID, hostID, cfg.DockerContainerID, missingSince).Scan(&name, &lastSeen)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, fmt.Sprintf("Container %s has been missing since %s", name, lastSeen.UTC().Format(time.RFC3339)), nil
+}
+
+func dockerNetworkIOAlertCondition(ctx context.Context, pool *pgxpool.Pool, instanceID, hostID string, cfg dockerContainerAlertConfig, windowStart time.Time) (bool, string, error) {
+	const q = `
+		WITH per_container AS (
+			SELECT
+				dc.docker_container_id,
+				COALESCE(dc.primary_name, dc.docker_container_id) AS name,
+				COUNT(*)::int AS samples,
+				EXTRACT(EPOCH FROM MAX(m.recorded_at) - MIN(m.recorded_at))::double precision AS seconds,
+				(MAX(COALESCE(m.network_rx_bytes, 0) + COALESCE(m.network_tx_bytes, 0)) -
+				 MIN(COALESCE(m.network_rx_bytes, 0) + COALESCE(m.network_tx_bytes, 0)))::double precision AS bytes_delta
+			FROM docker_container_metrics m
+			INNER JOIN docker_containers dc ON dc.id = m.docker_container_row_id
+			WHERE m.instance_id = $1
+			  AND m.host_id = $2
+			  AND m.recorded_at >= $3
+			  AND ($4 = '' OR m.docker_container_id = $4)
+			GROUP BY dc.docker_container_id, dc.primary_name
+		)
+		SELECT name, samples, bytes_delta / NULLIF(seconds, 0) AS bytes_per_second
+		FROM per_container
+		WHERE samples >= $6
+		  AND seconds > 0
+		  AND bytes_delta / NULLIF(seconds, 0) >= $5
+		ORDER BY bytes_per_second DESC NULLS LAST
+		LIMIT 1
+	`
+	var name string
+	var samples int
+	var bytesPerSecond float64
+	err := pool.QueryRow(ctx, q, instanceID, hostID, windowStart, cfg.DockerContainerID, cfg.Threshold, max(2, cfg.SampleThreshold)).Scan(&name, &samples, &bytesPerSecond)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	return true, fmt.Sprintf("Container %s averaged %.0f B/s network I/O across %d samples", name, bytesPerSecond, samples), nil
 }
 
 func evaluateCheckStatusRule(

--- a/apps/ingest/internal/handlers/docker_telemetry.go
+++ b/apps/ingest/internal/handlers/docker_telemetry.go
@@ -96,6 +96,9 @@ func (h *InventoryHandler) SubmitDockerTelemetry(stream agentv1.IngestService_Su
 			slog.Error("docker telemetry: inserting container metrics", "host_id", hostID, "err", err)
 			return status.Error(codes.Internal, "failed to persist Docker metrics")
 		}
+		if len(reports) > 0 || len(metricReports) > 0 {
+			evaluateDockerContainerAlerts(ctx, h.pool, agent.InstanceID, hostID, agent.Hostname, now)
+		}
 
 		totalInventory += len(reports)
 		totalSamples += len(metricReports)

--- a/apps/ingest/internal/handlers/docker_telemetry_test.go
+++ b/apps/ingest/internal/handlers/docker_telemetry_test.go
@@ -89,3 +89,47 @@ func TestValidateDockerTelemetryBatchAllowsEmptyAgentID(t *testing.T) {
 		t.Fatalf("validateDockerTelemetryBatch() error = %v, want nil", err)
 	}
 }
+
+func TestNormaliseDockerContainerAlertConfigDefaultsAndBounds(t *testing.T) {
+	t.Parallel()
+
+	cfg := dockerContainerAlertConfig{
+		Rule:              "sustained_cpu",
+		DockerContainerID: " container-1 ",
+		WindowMinutes:     0,
+		Threshold:         200,
+		SampleThreshold:   0,
+	}
+
+	normaliseDockerContainerAlertConfig(&cfg)
+
+	if cfg.DockerContainerID != "container-1" {
+		t.Fatalf("DockerContainerID = %q, want trimmed", cfg.DockerContainerID)
+	}
+	if cfg.WindowMinutes != 10 {
+		t.Fatalf("WindowMinutes = %d, want default 10", cfg.WindowMinutes)
+	}
+	if cfg.Threshold != 90 {
+		t.Fatalf("Threshold = %v, want default 90", cfg.Threshold)
+	}
+	if cfg.SampleThreshold != 3 {
+		t.Fatalf("SampleThreshold = %d, want default 3", cfg.SampleThreshold)
+	}
+}
+
+func TestNormaliseDockerContainerAlertConfigNetworkDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := dockerContainerAlertConfig{Rule: "high_network_io", Threshold: 0, WindowMinutes: 2000, SampleThreshold: 2000}
+	normaliseDockerContainerAlertConfig(&cfg)
+
+	if cfg.Threshold != 1024*1024 {
+		t.Fatalf("Threshold = %v, want default bytes/sec", cfg.Threshold)
+	}
+	if cfg.WindowMinutes != 1440 {
+		t.Fatalf("WindowMinutes = %d, want capped 1440", cfg.WindowMinutes)
+	}
+	if cfg.SampleThreshold != 1000 {
+		t.Fatalf("SampleThreshold = %d, want capped 1000", cfg.SampleThreshold)
+	}
+}

--- a/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/alerts-tab.tsx
@@ -48,12 +48,13 @@ import {
 } from '@/lib/actions/alerts'
 import { getChecksWithHistory } from '@/lib/actions/checks'
 import { getCertificates } from '@/lib/actions/certificates'
+import { getHostDockerContainers } from '@/lib/actions/docker-containers'
 import type { AlertRule, AlertSeverity, AlertSilence } from '@/lib/db/schema'
 
 // ─── Form schema (flat — validation applied per conditionType in onSubmit) ─────
 
 const ruleFormSchema = z.object({
-  conditionType: z.enum(['check_status', 'metric_threshold', 'cert_expiry']),
+  conditionType: z.enum(['check_status', 'metric_threshold', 'cert_expiry', 'docker_container']),
   name: z.string().min(1, 'Name is required').max(100),
   severity: z.enum(['info', 'warning', 'critical']),
   // check_status fields
@@ -67,6 +68,18 @@ const ruleFormSchema = z.object({
   certScope: z.enum(['all', 'specific']).optional(),
   certificateId: z.string().optional(),
   daysBeforeExpiry: z.number().int().min(1).max(365).optional(),
+  // docker_container fields
+  dockerRule: z.enum([
+    'restart_loop',
+    'memory_near_limit',
+    'sustained_cpu',
+    'container_missing',
+    'high_network_io',
+  ]).optional(),
+  dockerContainerId: z.string().optional(),
+  dockerWindowMinutes: z.number().int().min(1).max(1440).optional(),
+  dockerThreshold: z.number().min(0).optional(),
+  dockerSampleThreshold: z.number().int().min(1).max(1000).optional(),
 })
 
 type RuleFormValues = z.infer<typeof ruleFormSchema>
@@ -97,7 +110,37 @@ function ruleConditionSummary(rule: AlertRule): string {
     const scope = cfg['scope'] === 'specific' ? 'specific cert' : 'any cert'
     return `${scope} expires within ${cfg['daysBeforeExpiry'] ?? 30} days`
   }
+  if (rule.conditionType === 'docker_container') {
+    const window = cfg['windowMinutes'] ?? 10
+    switch (cfg['rule']) {
+      case 'restart_loop':
+        return `container restarts >= ${cfg['threshold'] ?? 3} in ${window}m`
+      case 'memory_near_limit':
+        return `container memory >= ${cfg['threshold'] ?? 90}% in ${window}m`
+      case 'sustained_cpu':
+        return `container CPU >= ${cfg['threshold'] ?? 90}% for ${window}m`
+      case 'container_missing':
+        return `container missing for ${cfg['threshold'] ?? 5}m`
+      case 'high_network_io':
+        return `container network I/O >= ${cfg['threshold'] ?? 1048576} B/s in ${window}m`
+    }
+  }
   return '—'
+}
+
+function defaultDockerThreshold(rule: RuleFormValues['dockerRule']): number {
+  switch (rule) {
+    case 'memory_near_limit':
+    case 'sustained_cpu':
+      return 90
+    case 'container_missing':
+      return 5
+    case 'high_network_io':
+      return 1048576
+    case 'restart_loop':
+    default:
+      return 3
+  }
 }
 
 // ─── Silence Dialog (host-scoped) ─────────────────────────────────────────────
@@ -214,8 +257,9 @@ function AddRuleDialog({
   onOpenChange: (v: boolean) => void
   onSuccess: () => void
 }) {
-  const [conditionType, setConditionType] = useState<'check_status' | 'metric_threshold' | 'cert_expiry'>('check_status')
+  const [conditionType, setConditionType] = useState<'check_status' | 'metric_threshold' | 'cert_expiry' | 'docker_container'>('check_status')
   const [certScope, setCertScope] = useState<'all' | 'specific'>('all')
+  const [dockerRule, setDockerRule] = useState<RuleFormValues['dockerRule']>('restart_loop')
 
   const { data: checks = [] } = useQuery({
     queryKey: ['checks-history', scopeId, hostId],
@@ -228,10 +272,18 @@ function AddRuleDialog({
     enabled: conditionType === 'cert_expiry' && certScope === 'specific',
   })
 
+  const { data: dockerContainersResult } = useQuery({
+    queryKey: ['docker-containers-alert-options', scopeId, hostId],
+    queryFn: () => getHostDockerContainers(scopeId, hostId),
+    enabled: conditionType === 'docker_container',
+  })
+  const dockerContainers = dockerContainersResult?.containers ?? []
+
   const {
     register,
     handleSubmit,
     control,
+    setValue,
     reset,
     formState: { errors, isSubmitting },
   } = useForm<RuleFormValues>({
@@ -242,6 +294,10 @@ function AddRuleDialog({
       checkId: '',
       failureThreshold: 3,
       severity: 'warning',
+      dockerRule: 'restart_loop',
+      dockerWindowMinutes: 10,
+      dockerThreshold: 3,
+      dockerSampleThreshold: 3,
     },
   })
 
@@ -267,6 +323,22 @@ function AddRuleDialog({
           scope,
           ...(scope === 'specific' && values.certificateId ? { certificateId: values.certificateId } : {}),
           daysBeforeExpiry: values.daysBeforeExpiry ?? 30,
+        },
+        severity: values.severity,
+      }
+    } else if (values.conditionType === 'docker_container') {
+      const selectedRule = values.dockerRule ?? 'restart_loop'
+      if (selectedRule === 'container_missing' && !values.dockerContainerId) return
+      input = {
+        hostId,
+        name: values.name,
+        conditionType: 'docker_container',
+        config: {
+          rule: selectedRule,
+          ...(values.dockerContainerId ? { dockerContainerId: values.dockerContainerId } : {}),
+          windowMinutes: values.dockerWindowMinutes ?? 10,
+          threshold: values.dockerThreshold ?? defaultDockerThreshold(selectedRule),
+          sampleThreshold: values.dockerSampleThreshold ?? 3,
         },
         severity: values.severity,
       }
@@ -306,7 +378,7 @@ function AddRuleDialog({
                   value={field.value}
                   onValueChange={(v) => {
                     field.onChange(v)
-                    setConditionType(v as 'check_status' | 'metric_threshold' | 'cert_expiry')
+                    setConditionType(v as 'check_status' | 'metric_threshold' | 'cert_expiry' | 'docker_container')
                   }}
                 >
                   <SelectTrigger>
@@ -316,6 +388,7 @@ function AddRuleDialog({
                     <SelectItem value="check_status">Check failure</SelectItem>
                     <SelectItem value="metric_threshold">Metric threshold</SelectItem>
                     <SelectItem value="cert_expiry">Certificate expiry</SelectItem>
+                    <SelectItem value="docker_container">Docker container</SelectItem>
                   </SelectContent>
                 </Select>
               )}
@@ -486,6 +559,116 @@ function AddRuleDialog({
                   placeholder="e.g. 30"
                   {...register('daysBeforeExpiry', { valueAsNumber: true })}
                 />
+              </div>
+            </>
+          )}
+
+          {/* docker_container fields */}
+          {conditionType === 'docker_container' && (
+            <>
+              <div className="space-y-1.5">
+                <Label>Docker condition</Label>
+                <Controller
+                  name="dockerRule"
+                  control={control}
+                  defaultValue="restart_loop"
+                  render={({ field }) => (
+                    <Select
+                      value={field.value ?? 'restart_loop'}
+                      onValueChange={(v) => {
+                        const nextRule = v as RuleFormValues['dockerRule']
+                        field.onChange(nextRule)
+                        setDockerRule(nextRule)
+                        setValue('dockerThreshold', defaultDockerThreshold(nextRule))
+                        if (nextRule === 'container_missing') {
+                          setValue('dockerSampleThreshold', 1)
+                          setValue('dockerContainerId', '')
+                        } else {
+                          setValue('dockerSampleThreshold', 3)
+                        }
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="restart_loop">Restart loop</SelectItem>
+                        <SelectItem value="memory_near_limit">Memory near limit</SelectItem>
+                        <SelectItem value="sustained_cpu">Sustained CPU</SelectItem>
+                        <SelectItem value="container_missing">Container missing</SelectItem>
+                        <SelectItem value="high_network_io">High network I/O</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Container</Label>
+                <Controller
+                  name="dockerContainerId"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      value={field.value ? field.value : dockerRule === 'container_missing' ? undefined : 'all'}
+                      onValueChange={(v) => field.onChange(v === 'all' ? '' : v)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={dockerRule === 'container_missing' ? 'Select a container…' : 'All containers'}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {dockerRule !== 'container_missing' && <SelectItem value="all">All containers</SelectItem>}
+                        {dockerContainers.map((c) => (
+                          <SelectItem key={c.dockerContainerId} value={c.dockerContainerId}>
+                            {c.primaryName ?? c.dockerContainerId.slice(0, 12)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="docker-window">Window (minutes)</Label>
+                  <Input
+                    id="docker-window"
+                    type="number"
+                    min={1}
+                    max={1440}
+                    {...register('dockerWindowMinutes', { valueAsNumber: true })}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="docker-threshold">
+                    {dockerRule === 'high_network_io'
+                      ? 'Bytes/sec'
+                      : dockerRule === 'container_missing'
+                        ? 'Missing minutes'
+                        : dockerRule === 'restart_loop'
+                          ? 'Restarts'
+                          : 'Threshold (%)'}
+                  </Label>
+                  <Input
+                    id="docker-threshold"
+                    type="number"
+                    min={0}
+                    placeholder="e.g. 90"
+                    {...register('dockerThreshold', { valueAsNumber: true })}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="docker-samples">Samples</Label>
+                  <Input
+                    id="docker-samples"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    disabled={dockerRule === 'container_missing'}
+                    {...register('dockerSampleThreshold', { valueAsNumber: true })}
+                  />
+                </div>
               </div>
             </>
           )}

--- a/apps/web/lib/actions/alerts.ts
+++ b/apps/web/lib/actions/alerts.ts
@@ -75,11 +75,40 @@ const certExpiryConfigSchema = z.object({
   daysBeforeExpiry: z.number().int().min(1).max(365),
 })
 
+const dockerContainerAlertConfigSchema = z.object({
+  rule: z.enum([
+    'restart_loop',
+    'memory_near_limit',
+    'sustained_cpu',
+    'container_missing',
+    'high_network_io',
+  ]),
+  dockerContainerId: z.string().min(1).max(128).optional(),
+  windowMinutes: z.number().int().min(1).max(1440),
+  threshold: z.number().min(0).max(1_000_000_000_000),
+  sampleThreshold: z.number().int().min(1).max(1000).optional(),
+}).superRefine((value, ctx) => {
+  if (value.rule === 'container_missing' && !value.dockerContainerId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dockerContainerId'],
+      message: 'Select a container for missing-container alerts',
+    })
+  }
+  if ((value.rule === 'memory_near_limit' || value.rule === 'sustained_cpu') && value.threshold > 100) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['threshold'],
+      message: 'Percentage thresholds cannot exceed 100',
+    })
+  }
+})
+
 const createAlertRuleSchema = z.object({
   hostId: z.string().min(1).nullable().optional(),
   name: z.string().min(1).max(100),
-  conditionType: z.enum(['check_status', 'metric_threshold', 'cert_expiry']),
-  config: z.union([checkStatusConfigSchema, metricThresholdConfigSchema, certExpiryConfigSchema]),
+  conditionType: z.enum(['check_status', 'metric_threshold', 'cert_expiry', 'docker_container']),
+  config: z.union([checkStatusConfigSchema, metricThresholdConfigSchema, certExpiryConfigSchema, dockerContainerAlertConfigSchema]),
   severity: z.enum(['info', 'warning', 'critical']).default('warning'),
 })
 
@@ -87,7 +116,7 @@ const updateAlertRuleSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   enabled: z.boolean().optional(),
   severity: z.enum(['info', 'warning', 'critical']).optional(),
-  config: z.union([checkStatusConfigSchema, metricThresholdConfigSchema, certExpiryConfigSchema]).optional(),
+  config: z.union([checkStatusConfigSchema, metricThresholdConfigSchema, certExpiryConfigSchema, dockerContainerAlertConfigSchema]).optional(),
 })
 
 const httpsUrl = z

--- a/apps/web/lib/db/schema/alerts.ts
+++ b/apps/web/lib/db/schema/alerts.ts
@@ -25,8 +25,21 @@ export interface CertExpiryConfig {
   daysBeforeExpiry: number
 }
 
-export type AlertConditionType = 'check_status' | 'metric_threshold' | 'cert_expiry'
-export type AlertRuleConfig = CheckStatusConfig | MetricThresholdConfig | CertExpiryConfig
+export interface DockerContainerAlertConfig {
+  rule:
+    | 'restart_loop'
+    | 'memory_near_limit'
+    | 'sustained_cpu'
+    | 'container_missing'
+    | 'high_network_io'
+  dockerContainerId?: string
+  windowMinutes: number
+  threshold: number
+  sampleThreshold?: number
+}
+
+export type AlertConditionType = 'check_status' | 'metric_threshold' | 'cert_expiry' | 'docker_container'
+export type AlertRuleConfig = CheckStatusConfig | MetricThresholdConfig | CertExpiryConfig | DockerContainerAlertConfig
 export type AlertSeverity = 'info' | 'warning' | 'critical'
 export type AlertInstanceStatus = 'firing' | 'resolved' | 'acknowledged'
 

--- a/docs/docker-container-telemetry-implementation-plan.md
+++ b/docs/docker-container-telemetry-implementation-plan.md
@@ -199,7 +199,7 @@ Purpose: make the feature operationally useful beyond basic charts.
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Add top containers views | Codex | done | web actions/components | Phase 3 metrics | Users can rank containers by CPU, memory, network, and block I/O over a selected time range. | [#1379](https://github.com/carrtech-dev/ct-ops/pull/1379) | Merged in #1379. Uses max and p95 ranking options across CPU, memory, network I/O, and block I/O. E2E spec added; local E2E run blocked by unavailable container runtime. |
 | Add container lifecycle timeline | Codex | done | agent/inventory ingest/UI | Phase 2 inventory | Users can see starts, stops, restarts, and disappeared containers over time. | [#1382](https://github.com/carrtech-dev/ct-ops/pull/1382) | Merged in #1382 and released in #1383 as ingest v0.14.0, web v0.146.0, and bundle v0.13.0. |
-| Add alert rules for containers | unclaimed | pending | alert schema/evaluator/UI | Phase 3 metrics | Alerts cover restart loop, memory near limit, sustained CPU, container missing, and high network I/O. | TBD | Avoid alerting on short one-sample noise by default. |
+| Add alert rules for containers | Codex | review | alert schema/evaluator/UI | Phase 3 metrics | Alerts cover restart loop, memory near limit, sustained CPU, container missing, and high network I/O. | [#1385](https://github.com/carrtech-dev/ct-ops/pull/1385) | PR opened in #1385. Avoids one-sample noise with sample/window thresholds for metric-derived rules. |
 | Add fleet/container search | unclaimed | pending | web routes/actions/components | Phase 2 inventory | Users can search across hosts by container name, image, label, and state. | TBD | Useful for finding where a workload is running. |
 
 ## Testing Requirements


### PR DESCRIPTION
## Summary
- add docker_container alert rule config support for restart loops, memory near limit, sustained CPU, missing containers, and high network I/O
- evaluate Docker container alert rules after telemetry batches are stored, with sample/window guards to avoid one-sample noise
- expose Docker container alert rule creation in the host Alerts tab and update the shared telemetry plan claim

## Validation
- git diff --check
- go test ./... (apps/ingest)

## Notes
- Web type-check was not run locally because this automation environment has Node but no npm/pnpm/yarn/bun binary and no web node_modules installed.