### PR TITLE
fix(password-manager): align launch assertion tenant claims

### DIFF
--- a/apps/web/lib/password-manager/launch-assertion.test.mjs
+++ b/apps/web/lib/password-manager/launch-assertion.test.mjs
@@ -75,8 +75,8 @@ test('signPasswordManagerLaunchAssertion emits the required claims', async () =>
   assert.equal(protectedHeader.alg, 'EdDSA')
   assert.equal(payload.product, 'ct-password-manager')
   assert.equal(payload.ct_ops_instance_id, 'ct-ops-prod-1')
-  assert.equal(payload.ct_ops_instance_settings_id, 'instance-123')
-  assert.equal(payload.ct_ops_instance_name, 'Example Instance')
+  assert.equal(payload.ct_ops_organization_id, 'instance-123')
+  assert.equal(payload.ct_ops_organization_name, 'Example Instance')
   assert.equal(payload.ct_ops_user_id, 'user-456')
   assert.equal(payload.email, 'ops@example.com')
   assert.equal(payload.name, 'Example Operator')
@@ -111,5 +111,5 @@ test('signPasswordManagerLaunchAssertion omits the optional instance name when a
     currentDate: new Date('2026-05-05T17:45:30.000Z'),
   })
 
-  assert.equal('ct_ops_instance_name' in payload, false)
+  assert.equal('ct_ops_organization_name' in payload, false)
 })

--- a/apps/web/lib/password-manager/launch-assertion.ts
+++ b/apps/web/lib/password-manager/launch-assertion.ts
@@ -112,7 +112,7 @@ export async function signPasswordManagerLaunchAssertion(
   const payload: Record<string, string> = {
     product: config.product,
     ct_ops_instance_id: config.ctOpsInstanceId,
-    ct_ops_instance_settings_id: assertNonEmptyPrincipalField(principal.instanceId, 'instanceId'),
+    ct_ops_organization_id: assertNonEmptyPrincipalField(principal.instanceId, 'instanceId'),
     ct_ops_user_id: assertNonEmptyPrincipalField(principal.userId, 'userId'),
     email: assertNonEmptyPrincipalField(principal.email, 'email'),
     name: assertNonEmptyPrincipalField(principal.name, 'name'),
@@ -120,7 +120,7 @@ export async function signPasswordManagerLaunchAssertion(
 
   const instanceName = principal.instanceName?.trim()
   if (instanceName) {
-    payload.ct_ops_instance_name = instanceName
+    payload.ct_ops_organization_name = instanceName
   }
 
   return new SignJWT(payload)

--- a/apps/web/tests/e2e/fixtures/password-manager.ts
+++ b/apps/web/tests/e2e/fixtures/password-manager.ts
@@ -264,7 +264,7 @@ export async function createPasswordManagerMock(context: BrowserContext): Promis
       const payload = decodeJwtPayload(assertion)
       state.launchAssertions.push(assertion)
       state.currentUserId = payload.ct_ops_user_id || state.currentUserId
-      state.currentInstanceId = payload.ct_ops_instance_settings_id || state.currentInstanceId
+      state.currentInstanceId = payload.ct_ops_organization_id || state.currentInstanceId
       state.sessionToken = randomUUID()
 
       await fulfillEmpty(route, 204, {


### PR DESCRIPTION
## Summary
- align CT-Ops Password Manager launch assertions with the bundled API tenant claim names
- update the launch assertion unit test and hosted Password Manager fixture to use organization claims

## Validation
- pnpm --dir apps/web exec node --experimental-strip-types --test lib/password-manager/launch-assertion.test.mjs
- pnpm --dir apps/web lint lib/password-manager/launch-assertion.ts lib/password-manager/launch-assertion.test.mjs tests/e2e/fixtures/password-manager.ts
- live dev-stack launch exchange returned 204 with the patched assertion