### PR TITLE
fix(ldap): align add form with AD defaults

### DIFF
--- a/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
+++ b/apps/web/app/(dashboard)/settings/ldap/ldap-client.tsx
@@ -35,6 +35,22 @@ import {
 } from '@/lib/actions/ldap'
 import type { LdapConfigurationSafe } from '@/lib/actions/ldap'
 
+const AD_DEFAULTS = {
+  userSearchFilter: '(sAMAccountName={{username}})',
+  usernameAttribute: 'sAMAccountName',
+  emailAttribute: 'mail',
+  displayNameAttribute: 'displayName',
+}
+
+const AD_PLACEHOLDERS = {
+  host: 'dc01.corp.example.com',
+  baseDn: 'DC=corp,DC=example,DC=com',
+  bindDn: 'CN=svc-ldap,OU=Service Accounts,DC=corp,DC=example,DC=com',
+  userSearchBase: 'OU=Users',
+  groupSearchBase: 'OU=Groups',
+  groupSearchFilter: '(objectClass=group)',
+}
+
 const EMPTY_FORM = {
   name: '',
   host: '',
@@ -46,12 +62,12 @@ const EMPTY_FORM = {
   bindDn: '',
   bindPassword: '',
   userSearchBase: '',
-  userSearchFilter: '(uid={{username}})',
+  userSearchFilter: AD_DEFAULTS.userSearchFilter,
   groupSearchBase: '',
   groupSearchFilter: '',
-  usernameAttribute: 'uid',
-  emailAttribute: 'mail',
-  displayNameAttribute: 'cn',
+  usernameAttribute: AD_DEFAULTS.usernameAttribute,
+  emailAttribute: AD_DEFAULTS.emailAttribute,
+  displayNameAttribute: AD_DEFAULTS.displayNameAttribute,
   allowLogin: false,
 }
 
@@ -275,7 +291,7 @@ export function LdapSettingsClient({
                   <Input
                     value={addForm.host}
                     onChange={(e) => setAddForm({ ...addForm, host: e.target.value })}
-                    placeholder="ldap.example.com"
+                    placeholder={AD_PLACEHOLDERS.host}
                     data-testid="ldap-settings-add-host"
                   />
                 </div>
@@ -315,7 +331,7 @@ export function LdapSettingsClient({
                 <Input
                   value={addForm.baseDn}
                   onChange={(e) => setAddForm({ ...addForm, baseDn: e.target.value })}
-                  placeholder="dc=example,dc=com"
+                  placeholder={AD_PLACEHOLDERS.baseDn}
                   data-testid="ldap-settings-add-base-dn"
                 />
               </div>
@@ -324,7 +340,7 @@ export function LdapSettingsClient({
                 <Input
                   value={addForm.bindDn}
                   onChange={(e) => setAddForm({ ...addForm, bindDn: e.target.value })}
-                  placeholder="cn=admin,dc=example,dc=com"
+                  placeholder={AD_PLACEHOLDERS.bindDn}
                   data-testid="ldap-settings-add-bind-dn"
                 />
               </div>
@@ -342,7 +358,8 @@ export function LdapSettingsClient({
                 <Input
                   value={addForm.userSearchBase}
                   onChange={(e) => setAddForm({ ...addForm, userSearchBase: e.target.value })}
-                  placeholder="ou=users"
+                  placeholder={AD_PLACEHOLDERS.userSearchBase}
+                  data-testid="ldap-settings-add-user-search-base"
                 />
               </div>
               <div className="space-y-1.5">
@@ -350,7 +367,55 @@ export function LdapSettingsClient({
                 <Input
                   value={addForm.userSearchFilter}
                   onChange={(e) => setAddForm({ ...addForm, userSearchFilter: e.target.value })}
-                  placeholder="(uid={{username}})"
+                  placeholder={AD_DEFAULTS.userSearchFilter}
+                  data-testid="ldap-settings-add-user-filter"
+                />
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-1.5">
+                  <Label>Username Attr</Label>
+                  <Input
+                    value={addForm.usernameAttribute}
+                    onChange={(e) => setAddForm({ ...addForm, usernameAttribute: e.target.value })}
+                    placeholder={AD_DEFAULTS.usernameAttribute}
+                    data-testid="ldap-settings-add-username-attribute"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Email Attr</Label>
+                  <Input
+                    value={addForm.emailAttribute}
+                    onChange={(e) => setAddForm({ ...addForm, emailAttribute: e.target.value })}
+                    placeholder={AD_DEFAULTS.emailAttribute}
+                    data-testid="ldap-settings-add-email-attribute"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Display Name Attr</Label>
+                  <Input
+                    value={addForm.displayNameAttribute}
+                    onChange={(e) => setAddForm({ ...addForm, displayNameAttribute: e.target.value })}
+                    placeholder={AD_DEFAULTS.displayNameAttribute}
+                    data-testid="ldap-settings-add-display-name-attribute"
+                  />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Group Search Base (optional)</Label>
+                <Input
+                  value={addForm.groupSearchBase}
+                  onChange={(e) => setAddForm({ ...addForm, groupSearchBase: e.target.value })}
+                  placeholder={AD_PLACEHOLDERS.groupSearchBase}
+                  data-testid="ldap-settings-add-group-search-base"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Group Search Filter (optional)</Label>
+                <Input
+                  value={addForm.groupSearchFilter}
+                  onChange={(e) => setAddForm({ ...addForm, groupSearchFilter: e.target.value })}
+                  placeholder={AD_PLACEHOLDERS.groupSearchFilter}
+                  data-testid="ldap-settings-add-group-filter"
                 />
               </div>
               <div className="flex items-center justify-between">
@@ -513,7 +578,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.host}
                 onChange={(e) => setEditForm({ ...editForm, host: e.target.value })}
-                placeholder="ldap.example.com"
+                placeholder={AD_PLACEHOLDERS.host}
                 data-testid="ldap-settings-edit-host"
               />
               </div>
@@ -554,7 +619,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.baseDn}
                 onChange={(e) => setEditForm({ ...editForm, baseDn: e.target.value })}
-                placeholder="dc=example,dc=com"
+                placeholder={AD_PLACEHOLDERS.baseDn}
               />
             </div>
             <div className="space-y-1.5">
@@ -562,7 +627,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.bindDn}
                 onChange={(e) => setEditForm({ ...editForm, bindDn: e.target.value })}
-                placeholder="cn=admin,dc=example,dc=com"
+                placeholder={AD_PLACEHOLDERS.bindDn}
               />
             </div>
             <div className="space-y-1.5">
@@ -579,7 +644,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.userSearchBase}
                 onChange={(e) => setEditForm({ ...editForm, userSearchBase: e.target.value })}
-                placeholder="ou=users"
+                placeholder={AD_PLACEHOLDERS.userSearchBase}
               />
             </div>
             <div className="space-y-1.5">
@@ -587,7 +652,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.userSearchFilter}
                 onChange={(e) => setEditForm({ ...editForm, userSearchFilter: e.target.value })}
-                placeholder="(uid={{username}})"
+                placeholder={AD_DEFAULTS.userSearchFilter}
                 data-testid="ldap-settings-edit-user-filter"
               />
             </div>
@@ -597,6 +662,7 @@ export function LdapSettingsClient({
                 <Input
                   value={editForm.usernameAttribute}
                   onChange={(e) => setEditForm({ ...editForm, usernameAttribute: e.target.value })}
+                  placeholder={AD_DEFAULTS.usernameAttribute}
                 />
               </div>
               <div className="space-y-1.5">
@@ -604,6 +670,7 @@ export function LdapSettingsClient({
                 <Input
                   value={editForm.emailAttribute}
                   onChange={(e) => setEditForm({ ...editForm, emailAttribute: e.target.value })}
+                  placeholder={AD_DEFAULTS.emailAttribute}
                 />
               </div>
               <div className="space-y-1.5">
@@ -611,6 +678,7 @@ export function LdapSettingsClient({
                 <Input
                   value={editForm.displayNameAttribute}
                   onChange={(e) => setEditForm({ ...editForm, displayNameAttribute: e.target.value })}
+                  placeholder={AD_DEFAULTS.displayNameAttribute}
                 />
               </div>
             </div>
@@ -619,7 +687,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.groupSearchBase}
                 onChange={(e) => setEditForm({ ...editForm, groupSearchBase: e.target.value })}
-                placeholder="ou=groups"
+                placeholder={AD_PLACEHOLDERS.groupSearchBase}
               />
             </div>
             <div className="space-y-1.5">
@@ -627,7 +695,7 @@ export function LdapSettingsClient({
               <Input
                 value={editForm.groupSearchFilter}
                 onChange={(e) => setEditForm({ ...editForm, groupSearchFilter: e.target.value })}
-                placeholder="(objectClass=groupOfNames)"
+                placeholder={AD_PLACEHOLDERS.groupSearchFilter}
               />
             </div>
             <div className="flex items-center justify-between">

--- a/apps/web/lib/actions/ldap.ts
+++ b/apps/web/lib/actions/ldap.ts
@@ -22,6 +22,11 @@ import type { LdapUser, LdapUserDetail } from '@/lib/ldap/client'
 
 export type { LdapConfigurationSafe } from '@/lib/ldap/config-client'
 
+const AD_DEFAULT_USER_SEARCH_FILTER = '(sAMAccountName={{username}})'
+const AD_DEFAULT_USERNAME_ATTRIBUTE = 'sAMAccountName'
+const AD_DEFAULT_EMAIL_ATTRIBUTE = 'mail'
+const AD_DEFAULT_DISPLAY_NAME_ATTRIBUTE = 'displayName'
+
 async function getInstanceInstanceId(): Promise<string> {
   const instanceId = await getDefaultInstanceId()
   if (!instanceId) {
@@ -53,12 +58,12 @@ const createLdapConfigSchema = z.object({
   bindDn: z.string().min(1, 'Bind DN is required'),
   bindPassword: z.string().min(1, 'Bind password is required'),
   userSearchBase: z.string().optional(),
-  userSearchFilter: z.string().default('(uid={{username}})'),
+  userSearchFilter: z.string().default(AD_DEFAULT_USER_SEARCH_FILTER),
   groupSearchBase: z.string().optional(),
   groupSearchFilter: z.string().optional(),
-  usernameAttribute: z.string().default('uid'),
-  emailAttribute: z.string().default('mail'),
-  displayNameAttribute: z.string().default('cn'),
+  usernameAttribute: z.string().default(AD_DEFAULT_USERNAME_ATTRIBUTE),
+  emailAttribute: z.string().default(AD_DEFAULT_EMAIL_ATTRIBUTE),
+  displayNameAttribute: z.string().default(AD_DEFAULT_DISPLAY_NAME_ATTRIBUTE),
   allowLogin: z.boolean().default(false),
 })
 

--- a/apps/web/tests/e2e/settings/ldap.spec.ts
+++ b/apps/web/tests/e2e/settings/ldap.spec.ts
@@ -20,11 +20,19 @@ test('admin can create, edit, toggle, and delete an LDAP configuration', async (
   await expect(page.getByTestId('ldap-settings-empty-state')).toBeVisible()
 
   await page.getByTestId('ldap-settings-add-open').click()
+  await expect(page.getByTestId('ldap-settings-add-host')).toHaveAttribute('placeholder', 'dc01.corp.example.com')
+  await expect(page.getByTestId('ldap-settings-add-base-dn')).toHaveAttribute('placeholder', 'DC=corp,DC=example,DC=com')
+  await expect(page.getByTestId('ldap-settings-add-bind-dn')).toHaveAttribute('placeholder', 'CN=svc-ldap,OU=Service Accounts,DC=corp,DC=example,DC=com')
   await page.getByTestId('ldap-settings-add-name').fill('Corporate AD')
   await page.getByTestId('ldap-settings-add-host').fill('ldap.internal.example')
-  await page.getByTestId('ldap-settings-add-base-dn').fill('dc=internal,dc=example')
-  await page.getByTestId('ldap-settings-add-bind-dn').fill('cn=svc-ldap,dc=internal,dc=example')
+  await page.getByTestId('ldap-settings-add-base-dn').fill('DC=internal,DC=example')
+  await page.getByTestId('ldap-settings-add-bind-dn').fill('CN=svc-ldap,DC=internal,DC=example')
   await page.getByTestId('ldap-settings-add-bind-password').fill('SuperSecret123!')
+  await expect(page.getByTestId('ldap-settings-add-user-filter')).toHaveValue('(sAMAccountName={{username}})')
+  await expect(page.getByTestId('ldap-settings-add-username-attribute')).toHaveValue('sAMAccountName')
+  await page.getByTestId('ldap-settings-add-user-search-base').fill('ou=Staff')
+  await page.getByTestId('ldap-settings-add-group-search-base').fill('ou=Security Groups')
+  await page.getByTestId('ldap-settings-add-group-filter').fill('(objectClass=group)')
   await page.getByTestId('ldap-settings-add-submit').click()
   await expect(page.getByText('Corporate AD')).toBeVisible()
 
@@ -32,11 +40,31 @@ test('admin can create, edit, toggle, and delete an LDAP configuration', async (
     id: string
     host: string
     port: number
+    user_search_base: string | null
+    user_search_filter: string
+    group_search_base: string | null
+    group_search_filter: string | null
+    username_attribute: string
+    email_attribute: string
+    display_name_attribute: string
     allow_login: boolean
     enabled: boolean
     deleted_at: string | null
   }>>`
-    SELECT id, host, port, allow_login, enabled, deleted_at
+    SELECT
+      id,
+      host,
+      port,
+      user_search_base,
+      user_search_filter,
+      group_search_base,
+      group_search_filter,
+      username_attribute,
+      email_attribute,
+      display_name_attribute,
+      allow_login,
+      enabled,
+      deleted_at
     FROM ldap_configurations
     WHERE instance_id = ${instanceId}
       AND name = 'Corporate AD'
@@ -46,6 +74,13 @@ test('admin can create, edit, toggle, and delete an LDAP configuration', async (
   expect(createdRows).toHaveLength(1)
   expect(createdRows[0]?.host).toBe('ldap.internal.example')
   expect(createdRows[0]?.port).toBe(389)
+  expect(createdRows[0]?.user_search_base).toBe('ou=Staff')
+  expect(createdRows[0]?.user_search_filter).toBe('(sAMAccountName={{username}})')
+  expect(createdRows[0]?.group_search_base).toBe('ou=Security Groups')
+  expect(createdRows[0]?.group_search_filter).toBe('(objectClass=group)')
+  expect(createdRows[0]?.username_attribute).toBe('sAMAccountName')
+  expect(createdRows[0]?.email_attribute).toBe('mail')
+  expect(createdRows[0]?.display_name_attribute).toBe('displayName')
   expect(createdRows[0]?.allow_login).toBe(false)
   expect(createdRows[0]?.enabled).toBe(true)
   expect(createdRows[0]?.deleted_at).toBeNull()


### PR DESCRIPTION
## Summary
- add the edit-only LDAP tuning fields to the add configuration dialog
- switch LDAP add/edit examples and create defaults to Microsoft AD values
- expand LDAP E2E coverage for AD defaults and persisted add-form fields

## Validation
- pnpm --dir apps/web test:e2e tests/e2e/settings/ldap.spec.ts
- pnpm --dir apps/web type-check
- pnpm --dir apps/web lint (passes with existing warnings)