### PR TITLE
fix(calendar): refresh host-linked entries automatically

### DIFF
--- a/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
+++ b/apps/web/app/(dashboard)/calendar/operations-calendar-client.tsx
@@ -397,6 +397,13 @@ function eventClassName(event: CalendarEventInstanceView): string[] {
   ].filter(Boolean)
 }
 
+function invalidateCalendarQueries(queryClient: ReturnType<typeof useQueryClient>, instanceId: string): Promise<unknown[]> {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ['calendar-events', instanceId] }),
+    queryClient.invalidateQueries({ queryKey: ['host-calendar-events', instanceId] }),
+  ])
+}
+
 export function OperationsCalendarClient({
   instanceId,
   canEdit,
@@ -472,7 +479,7 @@ export function OperationsCalendarClient({
         return
       }
       setDialogOpen(false)
-      queryClient.invalidateQueries({ queryKey: ['calendar-events', instanceId] })
+      void invalidateCalendarQueries(queryClient, instanceId)
     },
     onError: (err) => {
       setFormError(err instanceof Error ? err.message : 'Failed to save calendar event')
@@ -494,7 +501,7 @@ export function OperationsCalendarClient({
         return
       }
       setDialogOpen(false)
-      queryClient.invalidateQueries({ queryKey: ['calendar-events', instanceId] })
+      void invalidateCalendarQueries(queryClient, instanceId)
     },
   })
 
@@ -511,7 +518,7 @@ export function OperationsCalendarClient({
       if ('error' in result) {
         throw new Error(result.error)
       }
-      await queryClient.invalidateQueries({ queryKey: ['calendar-events', instanceId] })
+      await invalidateCalendarQueries(queryClient, instanceId)
     },
     [instanceId, queryClient],
   )

--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -40,6 +40,7 @@ const STATUS_BADGE_CLASS: Record<CalendarEventStatus, string> = {
   completed: 'bg-slate-100 text-slate-800 border-slate-200 hover:bg-slate-100',
   cancelled: 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100',
 }
+const HOST_CALENDAR_REFETCH_INTERVAL_MS = 5_000
 
 function safeTestId(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, '-')
@@ -85,6 +86,7 @@ export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: 
   const { data, isLoading, error } = useQuery({
     queryKey: ['host-calendar-events', scopeId, hostId],
     queryFn: () => listCalendarEventsForHost(scopeId, hostId),
+    refetchInterval: HOST_CALENDAR_REFETCH_INTERVAL_MS,
   })
 
   const events = data && !('error' in data) ? data.events : []

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -88,3 +88,57 @@ test('host admin calendar shows an empty state when no events are linked', async
 
   await expect(page.getByTestId('host-calendar-tab')).toContainText('No calendar events linked to this host')
 })
+
+test('host admin calendar picks up newly linked events without a browser refresh', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { instanceId, userId } = await getInstanceAndUserIds(sql)
+
+  await sql`
+    INSERT INTO hosts (id, instance_id, hostname, display_name, os, arch, ip_addresses, status, last_seen_at)
+    VALUES ('host-calendar-live', ${instanceId}, 'host-calendar-live', 'Host Calendar Live', 'Ubuntu 24.04', 'x86_64', '["10.70.0.13"]'::jsonb, 'online', NOW())
+  `
+
+  await page.goto('/hosts/host-calendar-live')
+  await expect(page.getByRole('heading', { name: 'Host Calendar Live' })).toBeVisible()
+
+  await page.getByTestId('host-parent-tab-admin').click()
+  await page.getByTestId('host-tab-calendar').click()
+
+  await expect(page.getByTestId('host-calendar-tab')).toContainText('No calendar events linked to this host')
+
+  await sql`
+    INSERT INTO calendar_events (
+      id,
+      instance_id,
+      created_by,
+      title,
+      description,
+      starts_at,
+      ends_at,
+      all_day,
+      timezone,
+      status,
+      category
+    )
+    VALUES (
+      'host-calendar-live-event',
+      ${instanceId},
+      ${userId},
+      'Live host patch',
+      'Created while the host calendar tab is open.',
+      '2026-05-24T09:00:00Z',
+      '2026-05-24T10:00:00Z',
+      false,
+      'UTC',
+      'planned',
+      'patching'
+    )
+  `
+
+  await sql`
+    INSERT INTO calendar_event_hosts (instance_id, event_id, host_id)
+    VALUES (${instanceId}, 'host-calendar-live-event', 'host-calendar-live')
+  `
+
+  await expect(page.getByTestId('host-calendar-event-host-calendar-live-event')).toContainText('Live host patch', { timeout: 15_000 })
+})


### PR DESCRIPTION
## Summary
- refresh Host Admin -> Calendar every 5 seconds while the tab is open
- invalidate host calendar queries after operations calendar create/update/delete/move mutations
- add an e2e regression for a host-linked event appearing without a browser refresh

## Validation
- pnpm --filter web type-check
- pnpm --filter web lint (passes with existing warnings)
- cd apps/web && node --experimental-strip-types --test lib/actions/calendar-source.test.mjs lib/calendar/recurrence.test.mjs lib/hosts/host-detail-tabs.test.mjs

## Notes
- `pnpm --filter web test:unit` is blocked by missing `/home/theo/dev/ct-password-manager/docs/api-contract/openapi.json`; filed #1414.
- `pnpm --filter web test:e2e tests/e2e/hosts/host-calendar.spec.ts` did not reach the focused spec after more than ten minutes of unrelated route warmup; filed #1413.
