### PR TITLE
feat(hosts): improve host calendar event cues

### DIFF
--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -120,10 +120,13 @@ function HostCalendarEventDetailsDialog({
 }) {
   return (
     <Dialog open={event != null} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl" data-testid="host-calendar-event-dialog">
+      <DialogContent
+        className="flex max-h-[calc(100vh-2rem)] max-w-2xl grid-rows-none flex-col overflow-hidden"
+        data-testid="host-calendar-event-dialog"
+      >
         {event ? (
           <>
-            <DialogHeader>
+            <DialogHeader className="shrink-0">
               <div className="flex flex-wrap items-center gap-2 pr-8">
                 <DialogTitle>{event.title}</DialogTitle>
                 <Badge variant="outline" className={STATUS_BADGE_CLASS[event.status]}>
@@ -133,8 +136,11 @@ function HostCalendarEventDetailsDialog({
               <DialogDescription>{CATEGORY_LABELS[event.category]} event</DialogDescription>
             </DialogHeader>
 
-            <div className="space-y-5">
-              <div className="rounded-md border bg-background p-4">
+            <div className="min-h-0 flex-1 space-y-5 overflow-hidden">
+              <div
+                className="max-h-[min(22rem,45vh)] overflow-y-auto rounded-md border bg-background p-4"
+                data-testid="host-calendar-event-description"
+              >
                 {event.description ? (
                   <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
                     {event.description}

--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -1,12 +1,20 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { format } from 'date-fns'
+import { format, isSameDay, isToday, isTomorrow } from 'date-fns'
 import { CalendarDays, Loader2 } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   Dialog,
   DialogContent,
@@ -23,7 +31,12 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { listCalendarEventsForHost, type HostCalendarEventView } from '@/lib/actions/calendar'
-import type { CalendarEventCategory, CalendarEventStatus } from '@/lib/db/schema/calendar'
+import {
+  CALENDAR_EVENT_CATEGORIES,
+  CALENDAR_EVENT_STATUSES,
+  type CalendarEventCategory,
+  type CalendarEventStatus,
+} from '@/lib/db/schema/calendar'
 
 const CATEGORY_LABELS: Record<CalendarEventCategory, string> = {
   maintenance: 'Maintenance',
@@ -50,27 +63,43 @@ const STATUS_BADGE_CLASS: Record<CalendarEventStatus, string> = {
   cancelled: 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100',
 }
 const HOST_CALENDAR_REFETCH_INTERVAL_MS = 5_000
+const EMPTY_HOST_CALENDAR_EVENTS: HostCalendarEventView[] = []
+type CategoryFilter = CalendarEventCategory | 'all'
+type StatusFilter = CalendarEventStatus | 'all'
 
 function safeTestId(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
+function formatDateLabel(date: Date): string {
+  if (isToday(date)) return 'Today'
+  if (isTomorrow(date)) return 'Tomorrow'
+  return format(date, 'd MMM yyyy')
+}
+
+function isPastEvent(event: HostCalendarEventView): boolean {
+  return new Date(event.endsAt).getTime() < Date.now()
 }
 
 function formatEventDate(event: HostCalendarEventView): string {
   const startsAt = new Date(event.startsAt)
   const endsAt = new Date(event.endsAt)
   if (event.allDay) {
-    return format(startsAt, 'd MMM yyyy')
+    return formatDateLabel(startsAt)
   }
-  return `${format(startsAt, 'd MMM yyyy, HH:mm')} - ${format(endsAt, 'HH:mm')}`
+  if (isSameDay(startsAt, endsAt)) {
+    return `${formatDateLabel(startsAt)}, ${format(startsAt, 'HH:mm')} - ${format(endsAt, 'HH:mm')}`
+  }
+  return `${formatDateLabel(startsAt)}, ${format(startsAt, 'HH:mm')} - ${formatDateLabel(endsAt)}, ${format(endsAt, 'HH:mm')}`
 }
 
 function formatEventDateRange(event: HostCalendarEventView): string {
   const startsAt = new Date(event.startsAt)
   const endsAt = new Date(event.endsAt)
   if (event.allDay) {
-    return `${format(startsAt, 'd MMM yyyy')} - ${format(endsAt, 'd MMM yyyy')}`
+    return `${formatDateLabel(startsAt)} - ${formatDateLabel(endsAt)}`
   }
-  return `${format(startsAt, 'd MMM yyyy, HH:mm')} - ${format(endsAt, 'd MMM yyyy, HH:mm')}`
+  return `${formatDateLabel(startsAt)}, ${format(startsAt, 'HH:mm')} - ${formatDateLabel(endsAt)}, ${format(endsAt, 'HH:mm')}`
 }
 
 function EventDetail({ label, children }: { label: string; children: ReactNode }) {
@@ -141,11 +170,12 @@ function HostCalendarEventRow({
   onSelect: (event: HostCalendarEventView) => void
 }) {
   const openDetails = () => onSelect(event)
+  const past = isPastEvent(event)
 
   return (
     <TableRow
       aria-label={`View details for ${event.title}`}
-      className="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className={`cursor-pointer transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${past ? 'bg-muted/30 text-muted-foreground' : ''} ${event.isLinkedToCurrentUser ? 'border-l-4 border-l-primary' : ''}`}
       data-testid={`host-calendar-event-${safeTestId(event.id)}`}
       onClick={openDetails}
       onKeyDown={(event) => {
@@ -158,7 +188,19 @@ function HostCalendarEventRow({
       tabIndex={0}
     >
       <TableCell>
-        <div className="font-medium text-foreground">{event.title}</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`font-medium ${past ? 'text-muted-foreground' : 'text-foreground'}`}>{event.title}</span>
+          {event.isLinkedToCurrentUser ? (
+            <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary hover:bg-primary/10">
+              Linked to you
+            </Badge>
+          ) : null}
+          {past ? (
+            <Badge variant="outline" className="border-slate-200 bg-slate-100 text-slate-700 hover:bg-slate-100">
+              Past
+            </Badge>
+          ) : null}
+        </div>
       </TableCell>
       <TableCell className="whitespace-nowrap text-sm">{formatEventDate(event)}</TableCell>
       <TableCell>
@@ -178,13 +220,22 @@ function HostCalendarEventRow({
 
 export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: string }) {
   const [selectedEvent, setSelectedEvent] = useState<HostCalendarEventView | null>(null)
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const { data, isLoading, error } = useQuery({
     queryKey: ['host-calendar-events', scopeId, hostId],
     queryFn: () => listCalendarEventsForHost(scopeId, hostId),
     refetchInterval: HOST_CALENDAR_REFETCH_INTERVAL_MS,
   })
 
-  const events = data && !('error' in data) ? data.events : []
+  const events = data && !('error' in data) ? data.events : EMPTY_HOST_CALENDAR_EVENTS
+  const filteredEvents = useMemo(
+    () => events.filter((event) => (
+      (categoryFilter === 'all' || event.category === categoryFilter) &&
+      (statusFilter === 'all' || event.status === statusFilter)
+    )),
+    [categoryFilter, events, statusFilter],
+  )
   const errorMessage = data && 'error' in data ? data.error : error instanceof Error ? error.message : null
 
   return (
@@ -206,22 +257,62 @@ export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: 
         ) : events.length === 0 ? (
           <p className="text-sm text-muted-foreground">No calendar events linked to this host.</p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Event</TableHead>
-                <TableHead>Date and time</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Category</TableHead>
-                <TableHead>Schedule</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {events.map((event) => (
-                <HostCalendarEventRow key={event.id} event={event} onSelect={setSelectedEvent} />
-              ))}
-            </TableBody>
-          </Table>
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="host-calendar-category-filter">Category</Label>
+                <Select value={categoryFilter} onValueChange={(value) => setCategoryFilter(value as CategoryFilter)}>
+                  <SelectTrigger id="host-calendar-category-filter" className="w-44" data-testid="host-calendar-category-filter">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All categories</SelectItem>
+                    {CALENDAR_EVENT_CATEGORIES.map((category) => (
+                      <SelectItem key={category} value={category}>
+                        {CATEGORY_LABELS[category]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="host-calendar-status-filter">Status</Label>
+                <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as StatusFilter)}>
+                  <SelectTrigger id="host-calendar-status-filter" className="w-40" data-testid="host-calendar-status-filter">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All statuses</SelectItem>
+                    {CALENDAR_EVENT_STATUSES.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {STATUS_LABELS[status]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            {filteredEvents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No calendar events match these filters.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Event</TableHead>
+                    <TableHead>Date and time</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Category</TableHead>
+                    <TableHead>Schedule</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredEvents.map((event) => (
+                    <HostCalendarEventRow key={event.id} event={event} onSelect={setSelectedEvent} />
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
         )}
       </CardContent>
       <HostCalendarEventDetailsDialog

--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -158,12 +158,7 @@ function HostCalendarEventRow({
       tabIndex={0}
     >
       <TableCell>
-        <div className="space-y-1">
-          <div className="font-medium text-foreground">{event.title}</div>
-          {event.description ? (
-            <div className="line-clamp-2 text-xs text-muted-foreground">{event.description}</div>
-          ) : null}
-        </div>
+        <div className="font-medium text-foreground">{event.title}</div>
       </TableCell>
       <TableCell className="whitespace-nowrap text-sm">{formatEventDate(event)}</TableCell>
       <TableCell>

--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -66,40 +66,96 @@ const HOST_CALENDAR_REFETCH_INTERVAL_MS = 5_000
 const EMPTY_HOST_CALENDAR_EVENTS: HostCalendarEventView[] = []
 type CategoryFilter = CalendarEventCategory | 'all'
 type StatusFilter = CalendarEventStatus | 'all'
+type DateLabel = {
+  text: string
+  isRelative: boolean
+}
+type FormattedEventDate = {
+  text: string
+  title?: string
+}
 
 function safeTestId(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, '-')
 }
 
-function formatDateLabel(date: Date): string {
-  if (isToday(date)) return 'Today'
-  if (isTomorrow(date)) return 'Tomorrow'
+function formatDateLabel(date: Date): DateLabel {
+  if (isToday(date)) return { text: 'Today', isRelative: true }
+  if (isTomorrow(date)) return { text: 'Tomorrow', isRelative: true }
+  return { text: format(date, 'd MMM yyyy'), isRelative: false }
+}
+
+function formatAbsoluteDate(date: Date): string {
   return format(date, 'd MMM yyyy')
+}
+
+function formatAbsoluteDateTime(date: Date): string {
+  return format(date, 'd MMM yyyy, HH:mm')
 }
 
 function isPastEvent(event: HostCalendarEventView): boolean {
   return new Date(event.endsAt).getTime() < Date.now()
 }
 
-function formatEventDate(event: HostCalendarEventView): string {
+function formatEventDate(event: HostCalendarEventView): FormattedEventDate {
   const startsAt = new Date(event.startsAt)
   const endsAt = new Date(event.endsAt)
+  const startLabel = formatDateLabel(startsAt)
+  const endLabel = formatDateLabel(endsAt)
+  const usesRelativeDate = startLabel.isRelative || endLabel.isRelative
   if (event.allDay) {
-    return formatDateLabel(startsAt)
+    const text = isSameDay(startsAt, endsAt)
+      ? startLabel.text
+      : `${startLabel.text} - ${endLabel.text}`
+    const title = usesRelativeDate
+      ? isSameDay(startsAt, endsAt)
+        ? formatAbsoluteDate(startsAt)
+        : `${formatAbsoluteDate(startsAt)} - ${formatAbsoluteDate(endsAt)}`
+      : undefined
+    return { text, title }
   }
   if (isSameDay(startsAt, endsAt)) {
-    return `${formatDateLabel(startsAt)}, ${format(startsAt, 'HH:mm')} - ${format(endsAt, 'HH:mm')}`
+    return {
+      text: `${startLabel.text}, ${format(startsAt, 'HH:mm')} - ${format(endsAt, 'HH:mm')}`,
+      title: usesRelativeDate ? `${formatAbsoluteDateTime(startsAt)} - ${formatAbsoluteDateTime(endsAt)}` : undefined,
+    }
   }
-  return `${formatDateLabel(startsAt)}, ${format(startsAt, 'HH:mm')} - ${formatDateLabel(endsAt)}, ${format(endsAt, 'HH:mm')}`
+  return {
+    text: `${startLabel.text}, ${format(startsAt, 'HH:mm')} - ${endLabel.text}, ${format(endsAt, 'HH:mm')}`,
+    title: usesRelativeDate ? `${formatAbsoluteDateTime(startsAt)} - ${formatAbsoluteDateTime(endsAt)}` : undefined,
+  }
 }
 
-function formatEventDateRange(event: HostCalendarEventView): string {
+function formatEventDateRange(event: HostCalendarEventView): FormattedEventDate {
   const startsAt = new Date(event.startsAt)
   const endsAt = new Date(event.endsAt)
+  const startLabel = formatDateLabel(startsAt)
+  const endLabel = formatDateLabel(endsAt)
+  const usesRelativeDate = startLabel.isRelative || endLabel.isRelative
   if (event.allDay) {
-    return `${formatDateLabel(startsAt)} - ${formatDateLabel(endsAt)}`
+    return {
+      text: `${startLabel.text} - ${endLabel.text}`,
+      title: usesRelativeDate ? `${formatAbsoluteDate(startsAt)} - ${formatAbsoluteDate(endsAt)}` : undefined,
+    }
   }
-  return `${formatDateLabel(startsAt)}, ${format(startsAt, 'HH:mm')} - ${formatDateLabel(endsAt)}, ${format(endsAt, 'HH:mm')}`
+  return {
+    text: `${startLabel.text}, ${format(startsAt, 'HH:mm')} - ${endLabel.text}, ${format(endsAt, 'HH:mm')}`,
+    title: usesRelativeDate ? `${formatAbsoluteDateTime(startsAt)} - ${formatAbsoluteDateTime(endsAt)}` : undefined,
+  }
+}
+
+function EventDateText({
+  value,
+  testId,
+}: {
+  value: FormattedEventDate
+  testId: string
+}) {
+  return (
+    <span data-testid={testId} title={value.title}>
+      {value.text}
+    </span>
+  )
 }
 
 function EventDetail({ label, children }: { label: string; children: ReactNode }) {
@@ -118,6 +174,8 @@ function HostCalendarEventDetailsDialog({
   event: HostCalendarEventView | null
   onOpenChange: (open: boolean) => void
 }) {
+  const formattedDateRange = event ? formatEventDateRange(event) : null
+
   return (
     <Dialog open={event != null} onOpenChange={onOpenChange}>
       <DialogContent
@@ -151,7 +209,11 @@ function HostCalendarEventDetailsDialog({
               </div>
 
               <dl className="grid gap-4 sm:grid-cols-2">
-                <EventDetail label="Date and time">{formatEventDateRange(event)}</EventDetail>
+                <EventDetail label="Date and time">
+                  {formattedDateRange ? (
+                    <EventDateText value={formattedDateRange} testId="host-calendar-event-detail-date" />
+                  ) : null}
+                </EventDetail>
                 <EventDetail label="Timezone">{event.timezone}</EventDetail>
                 <EventDetail label="Status">{STATUS_LABELS[event.status]}</EventDetail>
                 <EventDetail label="Category">{CATEGORY_LABELS[event.category]}</EventDetail>
@@ -177,6 +239,7 @@ function HostCalendarEventRow({
 }) {
   const openDetails = () => onSelect(event)
   const past = isPastEvent(event)
+  const formattedDate = formatEventDate(event)
 
   return (
     <TableRow
@@ -208,7 +271,9 @@ function HostCalendarEventRow({
           ) : null}
         </div>
       </TableCell>
-      <TableCell className="whitespace-nowrap text-sm">{formatEventDate(event)}</TableCell>
+      <TableCell className="whitespace-nowrap text-sm">
+        <EventDateText value={formattedDate} testId="host-calendar-event-date" />
+      </TableCell>
       <TableCell>
         <Badge variant="outline" className={STATUS_BADGE_CLASS[event.status]}>
           {STATUS_LABELS[event.status]}

--- a/apps/web/lib/actions/calendar.ts
+++ b/apps/web/lib/actions/calendar.ts
@@ -154,6 +154,7 @@ export interface HostCalendarEventView {
   status: CalendarEventStatus
   category: CalendarEventCategory
   isRecurring: boolean
+  isLinkedToCurrentUser: boolean
 }
 
 type ParsedCalendarInput = Omit<CalendarEventInput, 'startsAt' | 'endsAt' | 'recurrenceRule'> & {
@@ -534,7 +535,7 @@ export async function listCalendarEventsForHost(
   instanceId: string,
   hostId: string,
 ): Promise<{ events: HostCalendarEventView[] } | { error: string }> {
-  await requireInstanceAccess(instanceId)
+  const session = await requireInstanceAccess(instanceId)
   const parsedHostId = z.string().min(1).safeParse(hostId)
   if (!parsedHostId.success) return { error: 'Host is required' }
 
@@ -551,6 +552,7 @@ export async function listCalendarEventsForHost(
         status: calendarEvents.status,
         category: calendarEvents.category,
         recurrenceRule: calendarEvents.recurrenceRule,
+        createdBy: calendarEvents.createdBy,
       })
       .from(calendarEventHosts)
       .innerJoin(
@@ -576,6 +578,19 @@ export async function listCalendarEventsForHost(
       .orderBy(asc(calendarEvents.startsAt))
       .limit(250)
 
+    const eventIds = rows.map((row) => row.id)
+    const participantRows = eventIds.length > 0
+      ? await db.query.calendarEventParticipants.findMany({
+          where: and(
+            eq(calendarEventParticipants.instanceId, instanceId),
+            eq(calendarEventParticipants.userId, session.user.id),
+            inArray(calendarEventParticipants.eventId, eventIds),
+          ),
+          columns: { eventId: true },
+        })
+      : []
+    const currentUserEventIds = new Set(participantRows.map((row) => row.eventId))
+
     return {
       events: rows.map((row) => ({
         id: row.id,
@@ -588,6 +603,7 @@ export async function listCalendarEventsForHost(
         status: row.status,
         category: row.category,
         isRecurring: Boolean(row.recurrenceRule),
+        isLinkedToCurrentUser: row.createdBy === session.user.id || currentUserEventIds.has(row.id),
       })),
     }
   } catch (err) {

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -78,10 +78,18 @@ test('host admin calendar shows only events linked to the current host', async (
   await expect(firstEventRow).toContainText('Patching')
   await expect(firstEventRow).toContainText('Linked to you')
   await expect(firstEventRow).toContainText('Today, 09:00 - 10:00')
+  await expect(firstEventRow.getByTestId('host-calendar-event-date')).toHaveAttribute(
+    'title',
+    /^\d{1,2} [A-Z][a-z]{2} \d{4}, 09:00 - \d{1,2} [A-Z][a-z]{2} \d{4}, 10:00$/,
+  )
   const secondEventRow = page.getByTestId('host-calendar-event-host-calendar-event-2')
   await expect(secondEventRow).toContainText('Host maintenance window')
   await expect(secondEventRow).not.toContainText('Linked to you')
   await expect(secondEventRow).toContainText('Tomorrow, 13:30 - 15:00')
+  await expect(secondEventRow.getByTestId('host-calendar-event-date')).toHaveAttribute(
+    'title',
+    /^\d{1,2} [A-Z][a-z]{2} \d{4}, 13:30 - \d{1,2} [A-Z][a-z]{2} \d{4}, 15:00$/,
+  )
   const pastEventRow = page.getByTestId('host-calendar-event-host-calendar-event-past')
   await expect(pastEventRow).toContainText('Past maintenance window')
   await expect(pastEventRow).toContainText('Past')
@@ -108,6 +116,10 @@ test('host admin calendar shows only events linked to the current host', async (
   await expect(detailsDialog.getByRole('heading', { name: 'Host kernel patch' })).toBeVisible()
   await expect(detailsDialog).toContainText('Patch the current host.')
   await expect(detailsDialog).toContainText('Today, 09:00 - Today, 10:00')
+  await expect(detailsDialog.getByTestId('host-calendar-event-detail-date')).toHaveAttribute(
+    'title',
+    /^\d{1,2} [A-Z][a-z]{2} \d{4}, 09:00 - \d{1,2} [A-Z][a-z]{2} \d{4}, 10:00$/,
+  )
   await expect(detailsDialog).toContainText('UTC')
   await expect(detailsDialog).toContainText('One-off')
 })

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -66,6 +66,7 @@ test('host admin calendar shows only events linked to the current host', async (
   await expect(page.getByTestId('host-calendar-tab')).toBeVisible()
   const firstEventRow = page.getByTestId('host-calendar-event-host-calendar-event-1')
   await expect(firstEventRow).toContainText('Host kernel patch', { timeout: 15_000 })
+  await expect(firstEventRow).not.toContainText('Patch the current host.')
   await expect(firstEventRow).toContainText('Confirmed')
   await expect(firstEventRow).toContainText('Patching')
   await expect(page.getByTestId('host-calendar-event-host-calendar-event-2')).toContainText('Host maintenance window')

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -44,9 +44,10 @@ test('host admin calendar shows only events linked to the current host', async (
       category
     )
     VALUES
-      ('host-calendar-event-1', ${instanceId}, ${userId}, 'Host kernel patch', 'Patch the current host.', '2026-05-20T09:00:00Z', '2026-05-20T10:00:00Z', false, 'UTC', 'confirmed', 'patching'),
-      ('host-calendar-event-2', ${instanceId}, ${userId}, 'Host maintenance window', NULL, '2026-05-22T13:30:00Z', '2026-05-22T15:00:00Z', false, 'UTC', 'planned', 'maintenance'),
-      ('host-calendar-event-other', ${instanceId}, ${userId}, 'Other host outage', NULL, '2026-05-21T09:00:00Z', '2026-05-21T10:00:00Z', false, 'UTC', 'planned', 'maintenance')
+      ('host-calendar-event-1', ${instanceId}, NULL, 'Host kernel patch', 'Patch the current host.', date_trunc('day', NOW()) + interval '9 hours', date_trunc('day', NOW()) + interval '10 hours', false, 'UTC', 'confirmed', 'patching'),
+      ('host-calendar-event-2', ${instanceId}, NULL, 'Host maintenance window', NULL, date_trunc('day', NOW()) + interval '1 day 13 hours 30 minutes', date_trunc('day', NOW()) + interval '1 day 15 hours', false, 'UTC', 'planned', 'maintenance'),
+      ('host-calendar-event-past', ${instanceId}, NULL, 'Past maintenance window', NULL, date_trunc('day', NOW()) - interval '2 days' + interval '8 hours', date_trunc('day', NOW()) - interval '2 days' + interval '9 hours', false, 'UTC', 'completed', 'maintenance'),
+      ('host-calendar-event-other', ${instanceId}, NULL, 'Other host outage', NULL, date_trunc('day', NOW()) + interval '2 days 9 hours', date_trunc('day', NOW()) + interval '2 days 10 hours', false, 'UTC', 'planned', 'maintenance')
   `
 
   await sql`
@@ -54,7 +55,13 @@ test('host admin calendar shows only events linked to the current host', async (
     VALUES
       (${instanceId}, 'host-calendar-event-1', 'host-calendar-1'),
       (${instanceId}, 'host-calendar-event-2', 'host-calendar-1'),
+      (${instanceId}, 'host-calendar-event-past', 'host-calendar-1'),
       (${instanceId}, 'host-calendar-event-other', 'host-calendar-2')
+  `
+
+  await sql`
+    INSERT INTO calendar_event_participants (instance_id, event_id, user_id, role)
+    VALUES (${instanceId}, 'host-calendar-event-1', ${userId}, 'implementer')
   `
 
   await page.goto('/hosts/host-calendar-1')
@@ -69,16 +76,38 @@ test('host admin calendar shows only events linked to the current host', async (
   await expect(firstEventRow).not.toContainText('Patch the current host.')
   await expect(firstEventRow).toContainText('Confirmed')
   await expect(firstEventRow).toContainText('Patching')
-  await expect(page.getByTestId('host-calendar-event-host-calendar-event-2')).toContainText('Host maintenance window')
+  await expect(firstEventRow).toContainText('Linked to you')
+  await expect(firstEventRow).toContainText('Today, 09:00 - 10:00')
+  const secondEventRow = page.getByTestId('host-calendar-event-host-calendar-event-2')
+  await expect(secondEventRow).toContainText('Host maintenance window')
+  await expect(secondEventRow).not.toContainText('Linked to you')
+  await expect(secondEventRow).toContainText('Tomorrow, 13:30 - 15:00')
+  const pastEventRow = page.getByTestId('host-calendar-event-host-calendar-event-past')
+  await expect(pastEventRow).toContainText('Past maintenance window')
+  await expect(pastEventRow).toContainText('Past')
   await expect(page.getByText('Other host outage')).toHaveCount(0)
 
-  await firstEventRow.click()
+  await page.getByTestId('host-calendar-category-filter').click()
+  await page.getByRole('option', { name: 'Patching' }).click()
+  await expect(firstEventRow).toBeVisible()
+  await expect(secondEventRow).toHaveCount(0)
+  await page.getByTestId('host-calendar-category-filter').click()
+  await page.getByRole('option', { name: 'All categories' }).click()
+
+  await page.getByTestId('host-calendar-status-filter').click()
+  await page.getByRole('option', { name: 'Completed' }).click()
+  await expect(pastEventRow).toBeVisible()
+  await expect(firstEventRow).toHaveCount(0)
+
+  await page.getByTestId('host-calendar-status-filter').click()
+  await page.getByRole('option', { name: 'All statuses' }).click()
+  await page.getByTestId('host-calendar-event-host-calendar-event-1').click()
 
   const detailsDialog = page.getByTestId('host-calendar-event-dialog')
   await expect(detailsDialog).toBeVisible()
   await expect(detailsDialog.getByRole('heading', { name: 'Host kernel patch' })).toBeVisible()
   await expect(detailsDialog).toContainText('Patch the current host.')
-  await expect(detailsDialog).toContainText('20 May 2026, 09:00 - 20 May 2026, 10:00')
+  await expect(detailsDialog).toContainText('Today, 09:00 - Today, 10:00')
   await expect(detailsDialog).toContainText('UTC')
   await expect(detailsDialog).toContainText('One-off')
 })

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -112,6 +112,75 @@ test('host admin calendar shows only events linked to the current host', async (
   await expect(detailsDialog).toContainText('One-off')
 })
 
+test('host calendar event dialog keeps long descriptions scrollable', async ({ authenticatedPage: page }) => {
+  const sql = getTestDb()
+  const { instanceId, userId } = await getInstanceAndUserIds(sql)
+  const longDescription = Array.from({ length: 120 }, (_, index) => `Long description line ${index + 1}`).join('\n')
+
+  await sql`
+    INSERT INTO hosts (id, instance_id, hostname, display_name, os, arch, ip_addresses, status, last_seen_at)
+    VALUES ('host-calendar-long-description', ${instanceId}, 'host-calendar-long-description', 'Host Calendar Long Description', 'Ubuntu 24.04', 'x86_64', '["10.70.0.14"]'::jsonb, 'online', NOW())
+  `
+
+  await sql`
+    INSERT INTO calendar_events (
+      id,
+      instance_id,
+      created_by,
+      title,
+      description,
+      starts_at,
+      ends_at,
+      all_day,
+      timezone,
+      status,
+      category
+    )
+    VALUES (
+      'host-calendar-long-description-event',
+      ${instanceId},
+      ${userId},
+      'Long description change',
+      ${longDescription},
+      date_trunc('day', NOW()) + interval '11 hours',
+      date_trunc('day', NOW()) + interval '12 hours',
+      false,
+      'UTC',
+      'planned',
+      'change'
+    )
+  `
+
+  await sql`
+    INSERT INTO calendar_event_hosts (instance_id, event_id, host_id)
+    VALUES (${instanceId}, 'host-calendar-long-description-event', 'host-calendar-long-description')
+  `
+
+  await page.goto('/hosts/host-calendar-long-description')
+  await expect(page.getByRole('heading', { name: 'Host Calendar Long Description' })).toBeVisible()
+
+  await page.getByTestId('host-parent-tab-admin').click()
+  await page.getByTestId('host-tab-calendar').click()
+  await page.getByTestId('host-calendar-event-host-calendar-long-description-event').click()
+
+  const detailsDialog = page.getByTestId('host-calendar-event-dialog')
+  const description = page.getByTestId('host-calendar-event-description')
+  await expect(detailsDialog).toBeVisible()
+  await expect(description).toContainText('Long description line 120')
+
+  const viewport = page.viewportSize()
+  expect(viewport).not.toBeNull()
+  const dialogBox = await detailsDialog.boundingBox()
+  expect(dialogBox).not.toBeNull()
+  expect(dialogBox!.y).toBeGreaterThanOrEqual(0)
+  expect(dialogBox!.y + dialogBox!.height).toBeLessThanOrEqual(viewport!.height)
+
+  const isDescriptionScrollable = await description.evaluate((element) => (
+    element.scrollHeight > element.clientHeight && getComputedStyle(element).overflowY !== 'visible'
+  ))
+  expect(isDescriptionScrollable).toBe(true)
+})
+
 test('host admin calendar shows an empty state when no events are linked', async ({ authenticatedPage: page }) => {
   const sql = getTestDb()
   const { instanceId } = await getInstanceAndUserIds(sql)


### PR DESCRIPTION
## Summary
- highlight host calendar events linked to the current user
- add category and status filters to the host calendar table
- distinguish past events, use Today/Tomorrow labels with full-date hover text, and keep long modal descriptions scrollable

## Validation
- pnpm --dir apps/web run type-check
- pnpm --dir apps/web run lint

## Notes
- Focused local browser E2E was not run because the dev-stack Next server is holding the app .next/dev lock; CI should run the browser coverage.