### PR TITLE
fix(docker): collect running container metrics

### DIFF
--- a/agent/internal/heartbeat/docker_metrics.go
+++ b/agent/internal/heartbeat/docker_metrics.go
@@ -18,6 +18,7 @@ const (
 	dockerMetricStatsTimeout          = 5 * time.Second
 	defaultDockerMetricSampleInterval = 2 * time.Second
 	defaultDockerMetricBufferSamples  = 10_000
+	maxDockerMetricConcurrentStats    = 8
 )
 
 type dockerMetricCollector func(context.Context) ([]*agentv1.DockerContainerMetricSample, error)
@@ -37,6 +38,11 @@ type dockerMetricBuffer struct {
 	max     int
 	samples []*agentv1.DockerContainerMetricSample
 	dropped uint32
+}
+
+type dockerMetricSampleResult struct {
+	index  int
+	sample *agentv1.DockerContainerMetricSample
 }
 
 type dockerContainerStats struct {
@@ -170,21 +176,62 @@ func collectDockerMetricSamplesWithClient(ctx context.Context, client *http.Clie
 	}
 
 	recordedAt := time.Now().Unix()
-	samples := make([]*agentv1.DockerContainerMetricSample, 0, len(containers))
+	running := make([]dockerContainerListItem, 0, len(containers))
 	for _, container := range containers {
+		state := strings.TrimSpace(container.State)
+		if state != "" && !strings.EqualFold(state, "running") {
+			continue
+		}
 		containerID := truncateUTF8(strings.TrimSpace(container.ID), maxDockerContainerIDBytes)
 		if containerID == "" {
 			continue
 		}
-		stats, err := fetchDockerContainerStats(ctx, client, baseURL, containerID)
-		if err != nil {
+		container.ID = containerID
+		running = append(running, container)
+	}
+
+	results := make(chan dockerMetricSampleResult, len(running))
+	sem := make(chan struct{}, maxDockerMetricConcurrentStats)
+	var wg sync.WaitGroup
+	for index, container := range running {
+		wg.Add(1)
+		go func(index int, containerID string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+
+			stats, err := fetchDockerContainerStats(ctx, client, baseURL, containerID)
+			if err != nil {
+				return
+			}
+			sample := dockerMetricSampleFromStats(containerID, recordedAt, stats)
+			if inspect, err := inspectDockerContainer(ctx, client, baseURL, containerID); err == nil {
+				sample.RestartCount = inspect.RestartCount
+			}
+			results <- dockerMetricSampleResult{index: index, sample: sample}
+		}(index, container.ID)
+	}
+	wg.Wait()
+	close(results)
+
+	ordered := make([]*agentv1.DockerContainerMetricSample, len(running))
+	count := 0
+	for result := range results {
+		if result.sample == nil || result.index < 0 || result.index >= len(ordered) {
 			continue
 		}
-		sample := dockerMetricSampleFromStats(containerID, recordedAt, stats)
-		if inspect, err := inspectDockerContainer(ctx, client, baseURL, containerID); err == nil {
-			sample.RestartCount = inspect.RestartCount
+		ordered[result.index] = result.sample
+		count++
+	}
+	samples := make([]*agentv1.DockerContainerMetricSample, 0, count)
+	for _, sample := range ordered {
+		if sample != nil {
+			samples = append(samples, sample)
 		}
-		samples = append(samples, sample)
 	}
 	return samples, nil
 }
@@ -194,7 +241,7 @@ func listDockerContainersForMetrics(ctx context.Context, client *http.Client, ba
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL+"?all=1", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/internal/heartbeat/docker_metrics_test.go
+++ b/agent/internal/heartbeat/docker_metrics_test.go
@@ -15,11 +15,11 @@ import (
 func TestCollectDockerMetricSamplesCalculatesStats(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/containers/json", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("all") != "1" {
-			t.Fatalf("all query = %q, want 1", r.URL.Query().Get("all"))
+		if r.URL.Query().Has("all") {
+			t.Fatalf("all query = %q, want omitted so Docker returns running containers", r.URL.Query().Get("all"))
 		}
 		_ = json.NewEncoder(w).Encode([]dockerContainerListItem{
-			{ID: "abcdef123456"},
+			{ID: "abcdef123456", State: "running"},
 		})
 	})
 	handler.HandleFunc("/containers/abcdef123456/stats", func(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +93,48 @@ func TestCollectDockerMetricSamplesCalculatesStats(t *testing.T) {
 	}
 	if got.PidsCurrent != 7 || got.RestartCount != 4 {
 		t.Fatalf("pids/restarts = %d/%d", got.PidsCurrent, got.RestartCount)
+	}
+}
+
+func TestCollectDockerMetricSamplesSkipsNonRunningContainers(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/containers/json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]dockerContainerListItem{
+			{ID: "exited-container", State: "exited"},
+			{ID: "running-container", State: "running"},
+		})
+	})
+	handler.HandleFunc("/containers/exited-container/stats", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("stats endpoint should not be called for exited containers")
+	})
+	handler.HandleFunc("/containers/running-container/stats", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(dockerContainerStats{
+			CPUStats: dockerCPUStats{
+				CPUUsage:       dockerCPUUsage{TotalUsage: 2},
+				SystemCPUUsage: 2,
+				OnlineCPUs:     1,
+			},
+			PreCPUStats: dockerCPUStats{
+				CPUUsage:       dockerCPUUsage{TotalUsage: 1},
+				SystemCPUUsage: 1,
+			},
+		})
+	})
+	handler.HandleFunc("/containers/running-container/json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(dockerContainerInspect{})
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	samples, err := collectDockerMetricSamplesWithClient(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("collectDockerMetricSamplesWithClient() error = %v", err)
+	}
+	if len(samples) != 1 {
+		t.Fatalf("samples length = %d, want 1", len(samples))
+	}
+	if samples[0].DockerContainerId != "running-container" {
+		t.Fatalf("sample container = %q, want running-container", samples[0].DockerContainerId)
 	}
 }
 

--- a/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
@@ -322,7 +322,11 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
 
   const containers = useMemo(() => data?.containers ?? [], [data?.containers])
   const imageOptions = data?.imageOptions ?? []
-  const selectedContainer = containers.find((container) => container.dockerContainerId === selectedContainerId) ?? containers[0] ?? null
+  const defaultMetricsContainer = containers.find((container) => container.isPresent && container.state === 'running')
+    ?? containers.find((container) => container.isPresent)
+    ?? containers[0]
+    ?? null
+  const selectedContainer = containers.find((container) => container.dockerContainerId === selectedContainerId) ?? defaultMetricsContainer
   const effectiveSelectedContainerId = selectedContainer?.dockerContainerId ?? null
   const { data: metricsData, isLoading: metricsLoading } = useQuery({
     queryKey: ['host-docker-container-metrics', scopeId, hostId, effectiveSelectedContainerId, metricsRange],

--- a/apps/web/lib/actions/docker-containers.test.mjs
+++ b/apps/web/lib/actions/docker-containers.test.mjs
@@ -58,5 +58,7 @@ test('getHostDockerContainerLifecycleEvents validates host scope before querying
   assert.match(segment, /eq\(hosts\.instanceId, instanceId\)/, 'host lookup must be scoped to the caller instance')
   assert.match(segment, /WHERE e\.instance_id = \$\{instanceId\}/, 'timeline query must be scoped to instance')
   assert.match(segment, /AND e\.host_id = \$\{hostId\}/, 'timeline query must be scoped to host')
+  assert.match(segment, /LEFT JOIN docker_containers dc/, 'timeline query should join current container inventory')
+  assert.match(segment, /CASE WHEN dc\.is_present = true THEN dc\.status ELSE e\.status END AS status/, 'present containers should show current Docker status text')
   assert.match(segment, /LIMIT \$\{MAX_LIFECYCLE_EVENTS\}/, 'timeline query must cap returned events')
 })

--- a/apps/web/lib/actions/docker-containers.ts
+++ b/apps/web/lib/actions/docker-containers.ts
@@ -417,14 +417,19 @@ export async function getHostDockerContainerLifecycleEvents(
     SELECT
       e.id,
       e.docker_container_id,
-      e.primary_name,
-      e.image,
-      e.state,
-      e.status,
+      COALESCE(dc.primary_name, e.primary_name) AS primary_name,
+      COALESCE(dc.image, e.image) AS image,
+      CASE WHEN dc.is_present = true THEN dc.state ELSE e.state END AS state,
+      CASE WHEN dc.is_present = true THEN dc.status ELSE e.status END AS status,
       e.event_type,
       e.occurred_at,
-      e.restart_count
+      CASE WHEN dc.is_present = true THEN dc.restart_count ELSE e.restart_count END AS restart_count
     FROM docker_container_lifecycle_events e
+    LEFT JOIN docker_containers dc
+      ON dc.id = e.docker_container_row_id
+     AND dc.instance_id = e.instance_id
+     AND dc.host_id = e.host_id
+     AND dc.docker_container_id = e.docker_container_id
     WHERE e.instance_id = ${instanceId}
       AND e.host_id = ${hostId}
     ORDER BY e.occurred_at DESC, e.created_at DESC


### PR DESCRIPTION
## Summary
- collect Docker metrics from running containers only and avoid stopped-container stats calls
- collect container stats concurrently with a small limit so one slow stats call does not starve the whole sample interval
- default the container metrics panel to a running container and show current status text in lifecycle rows for still-present containers

## Validation
- go test ./agent/internal/heartbeat
- go test ./apps/ingest/internal/db/queries ./apps/ingest/internal/handlers ./agent/internal/heartbeat
- node --test apps/web/lib/actions/docker-containers.test.mjs

Note: web type-check was not run locally because this shell does not have pnpm/npm/corepack installed.