### PR TITLE
build(dev-stack): use node 24 image

### DIFF
--- a/docker-compose.dev-stack.yml
+++ b/docker-compose.dev-stack.yml
@@ -84,7 +84,7 @@ services:
       start_period: 10s
 
   web-migrate:
-    image: node:20-bookworm-slim
+    image: node:24-bookworm-slim
     restart: "no"
     working_dir: /workspace
     depends_on:
@@ -112,7 +112,7 @@ services:
         pnpm run db:migrate
 
   web-dev:
-    image: node:20-bookworm-slim
+    image: node:24-bookworm-slim
     restart: unless-stopped
     working_dir: /workspace
     depends_on:


### PR DESCRIPTION
## Summary
- Update the ct-ops dev stack web migration and dev services to use node:24-bookworm-slim instead of node:20-bookworm-slim.

## Validation
- ./deploy/scripts/test-dev-stack.sh
- ./dev-stack.sh --write-config-only && docker compose --project-name ct-ops-dev --env-file .dev/dev.env -f docker-compose.dev-stack.yml config