### PR TITLE
feat(web): show Ansible API image path

### DIFF
--- a/apps/web/app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx
@@ -26,6 +26,8 @@ interface AutomationSettingsClientProps {
   initialCredentialProfiles: AnsibleCredentialProfileSummary[]
 }
 
+const ANSIBLE_API_IMAGE = 'ghcr.io/carrtech-dev/ct-ops/ansible-api:latest'
+
 function statusBadge(settings: AutomationSettingsResult) {
   if (settings.status === 'healthy') {
     return <Badge className="gap-1"><CheckCircle2 className="h-3 w-3" /> Healthy</Badge>
@@ -191,9 +193,15 @@ export function AutomationSettingsClient({ initialSettings, initialCredentialPro
           <Alert>
             <ServerCog className="h-4 w-4" />
             <AlertTitle>{settings.status === 'healthy' ? 'Service connected' : 'Deployment boundary'}</AlertTitle>
-            <AlertDescription>
-              {settings.statusMessage}
-              {settings.ansibleVersion ? ` Ansible version: ${settings.ansibleVersion}.` : ''}
+            <AlertDescription className="space-y-2">
+              <p>
+                {settings.statusMessage}
+                {settings.ansibleVersion ? ` Ansible version: ${settings.ansibleVersion}.` : ''}
+              </p>
+              <p>
+                Pull the latest Ansible API image from{' '}
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{ANSIBLE_API_IMAGE}</code>.
+              </p>
             </AlertDescription>
           </Alert>
 
@@ -214,104 +222,106 @@ export function AutomationSettingsClient({ initialSettings, initialCredentialPro
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <ServerCog className="h-4 w-4" />
-            Ansible module connection
-          </CardTitle>
-          <CardDescription>
-            Point CT-Ops at a manually deployed Ansible API, on this server or behind a reverse proxy.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-5">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="ansible-connection-name">Connection name</Label>
-              <Input
-                id="ansible-connection-name"
-                value={connectionName}
-                onChange={(event) => setConnectionName(event.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="ansible-connection-url">Ansible API URL</Label>
-              <Input
-                id="ansible-connection-url"
-                type="url"
-                value={connectionBaseUrl}
-                onChange={(event) => setConnectionBaseUrl(event.target.value)}
-                placeholder="https://ansible-api.example.com"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="ansible-auth-mode">Authentication</Label>
-              <select
-                id="ansible-auth-mode"
-                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                value={connectionAuthMode}
-                onChange={(event) => setConnectionAuthMode(event.target.value as typeof connectionAuthMode)}
-              >
-                <option value="service-token-hmac">Service token HMAC</option>
-                <option value="none">None</option>
-              </select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="ansible-tls-mode">TLS mode</Label>
-              <select
-                id="ansible-tls-mode"
-                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                value={connectionTlsMode}
-                onChange={(event) => setConnectionTlsMode(event.target.value as typeof connectionTlsMode)}
-              >
-                <option value="public-ca">Public CA</option>
-                <option value="insecure">Insecure HTTP/private network</option>
-              </select>
-            </div>
-            {connectionAuthMode === 'service-token-hmac' && (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor="ansible-token-id">Token ID</Label>
-                  <Input
-                    id="ansible-token-id"
-                    value={connectionTokenId}
-                    onChange={(event) => setConnectionTokenId(event.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="ansible-token-secret">Token secret</Label>
-                  <Input
-                    id="ansible-token-secret"
-                    type="password"
-                    value={connectionTokenSecret}
-                    onChange={(event) => setConnectionTokenSecret(event.target.value)}
-                    placeholder={settings.ansibleConnection.hasTokenSecret ? 'Leave blank to keep existing' : 'Required for HMAC'}
-                  />
-                </div>
-              </>
-            )}
-            <div className="space-y-2">
-              <Label htmlFor="ansible-timeout">Request timeout ms</Label>
-              <Input
-                id="ansible-timeout"
-                inputMode="numeric"
-                value={connectionTimeoutMs}
-                onChange={(event) => setConnectionTimeoutMs(event.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center gap-3">
-            <Button type="button" onClick={() => saveConnection.mutate()} disabled={saveConnection.isPending}>
+      {enabled && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
               <ServerCog className="h-4 w-4" />
-              Save connection
-            </Button>
-            {saveConnection.isPending && <span className="text-sm text-muted-foreground">Saving...</span>}
-            {connectionSaved && <span className="text-sm text-green-700">Saved</span>}
-            {connectionError && <span className="text-sm text-destructive">{connectionError}</span>}
-          </div>
-        </CardContent>
-      </Card>
+              Ansible module connection
+            </CardTitle>
+            <CardDescription>
+              Point CT-Ops at a manually deployed Ansible API, on this server or behind a reverse proxy.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="ansible-connection-name">Connection name</Label>
+                <Input
+                  id="ansible-connection-name"
+                  value={connectionName}
+                  onChange={(event) => setConnectionName(event.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ansible-connection-url">Ansible API URL</Label>
+                <Input
+                  id="ansible-connection-url"
+                  type="url"
+                  value={connectionBaseUrl}
+                  onChange={(event) => setConnectionBaseUrl(event.target.value)}
+                  placeholder="https://ansible-api.example.com"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ansible-auth-mode">Authentication</Label>
+                <select
+                  id="ansible-auth-mode"
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  value={connectionAuthMode}
+                  onChange={(event) => setConnectionAuthMode(event.target.value as typeof connectionAuthMode)}
+                >
+                  <option value="service-token-hmac">Service token HMAC</option>
+                  <option value="none">None</option>
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="ansible-tls-mode">TLS mode</Label>
+                <select
+                  id="ansible-tls-mode"
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  value={connectionTlsMode}
+                  onChange={(event) => setConnectionTlsMode(event.target.value as typeof connectionTlsMode)}
+                >
+                  <option value="public-ca">Public CA</option>
+                  <option value="insecure">Insecure HTTP/private network</option>
+                </select>
+              </div>
+              {connectionAuthMode === 'service-token-hmac' && (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="ansible-token-id">Token ID</Label>
+                    <Input
+                      id="ansible-token-id"
+                      value={connectionTokenId}
+                      onChange={(event) => setConnectionTokenId(event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="ansible-token-secret">Token secret</Label>
+                    <Input
+                      id="ansible-token-secret"
+                      type="password"
+                      value={connectionTokenSecret}
+                      onChange={(event) => setConnectionTokenSecret(event.target.value)}
+                      placeholder={settings.ansibleConnection.hasTokenSecret ? 'Leave blank to keep existing' : 'Required for HMAC'}
+                    />
+                  </div>
+                </>
+              )}
+              <div className="space-y-2">
+                <Label htmlFor="ansible-timeout">Request timeout ms</Label>
+                <Input
+                  id="ansible-timeout"
+                  inputMode="numeric"
+                  value={connectionTimeoutMs}
+                  onChange={(event) => setConnectionTimeoutMs(event.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button type="button" onClick={() => saveConnection.mutate()} disabled={saveConnection.isPending}>
+                <ServerCog className="h-4 w-4" />
+                Save connection
+              </Button>
+              {saveConnection.isPending && <span className="text-sm text-muted-foreground">Saving...</span>}
+              {connectionSaved && <span className="text-sm text-green-700">Saved</span>}
+              {connectionError && <span className="text-sm text-destructive">{connectionError}</span>}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {enabled && (
         <Card>

--- a/apps/web/tests/e2e/settings/automation.spec.ts
+++ b/apps/web/tests/e2e/settings/automation.spec.ts
@@ -12,11 +12,14 @@ test('admin can enable Ansible automation and create an SSH credential profile',
   await page.goto('/settings/integrations/automation')
 
   await expect(page.getByRole('heading', { name: 'Automation' })).toBeVisible()
-  await expect(page.getByText('Ansible automation')).toBeVisible()
+  await expect(page.getByText('Ansible automation', { exact: true })).toBeVisible()
+  await expect(page.getByText('Ansible module connection')).toBeHidden()
 
   await page.getByTestId('settings-automation-ansible-toggle').click()
   await expect(page.getByText('Restart required')).toBeVisible()
-  await expect(page.getByText(/Run \.\/start\.sh/)).toBeVisible()
+  await expect(page.getByText('Ansible module connection')).toBeVisible()
+  await expect(page.getByText(/Check the configured Ansible API URL/)).toBeVisible()
+  await expect(page.getByText('ghcr.io/carrtech-dev/ct-ops/ansible-api:latest')).toBeVisible()
 
   await page.getByTestId('ansible-credential-name').fill('Linux admin key')
   await page.getByTestId('ansible-credential-username').fill('deploy')
@@ -24,5 +27,5 @@ test('admin can enable Ansible automation and create an SSH credential profile',
   await page.getByTestId('ansible-credential-save').click()
 
   await expect(page.getByText('Linux admin key')).toBeVisible()
-  await expect(page.getByText('deploy')).toBeVisible()
+  await expect(page.getByText('deploy', { exact: true })).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- show the latest GHCR Ansible API image path on Administration -> Integrations -> Automation
- hide the Ansible module connection section until the Ansible provider is enabled
- cover the image path and visibility behavior in the Automation e2e spec

## Validation
- pnpm --dir apps/web lint -- 'app/(dashboard)/settings/integrations/automation/automation-settings-client.tsx' 'tests/e2e/settings/automation.spec.ts'
- pnpm --dir apps/web type-check
- pnpm --dir apps/web test:e2e tests/e2e/settings/automation.spec.ts

## Release / image
- Requires normal web image release publication after merge.