### PR TITLE
feat(web): show host calendar events

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { CalendarDays, Loader2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { listCalendarEventsForHost, type HostCalendarEventView } from '@/lib/actions/calendar'
+import type { CalendarEventCategory, CalendarEventStatus } from '@/lib/db/schema/calendar'
+
+const CATEGORY_LABELS: Record<CalendarEventCategory, string> = {
+  maintenance: 'Maintenance',
+  patching: 'Patching',
+  application: 'Application',
+  change: 'Change',
+  meeting: 'Meeting',
+  other: 'Other',
+}
+
+const STATUS_LABELS: Record<CalendarEventStatus, string> = {
+  planned: 'Planned',
+  confirmed: 'Confirmed',
+  in_progress: 'In progress',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+}
+
+const STATUS_BADGE_CLASS: Record<CalendarEventStatus, string> = {
+  planned: 'bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100',
+  confirmed: 'bg-green-100 text-green-800 border-green-200 hover:bg-green-100',
+  in_progress: 'bg-amber-100 text-amber-800 border-amber-200 hover:bg-amber-100',
+  completed: 'bg-slate-100 text-slate-800 border-slate-200 hover:bg-slate-100',
+  cancelled: 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100',
+}
+
+function safeTestId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
+function formatEventDate(event: HostCalendarEventView): string {
+  const startsAt = new Date(event.startsAt)
+  const endsAt = new Date(event.endsAt)
+  if (event.allDay) {
+    return format(startsAt, 'd MMM yyyy')
+  }
+  return `${format(startsAt, 'd MMM yyyy, HH:mm')} - ${format(endsAt, 'HH:mm')}`
+}
+
+function HostCalendarEventRow({ event }: { event: HostCalendarEventView }) {
+  return (
+    <TableRow data-testid={`host-calendar-event-${safeTestId(event.id)}`}>
+      <TableCell>
+        <div className="space-y-1">
+          <div className="font-medium text-foreground">{event.title}</div>
+          {event.description ? (
+            <div className="line-clamp-2 text-xs text-muted-foreground">{event.description}</div>
+          ) : null}
+        </div>
+      </TableCell>
+      <TableCell className="whitespace-nowrap text-sm">{formatEventDate(event)}</TableCell>
+      <TableCell>
+        <Badge variant="outline" className={STATUS_BADGE_CLASS[event.status]}>
+          {STATUS_LABELS[event.status]}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant="secondary">{CATEGORY_LABELS[event.category]}</Badge>
+      </TableCell>
+      <TableCell className="text-sm text-muted-foreground">
+        {event.isRecurring ? 'Recurring' : 'One-off'}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: string }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['host-calendar-events', scopeId, hostId],
+    queryFn: () => listCalendarEventsForHost(scopeId, hostId),
+  })
+
+  const events = data && !('error' in data) ? data.events : []
+  const errorMessage = data && 'error' in data ? data.error : error instanceof Error ? error.message : null
+
+  return (
+    <Card data-testid="host-calendar-tab">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <CalendarDays className="size-5" />
+          Calendar
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            Loading calendar events...
+          </div>
+        ) : errorMessage ? (
+          <p className="text-sm text-destructive">{errorMessage}</p>
+        ) : events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No calendar events linked to this host.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Event</TableHead>
+                <TableHead>Date and time</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead>Schedule</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {events.map((event) => (
+                <HostCalendarEventRow key={event.id} event={event} />
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-detail-client.tsx
@@ -70,6 +70,7 @@ import { InventoryTab } from './inventory-tab'
 import { ContainersTab } from './containers-tab'
 import { PatchStatusTab } from './patch-status-tab'
 import { VulnerabilitiesTab } from './vulnerabilities-tab'
+import { HostCalendarTab } from './host-calendar-tab'
 import { HostTerminalLauncher } from './host-terminal-launcher'
 import { NotesTab } from '@/components/notes/notes-tab'
 import { PinnedNotesCard } from '@/components/notes/pinned-notes-card'
@@ -1421,6 +1422,11 @@ export function HostDetailClient({
           currentUserId={currentUserId}
           userRole={userRole}
         />
+      )}
+
+      {/* Calendar Tab */}
+      {activeTab === 'calendar' && (
+        <HostCalendarTab scopeId={scopeId} hostId={initialHost.id} />
       )}
 
       {/* Tasks Tab */}

--- a/apps/web/lib/actions/calendar.ts
+++ b/apps/web/lib/actions/calendar.ts
@@ -143,6 +143,19 @@ export interface CalendarEventInstanceView {
   participants: CalendarParticipantView[]
 }
 
+export interface HostCalendarEventView {
+  id: string
+  title: string
+  description: string | null
+  startsAt: string
+  endsAt: string
+  allDay: boolean
+  timezone: string
+  status: CalendarEventStatus
+  category: CalendarEventCategory
+  isRecurring: boolean
+}
+
 type ParsedCalendarInput = Omit<CalendarEventInput, 'startsAt' | 'endsAt' | 'recurrenceRule'> & {
   startsAt: Date
   endsAt: Date
@@ -514,6 +527,72 @@ export async function listCalendarEvents(
   } catch (err) {
     logError('Failed to list calendar events:', err)
     return { error: err instanceof Error ? err.message : 'Failed to load calendar events' }
+  }
+}
+
+export async function listCalendarEventsForHost(
+  instanceId: string,
+  hostId: string,
+): Promise<{ events: HostCalendarEventView[] } | { error: string }> {
+  await requireInstanceAccess(instanceId)
+  const parsedHostId = z.string().min(1).safeParse(hostId)
+  if (!parsedHostId.success) return { error: 'Host is required' }
+
+  try {
+    const rows = await db
+      .select({
+        id: calendarEvents.id,
+        title: calendarEvents.title,
+        description: calendarEvents.description,
+        startsAt: calendarEvents.startsAt,
+        endsAt: calendarEvents.endsAt,
+        allDay: calendarEvents.allDay,
+        timezone: calendarEvents.timezone,
+        status: calendarEvents.status,
+        category: calendarEvents.category,
+        recurrenceRule: calendarEvents.recurrenceRule,
+      })
+      .from(calendarEventHosts)
+      .innerJoin(
+        calendarEvents,
+        and(
+          eq(calendarEventHosts.eventId, calendarEvents.id),
+          eq(calendarEvents.instanceId, instanceId),
+          isNull(calendarEvents.deletedAt),
+        ),
+      )
+      .innerJoin(
+        hosts,
+        and(
+          eq(calendarEventHosts.hostId, hosts.id),
+          eq(hosts.instanceId, instanceId),
+          isNull(hosts.deletedAt),
+        ),
+      )
+      .where(and(
+        eq(calendarEventHosts.instanceId, instanceId),
+        eq(calendarEventHosts.hostId, parsedHostId.data),
+      ))
+      .orderBy(asc(calendarEvents.startsAt))
+      .limit(250)
+
+    return {
+      events: rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        startsAt: row.startsAt.toISOString(),
+        endsAt: row.endsAt.toISOString(),
+        allDay: row.allDay,
+        timezone: row.timezone,
+        status: row.status,
+        category: row.category,
+        isRecurring: Boolean(row.recurrenceRule),
+      })),
+    }
+  } catch (err) {
+    logError('Failed to list host calendar events:', err)
+    return { error: 'Failed to load host calendar events' }
   }
 }
 

--- a/apps/web/lib/hosts/host-detail-tabs.ts
+++ b/apps/web/lib/hosts/host-detail-tabs.ts
@@ -27,6 +27,7 @@ export type Tab =
   | 'packages'
   | 'containers'
   | 'notes'
+  | 'calendar'
 
 export const TAB_LABELS: Record<Tab, string> = {
   overview: 'Overview',
@@ -47,6 +48,7 @@ export const TAB_LABELS: Record<Tab, string> = {
   packages: 'Packages',
   containers: 'Containers',
   notes: 'Notes',
+  calendar: 'Calendar',
 }
 
 export const PARENT_TABS: Array<{
@@ -60,7 +62,7 @@ export const PARENT_TABS: Array<{
   { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network', 'host-networks', 'patch-status'] },
   { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages', 'vulnerabilities'] },
   { id: 'containers', label: 'Containers', defaultTab: 'containers', children: null },
-  { id: 'admin', label: 'Admin', defaultTab: 'notes', children: ['notes'] },
+  { id: 'admin', label: 'Admin', defaultTab: 'notes', children: ['notes', 'calendar'] },
   { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'settings'] },
   { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
 ]

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '../fixtures/test'
+import { getTestDb } from '../fixtures/db'
+import { TEST_ORG, TEST_USER } from '../fixtures/seed'
+
+async function getOrgAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ instanceId: string; userId: string }> {
+  const rows = await sql<Array<{ instance_id: string; user_id: string }>>`
+    SELECT instanceSettings.id AS instance_id, "user".id AS user_id
+    FROM instance_settings
+    JOIN "user" ON "user".instance_id = instanceSettings.id
+    WHERE instanceSettings.slug = ${TEST_ORG.slug}
+      AND "user".email = ${TEST_USER.email}
+    LIMIT 1
+  `
+  expect(rows).toHaveLength(1)
+  return {
+    instanceId: rows[0]!.instance_id,
+    userId: rows[0]!.user_id,
+  }
+}
+
+test('host admin calendar shows only events linked to the current host', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { instanceId, userId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (id, instance_id, hostname, display_name, os, arch, ip_addresses, status, last_seen_at)
+    VALUES
+      ('host-calendar-1', ${instanceId}, 'host-calendar-1', 'Host Calendar One', 'Ubuntu 24.04', 'x86_64', '["10.70.0.10"]'::jsonb, 'online', NOW()),
+      ('host-calendar-2', ${instanceId}, 'host-calendar-2', 'Host Calendar Two', 'Ubuntu 24.04', 'x86_64', '["10.70.0.11"]'::jsonb, 'online', NOW())
+  `
+
+  await sql`
+    INSERT INTO calendar_events (
+      id,
+      instance_id,
+      created_by,
+      title,
+      description,
+      starts_at,
+      ends_at,
+      all_day,
+      timezone,
+      status,
+      category
+    )
+    VALUES
+      ('host-calendar-event-1', ${instanceId}, ${userId}, 'Host kernel patch', 'Patch the current host.', '2026-05-20T09:00:00Z', '2026-05-20T10:00:00Z', false, 'UTC', 'confirmed', 'patching'),
+      ('host-calendar-event-2', ${instanceId}, ${userId}, 'Host maintenance window', NULL, '2026-05-22T13:30:00Z', '2026-05-22T15:00:00Z', false, 'UTC', 'planned', 'maintenance'),
+      ('host-calendar-event-other', ${instanceId}, ${userId}, 'Other host outage', NULL, '2026-05-21T09:00:00Z', '2026-05-21T10:00:00Z', false, 'UTC', 'planned', 'maintenance')
+  `
+
+  await sql`
+    INSERT INTO calendar_event_hosts (instance_id, event_id, host_id)
+    VALUES
+      (${instanceId}, 'host-calendar-event-1', 'host-calendar-1'),
+      (${instanceId}, 'host-calendar-event-2', 'host-calendar-1'),
+      (${instanceId}, 'host-calendar-event-other', 'host-calendar-2')
+  `
+
+  await page.goto('/hosts/host-calendar-1')
+  await expect(page.getByRole('heading', { name: 'Host Calendar One' })).toBeVisible()
+
+  await page.getByTestId('host-parent-tab-admin').click()
+  await page.getByTestId('host-tab-calendar').click()
+
+  await expect(page.getByTestId('host-calendar-tab')).toBeVisible()
+  await expect(page.getByTestId('host-calendar-event-host-calendar-event-1')).toContainText('Host kernel patch')
+  await expect(page.getByTestId('host-calendar-event-host-calendar-event-1')).toContainText('Confirmed')
+  await expect(page.getByTestId('host-calendar-event-host-calendar-event-1')).toContainText('Patching')
+  await expect(page.getByTestId('host-calendar-event-host-calendar-event-2')).toContainText('Host maintenance window')
+  await expect(page.getByText('Other host outage')).toHaveCount(0)
+})
+
+test('host admin calendar shows an empty state when no events are linked', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { instanceId } = await getOrgAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (id, instance_id, hostname, display_name, os, arch, ip_addresses, status, last_seen_at)
+    VALUES ('host-calendar-empty', ${instanceId}, 'host-calendar-empty', 'Host Calendar Empty', 'Ubuntu 24.04', 'x86_64', '["10.70.0.12"]'::jsonb, 'online', NOW())
+  `
+
+  await page.goto('/hosts/host-calendar-empty')
+  await expect(page.getByRole('heading', { name: 'Host Calendar Empty' })).toBeVisible()
+
+  await page.getByTestId('host-parent-tab-admin').click()
+  await page.getByTestId('host-tab-calendar').click()
+
+  await expect(page.getByTestId('host-calendar-tab')).toContainText('No calendar events linked to this host')
+})


### PR DESCRIPTION
## Summary
- add a Calendar subtab under the Host Admin tab
- list calendar events linked to the current host via calendar_event_hosts
- add E2E coverage for linked events and the empty state

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings outside this change)
- pnpm --filter web test:e2e tests/e2e/hosts/host-calendar.spec.ts (attempted locally; shared route warmup repeatedly failed before reaching this spec due Next dev server restart/connection refused)