### PR TITLE
feat(web): add host admin tab for notes

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -893,7 +893,7 @@ export function HostDetailClient({
             currentUserId={currentUserId}
             userRole={userRole}
             onViewAll={() => {
-              setActiveParentTab('notes')
+              setActiveParentTab('admin')
               setActiveTab('notes')
             }}
           />

--- a/apps/web/lib/hosts/host-detail-tabs.test.mjs
+++ b/apps/web/lib/hosts/host-detail-tabs.test.mjs
@@ -22,3 +22,14 @@ test('container inventory is available as a top-level host tab', () => {
   assert.equal(containers.children, null)
   assert.equal(inventory?.children?.includes('containers'), false)
 })
+
+test('notes live under the top-level admin host tab', () => {
+  const admin = PARENT_TABS.find((tab) => tab.id === 'admin')
+  const notes = PARENT_TABS.find((tab) => tab.id === 'notes')
+
+  assert.ok(admin)
+  assert.equal(admin.label, 'Admin')
+  assert.equal(admin.defaultTab, 'notes')
+  assert.deepEqual(admin.children, ['notes'])
+  assert.equal(notes, undefined)
+})

--- a/apps/web/lib/hosts/host-detail-tabs.ts
+++ b/apps/web/lib/hosts/host-detail-tabs.ts
@@ -4,7 +4,7 @@ export type ParentTabId =
   | 'infrastructure'
   | 'inventory'
   | 'containers'
-  | 'notes'
+  | 'admin'
   | 'management'
   | 'tools'
 
@@ -60,7 +60,7 @@ export const PARENT_TABS: Array<{
   { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network', 'host-networks', 'patch-status'] },
   { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages', 'vulnerabilities'] },
   { id: 'containers', label: 'Containers', defaultTab: 'containers', children: null },
-  { id: 'notes', label: 'Notes', defaultTab: 'notes', children: null },
+  { id: 'admin', label: 'Admin', defaultTab: 'notes', children: ['notes'] },
   { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'settings'] },
   { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
 ]


### PR DESCRIPTION
## Summary
- add a top-level Admin tab to host detail navigation
- move the existing Notes tab under Admin as a child tab
- update the pinned notes view-all action to select Admin > Notes
- add a host tab hierarchy regression test

## Validation
- node --experimental-strip-types --test apps/web/lib/hosts/host-detail-tabs.test.mjs
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings outside the changed files)

## Notes
- The first test-first run intentionally failed on the new Admin hierarchy assertion before implementation.
- The workspace initially had no node_modules, so dependencies were installed with pnpm install before type-check/lint validation.