### PR TITLE
fix(web): rename host admin tab to activity

### DIFF
--- a/apps/web/lib/hosts/host-detail-tabs.test.mjs
+++ b/apps/web/lib/hosts/host-detail-tabs.test.mjs
@@ -23,12 +23,12 @@ test('container inventory is available as a top-level host tab', () => {
   assert.equal(inventory?.children?.includes('containers'), false)
 })
 
-test('admin host tools live under the top-level admin host tab', () => {
+test('activity host tools live under the top-level activity host tab', () => {
   const admin = PARENT_TABS.find((tab) => tab.id === 'admin')
   const notes = PARENT_TABS.find((tab) => tab.id === 'notes')
 
   assert.ok(admin)
-  assert.equal(admin.label, 'Admin')
+  assert.equal(admin.label, 'Activity')
   assert.equal(admin.defaultTab, 'notes')
   assert.deepEqual(admin.children, ['notes', 'calendar'])
   assert.equal(notes, undefined)

--- a/apps/web/lib/hosts/host-detail-tabs.ts
+++ b/apps/web/lib/hosts/host-detail-tabs.ts
@@ -62,7 +62,7 @@ export const PARENT_TABS: Array<{
   { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network', 'host-networks', 'patch-status'] },
   { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages', 'vulnerabilities'] },
   { id: 'containers', label: 'Containers', defaultTab: 'containers', children: null },
-  { id: 'admin', label: 'Admin', defaultTab: 'notes', children: ['notes', 'calendar'] },
+  { id: 'admin', label: 'Activity', defaultTab: 'notes', children: ['notes', 'calendar'] },
   { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'settings'] },
   { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
 ]


### PR DESCRIPTION
## Summary
- Rename the host detail top-level Admin tab label to Activity
- Update the host tab grouping test expectation

## Validation
- pnpm --dir apps/web test:unit -- lib/hosts/host-detail-tabs.test.mjs

## Impact
The tab keeps its internal id and routing behavior, but users now see Activity above Notes and Calendar.