### PR TITLE
fix(ingest): close docker inventory rows before lifecycle inserts

### DIFF
--- a/apps/ingest/internal/db/queries/docker_inventory.go
+++ b/apps/ingest/internal/db/queries/docker_inventory.go
@@ -76,6 +76,11 @@ type dockerContainerLifecycleSnapshot struct {
 	IsPresent         bool
 }
 
+type dockerContainerLifecycleInsert struct {
+	RowID string
+	Event DockerContainerLifecycleEvent
+}
+
 func DockerContainerInventoryReportsFromProto(items []*agentv1.DockerContainerInventory, receivedAt time.Time) []DockerContainerInventoryReport {
 	reports := make([]DockerContainerInventoryReport, 0, len(items))
 	for _, item := range items {
@@ -229,7 +234,7 @@ func SyncDockerContainerInventory(ctx context.Context, pool *pgxpool.Pool, insta
 		if err != nil {
 			return err
 		}
-		defer rows.Close()
+		disappeared := make([]dockerContainerLifecycleInsert, 0)
 		for rows.Next() {
 			var rowID string
 			var containerID string
@@ -251,12 +256,16 @@ func SyncDockerContainerInventory(ctx context.Context, pool *pgxpool.Pool, insta
 				OccurredAt:        inventoryAt.UTC(),
 				RestartCount:      restartCount.Int32,
 			}
-			if err := insertDockerLifecycleEvent(ctx, tx, instanceID, hostID, rowID, event); err != nil {
-				return err
-			}
+			disappeared = append(disappeared, dockerContainerLifecycleInsert{RowID: rowID, Event: event})
 		}
+		rows.Close()
 		if err := rows.Err(); err != nil {
 			return err
+		}
+		for _, item := range disappeared {
+			if err := insertDockerLifecycleEvent(ctx, tx, instanceID, hostID, item.RowID, item.Event); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/apps/ingest/internal/db/queries/docker_inventory_test.go
+++ b/apps/ingest/internal/db/queries/docker_inventory_test.go
@@ -1,6 +1,7 @@
 package queries
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -77,6 +78,35 @@ func TestDockerContainerInventoryReportsFromProtoNormalizesInventory(t *testing.
 	}
 	if got.RestartCount != 3 {
 		t.Fatalf("RestartCount = %d, want 3", got.RestartCount)
+	}
+}
+
+func TestSyncDockerContainerInventoryClosesMarkMissingRowsBeforeLifecycleInserts(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile("docker_inventory.go")
+	if err != nil {
+		t.Fatalf("reading docker_inventory.go: %v", err)
+	}
+	markMissingStart := strings.Index(string(source), "if markMissing {")
+	if markMissingStart < 0 {
+		t.Fatal("markMissing block not found")
+	}
+	markMissingBlock := string(source[markMissingStart:])
+	insertIndex := strings.Index(markMissingBlock, "insertDockerLifecycleEvent")
+	closeIndex := strings.Index(markMissingBlock, "rows.Close()")
+	errIndex := strings.Index(markMissingBlock, "rows.Err()")
+	if insertIndex < 0 {
+		t.Fatal("markMissing lifecycle insert not found")
+	}
+	if closeIndex < 0 {
+		t.Fatal("markMissing rows.Close() not found")
+	}
+	if errIndex < 0 {
+		t.Fatal("markMissing rows.Err() check not found")
+	}
+	if closeIndex > insertIndex || errIndex > insertIndex {
+		t.Fatalf("markMissing rows must be closed and checked before lifecycle inserts to avoid pgx conn busy: close=%d err=%d insert=%d", closeIndex, errIndex, insertIndex)
 	}
 }
 


### PR DESCRIPTION
## Summary
- buffer disappeared Docker lifecycle events after mark-missing updates
- close and check the pgx rows before issuing lifecycle insert queries on the same transaction
- add a regression test for the query-ordering requirement

## Validation
- go test ./apps/ingest/internal/db/queries -run TestSyncDockerContainerInventoryClosesMarkMissingRowsBeforeLifecycleInserts -count=1
- go test ./apps/ingest/...
