### PR TITLE
fix(agent): include token in enrollment view command

### DIFF
--- a/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
+++ b/apps/web/app/(dashboard)/settings/agents/agents-client.tsx
@@ -41,7 +41,7 @@ import {
   revokeEnrolmentToken,
 } from '@/lib/actions/agents'
 import type { AgentEnrolmentToken } from '@/lib/db/schema'
-import type { EnrolmentTokenSafe } from '@/lib/actions/agents-core'
+import type { EnrolmentTokenForAdmin } from '@/lib/actions/agents-core'
 import { TagEditor, type EditorTag } from '@/components/shared/tag-editor'
 import {
   DEFAULT_ENROLMENT_TOKEN_EXPIRY_DAYS,
@@ -60,7 +60,7 @@ const createTokenSchema = z.object({
 type CreateTokenForm = z.infer<typeof createTokenSchema>
 
 interface AgentsSettingsClientProps {
-  initialTokens: EnrolmentTokenSafe[]
+  initialTokens: EnrolmentTokenForAdmin[]
   appUrl: string
 }
 
@@ -84,7 +84,7 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-function tokenStatus(token: EnrolmentTokenSafe): { label: string; className: string } {
+function tokenStatus(token: EnrolmentTokenForAdmin): { label: string; className: string } {
   if (token.deletedAt) {
     return { label: 'Revoked', className: 'bg-red-100 text-red-800 border-red-200' }
   }
@@ -105,7 +105,7 @@ export function AgentsSettingsClient({
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [newTokenValue, setNewTokenValue] = useState<string | null>(null)
   const [newInstallCommand, setNewInstallCommand] = useState<string | null>(null)
-  const [viewToken, setViewToken] = useState<EnrolmentTokenSafe | null>(null)
+  const [viewToken, setViewToken] = useState<EnrolmentTokenForAdmin | null>(null)
   const [showBundleDialog, setShowBundleDialog] = useState(false)
   const [tokenTags, setTokenTags] = useState<EditorTag[]>([])
   const [browserOrigin, setBrowserOrigin] = useState('')
@@ -170,7 +170,7 @@ export function AgentsSettingsClient({
   const onSubmit = handleSubmit((data) => createMutation.mutate(data))
   const installCommandBaseUrl = appUrl || browserOrigin
   const viewInstallCommand = viewToken && installCommandBaseUrl
-    ? buildAgentInstallCommand(installCommandBaseUrl, viewToken.skipVerify)
+    ? buildAgentInstallCommand(installCommandBaseUrl, viewToken.skipVerify, viewToken.token)
     : null
 
   useEffect(() => {
@@ -310,8 +310,8 @@ export function AgentsSettingsClient({
           {viewToken && (
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                The full token was shown only once when it was created. To use this token,
-                generate a new install bundle from the Download Agent Bundle dialog.
+                Use this command on each server you want to enrol. The token is passed through
+                the environment instead of being placed in the installer URL.
               </p>
               {viewInstallCommand && (
                 <div className="space-y-1.5">
@@ -325,9 +325,10 @@ export function AgentsSettingsClient({
                 </div>
               )}
               <div className="space-y-1.5">
-                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Token hint</p>
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Raw token</p>
                 <div className="flex items-center gap-2 p-3 bg-muted rounded-md">
-                  <code className="text-xs font-mono flex-1">········…{viewToken.tokenHint}</code>
+                  <code className="text-xs font-mono flex-1 break-all">{viewToken.token}</code>
+                  <CopyButton text={viewToken.token} />
                 </div>
               </div>
               <DialogFooter>
@@ -527,7 +528,7 @@ type TokenMode = 'create' | 'existing' | 'none'
 interface BundleDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  activeTokens: EnrolmentTokenSafe[]
+  activeTokens: EnrolmentTokenForAdmin[]
 }
 
 function BundleDialog({ open, onOpenChange, activeTokens }: BundleDialogProps) {

--- a/apps/web/lib/actions/agents-authz.test.mjs
+++ b/apps/web/lib/actions/agents-authz.test.mjs
@@ -30,3 +30,16 @@ test('privileged agent and host mutations require tooling access', () => {
     )
   }
 })
+
+test('listing enrolment tokens requires privileged access because plaintext tokens are returned', () => {
+  const start = agentsSource.lastIndexOf('export async function listEnrolmentTokens')
+  assert.notEqual(start, -1, 'expected listEnrolmentTokens to exist in agents-core.ts')
+  const next = agentsSource.indexOf('\nexport async function ', start + 1)
+  const segment = agentsSource.slice(start, next === -1 ? undefined : next)
+
+  assert.match(
+    segment,
+    /requireInstance(?:Admin|Tooling)Access\(instanceId\)/,
+    'listEnrolmentTokens must require privileged access before returning enrolment token secrets',
+  )
+})

--- a/apps/web/lib/actions/agents-core.ts
+++ b/apps/web/lib/actions/agents-core.ts
@@ -645,21 +645,21 @@ export async function createEnrolmentToken(
   }
 }
 
-export type EnrolmentTokenSafe = Omit<AgentEnrolmentToken, 'token' | 'tokenHash'> & {
+export type EnrolmentTokenForAdmin = Omit<AgentEnrolmentToken, 'tokenHash'> & {
   tokenHint: string
 }
 
-export async function listEnrolmentTokens(instanceId: string): Promise<EnrolmentTokenSafe[]> {
-  await requireInstanceAccess(instanceId)
+export async function listEnrolmentTokens(instanceId: string): Promise<EnrolmentTokenForAdmin[]> {
+  await requireInstanceAdminAccess(instanceId)
   const rows = await db.query.agentEnrolmentTokens.findMany({
     where: and(
       eq(agentEnrolmentTokens.instanceId, instanceId),
       isNull(agentEnrolmentTokens.deletedAt),
     ),
   })
-  return rows.map(({ token, tokenHash: _hash, ...rest }) => ({
+  return rows.map(({ tokenHash: _hash, ...rest }) => ({
     ...rest,
-    tokenHint: token.slice(-4),
+    tokenHint: rest.token.slice(-4),
   }))
 }
 

--- a/apps/web/lib/actions/agents.ts
+++ b/apps/web/lib/actions/agents.ts
@@ -18,7 +18,7 @@ import {
   listEnrolmentTokens as listEnrolmentTokensCore,
   revokeEnrolmentToken as revokeEnrolmentTokenCore,
   uninstallAndDeleteHost as uninstallAndDeleteHostCore,
-  type EnrolmentTokenSafe,
+  type EnrolmentTokenForAdmin,
   type HeartbeatPoint,
   type HostListParams,
   type HostListResult,
@@ -114,7 +114,7 @@ export async function createEnrolmentToken(
   return createEnrolmentTokenCore(resolveCurrentActionScope(session), input)
 }
 
-export async function listEnrolmentTokens(): Promise<EnrolmentTokenSafe[]> {
+export async function listEnrolmentTokens(): Promise<EnrolmentTokenForAdmin[]> {
   const session = await getRequiredSession()
   const currentScope = resolveOptionalActionScope(session)
   if (!currentScope) return []

--- a/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
+++ b/apps/web/tests/e2e/settings/agent-enrolment.spec.ts
@@ -148,6 +148,8 @@ test('admin can view the install URL for an existing enrolment token', async ({ 
   const dialog = page.getByRole('dialog')
   await expect(dialog).toContainText('View Existing Token')
   await expect(page.getByTestId('agent-enrolment-view-install-command')).toContainText('/api/agent/install')
+  await expect(page.getByTestId('agent-enrolment-view-install-command')).toContainText('CT_OPS_ENROLMENT_TOKEN=')
+  await expect(page.getByTestId('agent-enrolment-view-install-command')).toContainText('view-existing-token-value')
   await expect(page.getByTestId('agent-enrolment-view-install-command')).not.toContainText('token=')
 })
 


### PR DESCRIPTION
## Summary
- include stored enrolment tokens in the admin token list payload under an admin guard
- build the view-existing-token install command with CT_OPS_ENROLMENT_TOKEN
- update focused authz and E2E coverage for the existing-token view command

## Validation
- pnpm --dir apps/web type-check
- node apps/web/lib/actions/agents-authz.test.mjs
- node --test apps/web/lib/agent/install-script.test.mjs
- pnpm --dir apps/web test:unit
- pnpm --dir apps/web test:e2e tests/e2e/settings/agent-enrolment.spec.ts (issue-specific existing-token case passed; neighboring pre-existing failures tracked in #1427)