### PR TITLE
fix(agents): show enrolment install URL when viewing tokens

### DIFF
--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -108,6 +108,7 @@ export function AgentsSettingsClient({
   const [viewToken, setViewToken] = useState<EnrolmentTokenSafe | null>(null)
   const [showBundleDialog, setShowBundleDialog] = useState(false)
   const [tokenTags, setTokenTags] = useState<EditorTag[]>([])
+  const [browserOrigin, setBrowserOrigin] = useState('')
 
   const { data: tokens } = useQuery({
     queryKey: ['enrolment-tokens'],
@@ -167,6 +168,14 @@ export function AgentsSettingsClient({
   })
 
   const onSubmit = handleSubmit((data) => createMutation.mutate(data))
+  const installCommandBaseUrl = appUrl || browserOrigin
+  const viewInstallCommand = viewToken && installCommandBaseUrl
+    ? buildAgentInstallCommand(installCommandBaseUrl, viewToken.skipVerify)
+    : null
+
+  useEffect(() => {
+    setBrowserOrigin(window.location.origin)
+  }, [])
 
   return (
     <div className="space-y-6">
@@ -239,6 +248,7 @@ export function AgentsSettingsClient({
                             size="sm"
                             className="h-6 w-6 p-0"
                             onClick={() => setViewToken(token)}
+                            data-testid="agent-enrolment-view"
                           >
                             <Eye className="size-3 text-muted-foreground" />
                           </Button>
@@ -303,6 +313,17 @@ export function AgentsSettingsClient({
                 The full token was shown only once when it was created. To use this token,
                 generate a new install bundle from the Download Agent Bundle dialog.
               </p>
+              {viewInstallCommand && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Install command</p>
+                  <div className="flex items-start gap-2 p-3 bg-muted rounded-md">
+                    <code className="text-xs font-mono flex-1 break-all leading-relaxed" data-testid="agent-enrolment-view-install-command">
+                      {viewInstallCommand}
+                    </code>
+                    <CopyButton text={viewInstallCommand} />
+                  </div>
+                </div>
+              )}
               <div className="space-y-1.5">
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Token hint</p>
                 <div className="flex items-center gap-2 p-3 bg-muted rounded-md">

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -107,6 +107,50 @@ test('admin can create and revoke an enrolment token from agent settings', async
     .toBeTruthy()
 })
 
+test('admin can view the install URL for an existing enrolment token', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { instanceId, userId } = await getInstanceAndUserIds(sql)
+
+  await sql`
+    INSERT INTO agent_enrolment_tokens (
+      id,
+      instance_id,
+      label,
+      token,
+      created_by_id,
+      auto_approve,
+      skip_verify,
+      max_uses,
+      usage_count,
+      expires_at,
+      metadata
+    )
+    VALUES (
+      'view-existing-token-id',
+      ${instanceId},
+      'View Existing Token',
+      'view-existing-token-value',
+      ${userId},
+      false,
+      false,
+      5,
+      0,
+      NOW() + INTERVAL '14 days',
+      '{}'::jsonb
+    )
+  `
+
+  await page.goto('/settings/agents')
+
+  const tokenRow = page.getByTestId('agent-enrolment-row').filter({ hasText: 'View Existing Token' })
+  await tokenRow.getByTestId('agent-enrolment-view').click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toContainText('View Existing Token')
+  await expect(page.getByTestId('agent-enrolment-view-install-command')).toContainText('/api/agent/install')
+  await expect(page.getByTestId('agent-enrolment-view-install-command')).not.toContainText('token=')
+})
+
 test('admin cannot create an auto-approved token without super admin privileges', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const { instanceId } = await getInstanceAndUserIds(sql)


### PR DESCRIPTION
## Summary
- show a copyable agent install command when viewing an existing enrolment token
- fall back to the browser origin when AGENT_DOWNLOAD_BASE_URL is unset
- add E2E coverage for the existing-token view modal install URL

## Validation
- pnpm --dir apps/web run type-check
- pnpm --dir apps/web exec eslint "app/(dashboard)/settings/agents/agents-client.tsx" tests/e2e/settings/agent-enrolment.spec.ts (passes with existing warnings)
- pnpm --dir apps/web run test:e2e -- tests/e2e/settings/agent-enrolment.spec.ts --grep "install URL" --project=chromium (new install URL test passed; command also ran the whole spec due argument forwarding, with existing failures in unrelated tests: create/revoke timeout and auto-approve role expectation)