### PR TITLE
feat(hosts): add activity dialog association tabs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,20 @@
 
 ## What Has Been Built
 
+### Session 134 — Host calendar activity dialog tabs
+
+**Tabbed host activity detail dialog** (`apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx`, `apps/web/lib/actions/calendar.ts`, `apps/web/tests/e2e/hosts/host-calendar.spec.ts`)
+- Made the Hosts -> Activity -> Calendar event dialog wider with viewport
+  bounds for mobile screens.
+- Split the dialog into Activity Detail, Hosts, and Participants tabs while
+  preserving the existing detail content and long-description scroll behavior.
+- Hydrated host calendar events with linked hosts and participants, including
+  participant role labels and a clear Current host marker in the Hosts tab.
+
+**Validation**
+- `pnpm --dir apps/web type-check`
+- `pnpm --dir apps/web test:e2e tests/e2e/hosts/host-calendar.spec.ts`
+
 ### Session 133 — GitHub issue developer-experience fixes
 
 **Focused validation and dev-origin cleanup** (`apps/web/lib/password-manager/api-contract/openapi.json`, `apps/web/lib/password-manager/client.test.mjs`, `apps/web/lib/e2e/route-warmup.mjs`, `apps/web/lib/e2e/route-warmup.test.mjs`, `apps/web/tests/e2e/runner.mjs`, `apps/web/tests/e2e/auth.setup.ts`, `apps/web/lib/security/trusted-origins.ts`, `apps/web/lib/security/trusted-origins.test.mjs`, `apps/web/next.config.ts`)

--- a/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
+++ b/apps/web/app/(dashboard)/hosts/[id]/host-calendar-tab.tsx
@@ -30,10 +30,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { listCalendarEventsForHost, type HostCalendarEventView } from '@/lib/actions/calendar'
 import {
   CALENDAR_EVENT_CATEGORIES,
   CALENDAR_EVENT_STATUSES,
+  type CalendarParticipantRole,
   type CalendarEventCategory,
   type CalendarEventStatus,
 } from '@/lib/db/schema/calendar'
@@ -62,6 +64,16 @@ const STATUS_BADGE_CLASS: Record<CalendarEventStatus, string> = {
   completed: 'bg-slate-100 text-slate-800 border-slate-200 hover:bg-slate-100',
   cancelled: 'bg-red-100 text-red-800 border-red-200 hover:bg-red-100',
 }
+
+const PARTICIPANT_ROLE_LABELS: Record<CalendarParticipantRole, string> = {
+  owner: 'Owner',
+  requester: 'Requester',
+  implementer: 'Implementer',
+  approver: 'Approver',
+  reviewer: 'Reviewer',
+  observer: 'Observer',
+}
+
 const HOST_CALENDAR_REFETCH_INTERVAL_MS = 5_000
 const EMPTY_HOST_CALENDAR_EVENTS: HostCalendarEventView[] = []
 type CategoryFilter = CalendarEventCategory | 'all'
@@ -169,9 +181,11 @@ function EventDetail({ label, children }: { label: string; children: ReactNode }
 
 function HostCalendarEventDetailsDialog({
   event,
+  hostId,
   onOpenChange,
 }: {
   event: HostCalendarEventView | null
+  hostId: string
   onOpenChange: (open: boolean) => void
 }) {
   const formattedDateRange = event ? formatEventDateRange(event) : null
@@ -179,7 +193,7 @@ function HostCalendarEventDetailsDialog({
   return (
     <Dialog open={event != null} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex max-h-[calc(100vh-2rem)] max-w-2xl grid-rows-none flex-col overflow-hidden"
+        className="flex max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] grid-rows-none flex-col overflow-hidden sm:max-w-3xl lg:max-w-4xl"
         data-testid="host-calendar-event-dialog"
       >
         {event ? (
@@ -194,35 +208,107 @@ function HostCalendarEventDetailsDialog({
               <DialogDescription>{CATEGORY_LABELS[event.category]} event</DialogDescription>
             </DialogHeader>
 
-            <div className="min-h-0 flex-1 space-y-5 overflow-hidden">
-              <div
-                className="max-h-[min(22rem,45vh)] overflow-y-auto rounded-md border bg-background p-4"
-                data-testid="host-calendar-event-description"
+            <Tabs defaultValue="details" className="min-h-0 flex-1 overflow-hidden">
+              <TabsList className="w-full justify-start overflow-x-auto sm:w-fit">
+                <TabsTrigger value="details">Activity Detail</TabsTrigger>
+                <TabsTrigger value="hosts">Hosts</TabsTrigger>
+                <TabsTrigger value="participants">Participants</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="details" className="min-h-0 space-y-5 overflow-y-auto pt-2">
+                <div
+                  className="max-h-[min(22rem,45vh)] overflow-y-auto rounded-md border bg-background p-4"
+                  data-testid="host-calendar-event-description"
+                >
+                  {event.description ? (
+                    <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+                      {event.description}
+                    </p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No description provided.</p>
+                  )}
+                </div>
+
+                <dl className="grid gap-4 sm:grid-cols-2">
+                  <EventDetail label="Date and time">
+                    {formattedDateRange ? (
+                      <EventDateText value={formattedDateRange} testId="host-calendar-event-detail-date" />
+                    ) : null}
+                  </EventDetail>
+                  <EventDetail label="Timezone">{event.timezone}</EventDetail>
+                  <EventDetail label="Status">{STATUS_LABELS[event.status]}</EventDetail>
+                  <EventDetail label="Category">{CATEGORY_LABELS[event.category]}</EventDetail>
+                  <EventDetail label="Schedule">
+                    {event.isRecurring ? 'Recurring' : 'One-off'}
+                  </EventDetail>
+                  <EventDetail label="All day">{event.allDay ? 'Yes' : 'No'}</EventDetail>
+                </dl>
+              </TabsContent>
+
+              <TabsContent
+                value="hosts"
+                className="min-h-0 overflow-y-auto pt-2"
+                data-testid="host-calendar-event-hosts-tab"
               >
-                {event.description ? (
-                  <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
-                    {event.description}
+                {event.hosts.length === 0 ? (
+                  <p className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
+                    No hosts are linked to this activity.
                   </p>
                 ) : (
-                  <p className="text-sm text-muted-foreground">No description provided.</p>
+                  <div className="divide-y overflow-hidden rounded-md border bg-background">
+                    {event.hosts.map((host) => {
+                      const isCurrentHost = host.id === hostId
+                      return (
+                        <div key={host.id} className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="font-medium text-foreground">
+                                {host.displayName || host.hostname}
+                              </span>
+                              {isCurrentHost ? (
+                                <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary hover:bg-primary/10">
+                                  Current host
+                                </Badge>
+                              ) : null}
+                            </div>
+                            <p className="mt-1 break-all text-sm text-muted-foreground">{host.hostname}</p>
+                          </div>
+                          {host.os ? (
+                            <Badge variant="secondary" className="w-fit">{host.os}</Badge>
+                          ) : null}
+                        </div>
+                      )
+                    })}
+                  </div>
                 )}
-              </div>
+              </TabsContent>
 
-              <dl className="grid gap-4 sm:grid-cols-2">
-                <EventDetail label="Date and time">
-                  {formattedDateRange ? (
-                    <EventDateText value={formattedDateRange} testId="host-calendar-event-detail-date" />
-                  ) : null}
-                </EventDetail>
-                <EventDetail label="Timezone">{event.timezone}</EventDetail>
-                <EventDetail label="Status">{STATUS_LABELS[event.status]}</EventDetail>
-                <EventDetail label="Category">{CATEGORY_LABELS[event.category]}</EventDetail>
-                <EventDetail label="Schedule">
-                  {event.isRecurring ? 'Recurring' : 'One-off'}
-                </EventDetail>
-                <EventDetail label="All day">{event.allDay ? 'Yes' : 'No'}</EventDetail>
-              </dl>
-            </div>
+              <TabsContent
+                value="participants"
+                className="min-h-0 overflow-y-auto pt-2"
+                data-testid="host-calendar-event-participants-tab"
+              >
+                {event.participants.length === 0 ? (
+                  <p className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
+                    No participants are linked to this activity.
+                  </p>
+                ) : (
+                  <div className="divide-y overflow-hidden rounded-md border bg-background">
+                    {event.participants.map((participant) => (
+                      <div key={participant.id} className="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0">
+                          <p className="font-medium text-foreground">{participant.name || participant.email}</p>
+                          <p className="mt-1 break-all text-sm text-muted-foreground">{participant.email}</p>
+                        </div>
+                        <Badge variant="outline" className="w-fit">
+                          {PARTICIPANT_ROLE_LABELS[participant.participantRole]}
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+            </Tabs>
           </>
         ) : null}
       </DialogContent>
@@ -388,6 +474,7 @@ export function HostCalendarTab({ scopeId, hostId }: { scopeId: string; hostId: 
       </CardContent>
       <HostCalendarEventDetailsDialog
         event={selectedEvent}
+        hostId={hostId}
         onOpenChange={(open) => {
           if (!open) setSelectedEvent(null)
         }}

--- a/apps/web/lib/actions/calendar.ts
+++ b/apps/web/lib/actions/calendar.ts
@@ -155,6 +155,8 @@ export interface HostCalendarEventView {
   category: CalendarEventCategory
   isRecurring: boolean
   isLinkedToCurrentUser: boolean
+  hosts: CalendarHostOption[]
+  participants: CalendarParticipantView[]
 }
 
 type ParsedCalendarInput = Omit<CalendarEventInput, 'startsAt' | 'endsAt' | 'recurrenceRule'> & {
@@ -579,17 +581,76 @@ export async function listCalendarEventsForHost(
       .limit(250)
 
     const eventIds = rows.map((row) => row.id)
-    const participantRows = eventIds.length > 0
-      ? await db.query.calendarEventParticipants.findMany({
-          where: and(
-            eq(calendarEventParticipants.instanceId, instanceId),
-            eq(calendarEventParticipants.userId, session.user.id),
-            inArray(calendarEventParticipants.eventId, eventIds),
-          ),
-          columns: { eventId: true },
-        })
-      : []
-    const currentUserEventIds = new Set(participantRows.map((row) => row.eventId))
+    const [hostRows, participantRows] = eventIds.length > 0
+      ? await Promise.all([
+          db
+            .select({
+              eventId: calendarEventHosts.eventId,
+              id: hosts.id,
+              hostname: hosts.hostname,
+              displayName: hosts.displayName,
+              os: hosts.os,
+            })
+            .from(calendarEventHosts)
+            .innerJoin(
+              hosts,
+              and(
+                eq(calendarEventHosts.hostId, hosts.id),
+                eq(hosts.instanceId, instanceId),
+                isNull(hosts.deletedAt),
+              ),
+            )
+            .where(and(
+              eq(calendarEventHosts.instanceId, instanceId),
+              inArray(calendarEventHosts.eventId, eventIds),
+            ))
+            .orderBy(asc(hosts.hostname)),
+          db
+            .select({
+              eventId: calendarEventParticipants.eventId,
+              participantRole: calendarEventParticipants.role,
+              id: users.id,
+              name: users.name,
+              email: users.email,
+              role: users.role,
+            })
+            .from(calendarEventParticipants)
+            .innerJoin(
+              users,
+              and(
+                eq(calendarEventParticipants.userId, users.id),
+                eq(users.instanceId, instanceId),
+                isNull(users.deletedAt),
+              ),
+            )
+            .where(and(
+              eq(calendarEventParticipants.instanceId, instanceId),
+              inArray(calendarEventParticipants.eventId, eventIds),
+            ))
+            .orderBy(asc(users.email)),
+        ])
+      : [[], []]
+    const currentUserEventIds = new Set(
+      participantRows.filter((row) => row.id === session.user.id).map((row) => row.eventId),
+    )
+    const hostsByEvent = new Map<string, CalendarHostOption[]>()
+    for (const row of hostRows) {
+      const list = hostsByEvent.get(row.eventId) ?? []
+      list.push({ id: row.id, hostname: row.hostname, displayName: row.displayName, os: row.os })
+      hostsByEvent.set(row.eventId, list)
+    }
+    const participantsByEvent = new Map<string, CalendarParticipantView[]>()
+    for (const row of participantRows) {
+      const list = participantsByEvent.get(row.eventId) ?? []
+      list.push({
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        role: row.role,
+        participantRole: row.participantRole,
+      })
+      participantsByEvent.set(row.eventId, list)
+    }
 
     return {
       events: rows.map((row) => ({
@@ -604,6 +665,8 @@ export async function listCalendarEventsForHost(
         category: row.category,
         isRecurring: Boolean(row.recurrenceRule),
         isLinkedToCurrentUser: row.createdBy === session.user.id || currentUserEventIds.has(row.id),
+        hosts: hostsByEvent.get(row.id) ?? [],
+        participants: participantsByEvent.get(row.id) ?? [],
       })),
     }
   } catch (err) {

--- a/apps/web/tests/e2e/hosts/host-calendar.spec.ts
+++ b/apps/web/tests/e2e/hosts/host-calendar.spec.ts
@@ -30,6 +30,11 @@ test('host admin calendar shows only events linked to the current host', async (
   `
 
   await sql`
+    INSERT INTO "user" (id, name, email, email_verified, created_at, updated_at, instance_id, role, roles, is_active)
+    VALUES ('host-calendar-observer-1', 'Host Calendar Observer', 'host-calendar-observer@example.com', true, NOW(), NOW(), ${instanceId}, 'viewer', '["viewer"]'::jsonb, true)
+  `
+
+  await sql`
     INSERT INTO calendar_events (
       id,
       instance_id,
@@ -54,6 +59,7 @@ test('host admin calendar shows only events linked to the current host', async (
     INSERT INTO calendar_event_hosts (instance_id, event_id, host_id)
     VALUES
       (${instanceId}, 'host-calendar-event-1', 'host-calendar-1'),
+      (${instanceId}, 'host-calendar-event-1', 'host-calendar-2'),
       (${instanceId}, 'host-calendar-event-2', 'host-calendar-1'),
       (${instanceId}, 'host-calendar-event-past', 'host-calendar-1'),
       (${instanceId}, 'host-calendar-event-other', 'host-calendar-2')
@@ -61,7 +67,9 @@ test('host admin calendar shows only events linked to the current host', async (
 
   await sql`
     INSERT INTO calendar_event_participants (instance_id, event_id, user_id, role)
-    VALUES (${instanceId}, 'host-calendar-event-1', ${userId}, 'implementer')
+    VALUES
+      (${instanceId}, 'host-calendar-event-1', ${userId}, 'implementer'),
+      (${instanceId}, 'host-calendar-event-1', 'host-calendar-observer-1', 'observer')
   `
 
   await page.goto('/hosts/host-calendar-1')
@@ -122,6 +130,22 @@ test('host admin calendar shows only events linked to the current host', async (
   )
   await expect(detailsDialog).toContainText('UTC')
   await expect(detailsDialog).toContainText('One-off')
+
+  await detailsDialog.getByRole('tab', { name: 'Hosts' }).click()
+  await expect(detailsDialog.getByTestId('host-calendar-event-hosts-tab')).toContainText('Host Calendar One')
+  await expect(detailsDialog.getByTestId('host-calendar-event-hosts-tab')).toContainText('host-calendar-1')
+  await expect(detailsDialog.getByTestId('host-calendar-event-hosts-tab')).toContainText('Current host')
+  await expect(detailsDialog.getByTestId('host-calendar-event-hosts-tab')).toContainText('Host Calendar Two')
+  await expect(detailsDialog.getByTestId('host-calendar-event-hosts-tab')).toContainText('host-calendar-2')
+
+  await detailsDialog.getByRole('tab', { name: 'Participants' }).click()
+  await expect(detailsDialog.getByTestId('host-calendar-event-participants-tab')).toContainText(TEST_USER.email)
+  await expect(detailsDialog.getByTestId('host-calendar-event-participants-tab')).toContainText('Implementer')
+  await expect(detailsDialog.getByTestId('host-calendar-event-participants-tab')).toContainText('host-calendar-observer@example.com')
+  await expect(detailsDialog.getByTestId('host-calendar-event-participants-tab')).toContainText('Observer')
+
+  await detailsDialog.getByRole('tab', { name: 'Activity Detail' }).click()
+  await expect(detailsDialog.getByTestId('host-calendar-event-description')).toContainText('Patch the current host.')
 })
 
 test('host calendar event dialog keeps long descriptions scrollable', async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary
- widen the host Activity calendar event dialog while keeping mobile viewport bounds
- add Activity Detail, Hosts, and Participants tabs to the dialog
- hydrate host calendar events with linked hosts and participants, including participant role labels and current-host marking

## Validation
- pnpm --dir apps/web type-check
- pnpm --dir apps/web test:e2e tests/e2e/hosts/host-calendar.spec.ts

Replaces #1434, which became merge-conflicted after main advanced.
