### PR TITLE
fix(calendar): contain operations calendar scrolling

### DIFF
--- a/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
+++ b/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
@@ -800,7 +800,7 @@ export function OperationsCalendarClient({
   }
 
   return (
-    <div className="flex min-h-[calc(100svh-3rem)] flex-col gap-4">
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-hidden">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold text-foreground" data-testid="operations-calendar-heading">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -189,8 +189,7 @@
 .ct-ops-calendar {
   --ct-ops-calendar-time-gutter: 4.75rem;
   --ct-ops-calendar-time-slot-height: max(2rem, calc((100svh - 18rem) / 16));
-  height: calc(100svh - 12rem);
-  min-height: 560px;
+  min-height: 0;
   overflow: hidden;
   position: relative;
 }
@@ -257,6 +256,7 @@
 .ct-ops-calendar-time-scroll {
   flex: 1;
   min-height: 0;
+  overscroll-behavior: contain;
   overflow: auto;
 }
 

--- a/apps/web/tests/e2e/calendar/calendar.spec.ts
+++ b/apps/web/tests/e2e/calendar/calendar.spec.ts
@@ -248,6 +248,21 @@ test('calendar views use operational calendar labels and grid structure', async 
     return labels.find((label) => label.getBoundingClientRect().top >= scrollerTop - 1)?.textContent
   })
   expect(firstVisibleTimeLabel).toBe('09:00')
+  await expect.poll(async () =>
+    page.locator('main').evaluate((main) => main.scrollHeight - main.clientHeight),
+  ).toBeLessThanOrEqual(1)
+
+  const controlsTop = await page.getByTestId('calendar-view-work-week').evaluate((button) => button.getBoundingClientRect().top)
+  const headerTop = await page.locator('[data-testid^="calendar-time-header-"]').first().evaluate((header) => header.getBoundingClientRect().top)
+  const scrollerTopBefore = await page.getByTestId('calendar-time-scroll').evaluate((scroller) => scroller.scrollTop)
+  const scrollerBox = await page.getByTestId('calendar-time-scroll').boundingBox()
+  expect(scrollerBox).not.toBeNull()
+  await page.mouse.move(scrollerBox!.x + scrollerBox!.width / 2, scrollerBox!.y + scrollerBox!.height / 2)
+  await page.mouse.wheel(0, 420)
+  await expect.poll(async () => page.getByTestId('calendar-time-scroll').evaluate((scroller) => scroller.scrollTop)).toBeGreaterThan(scrollerTopBefore)
+  expect(await page.locator('main').evaluate((main) => main.scrollTop)).toBe(0)
+  expect(await page.getByTestId('calendar-view-work-week').evaluate((button) => button.getBoundingClientRect().top)).toBeCloseTo(controlsTop, 0)
+  expect(await page.locator('[data-testid^="calendar-time-header-"]').first().evaluate((header) => header.getBoundingClientRect().top)).toBeCloseTo(headerTop, 0)
 
   await page.getByTestId('calendar-view-full-week').click()
   await expect(page.locator('[data-testid^="calendar-time-header-"]').filter({ hasText: /^Mon, \d{1,2} [A-Z][a-z]{2}$/ }).first()).toBeVisible()


### PR DESCRIPTION
## Summary
- constrain the Operations Calendar page to the dashboard content height instead of viewport-derived minimum heights
- keep only the time-slot grid scrollable and contain overscroll so Chrome does not chain wheel events to the parent page
- add a calendar E2E regression assertion that the dashboard main area does not scroll while the time-slot scroller does

Fixes #1326

## Validation
- `pnpm --filter web lint 'app/(dashboard)/calendar/operations-calendar-client.tsx' app/globals.css tests/e2e/calendar/calendar.spec.ts` (passes; ESLint warns CSS is ignored by config)
- `pnpm --filter web type-check`
- `pnpm --filter web exec playwright test --list tests/e2e/calendar/calendar.spec.ts --grep "calendar views use operational calendar labels"`
- `BETTER_AUTH_URL=http://localhost:3000 BETTER_AUTH_SECRET=local-build-secret DATABASE_URL=postgres://test:test@localhost:5432/ctops_test pnpm --filter web build` (passes with existing Turbopack trace warnings and local low-entropy secret warnings)

## Not run
- `pnpm --filter web test:e2e tests/e2e/calendar/calendar.spec.ts --grep "calendar views use operational calendar labels"`: local run was stopped after the runner spent several minutes in warmup and hit test database connection timeouts (`CONNECT_TIMEOUT localhost:55001`) before the targeted calendar assertion could complete.
