### PR TITLE
feat(hosts): show calendar event details modal

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -3,8 +3,17 @@
 import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { CalendarDays, Loader2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import {
   Table,
   TableBody,
@@ -55,9 +64,99 @@ function formatEventDate(event: HostCalendarEventView): string {
   return `${format(startsAt, 'd MMM yyyy, HH:mm')} - ${format(endsAt, 'HH:mm')}`
 }
 
-function HostCalendarEventRow({ event }: { event: HostCalendarEventView }) {
+function formatEventDateRange(event: HostCalendarEventView): string {
+  const startsAt = new Date(event.startsAt)
+  const endsAt = new Date(event.endsAt)
+  if (event.allDay) {
+    return `${format(startsAt, 'd MMM yyyy')} - ${format(endsAt, 'd MMM yyyy')}`
+  }
+  return `${format(startsAt, 'd MMM yyyy, HH:mm')} - ${format(endsAt, 'd MMM yyyy, HH:mm')}`
+}
+
+function EventDetail({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <TableRow data-testid={`host-calendar-event-${safeTestId(event.id)}`}>
+    <div className="space-y-1">
+      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="text-sm text-foreground">{children}</dd>
+    </div>
+  )
+}
+
+function HostCalendarEventDetailsDialog({
+  event,
+  onOpenChange,
+}: {
+  event: HostCalendarEventView | null
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog open={event != null} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl" data-testid="host-calendar-event-dialog">
+        {event ? (
+          <>
+            <DialogHeader>
+              <div className="flex flex-wrap items-center gap-2 pr-8">
+                <DialogTitle>{event.title}</DialogTitle>
+                <Badge variant="outline" className={STATUS_BADGE_CLASS[event.status]}>
+                  {STATUS_LABELS[event.status]}
+                </Badge>
+              </div>
+              <DialogDescription>{CATEGORY_LABELS[event.category]} event</DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-5">
+              <div className="rounded-md border bg-background p-4">
+                {event.description ? (
+                  <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+                    {event.description}
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No description provided.</p>
+                )}
+              </div>
+
+              <dl className="grid gap-4 sm:grid-cols-2">
+                <EventDetail label="Date and time">{formatEventDateRange(event)}</EventDetail>
+                <EventDetail label="Timezone">{event.timezone}</EventDetail>
+                <EventDetail label="Status">{STATUS_LABELS[event.status]}</EventDetail>
+                <EventDetail label="Category">{CATEGORY_LABELS[event.category]}</EventDetail>
+                <EventDetail label="Schedule">
+                  {event.isRecurring ? 'Recurring' : 'One-off'}
+                </EventDetail>
+                <EventDetail label="All day">{event.allDay ? 'Yes' : 'No'}</EventDetail>
+              </dl>
+            </div>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function HostCalendarEventRow({
+  event,
+  onSelect,
+}: {
+  event: HostCalendarEventView
+  onSelect: (event: HostCalendarEventView) => void
+}) {
+  const openDetails = () => onSelect(event)
+
+  return (
+    <TableRow
+      aria-label={`View details for ${event.title}`}
+      className="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      data-testid={`host-calendar-event-${safeTestId(event.id)}`}
+      onClick={openDetails}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          openDetails()
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
       <TableCell>
         <div className="space-y-1">
           <div className="font-medium text-foreground">{event.title}</div>
@@ -83,6 +182,7 @@ function HostCalendarEventRow({ event }: { event: HostCalendarEventView }) {
 }
 
 export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: string }) {
+  const [selectedEvent, setSelectedEvent] = useState<HostCalendarEventView | null>(null)
   const { data, isLoading, error } = useQuery({
     queryKey: ['host-calendar-events', scopeId, hostId],
     queryFn: () => listCalendarEventsForHost(scopeId, hostId),
@@ -123,12 +223,18 @@ export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: 
             </TableHeader>
             <TableBody>
               {events.map((event) => (
-                <HostCalendarEventRow key={event.id} event={event} />
+                <HostCalendarEventRow key={event.id} event={event} onSelect={setSelectedEvent} />
               ))}
             </TableBody>
           </Table>
         )}
       </CardContent>
+      <HostCalendarEventDetailsDialog
+        event={selectedEvent}
+        onOpenChange={(open) => {
+          if (!open) setSelectedEvent(null)
+        }}
+      />
     </Card>
   )
 }

--- a/apps/web/lib/hosts/host-detail-tabs.test.mjs
+++ b/apps/web/lib/hosts/host-detail-tabs.test.mjs
@@ -23,12 +23,12 @@ test('container inventory is available as a top-level host tab', () => {
   assert.equal(inventory?.children?.includes('containers'), false)
 })
 
-test('admin host tools live under the top-level admin host tab', () => {
+test('activity host tools live under the top-level activity host tab', () => {
   const admin = PARENT_TABS.find((tab) => tab.id === 'admin')
   const notes = PARENT_TABS.find((tab) => tab.id === 'notes')
 
   assert.ok(admin)
-  assert.equal(admin.label, 'Admin')
+  assert.equal(admin.label, 'Activity')
   assert.equal(admin.defaultTab, 'notes')
   assert.deepEqual(admin.children, ['notes', 'calendar'])
   assert.equal(notes, undefined)

--- a/apps/web/lib/hosts/host-detail-tabs.ts
+++ b/apps/web/lib/hosts/host-detail-tabs.ts
@@ -62,7 +62,7 @@ export const PARENT_TABS: Array<{
   { id: 'infrastructure', label: 'Infrastructure', defaultTab: 'storage', children: ['storage', 'network', 'host-networks', 'patch-status'] },
   { id: 'inventory', label: 'Inventory', defaultTab: 'packages', children: ['packages', 'vulnerabilities'] },
   { id: 'containers', label: 'Containers', defaultTab: 'containers', children: null },
-  { id: 'admin', label: 'Admin', defaultTab: 'notes', children: ['notes', 'calendar'] },
+  { id: 'admin', label: 'Activity', defaultTab: 'notes', children: ['notes', 'calendar'] },
   { id: 'management', label: 'Management', defaultTab: 'groups', children: ['users', 'groups', 'settings'] },
   { id: 'tools', label: 'Tools', defaultTab: 'tasks', children: ['tasks', 'logs', 'terminal'] },
 ]

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -4,10 +4,10 @@ import { TEST_INSTANCE, TEST_USER } from '../fixtures/seed'
 
 async function getInstanceAndUserIds(sql: ReturnType<typeof getTestDb>): Promise<{ instanceId: string; userId: string }> {
   const rows = await sql<Array<{ instance_id: string; user_id: string }>>`
-    SELECT instanceSettings.id AS instance_id, "user".id AS user_id
+    SELECT instance_settings.id AS instance_id, "user".id AS user_id
     FROM instance_settings
-    JOIN "user" ON "user".instance_id = instanceSettings.id
-    WHERE instanceSettings.slug = ${TEST_INSTANCE.slug}
+    JOIN "user" ON "user".instance_id = instance_settings.id
+    WHERE instance_settings.slug = ${TEST_INSTANCE.slug}
       AND "user".email = ${TEST_USER.email}
     LIMIT 1
   `
@@ -64,11 +64,22 @@ test('host admin calendar shows only events linked to the current host', async (
   await page.getByTestId('host-tab-calendar').click()
 
   await expect(page.getByTestId('host-calendar-tab')).toBeVisible()
-  await expect(page.getByTestId('host-calendar-event-host-calendar-event-1')).toContainText('Host kernel patch')
-  await expect(page.getByTestId('host-calendar-event-host-calendar-event-1')).toContainText('Confirmed')
-  await expect(page.getByTestId('host-calendar-event-host-calendar-event-1')).toContainText('Patching')
+  const firstEventRow = page.getByTestId('host-calendar-event-host-calendar-event-1')
+  await expect(firstEventRow).toContainText('Host kernel patch', { timeout: 15_000 })
+  await expect(firstEventRow).toContainText('Confirmed')
+  await expect(firstEventRow).toContainText('Patching')
   await expect(page.getByTestId('host-calendar-event-host-calendar-event-2')).toContainText('Host maintenance window')
   await expect(page.getByText('Other host outage')).toHaveCount(0)
+
+  await firstEventRow.click()
+
+  const detailsDialog = page.getByTestId('host-calendar-event-dialog')
+  await expect(detailsDialog).toBeVisible()
+  await expect(detailsDialog.getByRole('heading', { name: 'Host kernel patch' })).toBeVisible()
+  await expect(detailsDialog).toContainText('Patch the current host.')
+  await expect(detailsDialog).toContainText('20 May 2026, 09:00 - 20 May 2026, 10:00')
+  await expect(detailsDialog).toContainText('UTC')
+  await expect(detailsDialog).toContainText('One-off')
 })
 
 test('host admin calendar shows an empty state when no events are linked', async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary
- Add a click/keyboard-accessible details modal for host calendar events
- Show the full event description and key event metadata in the modal
- Extend host calendar E2E coverage for the modal and stabilize the fixture helper

## Tests
- pnpm --dir apps/web lint 'app/(dashboard)/hosts/[id]/host-calendar-tab.tsx' 'tests/e2e/hosts/host-calendar.spec.ts'\n- pnpm --dir apps/web exec tsc --noEmit --pretty false\n- pnpm --dir apps/web test:e2e tests/e2e/hosts/host-calendar.spec.ts