### PR TITLE
ci: disable setup-go cache on cleanup jobs

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: agent/go.mod
+          cache: false
           cache-dependency-path: |
             agent/go.sum
             go.work.sum

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache: false
           cache-dependency-path: |
             agent/go.sum
             apps/ingest/go.sum

--- a/.github/workflows/pr-checks-go.yml
+++ b/.github/workflows/pr-checks-go.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          cache: false
           cache-dependency-path: |
             agent/go.sum
             apps/ingest/go.sum

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache: false
           cache-dependency-path: ${{ matrix.path }}/go.sum
 
       - name: Install gosec


### PR DESCRIPTION
## Summary
- disable actions/setup-go cache post-actions in workflows that delete the workspace during cleanup
- cover Go checks, SAST gosec jobs, CodeQL Go analysis, and agent release builds
- avoid self-hosted runner hangs in Post Set up Go after successful scans/tests

## Validation
- git diff --check