### PR TITLE
feat(web): improve host container telemetry views

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/containers-tab.tsx
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   Table,
   TableBody,
@@ -29,6 +30,7 @@ import {
 } from '@/components/ui/table'
 import {
   getHostDockerContainerMetrics,
+  getHostDockerContainerMetricSparklines,
   getHostDockerContainerLifecycleEvents,
   getHostDockerContainers,
   getHostDockerTopContainers,
@@ -302,11 +304,52 @@ function ContainerMetricChart({
   )
 }
 
+function ContainerSparkline({ points, containerId }: { points: Array<{ recordedAt: Date; cpuMax: number | null }> | undefined; containerId: string }) {
+  const values = points?.map((point) => point.cpuMax).filter((value): value is number => typeof value === 'number') ?? []
+  const width = 96
+  const height = 28
+
+  if (values.length === 0) {
+    return (
+      <svg
+        role="img"
+        aria-label="No CPU trend data"
+        data-testid={`host-docker-container-sparkline-${containerId}`}
+        viewBox={`0 0 ${width} ${height}`}
+        className="h-7 w-24 text-muted-foreground"
+      >
+        <line x1="2" y1={height / 2} x2={width - 2} y2={height / 2} stroke="currentColor" strokeDasharray="3 3" strokeWidth="1.5" />
+      </svg>
+    )
+  }
+
+  const max = Math.max(...values, 1)
+  const path = values.map((value, index) => {
+    const x = values.length === 1 ? width / 2 : (index / (values.length - 1)) * (width - 4) + 2
+    const y = height - 3 - (value / max) * (height - 6)
+    return `${index === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`
+  }).join(' ')
+
+  return (
+    <svg
+      role="img"
+      aria-label="CPU trend"
+      data-testid={`host-docker-container-sparkline-${containerId}`}
+      viewBox={`0 0 ${width} ${height}`}
+      className="h-7 w-24 text-blue-600"
+    >
+      <path d={path} fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" />
+    </svg>
+  )
+}
+
 export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
+  const [activeSubTab, setActiveSubTab] = useState('overview')
   const [search, setSearch] = useState('')
   const [state, setState] = useState('all')
   const [image, setImage] = useState('all')
   const [selectedContainerId, setSelectedContainerId] = useState<string | null>(null)
+  const [selectedLifecycleContainerId, setSelectedLifecycleContainerId] = useState('none')
   const [metricsRange, setMetricsRange] = useState<DockerContainerMetricsPreset>('1h')
   const [topRange, setTopRange] = useState<DockerContainerMetricsPreset>('1h')
   const [topMetric, setTopMetric] = useState<DockerTopContainerMetric>('cpu')
@@ -321,6 +364,7 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
   })
 
   const containers = useMemo(() => data?.containers ?? [], [data?.containers])
+  const containerIds = useMemo(() => containers.map((container) => container.dockerContainerId), [containers])
   const imageOptions = data?.imageOptions ?? []
   const defaultMetricsContainer = containers.find((container) => container.isPresent && container.state === 'running')
     ?? containers.find((container) => container.isPresent)
@@ -328,6 +372,9 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
     ?? null
   const selectedContainer = containers.find((container) => container.dockerContainerId === selectedContainerId) ?? defaultMetricsContainer
   const effectiveSelectedContainerId = selectedContainer?.dockerContainerId ?? null
+  const selectedLifecycleContainer = selectedLifecycleContainerId === 'none'
+    ? null
+    : containers.find((container) => container.dockerContainerId === selectedLifecycleContainerId) ?? null
   const { data: metricsData, isLoading: metricsLoading } = useQuery({
     queryKey: ['host-docker-container-metrics', scopeId, hostId, effectiveSelectedContainerId, metricsRange],
     queryFn: () => getHostDockerContainerMetrics(scopeId, hostId, effectiveSelectedContainerId!, { range: metricsRange }),
@@ -343,12 +390,18 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
     enabled: !dockerUnavailable,
   })
   const { data: lifecycleData, isLoading: lifecycleLoading } = useQuery({
-    queryKey: ['host-docker-container-lifecycle-events', scopeId, hostId],
-    queryFn: () => getHostDockerContainerLifecycleEvents(scopeId, hostId),
-    enabled: !dockerUnavailable,
+    queryKey: ['host-docker-container-lifecycle-events', scopeId, hostId, selectedLifecycleContainerId],
+    queryFn: () => getHostDockerContainerLifecycleEvents(scopeId, hostId, selectedLifecycleContainerId),
+    enabled: !dockerUnavailable && selectedLifecycleContainerId !== 'none',
+  })
+  const { data: sparklineData } = useQuery({
+    queryKey: ['host-docker-container-metric-sparklines', scopeId, hostId, containerIds],
+    queryFn: () => getHostDockerContainerMetricSparklines(scopeId, hostId, containerIds),
+    enabled: !dockerUnavailable && containerIds.length > 0,
   })
   const topContainers = topContainersData?.containers ?? []
   const lifecycleEvents = lifecycleData?.events ?? []
+  const sparklines = sparklineData?.sparklines ?? {}
   const metricPoints = useMemo(() => metricsData?.points ?? [], [metricsData?.points])
   const chartData = useMemo(() => metricPoints.map((point) => ({
     time: new Date(point.recordedAt).getTime(),
@@ -434,14 +487,26 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
         </div>
       </div>
 
-      <Card data-testid="host-docker-top-containers">
-        <CardHeader className="pb-3">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <CardTitle className="text-base flex items-center gap-2">
-              <BarChart3 className="size-4 text-muted-foreground" />
-              Top containers
-            </CardTitle>
-            <div className="flex flex-wrap items-center gap-2">
+      <Tabs value={activeSubTab} onValueChange={setActiveSubTab} className="gap-4">
+        <TabsList data-testid="host-docker-containers-subtabs">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="lifecycle">Lifecycle</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4">
+          <Card data-testid="host-docker-top-containers">
+            <CardHeader className="pb-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <BarChart3 className="size-4 text-muted-foreground" />
+                    Top containers
+                  </CardTitle>
+                  <p className="text-xs text-muted-foreground">
+                    Ranks containers by their highest or P95 resource use over the selected range.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
               <Select value={topMetric} onValueChange={(value) => setTopMetric(value as DockerTopContainerMetric)}>
                 <SelectTrigger className="w-36" data-testid="host-docker-top-metric-select">
                   <SelectValue />
@@ -478,10 +543,10 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
                   ))}
                 </SelectContent>
               </Select>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
           {topContainersLoading ? (
             <div className="py-8 text-center text-sm text-muted-foreground">
               <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
@@ -535,26 +600,235 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
               </TableBody>
             </Table>
           )}
-        </CardContent>
-      </Card>
+            </CardContent>
+          </Card>
 
-      <Card data-testid="host-docker-container-lifecycle">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base flex items-center gap-2">
-            <History className="size-4 text-muted-foreground" />
-            Lifecycle timeline
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {lifecycleLoading ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
-              Loading lifecycle events...
-            </div>
-          ) : lifecycleEvents.length === 0 ? (
-            <EmptyState title="No lifecycle events" body="Starts, stops, restarts and disappeared containers will appear after new inventory changes are reported." icon={History} />
-          ) : (
-            <Table>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Box className="size-4 text-muted-foreground" />
+                Container Inventory
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="py-12 text-center text-sm text-muted-foreground">
+                  <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
+                  Loading containers...
+                </div>
+              ) : containers.length === 0 ? (
+                hasActiveFilters ? (
+                  <EmptyState title="No containers match your filters" body="Clear the current filters to see all known Docker containers for this host." />
+                ) : (
+                  <EmptyState title="No containers reported" body="Docker is installed, but no current or recently seen containers have been reported yet." />
+                )
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Image</TableHead>
+                      <TableHead>State</TableHead>
+                      <TableHead>CPU trend</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Last seen</TableHead>
+                      <TableHead>Started</TableHead>
+                      <TableHead className="text-right">Restarts</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {containers.map((container) => (
+                      <TableRow
+                        key={container.id}
+                        data-testid={`host-docker-container-row-${container.dockerContainerId}`}
+                        className={container.dockerContainerId === effectiveSelectedContainerId ? 'bg-muted/50' : 'cursor-pointer'}
+                        onClick={() => setSelectedContainerId(container.dockerContainerId)}
+                      >
+                        <TableCell>
+                          <div className="font-medium text-foreground">
+                            {container.primaryName || container.namesJson[0] || container.dockerContainerId.slice(0, 12)}
+                          </div>
+                          <div className="font-mono text-xs text-muted-foreground">
+                            {container.dockerContainerId.slice(0, 12)}
+                          </div>
+                        </TableCell>
+                        <TableCell className="max-w-[260px] truncate text-sm">
+                          {container.image || '-'}
+                        </TableCell>
+                        <TableCell>
+                          <ContainerStateBadge state={container.state} present={container.isPresent} />
+                        </TableCell>
+                        <TableCell>
+                          <ContainerSparkline points={sparklines[container.dockerContainerId]} containerId={container.dockerContainerId} />
+                        </TableCell>
+                        <TableCell className="max-w-[280px] truncate text-sm text-muted-foreground">
+                          {container.status || '-'}
+                        </TableCell>
+                        <TableCell className="text-sm">{formatRelative(container.lastSeenAt)}</TableCell>
+                        <TableCell className="text-sm">{formatAbsolute(container.startedAtSource)}</TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {container.restartCount ?? '-'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+
+          {selectedContainer && (
+            <Card data-testid="host-docker-container-metrics">
+              <CardHeader className="pb-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Activity className="size-4 text-muted-foreground" />
+                    Container Metrics
+                  </CardTitle>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Select value={effectiveSelectedContainerId ?? undefined} onValueChange={setSelectedContainerId}>
+                      <SelectTrigger className="w-56" data-testid="host-docker-metrics-container-select">
+                        <SelectValue placeholder="Select container" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {containers.map((container) => (
+                          <SelectItem key={container.dockerContainerId} value={container.dockerContainerId}>
+                            {container.primaryName || container.dockerContainerId.slice(0, 12)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <div className="flex flex-wrap items-center gap-1">
+                      {metricRangeOptions.map((option) => (
+                        <Button
+                          key={option.value}
+                          type="button"
+                          variant={metricsRange === option.value ? 'default' : 'outline'}
+                          size="sm"
+                          onClick={() => setMetricsRange(option.value)}
+                        >
+                          {option.label}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {metricsLoading ? (
+                  <div className="py-12 text-center text-sm text-muted-foreground">
+                    <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
+                    Loading container metrics...
+                  </div>
+                ) : metricPoints.length === 0 ? (
+                  <EmptyState title="No metrics reported" body="Metric charts will appear after the agent uploads container samples for this container." icon={Activity} />
+                ) : (
+                  <div className="space-y-5">
+                    <div className="text-sm font-medium text-foreground">
+                      {selectedContainer.primaryName || selectedContainer.dockerContainerId.slice(0, 12)}
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+                      <MetricSummary label="CPU max" value={formatPercent(latestMax(metricPoints, 'cpuMax'))} />
+                      <MetricSummary label="Memory max" value={formatPercent(latestMax(metricPoints, 'memoryMax'))} />
+                      <MetricSummary label="Network RX max" value={formatBytes(latestMax(metricPoints, 'networkRxMax'))} />
+                      <MetricSummary label="Block read max" value={formatBytes(latestMax(metricPoints, 'blockReadMax'))} />
+                      <MetricSummary label="PIDs max" value={formatNumber(latestMax(metricPoints, 'pidsMax'))} />
+                    </div>
+                    <div className="grid gap-6 xl:grid-cols-2">
+                      <ContainerMetricChart
+                        title="CPU avg/max"
+                        data={chartData}
+                        yFormatter={(value) => `${value.toFixed(0)}%`}
+                        lines={[
+                          { key: 'cpuAvg', name: 'CPU avg', color: 'hsl(221, 83%, 53%)' },
+                          { key: 'cpuMax', name: 'CPU max', color: 'hsl(0, 84%, 60%)' },
+                        ]}
+                      />
+                      <ContainerMetricChart
+                        title="Memory avg/max"
+                        data={chartData}
+                        yFormatter={(value) => `${value.toFixed(0)}%`}
+                        lines={[
+                          { key: 'memoryAvg', name: 'Memory avg', color: 'hsl(142, 71%, 45%)' },
+                          { key: 'memoryMax', name: 'Memory max', color: 'hsl(38, 92%, 50%)' },
+                        ]}
+                      />
+                      <ContainerMetricChart
+                        title="Network I/O"
+                        data={chartData}
+                        yFormatter={formatBytes}
+                        lines={[
+                          { key: 'networkRxAvg', name: 'RX avg', color: 'hsl(221, 83%, 53%)' },
+                          { key: 'networkRxMax', name: 'RX max', color: 'hsl(0, 84%, 60%)' },
+                          { key: 'networkTxAvg', name: 'TX avg', color: 'hsl(142, 71%, 45%)' },
+                          { key: 'networkTxMax', name: 'TX max', color: 'hsl(38, 92%, 50%)' },
+                        ]}
+                      />
+                      <ContainerMetricChart
+                        title="Block I/O"
+                        data={chartData}
+                        yFormatter={formatBytes}
+                        lines={[
+                          { key: 'blockReadAvg', name: 'Read avg', color: 'hsl(221, 83%, 53%)' },
+                          { key: 'blockReadMax', name: 'Read max', color: 'hsl(0, 84%, 60%)' },
+                          { key: 'blockWriteAvg', name: 'Write avg', color: 'hsl(142, 71%, 45%)' },
+                          { key: 'blockWriteMax', name: 'Write max', color: 'hsl(38, 92%, 50%)' },
+                        ]}
+                      />
+                      <ContainerMetricChart
+                        title="PIDs"
+                        data={chartData}
+                        yFormatter={(value) => Math.round(value).toLocaleString()}
+                        lines={[
+                          { key: 'pidsAvg', name: 'PIDs avg', color: 'hsl(221, 83%, 53%)' },
+                          { key: 'pidsMax', name: 'PIDs max', color: 'hsl(0, 84%, 60%)' },
+                        ]}
+                      />
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+        </TabsContent>
+
+        <TabsContent value="lifecycle">
+          <Card data-testid="host-docker-container-lifecycle">
+            <CardHeader className="pb-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <History className="size-4 text-muted-foreground" />
+                  Lifecycle timeline
+                </CardTitle>
+                <Select value={selectedLifecycleContainerId} onValueChange={setSelectedLifecycleContainerId}>
+                  <SelectTrigger className="w-56" data-testid="host-docker-lifecycle-container-select">
+                    <SelectValue placeholder="Select container" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none" disabled>
+                      Select container
+                    </SelectItem>
+                    {containers.map((container) => (
+                      <SelectItem key={container.dockerContainerId} value={container.dockerContainerId}>
+                        {container.primaryName || container.dockerContainerId.slice(0, 12)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {!selectedLifecycleContainer ? (
+                <EmptyState title="Select a container" body="Choose one container to view its start, stop, restart and disappearance events." icon={History} />
+              ) : lifecycleLoading ? (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
+                  Loading lifecycle events...
+                </div>
+              ) : lifecycleEvents.length === 0 ? (
+                <EmptyState title="No lifecycle events" body="Starts, stops, restarts and disappeared containers will appear after new inventory changes are reported for this container." icon={History} />
+              ) : (
+                <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>Event</TableHead>
@@ -600,179 +874,11 @@ export function ContainersTab({ scopeId, hostId, dockerStatus }: Props) {
                 ))}
               </TableBody>
             </Table>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base flex items-center gap-2">
-            <Box className="size-4 text-muted-foreground" />
-            Container Inventory
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="py-12 text-center text-sm text-muted-foreground">
-              <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
-              Loading containers...
-            </div>
-          ) : containers.length === 0 ? (
-            hasActiveFilters ? (
-              <EmptyState title="No containers match your filters" body="Clear the current filters to see all known Docker containers for this host." />
-            ) : (
-              <EmptyState title="No containers reported" body="Docker is installed, but no current or recently seen containers have been reported yet." />
-            )
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Image</TableHead>
-                  <TableHead>State</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Last seen</TableHead>
-                  <TableHead>Started</TableHead>
-                  <TableHead className="text-right">Restarts</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {containers.map((container) => (
-                  <TableRow
-                    key={container.id}
-                    data-testid={`host-docker-container-row-${container.dockerContainerId}`}
-                    className={container.dockerContainerId === effectiveSelectedContainerId ? 'bg-muted/50' : 'cursor-pointer'}
-                    onClick={() => setSelectedContainerId(container.dockerContainerId)}
-                  >
-                    <TableCell>
-                      <div className="font-medium text-foreground">
-                        {container.primaryName || container.namesJson[0] || container.dockerContainerId.slice(0, 12)}
-                      </div>
-                      <div className="font-mono text-xs text-muted-foreground">
-                        {container.dockerContainerId.slice(0, 12)}
-                      </div>
-                    </TableCell>
-                    <TableCell className="max-w-[260px] truncate text-sm">
-                      {container.image || '-'}
-                    </TableCell>
-                    <TableCell>
-                      <ContainerStateBadge state={container.state} present={container.isPresent} />
-                    </TableCell>
-                    <TableCell className="max-w-[280px] truncate text-sm text-muted-foreground">
-                      {container.status || '-'}
-                    </TableCell>
-                    <TableCell className="text-sm">{formatRelative(container.lastSeenAt)}</TableCell>
-                    <TableCell className="text-sm">{formatAbsolute(container.startedAtSource)}</TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {container.restartCount ?? '-'}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
-
-      {selectedContainer && (
-        <Card data-testid="host-docker-container-metrics">
-          <CardHeader className="pb-3">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Activity className="size-4 text-muted-foreground" />
-                Container Metrics
-                <span className="font-mono text-xs font-normal text-muted-foreground">
-                  {selectedContainer.primaryName || selectedContainer.dockerContainerId.slice(0, 12)}
-                </span>
-              </CardTitle>
-              <div className="flex flex-wrap items-center gap-1">
-                {metricRangeOptions.map((option) => (
-                  <Button
-                    key={option.value}
-                    type="button"
-                    variant={metricsRange === option.value ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setMetricsRange(option.value)}
-                  >
-                    {option.label}
-                  </Button>
-                ))}
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {metricsLoading ? (
-              <div className="py-12 text-center text-sm text-muted-foreground">
-                <Loader2 className="size-5 mx-auto mb-2 animate-spin" />
-                Loading container metrics...
-              </div>
-            ) : metricPoints.length === 0 ? (
-              <EmptyState title="No metrics reported" body="Metric charts will appear after the agent uploads container samples for this container." icon={Activity} />
-            ) : (
-              <div className="space-y-5">
-                <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
-                  <MetricSummary label="CPU max" value={formatPercent(latestMax(metricPoints, 'cpuMax'))} />
-                  <MetricSummary label="Memory max" value={formatPercent(latestMax(metricPoints, 'memoryMax'))} />
-                  <MetricSummary label="Network RX max" value={formatBytes(latestMax(metricPoints, 'networkRxMax'))} />
-                  <MetricSummary label="Block read max" value={formatBytes(latestMax(metricPoints, 'blockReadMax'))} />
-                  <MetricSummary label="PIDs max" value={formatNumber(latestMax(metricPoints, 'pidsMax'))} />
-                </div>
-                <div className="grid gap-6 xl:grid-cols-2">
-                  <ContainerMetricChart
-                    title="CPU avg/max"
-                    data={chartData}
-                    yFormatter={(value) => `${value.toFixed(0)}%`}
-                    lines={[
-                      { key: 'cpuAvg', name: 'CPU avg', color: 'hsl(221, 83%, 53%)' },
-                      { key: 'cpuMax', name: 'CPU max', color: 'hsl(0, 84%, 60%)' },
-                    ]}
-                  />
-                  <ContainerMetricChart
-                    title="Memory avg/max"
-                    data={chartData}
-                    yFormatter={(value) => `${value.toFixed(0)}%`}
-                    lines={[
-                      { key: 'memoryAvg', name: 'Memory avg', color: 'hsl(142, 71%, 45%)' },
-                      { key: 'memoryMax', name: 'Memory max', color: 'hsl(38, 92%, 50%)' },
-                    ]}
-                  />
-                  <ContainerMetricChart
-                    title="Network I/O"
-                    data={chartData}
-                    yFormatter={formatBytes}
-                    lines={[
-                      { key: 'networkRxAvg', name: 'RX avg', color: 'hsl(221, 83%, 53%)' },
-                      { key: 'networkRxMax', name: 'RX max', color: 'hsl(0, 84%, 60%)' },
-                      { key: 'networkTxAvg', name: 'TX avg', color: 'hsl(142, 71%, 45%)' },
-                      { key: 'networkTxMax', name: 'TX max', color: 'hsl(38, 92%, 50%)' },
-                    ]}
-                  />
-                  <ContainerMetricChart
-                    title="Block I/O"
-                    data={chartData}
-                    yFormatter={formatBytes}
-                    lines={[
-                      { key: 'blockReadAvg', name: 'Read avg', color: 'hsl(221, 83%, 53%)' },
-                      { key: 'blockReadMax', name: 'Read max', color: 'hsl(0, 84%, 60%)' },
-                      { key: 'blockWriteAvg', name: 'Write avg', color: 'hsl(142, 71%, 45%)' },
-                      { key: 'blockWriteMax', name: 'Write max', color: 'hsl(38, 92%, 50%)' },
-                    ]}
-                  />
-                  <ContainerMetricChart
-                    title="PIDs"
-                    data={chartData}
-                    yFormatter={(value) => Math.round(value).toLocaleString()}
-                    lines={[
-                      { key: 'pidsAvg', name: 'PIDs avg', color: 'hsl(221, 83%, 53%)' },
-                      { key: 'pidsMax', name: 'PIDs max', color: 'hsl(0, 84%, 60%)' },
-                    ]}
-                  />
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/apps/web/lib/actions/docker-containers.test.mjs
+++ b/apps/web/lib/actions/docker-containers.test.mjs
@@ -62,3 +62,25 @@ test('getHostDockerContainerLifecycleEvents validates host scope before querying
   assert.match(segment, /CASE WHEN dc\.is_present = true THEN dc\.status ELSE e\.status END AS status/, 'present containers should show current Docker status text')
   assert.match(segment, /LIMIT \$\{MAX_LIFECYCLE_EVENTS\}/, 'timeline query must cap returned events')
 })
+
+test('getHostDockerContainerLifecycleEvents can scope the timeline to one container', () => {
+  const segment = getActionSegment('getHostDockerContainerLifecycleEvents')
+
+  assert.match(segment, /dockerContainerId\?: string/, 'timeline action should accept an optional container id')
+  assert.match(segment, /cleanFilter\(dockerContainerId\)/, 'timeline container id should be normalized')
+  assert.match(segment, /AND e\.docker_container_id = \$\{containerId\}/, 'timeline query should filter selected container events')
+})
+
+test('getHostDockerContainerMetricSparklines validates host scope and caps selected containers', () => {
+  const segment = getActionSegment('getHostDockerContainerMetricSparklines')
+  const hostLookupIndex = segment.indexOf('db.query.hosts.findFirst')
+  const metricQueryIndex = segment.indexOf('FROM docker_container_metrics')
+
+  assert.notEqual(hostLookupIndex, -1, 'host ownership must be validated')
+  assert.notEqual(metricQueryIndex, -1, 'sparkline metric query must exist')
+  assert.ok(hostLookupIndex < metricQueryIndex, 'host validation must run before sparkline query')
+  assert.match(segment, /eq\(hosts\.instanceId, instanceId\)/, 'host lookup must be scoped to the caller instance')
+  assert.match(segment, /MAX_SPARKLINE_CONTAINERS/, 'sparkline action must cap selected containers')
+  assert.match(segment, /m\.docker_container_id IN \(\$\{sql\.join/, 'sparkline query must only return requested containers')
+  assert.match(segment, /MAX\(m\.cpu_percent\)::double precision AS cpu_max/, 'sparkline should expose CPU trend values')
+})

--- a/apps/web/lib/actions/docker-containers.ts
+++ b/apps/web/lib/actions/docker-containers.ts
@@ -21,6 +21,7 @@ const MAX_CONTAINER_ROWS = 200
 const MAX_FILTER_LENGTH = 256
 const MAX_METRIC_POINTS = 300
 const MAX_LIFECYCLE_EVENTS = 100
+const MAX_SPARKLINE_CONTAINERS = 200
 
 export type DockerContainerMetricsPreset = '1h' | '6h' | '24h' | '7d'
 
@@ -93,6 +94,15 @@ export interface DockerContainerLifecycleEventRow {
 
 export interface HostDockerContainerLifecycleEventsResult {
   events: DockerContainerLifecycleEventRow[]
+}
+
+export interface DockerContainerMetricSparklinePoint {
+  recordedAt: Date
+  cpuMax: number | null
+}
+
+export interface HostDockerContainerMetricSparklinesResult {
+  sparklines: Record<string, DockerContainerMetricSparklinePoint[]>
 }
 
 function cleanFilter(value: string | undefined): string | undefined {
@@ -394,6 +404,7 @@ export async function getHostDockerTopContainers(
 export async function getHostDockerContainerLifecycleEvents(
   instanceId: string,
   hostId: string,
+  dockerContainerId?: string,
 ): Promise<HostDockerContainerLifecycleEventsResult> {
   await requireInstanceAccess(instanceId)
 
@@ -402,6 +413,9 @@ export async function getHostDockerContainerLifecycleEvents(
     where: and(eq(hosts.id, hostId), eq(hosts.instanceId, instanceId), isNull(hosts.deletedAt)),
   })
   if (!host) return { events: [] }
+
+  const containerId = cleanFilter(dockerContainerId)
+  const containerFilter = containerId ? sql`AND e.docker_container_id = ${containerId}` : sql``
 
   const rows = await db.execute<{
     id: string
@@ -432,6 +446,7 @@ export async function getHostDockerContainerLifecycleEvents(
      AND dc.docker_container_id = e.docker_container_id
     WHERE e.instance_id = ${instanceId}
       AND e.host_id = ${hostId}
+      ${containerFilter}
     ORDER BY e.occurred_at DESC, e.created_at DESC
     LIMIT ${MAX_LIFECYCLE_EVENTS}
   `)
@@ -449,4 +464,57 @@ export async function getHostDockerContainerLifecycleEvents(
       restartCount: row.restart_count,
     })),
   }
+}
+
+export async function getHostDockerContainerMetricSparklines(
+  instanceId: string,
+  hostId: string,
+  dockerContainerIds: string[],
+): Promise<HostDockerContainerMetricSparklinesResult> {
+  await requireInstanceAccess(instanceId)
+
+  const host = await db.query.hosts.findFirst({
+    columns: { id: true },
+    where: and(eq(hosts.id, hostId), eq(hosts.instanceId, instanceId), isNull(hosts.deletedAt)),
+  })
+  if (!host) return { sparklines: {} }
+
+  const selectedContainerIds = Array.from(new Set(dockerContainerIds
+    .map((id) => cleanFilter(id))
+    .filter((id): id is string => Boolean(id))))
+    .slice(0, MAX_SPARKLINE_CONTAINERS)
+
+  if (selectedContainerIds.length === 0) return { sparklines: {} }
+
+  const range = resolveMetricRange('1h')
+  const bucket = sql.raw(`time_bucket('5 minutes'::interval, m.recorded_at)`)
+  const rows = await db.execute<{
+    docker_container_id: string
+    recorded_at: Date
+    cpu_max: number | null
+  }>(sql`
+    SELECT
+      m.docker_container_id,
+      ${bucket} AS recorded_at,
+      MAX(m.cpu_percent)::double precision AS cpu_max
+    FROM docker_container_metrics m
+    WHERE m.instance_id = ${instanceId}
+      AND m.host_id = ${hostId}
+      AND m.docker_container_id IN (${sql.join(selectedContainerIds.map((id) => sql`${id}`), sql`, `)})
+      AND m.recorded_at >= ${range.from.toISOString()}
+      AND m.recorded_at <= ${range.to.toISOString()}
+    GROUP BY m.docker_container_id, ${bucket}
+    ORDER BY m.docker_container_id ASC, recorded_at ASC
+  `)
+
+  const sparklines: HostDockerContainerMetricSparklinesResult['sparklines'] = {}
+  for (const row of Array.from(rows)) {
+    sparklines[row.docker_container_id] ??= []
+    sparklines[row.docker_container_id]!.push({
+      recordedAt: new Date(row.recorded_at),
+      cpuMax: row.cpu_max,
+    })
+  }
+
+  return { sparklines }
 }

--- a/apps/web/tests/e2e/hosts/docker-containers.spec.ts
+++ b/apps/web/tests/e2e/hosts/docker-containers.spec.ts
@@ -43,12 +43,14 @@ async function seedHost(sql: ReturnType<typeof getTestDb>, instanceId: string, h
 async function seedDockerStatus(sql: ReturnType<typeof getTestDb>, instanceId: string, hostId: string, status: string) {
   await sql`
     INSERT INTO host_docker_status (
+      id,
       instance_id,
       host_id,
       status,
       checked_at
     )
     VALUES (
+      ${`${hostId}-docker-status`},
       ${instanceId},
       ${hostId},
       ${status},
@@ -65,6 +67,7 @@ test('host Containers tab lists containers and filters by name and state', async
 
   await sql`
     INSERT INTO docker_containers (
+      id,
       instance_id,
       host_id,
       docker_container_id,
@@ -85,6 +88,7 @@ test('host Containers tab lists containers and filters by name and state', async
     )
     VALUES
       (
+        'docker-containers-web-row',
         ${instanceId},
         'docker-containers-host',
         'web-container-id',
@@ -104,6 +108,7 @@ test('host Containers tab lists containers and filters by name and state', async
         true
       ),
       (
+        'docker-containers-worker-row',
         ${instanceId},
         'docker-containers-host',
         'worker-container-id',
@@ -130,6 +135,7 @@ test('host Containers tab lists containers and filters by name and state', async
   await expect(page.getByTestId('host-containers-tab')).toContainText('2 containers')
   await expect(page.getByTestId('host-docker-container-row-web-container-id')).toContainText('web')
   await expect(page.getByTestId('host-docker-container-row-web-container-id')).toContainText('nginx:1.27')
+  await expect(page.getByTestId('host-docker-container-sparkline-web-container-id')).toBeVisible()
   await expect(page.getByTestId('host-docker-container-row-worker-container-id')).toContainText('worker')
   await expect(page.getByTestId('host-docker-container-row-worker-container-id')).toContainText('Not present')
 
@@ -169,24 +175,43 @@ test('host Containers tab shows per-container metric charts with max spike value
       restart_count,
       is_present
     )
-    VALUES (
-      'docker-metrics-row',
-      ${instanceId},
-      'docker-container-metrics-host',
-      'metrics-container-id',
-      'metrics-web',
-      '["metrics-web"]'::jsonb,
-      'nginx:metrics',
-      'sha256:metrics',
-      '{}'::jsonb,
-      'running',
-      'Up 8 minutes',
-      NOW() - INTERVAL '10 minutes',
-      NOW() - INTERVAL '30 seconds',
-      NOW() - INTERVAL '30 seconds',
-      1,
-      true
-    )
+    VALUES
+      (
+        'docker-metrics-row',
+        ${instanceId},
+        'docker-container-metrics-host',
+        'metrics-container-id',
+        'metrics-web',
+        '["metrics-web"]'::jsonb,
+        'nginx:metrics',
+        'sha256:metrics',
+        '{}'::jsonb,
+        'running',
+        'Up 8 minutes',
+        NOW() - INTERVAL '10 minutes',
+        NOW() - INTERVAL '30 seconds',
+        NOW() - INTERVAL '30 seconds',
+        1,
+        true
+      ),
+      (
+        'docker-metrics-worker-row',
+        ${instanceId},
+        'docker-container-metrics-host',
+        'metrics-worker-container-id',
+        'metrics-worker',
+        '["metrics-worker"]'::jsonb,
+        'worker:metrics',
+        'sha256:metrics-worker',
+        '{}'::jsonb,
+        'running',
+        'Up 7 minutes',
+        NOW() - INTERVAL '10 minutes',
+        NOW() - INTERVAL '30 seconds',
+        NOW() - INTERVAL '30 seconds',
+        0,
+        true
+      )
   `
 
   await sql`
@@ -244,6 +269,24 @@ test('host Containers tab shows per-container metric charts with max spike value
         32768,
         18,
         1
+      ),
+      (
+        'docker-metrics-worker-sample-1',
+        ${instanceId},
+        'docker-container-metrics-host',
+        'docker-metrics-worker-row',
+        'metrics-worker-container-id',
+        NOW() - INTERVAL '10 minutes',
+        33.0,
+        134217728,
+        1073741824,
+        12.5,
+        100,
+        250,
+        2048,
+        4096,
+        2,
+        0
       )
   `
 
@@ -261,6 +304,75 @@ test('host Containers tab shows per-container metric charts with max spike value
   await expect(metrics.getByText('CPU avg/max')).toBeVisible()
   await expect(metrics.getByText('Network I/O')).toBeVisible()
   await expect(metrics.getByText('Block I/O')).toBeVisible()
+
+  await page.getByTestId('host-docker-metrics-container-select').click()
+  await page.getByRole('option', { name: 'metrics-worker' }).click()
+  await expect(metrics).toContainText('metrics-worker')
+  await expect(metrics).toContainText('33.0%')
+})
+
+test('host Containers tab shows lifecycle in a sub tab scoped to the selected container', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const instanceId = await getOrgId(sql)
+  await seedHost(sql, instanceId, 'docker-lifecycle-host')
+  await seedDockerStatus(sql, instanceId, 'docker-lifecycle-host', 'installed')
+
+  await sql`
+    INSERT INTO docker_containers (
+      id,
+      instance_id,
+      host_id,
+      docker_container_id,
+      primary_name,
+      names_json,
+      image,
+      image_id,
+      labels_json,
+      state,
+      status,
+      first_seen_at,
+      last_seen_at,
+      last_inventory_at,
+      restart_count,
+      is_present
+    )
+    VALUES
+      ('docker-lifecycle-api-row', ${instanceId}, 'docker-lifecycle-host', 'lifecycle-api-container-id', 'lifecycle-api', '["lifecycle-api"]'::jsonb, 'api:latest', 'sha256:api', '{}'::jsonb, 'running', 'Up 9 minutes', NOW() - INTERVAL '20 minutes', NOW() - INTERVAL '30 seconds', NOW() - INTERVAL '30 seconds', 0, true),
+      ('docker-lifecycle-worker-row', ${instanceId}, 'docker-lifecycle-host', 'lifecycle-worker-container-id', 'lifecycle-worker', '["lifecycle-worker"]'::jsonb, 'worker:latest', 'sha256:worker', '{}'::jsonb, 'exited', 'Exited', NOW() - INTERVAL '20 minutes', NOW() - INTERVAL '30 seconds', NOW() - INTERVAL '30 seconds', 1, true)
+  `
+
+  await sql`
+    INSERT INTO docker_container_lifecycle_events (
+      id,
+      instance_id,
+      host_id,
+      docker_container_row_id,
+      docker_container_id,
+      primary_name,
+      image,
+      state,
+      status,
+      event_type,
+      occurred_at,
+      restart_count
+    )
+    VALUES
+      ('lifecycle-api-started', ${instanceId}, 'docker-lifecycle-host', 'docker-lifecycle-api-row', 'lifecycle-api-container-id', 'lifecycle-api', 'api:latest', 'running', 'Up', 'started', NOW() - INTERVAL '10 minutes', 0),
+      ('lifecycle-worker-stopped', ${instanceId}, 'docker-lifecycle-host', 'docker-lifecycle-worker-row', 'lifecycle-worker-container-id', 'lifecycle-worker', 'worker:latest', 'exited', 'Exited', 'stopped', NOW() - INTERVAL '5 minutes', 1)
+  `
+
+  await page.goto('/hosts/docker-lifecycle-host')
+  await page.getByTestId('host-parent-tab-containers').click()
+
+  await expect(page.getByTestId('host-docker-container-lifecycle')).toHaveCount(0)
+  await page.getByRole('tab', { name: 'Lifecycle' }).click()
+
+  await page.getByTestId('host-docker-lifecycle-container-select').click()
+  await page.getByRole('option', { name: 'lifecycle-worker' }).click()
+  const lifecycle = page.getByTestId('host-docker-container-lifecycle')
+  await expect(lifecycle).toContainText('lifecycle-worker')
+  await expect(lifecycle).toContainText('Stopped')
+  await expect(lifecycle).not.toContainText('lifecycle-api')
 })
 
 test('host Containers tab ranks top containers by selected metric and statistic', async ({ authenticatedPage: page }) => {
@@ -324,6 +436,7 @@ test('host Containers tab ranks top containers by selected metric and statistic'
 
   const topContainers = page.getByTestId('host-docker-top-containers')
   await expect(topContainers).toContainText('Top containers')
+  await expect(topContainers).toContainText('Ranks containers by their highest or P95 resource use over the selected range.')
   await expect(page.getByTestId('host-docker-top-container-row-top-api-container-id')).toContainText('82.4%')
 
   await page.getByTestId('host-docker-top-metric-select').click()


### PR DESCRIPTION
## Summary
- add host container sub-tabs so lifecycle events live behind their own view
- scope lifecycle events to an explicitly selected container
- add container selectors for metrics and CPU sparklines in inventory rows
- explain how Top containers ranks containers

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint -- app/'(dashboard)'/hosts/'[id]'/containers-tab.tsx lib/actions/docker-containers.ts tests/e2e/hosts/docker-containers.spec.ts lib/actions/docker-containers.test.mjs
- cd apps/web && node --experimental-strip-types --test lib/actions/docker-containers.test.mjs

## Notes
- Attempted E2E with E2E_PORT=3101 pnpm --filter web test:e2e -- tests/e2e/hosts/docker-containers.spec.ts. The run completed setup but failed before a clean final pass: first on stale fixture IDs, then on the sparkline SQL array expression. Both were fixed after the run, but the full warm-up is long and was not rerun to completion.